### PR TITLE
Default qualities for Standard eBooks and unglue.it

### DIFF
--- a/model.py
+++ b/model.py
@@ -2682,9 +2682,9 @@ class Work(Base):
         DataSource.OVERDRIVE: 0.4,
         DataSource.THREEM : 0.65,
         DataSource.AXIS_360: 0.65,
-        DataSource.STANDARD_EBOOKS: 0.75,
+        DataSource.STANDARD_EBOOKS: 0.8,
         DataSource.UNGLUE_IT: 0.4,
-        DataSource.PLYMPTON: 0.6,
+        DataSource.PLYMPTON: 0.5,
     }
 
     __tablename__ = 'works'


### PR DESCRIPTION
These need to be set for the books to show up in the content server feeds. What should they be?
