### PR TITLE
Best open access link won't always have open access rel

### DIFF
--- a/model.py
+++ b/model.py
@@ -2461,13 +2461,14 @@ class Edition(Base):
     @property
     def best_open_access_link(self):
         """Find the best open-access Resource for this LicensePool."""
-        open_access = Hyperlink.OPEN_ACCESS_DOWNLOAD
+        if not self.license_pool.open_access:
+            return None
 
         _db = Session.object_session(self)
         best = None
         best_priority = None
         q = Identifier.resources_for_identifier_ids(
-            _db, [self.primary_identifier.id], open_access)
+            _db, [self.primary_identifier.id])
         for resource in q:
             if not any(
                     [resource.representation and


### PR DESCRIPTION
In unglue.it's OPDS feed, all of the book links have rel=http://opds-spec.org/acquisition, but many of them are open access links. 

I changed best_open_access_link to assume that if the license pool is open access, the book links are open access and any of them could be the best open access link. This seems like the simplest way to get unglue.it books to show up, but I'm not sure if it's correct or if it will work for all other sources. 

This may not be necessary later if the unglue.it OPDS feed changes. 
