### PR TITLE
Add availability time to materialized views

### DIFF
--- a/files/materialized_view_works.sql
+++ b/files/materialized_view_works.sql
@@ -26,29 +26,52 @@ as
     works.last_update_time,
     works.simple_opds_entry,
     works.verbose_opds_entry,
-    licensepools.id AS license_pool_id
+    licensepools.id AS license_pool_id,
+    licensepools.availability_time
+
    FROM works
      JOIN editions ON editions.work_id = works.id AND editions.is_primary_for_work = true
      JOIN licensepools ON editions.data_source_id = licensepools.data_source_id AND editions.primary_identifier_id = licensepools.identifier_id
      JOIN datasources ON editions.data_source_id = datasources.id
      JOIN identifiers on editions.primary_identifier_id = identifiers.id
-  WHERE works.was_merged_into_id IS NULL AND works.presentation_ready = true AND works.simple_opds_entry IS NOT NULL
-  ORDER BY editions.sort_title, editions.sort_author;
+  WHERE works.was_merged_into_id IS NULL
+    AND works.presentation_ready = true
+    AND works.simple_opds_entry IS NOT NULL
+  
+  ORDER BY editions.sort_title, editions.sort_author, licensepools.availability_time;
 
 create index mv_works_editions_adult_fiction_author_ds_id on mv_works_editions_datasources_identifiers (sort_author, sort_title, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
 create index mv_works_editions_adult_fiction_author_iden on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
 create index mv_works_editions_adult_fiction_author_other_iden on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
 create index mv_works_editions_adult_fiction_author_w_ds_id on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
 create index mv_works_editions_adult_fiction_title_ds_id on mv_works_editions_datasources_identifiers (sort_title, sort_author, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
 create index mv_works_editions_adult_fiction_title_iden on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
 create index mv_works_editions_adult_fiction_title_other_iden on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
 create index mv_works_editions_adult_fiction_title_w_ds_id on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
 create index mv_works_editions_adult_nfiction_author_iden on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
 create index mv_works_editions_adult_nfiction_author_other_iden on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
 create index mv_works_editions_adult_nfiction_title_iden on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
 create index mv_works_editions_adult_nfiction_title_other_iden on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
 create index mv_works_editions_yachild_fiction_author_iden on mv_works_editions_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
 create index mv_works_editions_yachild_nonfiction_author_iden on mv_works_editions_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
 create index mv_works_editions_yachild_nonfiction_title_iden on mv_works_editions_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
-;
+
+-- Create indexes that order primarily by availability_time
+
+create index mv_works_editions_english_adult_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time, sort_title, sort_author, language, works_id) where audience in ('Adult', 'Adults Only') AND fiction = true and language='eng';
+
+create index mv_works_editions_english_adult_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time, sort_title, sort_author, language, works_id) where audience in ('Adult', 'Adults Only') AND fiction = true and language='eng';
+
+create index mv_works_editions_english_ya_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time, sort_title, sort_author, language, works_id) where audience in ('Children', 'Young Adult') AND fiction = true and language='eng';
+
+create index mv_works_editions_ya_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time, sort_title, sort_author, language, works_id) where audience in ('Children', 'Young Adult') AND fiction = true and language='eng';
+
+-- Create a unique index so that searches can look up books by work ID.
+
 create unique index mv_works_editions_work_id on mv_works_editions_datasources_identifiers (works_id);
+

--- a/files/materialized_view_works.sql
+++ b/files/materialized_view_works.sql
@@ -51,11 +51,11 @@ create unique index mv_works_editions_work_id on mv_works_editions_datasources_i
 
 -- English adult fiction
 
-create index mv_works_editions_english_adult_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+create index mv_works_editions_english_adult_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
 
-create index mv_works_editions_english_adult_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+create index mv_works_editions_english_adult_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
 
-create index mv_works_editions_english_adult_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+create index mv_works_editions_english_adult_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
 
 -- English adult nonfiction
 

--- a/files/materialized_view_works.sql
+++ b/files/materialized_view_works.sql
@@ -40,38 +40,61 @@ as
   
   ORDER BY editions.sort_title, editions.sort_author, licensepools.availability_time;
 
-create index mv_works_editions_adult_fiction_author_ds_id on mv_works_editions_datasources_identifiers (sort_author, sort_title, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
-create index mv_works_editions_adult_fiction_author_iden on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
-create index mv_works_editions_adult_fiction_author_other_iden on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
-create index mv_works_editions_adult_fiction_author_w_ds_id on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
-
-create index mv_works_editions_adult_fiction_title_ds_id on mv_works_editions_datasources_identifiers (sort_title, sort_author, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
-create index mv_works_editions_adult_fiction_title_iden on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
-create index mv_works_editions_adult_fiction_title_other_iden on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
-create index mv_works_editions_adult_fiction_title_w_ds_id on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
-
-create index mv_works_editions_adult_nfiction_author_iden on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
-create index mv_works_editions_adult_nfiction_author_other_iden on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
-
-create index mv_works_editions_adult_nfiction_title_iden on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
-create index mv_works_editions_adult_nfiction_title_other_iden on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
-
-create index mv_works_editions_yachild_fiction_author_iden on mv_works_editions_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
-create index mv_works_editions_yachild_nonfiction_author_iden on mv_works_editions_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
-
-create index mv_works_editions_yachild_nonfiction_title_iden on mv_works_editions_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
-
--- Create indexes that order primarily by availability_time
-
-create index mv_works_editions_english_adult_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time, sort_title, sort_author, language, works_id) where audience in ('Adult', 'Adults Only') AND fiction = true and language='eng';
-
-create index mv_works_editions_english_adult_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time, sort_title, sort_author, language, works_id) where audience in ('Adult', 'Adults Only') AND fiction = true and language='eng';
-
-create index mv_works_editions_english_ya_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time, sort_title, sort_author, language, works_id) where audience in ('Children', 'Young Adult') AND fiction = true and language='eng';
-
-create index mv_works_editions_ya_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time, sort_title, sort_author, language, works_id) where audience in ('Children', 'Young Adult') AND fiction = true and language='eng';
-
 -- Create a unique index so that searches can look up books by work ID.
 
 create unique index mv_works_editions_work_id on mv_works_editions_datasources_identifiers (works_id);
 
+-- We need three versions of each index:
+--- One that orders by sort_author, sort_title, and works_id
+--- One that orders by sort_title, sort_author, and works_id
+--- One that orders by availability_time (descending!), sort_title, sort_author, and works_id
+
+-- English adult fiction
+
+create index mv_works_editions_english_adult_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_editions_english_adult_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_editions_english_adult_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+-- English adult nonfiction
+
+create index mv_works_editions_english_adult_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_editions_english_adult_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_editions_english_adult_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+-- Nonenglish adult fiction
+--- These are also ordered by language
+
+create index mv_works_editions_nonenglish_adult_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+-- Nonenglish adult nonfiction
+--- These are also ordered by language
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+-- YA/Children's fiction, regardless of language
+
+create index mv_works_editions_ya_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_editions_ya_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_editions_ya_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+-- YA/Children's nonfiction, regardless of language
+
+create index mv_works_editions_ya_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_editions_ya_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_editions_ya_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;

--- a/files/materialized_view_works_workgenres.sql
+++ b/files/materialized_view_works_workgenres.sql
@@ -29,7 +29,8 @@ as
     works.last_update_time,
     works.simple_opds_entry,
     works.verbose_opds_entry,
-    licensepools.id AS license_pool_id
+    licensepools.id AS license_pool_id,
+    licensepools.availability_time
    FROM works
      JOIN editions ON editions.work_id = works.id AND editions.is_primary_for_work = true
      JOIN licensepools ON editions.data_source_id = licensepools.data_source_id AND editions.primary_identifier_id = licensepools.identifier_id
@@ -37,20 +38,62 @@ as
      JOIN identifiers on editions.primary_identifier_id = identifiers.id
      JOIN workgenres ON works.id = workgenres.work_id
   WHERE works.was_merged_into_id IS NULL AND works.presentation_ready = true AND works.simple_opds_entry IS NOT NULL
-  ORDER BY (editions.sort_title, editions.sort_author);
+  ORDER BY (editions.sort_title, editions.sort_author, licensepools.availability_time);
 
-create index mv_works_editions_adult_fiction_author_other_wg_iden on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
-create index mv_works_editions_adult_fiction_author_wg_iden on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language='eng';
-create index mv_works_editions_adult_fiction_title_g_ds_id on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language='eng';
-create index mv_works_editions_adult_fiction_title_other_wg_iden on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
-create index mv_works_editions_adult_fiction_title_wg_iden on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language='eng';
-create index mv_works_editions_adult_nfiction_author_other_wg_iden on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
-create index mv_works_editions_adult_nfiction_author_wg_iden on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language='eng';
-create index mv_works_editions_adult_nfiction_title_g_ds_id on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language='eng';
-create index mv_works_editions_adult_nfiction_title_other_wg_iden on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
-create index mv_works_editions_adult_nfiction_title_wg_iden on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id, license_pool_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language='eng';
-create index mv_works_editions_yachild_fiction_author_wg_iden on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
-create index mv_works_editions_yachild_fiction_title_wg_iden on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
-create index mv_works_editions_yachild_nonfiction_author_wg_iden on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
-create index mv_works_editions_yachild_nonfiction_title_wg_iden on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
-create unique index mv_works_editions_workgenres_work_id_genre_id on mv_works_editions_workgenres_datasources_identifiers (works_id, genre_id);
+-- Create a work/genre lookup.
+create unique index mv_works_genres_work_id_genre_id on mv_works_editions_workgenres_datasources_identifiers (works_id, genre_id);
+
+-- We need three versions of each index:
+--- One that orders by sort_author, sort_title, and works_id
+--- One that orders by sort_title, sort_author, and works_id
+--- One that orders by availability_time (descending!), sort_title, sort_author, and works_id
+
+-- English adult fiction
+
+create index mv_works_genres_english_adult_fiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_genres_english_adult_fiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_genres_english_adult_fiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+-- English adult nonfiction
+
+create index mv_works_genres_english_adult_nonfiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_genres_english_adult_nonfiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_genres_english_adult_nonfiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+-- Nonenglish adult fiction
+--- These are also ordered by language
+
+create index mv_works_genres_nonenglish_adult_fiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_fiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_fiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+-- Nonenglish adult nonfiction
+--- These are also ordered by language
+
+create index mv_works_genres_nonenglish_adult_nonfiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_nonfiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_nonfiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+-- YA/Children's fiction, regardless of language
+
+create index mv_works_genres_ya_fiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_genres_ya_fiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_genres_ya_fiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+-- YA/Children's nonfiction, regardless of language
+
+create index mv_works_genres_ya_nonfiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_genres_ya_nonfiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_genres_ya_nonfiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;

--- a/lane.py
+++ b/lane.py
@@ -282,7 +282,7 @@ class Facets(FacetConstants):
         else:
             work_id = work_model.works_id
         default_sort_order = [
-            edition_model.sort_title, edition_model.sort_author, work_id
+            edition_model.sort_author, edition_model.sort_title, work_id
         ]
     
         primary_order_by = self.order_facet_to_database_field(
@@ -300,11 +300,12 @@ class Facets(FacetConstants):
             # Use the default sort order
             order_by = default_order_by
 
-        # Set each field in the sort order to ascending or descending.
+        # order_ascending applies only to the first field in the sort order.
+        # For now, everything else is ordered ascending.
         if self.order_ascending:
             order_by_sorted = [x.asc() for x in order_by]
         else:
-            order_by_sorted = [x.desc() for x in order_by]
+            order_by_sorted = [order_by[0].desc()] + [x.asc() for x in order_by[1:]]
         return order_by_sorted, order_by
 
 
@@ -906,6 +907,7 @@ class Lane(object):
         q = q.join(LicensePool, LicensePool.id==mw.license_pool_id)
         q = q.options(contains_eager(mw.license_pool))
         q = self.apply_filters(q, facets, pagination, mw, mw)
+
         return q
 
     def apply_filters(self, q, facets=None, pagination=None, work_model=Work, edition_model=Edition):

--- a/lane.py
+++ b/lane.py
@@ -181,13 +181,20 @@ class Facets(FacetConstants):
                 # different.
                 return work_model.works_id
 
+        if order_facet == cls.ORDER_ADDED_TO_COLLECTION:
+            if work_model is Work:
+                # We must get this data from LicensePool.
+                return LicensePool.availability_time
+            else:
+                # We can get this data from the materialized view.
+                return work_model.availability_time
+
         # In all other cases the field names are the same whether
         # we are using Work/Edition or a materialized view.
         order_facet_to_database_field = {
             cls.ORDER_TITLE : edition_model.sort_title,
             cls.ORDER_AUTHOR : edition_model.sort_author,
             cls.ORDER_LAST_UPDATE : work_model.last_update_time,
-            cls.ORDER_ADDED_TO_COLLECTION : LicensePool.availability_time,
             cls.ORDER_RANDOM : work_model.random,
         }
         return order_facet_to_database_field[order_facet]

--- a/migration/20160121-recreate-materialized-views.sql
+++ b/migration/20160121-recreate-materialized-views.sql
@@ -1,0 +1,207 @@
+drop materialized view mv_works_editions_datasources_identifiers;
+create materialized view mv_works_editions_datasources_identifiers
+as
+ SELECT 
+    distinct works.id AS works_id,
+    editions.id AS editions_id,
+    editions.data_source_id,
+    editions.primary_identifier_id,
+    editions.sort_title,
+    editions.permanent_work_id,
+    editions.sort_author,
+    editions.medium,
+    editions.language,
+    editions.cover_full_url,
+    editions.cover_thumbnail_url,
+    editions.open_access_download_url,
+    datasources.name,
+    identifiers.type,
+    identifiers.identifier,
+    works.audience,
+    works.target_age,
+    works.fiction,
+    works.quality,
+    works.rating,
+    works.popularity,
+    works.random,
+    works.last_update_time,
+    works.simple_opds_entry,
+    works.verbose_opds_entry,
+    licensepools.id AS license_pool_id,
+    licensepools.availability_time
+
+   FROM works
+     JOIN editions ON editions.work_id = works.id AND editions.is_primary_for_work = true
+     JOIN licensepools ON editions.data_source_id = licensepools.data_source_id AND editions.primary_identifier_id = licensepools.identifier_id
+     JOIN datasources ON editions.data_source_id = datasources.id
+     JOIN identifiers on editions.primary_identifier_id = identifiers.id
+  WHERE works.was_merged_into_id IS NULL
+    AND works.presentation_ready = true
+    AND works.simple_opds_entry IS NOT NULL
+  
+  ORDER BY editions.sort_title, editions.sort_author, licensepools.availability_time;
+
+-- Create a unique index so that searches can look up books by work ID.
+
+create unique index mv_works_editions_work_id on mv_works_editions_datasources_identifiers (works_id);
+
+-- We need three versions of each index:
+--- One that orders by sort_author, sort_title, and works_id
+--- One that orders by sort_title, sort_author, and works_id
+--- One that orders by availability_time (descending!), sort_title, sort_author, and works_id
+
+-- English adult fiction
+
+create index mv_works_editions_english_adult_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_editions_english_adult_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_editions_english_adult_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+-- English adult nonfiction
+
+create index mv_works_editions_english_adult_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_editions_english_adult_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_editions_english_adult_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+-- Nonenglish adult fiction
+--- These are also ordered by language
+
+create index mv_works_editions_nonenglish_adult_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+-- Nonenglish adult nonfiction
+--- These are also ordered by language
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+-- YA/Children's fiction, regardless of language
+
+create index mv_works_editions_ya_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_editions_ya_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_editions_ya_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+-- YA/Children's nonfiction, regardless of language
+
+create index mv_works_editions_ya_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_editions_ya_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_editions_ya_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+-------------------------------------------------
+
+
+---------------------------------
+
+drop materialized view mv_works_editions_workgenres_datasources_identifiers;
+create materialized view mv_works_editions_workgenres_datasources_identifiers
+as
+ SELECT 
+    works.id AS works_id,
+    editions.id AS editions_id,
+    editions.data_source_id,
+    editions.primary_identifier_id,
+    editions.sort_title,
+    editions.permanent_work_id,
+    editions.sort_author,
+    editions.medium,
+    editions.language,
+    editions.cover_full_url,
+    editions.cover_thumbnail_url,
+    editions.open_access_download_url,
+    datasources.name,
+    identifiers.type,
+    identifiers.identifier,
+    workgenres.id AS workgenres_id,
+    workgenres.genre_id,
+    workgenres.affinity,
+    works.audience,
+    works.target_age,
+    works.fiction,
+    works.quality,
+    works.rating,
+    works.popularity,
+    works.random,
+    works.last_update_time,
+    works.simple_opds_entry,
+    works.verbose_opds_entry,
+    licensepools.id AS license_pool_id,
+    licensepools.availability_time
+   FROM works
+     JOIN editions ON editions.work_id = works.id AND editions.is_primary_for_work = true
+     JOIN licensepools ON editions.data_source_id = licensepools.data_source_id AND editions.primary_identifier_id = licensepools.identifier_id
+     JOIN datasources ON editions.data_source_id = datasources.id
+     JOIN identifiers on editions.primary_identifier_id = identifiers.id
+     JOIN workgenres ON works.id = workgenres.work_id
+  WHERE works.was_merged_into_id IS NULL AND works.presentation_ready = true AND works.simple_opds_entry IS NOT NULL
+  ORDER BY (editions.sort_title, editions.sort_author, licensepools.availability_time);
+
+-- Create a work/genre lookup.
+create unique index mv_works_genres_work_id_genre_id on mv_works_editions_workgenres_datasources_identifiers (works_id, genre_id);
+
+-- We need three versions of each index:
+--- One that orders by sort_author, sort_title, and works_id
+--- One that orders by sort_title, sort_author, and works_id
+--- One that orders by availability_time (descending!), sort_title, sort_author, and works_id
+
+-- English adult fiction
+
+create index mv_works_genres_english_adult_fiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_genres_english_adult_fiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_genres_english_adult_fiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+-- English adult nonfiction
+
+create index mv_works_genres_english_adult_nonfiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_genres_english_adult_nonfiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_genres_english_adult_nonfiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+-- Nonenglish adult fiction
+--- These are also ordered by language
+
+create index mv_works_genres_nonenglish_adult_fiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_fiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_fiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+-- Nonenglish adult nonfiction
+--- These are also ordered by language
+
+create index mv_works_genres_nonenglish_adult_nonfiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_nonfiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_nonfiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+-- YA/Children's fiction, regardless of language
+
+create index mv_works_genres_ya_fiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_genres_ya_fiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_genres_ya_fiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+-- YA/Children's nonfiction, regardless of language
+
+create index mv_works_genres_ya_nonfiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_genres_ya_nonfiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_genres_ya_nonfiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -121,7 +121,7 @@ class TestFacets(object):
             fields(Facets.ORDER_LAST_UPDATE))
 
         # ...by most recently added...
-        eq_([LicensePool.availability_time] * 3,
+        eq_([LicensePool.availability_time, mw.availability_time, mwg.availability_time],
             fields(Facets.ORDER_ADDED_TO_COLLECTION))
 
         # ...or randomly.
@@ -153,7 +153,7 @@ class TestFacets(object):
         actual = order(Facets.ORDER_AUTHOR, Work, Edition, True)  
         compare(expect, actual)
 
-        expect = [Edition.sort_author.desc(), Edition.sort_title.desc(), Work.id.desc()]
+        expect = [Edition.sort_author.desc(), Edition.sort_title.asc(), Work.id.asc()]
         actual = order(Facets.ORDER_AUTHOR, Work, Edition, False)  
         compare(expect, actual)
 
@@ -161,20 +161,16 @@ class TestFacets(object):
         actual = order(Facets.ORDER_TITLE, mw, mw, True)
         compare(expect, actual)
 
-        expect = [mwg.works_id.asc(), mwg.sort_title.asc(), mwg.sort_author.asc()]
-        actual = order(Facets.ORDER_WORK_ID, mwg, mwg, True)
-        compare(expect, actual)
-
-        expect = [Work.last_update_time.asc(), Edition.sort_title.asc(), Edition.sort_author.asc(), Work.id.asc()]
+        expect = [Work.last_update_time.asc(), Edition.sort_author.asc(), Edition.sort_title.asc(), Work.id.asc()]
         actual = order(Facets.ORDER_LAST_UPDATE, Work, Edition, True)
         compare(expect, actual)
 
-        expect = [mw.random.asc(), mw.sort_title.asc(), mw.sort_author.asc(),
+        expect = [mw.random.asc(), mw.sort_author.asc(), mw.sort_title.asc(),
                   mw.works_id.asc()]
         actual = order(Facets.ORDER_RANDOM, mw, mw, True)
         compare(expect, actual)
 
-        expect = [LicensePool.availability_time.desc(), Edition.sort_title.desc(), Edition.sort_author.desc(), Work.id.desc()]
+        expect = [LicensePool.availability_time.desc(), Edition.sort_author.asc(), Edition.sort_title.asc(), Work.id.asc()]
         actual = order(Facets.ORDER_ADDED_TO_COLLECTION, Work, Edition, None)  
         compare(expect, actual)
 
@@ -649,8 +645,8 @@ class TestLanesQuery(DatabaseTest):
         w, mw = test_expectations(
             lane, 7, lambda x: x.audience in audiences
         )
-        assert(2, len([x for x in w if x.audience==Lane.AUDIENCE_ADULTS_ONLY]))
-        assert(2, len([x for x in mw if x.audience==Lane.AUDIENCE_ADULTS_ONLY]))
+        eq_(2, len([x for x in w if x.audience==Lane.AUDIENCE_ADULTS_ONLY]))
+        eq_(2, len([x for x in mw if x.audience==Lane.AUDIENCE_ADULTS_ONLY]))
 
         # The 'Young Adults' lane contains five books.
         lane = Lane(self._db, "Young Adults", 


### PR DESCRIPTION
This branch addresses issue #23.

I change the materialized view definitions to include the LicensePool.availability_time field -- the time a book entered the collection. 

I organize the indexes on the materialized views into groups, so that they're not a bunch of confusing undifferentiated indexes. In this process I fixed a couple of inconsistent materialized views and removed some duplicates.

I add indexes to the materialized views in which the primary sort field is availability_time, so that we can show feeds ordered with recently added books first.

I change the default sort order to [author, title, work ID], not [title, author, work ID]. Without this change, queries against availability time will sort by [availability time, title, author, work ID]. This won't use the index, which sorts the data by [availability time, author, title, work ID].

I make the 'order_ascending' argument apply only to the primary sort argument, not all of them. Without this change, a query against availability time will sort by [availability time.desc(), author.desc(), title.desc(), work ID.desc()], when the index (and user expectation) goes [availability time.desc(), author.asc(), title.asc(), work ID.asc()].

This is beyond the scope of this branch, but I think we should either start using the order_ascending argument or get rid of it. Right now it works, but (e.g.) showing authors Z-A is very slow, because the [title, author, work ID] indexes on the materialized views only work when you sort authors A-Z. So order_ascending is promising something we can't deliver with good performance.
