### PR TITLE
Improve coverage provider

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -29,7 +29,7 @@ class CoverageFailure(object):
             # This is a permanent error. Turn it into a CoverageRecord
             # so we don't keep trying to provide coverage that isn't
             # gonna happen.
-            record, ignore = CoverageRecord.add_for(obj, self.output_source)
+            record, ignore = CoverageRecord.add_for(self.obj, self.output_source)
             record.exception = self.exception
         
 

--- a/coverage.py
+++ b/coverage.py
@@ -70,7 +70,7 @@ class CoverageProvider(object):
                 func.random())
 
     def run(self):
-        logging.info("%d records need coverage.", (
+        self.log.info("%d records need coverage.", (
             self.editions_that_need_coverage.count())
         )
         offset = 0
@@ -123,7 +123,7 @@ class CoverageProvider(object):
         # Finalize this batch before moving on to the next one.
         self.finalize_batch()
 
-        logging.info(
+        self.log.info(
             "Batch processed with %d successes, %d failures, %d ignored.",
             successes, failures, num_ignored
         )

--- a/coverage.py
+++ b/coverage.py
@@ -112,7 +112,7 @@ class CoverageProvider(object):
 
         # Perhaps some records were ignored--they neither succeeded nor
         # failed. Ignore them on this run and try them again later.
-        num_ignored = len(batch) - len(results)
+        num_ignored = batch.count() - len(results)
         offset += num_ignored
 
         self.log.info(

--- a/coverage.py
+++ b/coverage.py
@@ -116,11 +116,6 @@ class CoverageProvider(object):
         num_ignored = max(0, batch.count() - len(results))
         offset += num_ignored
 
-        self.log.info(
-            "%d successes, %d failures, %d ignored",
-            successes, failures, num_ignored
-        )
-
         # Finalize this batch before moving on to the next one.
         self.finalize_batch()
 

--- a/model.py
+++ b/model.py
@@ -1580,8 +1580,10 @@ class Identifier(Base):
         from `coverage_data_source`.
         """
         q = _db.query(Identifier).outerjoin(
-            CoverageRecord, Identifier.id==CoverageRecord.identifier_id).filter(
-                Identifier.type.in_(identifier_types))
+            CoverageRecord, Identifier.id==CoverageRecord.identifier_id
+        )
+        if identifier_types:
+            q = q.filter(Identifier.type.in_(identifier_types))
         q2 = q.filter(CoverageRecord.id==None)
         return q2
 
@@ -2318,8 +2320,9 @@ class Edition(Base):
                        (CoverageRecord.data_source_id==coverage_data_source.id))
         
         q = _db.query(Edition).outerjoin(
-            CoverageRecord, join_clause).filter(
-                Edition.data_source_id.in_(edition_data_source_ids))
+            CoverageRecord, join_clause)
+        if edition_data_source_ids:
+            q = q.filter(Edition.data_source_id.in_(edition_data_source_ids))
         q2 = q.filter(CoverageRecord.id==None)
         return q2
 

--- a/model.py
+++ b/model.py
@@ -1329,7 +1329,7 @@ class Identifier(Base):
         """Associate a new Measurement with this Identifier."""
         _db = Session.object_session(self)
 
-        logging.info(
+        logging.debug(
             "MEASUREMENT: %s on %s/%s: %s == %s (wt=%d)",
             data_source.name, self.type, self.identifier,
             quantity_measured, value, weight)
@@ -1380,7 +1380,7 @@ class Identifier(Base):
         #if is_new:
         #    print repr(subject)
 
-        logging.info(
+        logging.debug(
             "CLASSIFICATION: %s on %s/%s: %s %s/%s",
             data_source.name, self.type, self.identifier,
             subject.type, subject.identifier, subject.name
@@ -2366,7 +2366,7 @@ class Edition(Base):
                 if scaled_down.mirror_url and scaled_down.mirrored_at:
                     self.cover_thumbnail_url = scaled_down.mirror_url
                     break
-        logging.info(
+        logging.debug(
             "Setting cover for %s/%s: full=%s thumb=%s", 
             self.primary_identifier.type, self.primary_identifier.identifier,
             self.cover_full_url, self.cover_thumbnail_url

--- a/monitor.py
+++ b/monitor.py
@@ -13,6 +13,7 @@ import log # This sets the appropriate log format and level.
 from config import Configuration
 from model import (
     get_one_or_create,
+    CoverageRecord,
     DataSource,
     Edition,
     CustomListEntry,
@@ -381,7 +382,8 @@ class PresentationReadyMonitor(WorkSweepMonitor):
                 failures = self.prepare(work)
             except Exception, e:
                 self.log.error(
-                    "Exception %s when processing work %r", e, r, exc_info=e)
+                    "Exception processing work %r", work, exc_info=e
+                )
                 failures = e
             if failures and failures not in (None, True):
                 if isinstance(failures, list):
@@ -415,7 +417,8 @@ class PresentationReadyMonitor(WorkSweepMonitor):
         for provider in self.coverage_providers:
             if edition.data_source in provider.input_sources:
                 coverage_record = provider.ensure_coverage(edition)
-                if not isinstance(coverage_record, CoverageRecord):
+                if (not isinstance(coverage_record, CoverageRecord) 
+                    or coverage_record.exception is not None):
                     failures.append(provider)
         return failures
 

--- a/monitor.py
+++ b/monitor.py
@@ -415,7 +415,7 @@ class PresentationReadyMonitor(WorkSweepMonitor):
         for provider in self.coverage_providers:
             if edition.data_source in provider.input_sources:
                 coverage_record = provider.ensure_coverage(edition)
-                if not coverage_record:
+                if not isinstance(coverage_record, CoverageRecord):
                     failures.append(provider)
         return failures
 

--- a/opds_import.py
+++ b/opds_import.py
@@ -109,6 +109,7 @@ class StatusMessage(object):
         except ValueError, e:
             # The status code isn't a number. Leave it alone.
             success = False
+            transient = False
         self.status_code = status_code
         self.message = message
         self.success = success

--- a/opds_import.py
+++ b/opds_import.py
@@ -105,12 +105,14 @@ class StatusMessage(object):
         try:
             status_code = int(status_code)
             success = (status_code == 200)
+            transient = not success and status_code / 100 in (2, 3, 5)
         except ValueError, e:
             # The status code isn't a number. Leave it alone.
             success = False
         self.status_code = status_code
         self.message = message
         self.success = success
+        self.transient = transient
 
     def __repr__(self):
         return '<StatusMessage: code=%s message="%s">' % (

--- a/testing.py
+++ b/testing.py
@@ -28,7 +28,10 @@ from model import (
     get_one_or_create
 )
 from classifier import Classifier
-from coverage import CoverageProvider
+from coverage import (
+    CoverageProvider,
+    CoverageFailure,
+)
 
 class DatabaseTest(object):
 
@@ -288,18 +291,24 @@ class InstrumentedCoverageProvider(CoverageProvider):
         super(InstrumentedCoverageProvider, self).__init__(*args, **kwargs)
         self.attempts = []
 
-    def process_edition(self, edition):
-        self.attempts.append(edition)
-        return True
+    def run_once(self, offset):
+        super(InstrumentedCoverageProvider, self).run_once(offset)
+        return None
 
 class AlwaysSuccessfulCoverageProvider(InstrumentedCoverageProvider):
     """A CoverageProvider that does nothing and always succeeds."""
-    pass
+    def process_edition(self, edition):
+        return edition
+
 
 class NeverSuccessfulCoverageProvider(InstrumentedCoverageProvider):
     def process_edition(self, edition):
-        super(NeverSuccessfulCoverageProvider, self).process_edition(edition)
-        return False
+        return CoverageFailure(self, edition, "What did you expect?", False)
+
+
+class TransientFailureCoverageProvider(InstrumentedCoverageProvider):
+    def process_edition(self, edition):
+        return CoverageFailure(self, edition, "Oops!", True)
 
 class DummyCanonicalizeLookupResponse(object):
 

--- a/testing.py
+++ b/testing.py
@@ -295,19 +295,23 @@ class InstrumentedCoverageProvider(CoverageProvider):
         super(InstrumentedCoverageProvider, self).run_once(offset)
         return None
 
+    def process_edition(self, edition):
+        self.attempts.append(edition)
+        return edition
+
 class AlwaysSuccessfulCoverageProvider(InstrumentedCoverageProvider):
     """A CoverageProvider that does nothing and always succeeds."""
-    def process_edition(self, edition):
-        return edition
 
 
 class NeverSuccessfulCoverageProvider(InstrumentedCoverageProvider):
     def process_edition(self, edition):
+        self.attempts.append(edition)
         return CoverageFailure(self, edition, "What did you expect?", False)
 
 
 class TransientFailureCoverageProvider(InstrumentedCoverageProvider):
     def process_edition(self, edition):
+        self.attempts.append(edition)
         return CoverageFailure(self, edition, "Oops!", True)
 
 class DummyCanonicalizeLookupResponse(object):

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -15,6 +15,7 @@ from . import (
 
 from opds_import import (
     OPDSImporter,
+    StatusMessage,
 )
 from metadata_layer import (
     LinkData
@@ -35,19 +36,19 @@ class TestStatusMessage(object):
 
     def test_constructor(self):
 
-        message = StatusMessage("success", 200)
+        message = StatusMessage(200, "success")
         eq_(True, message.success)
         eq_(False, message.transient)
 
-        message = StatusMessage("try later", 201)
+        message = StatusMessage(201, "try later")
         eq_(False, message.success)
         eq_(True, message.transient)
 
-        message = StatusMessage("oops", 500)
+        message = StatusMessage(500, "oops")
         eq_(False, message.success)
         eq_(True, message.transient)
 
-        message = StatusMessage("nope", 404)
+        message = StatusMessage(404, "nope")
         eq_(False, message.success)
         eq_(False, message.transient)
 

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -31,6 +31,27 @@ from model import (
     Subject,
 )
 
+class TestStatusMessage(object):
+
+    def test_constructor(self):
+
+        message = StatusMessage("success", 200)
+        eq_(True, message.success)
+        eq_(False, message.transient)
+
+        message = StatusMessage("try later", 201)
+        eq_(False, message.success)
+        eq_(True, message.transient)
+
+        message = StatusMessage("oops", 500)
+        eq_(False, message.success)
+        eq_(True, message.transient)
+
+        message = StatusMessage("nope", 404)
+        eq_(False, message.success)
+        eq_(False, message.transient)
+
+
 class TestOPDSImporter(DatabaseTest):
 
     def setup(self):


### PR DESCRIPTION
Previously, coverage providers were supposed to return a list of successes and a list of failures. This was awkward because there was no way to distinguish between transient failures (which should be retried later) and permanent failures (which should not).

This branch introduces the CoverageFailure class, which contains all relevant information about a failure to provide coverage. Instead of two lists, coverage providers now return one list containing both identifiers or editions (the successes), and CoverageFailure objects (the failures). 

If we ask a CoverageProvider to provide coverage for an identifier, and it does not show up as either a success or a failure, we now treat it as a transient failure. Previously we were liable to immediately try to cover that identifier again.
