### PR TITLE
Workaround for "Resource temporarily unavailable" error

### DIFF
--- a/bibliocommons.py
+++ b/bibliocommons.py
@@ -7,7 +7,11 @@ from datetime import (
 import os
 import json
 import urlparse
-import isbnlib
+
+import imp
+ignore, isbnlib_path, ignore = imp.find_module("isbnlib")
+isbnlib = imp.load_source("isbnlib", isbnlib_path + "/_core.py")
+
 from sqlalchemy.orm.session import Session
 
 from model import (

--- a/model.py
+++ b/model.py
@@ -8,7 +8,11 @@ from lxml import etree
 from nose.tools import set_trace
 import bisect
 import datetime
-import isbnlib
+
+import imp
+ignore, isbnlib_path, ignore = imp.find_module("isbnlib")
+isbnlib = imp.load_source("isbnlib", isbnlib_path + "/_core.py")
+
 import json
 import logging
 import md5

--- a/nyt.py
+++ b/nyt.py
@@ -1,5 +1,4 @@
 """Interface to the New York Times APIs."""
-import isbnlib
 from nose.tools import set_trace
 from datetime import datetime, timedelta
 from collections import Counter

--- a/overdrive.py
+++ b/overdrive.py
@@ -1,7 +1,11 @@
 from nose.tools import set_trace
 import base64
 import datetime
-import isbnlib
+
+import imp
+ignore, isbnlib_path, ignore = imp.find_module("isbnlib")
+isbnlib = imp.load_source("isbnlib", isbnlib_path + "/_core.py")
+
 import os
 import json
 import logging


### PR DESCRIPTION
Some of us are getting a "Resource temporarily unavailable" error when running the app in debug mode with the flask reloader. I've been using gevent.WSGIServer instead, and I also found that setting use_reloader=False fixes the error, but I'd like to use the automatic reloader.

The error seems to be caused by isbnlib setting a global socket timeout (https://github.com/xlcnd/isbnlib/blob/master/isbnlib/config.py#L22). We're not using anything from isbnlib that requires sockets, so this commit only imports the file with the ISBN 10/13 conversions. Is there a better way to handle this?
