### PR TITLE
Refactor load facets paginations

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -257,8 +257,9 @@ class Annotator(object):
     def groups_url(cls, lane):
         raise NotImplementedError()
 
-    def default_lane_url(self):
-        return self.groups_url(None)
+    @classmethod
+    def default_lane_url(cls):
+        raise NotImplementedError()
 
     @classmethod
     def featured_feed_url(cls, lane, order=None):

--- a/problem_details.py
+++ b/problem_details.py
@@ -1,0 +1,8 @@
+from util.problem_detail import ProblemDetail as pd
+
+INVALID_INPUT = pd(
+      "http://librarysimplified.org/terms/problem/invalid-input",
+      400,
+      "Invalid input.",
+      "You provided invalid or unrecognized input.",
+)

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -74,6 +74,10 @@ class TestAnnotator(Annotator):
         return "http://groups/%s" % name
 
     @classmethod
+    def default_lane_url(cls):
+        return cls.groups_url(None)
+
+    @classmethod
     def facet_url(cls, facets):
         return "http://facet/" + "&".join(
             ["%s=%s" % (k, v) for k, v in sorted(facets.items())]


### PR DESCRIPTION
Pulls methods that load facets and paginations down from the Circulation Manager and Content Server layers.

Also, fixes broken tests caused by `default_lane_url()`.
