### PR TITLE
Move S3Uploader tests to their own file

### DIFF
--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,4 +1,3 @@
-import contextlib
 from nose.tools import (
     set_trace,
     eq_,
@@ -6,15 +5,10 @@ from nose.tools import (
 from . import (
     DatabaseTest
 )
-
 from testing import (
     AlwaysSuccessfulCoverageProvider,
     NeverSuccessfulCoverageProvider,
     TransientFailureCoverageProvider,
-)
-from config import (
-    Configuration,
-    temp_config as core_temp_config
 )
 from model import (
     CoverageRecord,
@@ -131,41 +125,3 @@ class TestCoverageProvider(DatabaseTest):
         # But the coverage provider did run, and the timestamp is now set.
         [timestamp] = self._db.query(Timestamp).all()
         eq_("Transient failure", timestamp.service)
-
-# TODO: This really should be in its own file but there's a problem
-# with the correct syntax for importing DatabaseTest which I can't fix
-# right now.
-
-import os
-from s3 import S3Uploader
-
-class TestS3URLGeneration(DatabaseTest):
-    
-    @contextlib.contextmanager
-    def temp_config(self):
-        with core_temp_config() as tmp:
-            i = tmp['integrations']
-            S3 = Configuration.S3_INTEGRATION
-            i[S3] = {
-                Configuration.S3_OPEN_ACCESS_CONTENT_BUCKET : 'test-open-access-s3-bucket',
-                Configuration.S3_BOOK_COVERS_BUCKET : 'test-book-covers-s3-bucket'
-            }
-            yield tmp
-
-    def test_content_root(self):
-        with self.temp_config():
-            eq_("http://s3.amazonaws.com/test-open-access-s3-bucket/",
-                S3Uploader.content_root())
-
-    def test_cover_image_root(self):
-        with self.temp_config():
-            gutenberg_illustrated = DataSource.lookup(
-                self._db, DataSource.GUTENBERG_COVER_GENERATOR)
-            overdrive = DataSource.lookup(
-                self._db, DataSource.OVERDRIVE)
-            eq_("http://s3.amazonaws.com/test-book-covers-s3-bucket/Gutenberg%20Illustrated/",
-                S3Uploader.cover_image_root(gutenberg_illustrated))
-            eq_("http://s3.amazonaws.com/test-book-covers-s3-bucket/Overdrive/",
-                S3Uploader.cover_image_root(overdrive))
-            eq_("http://s3.amazonaws.com/test-book-covers-s3-bucket/scaled/300/Overdrive/", 
-                S3Uploader.cover_image_root(overdrive, 300))

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,0 +1,46 @@
+import os
+import contextlib
+from nose.tools import (
+    set_trace,
+    eq_,
+)
+from . import (
+    DatabaseTest
+)
+from config import (
+    Configuration,
+    temp_config as core_temp_config
+)
+from model import DataSource
+from s3 import S3Uploader
+
+class TestS3URLGeneration(DatabaseTest):
+    
+    @contextlib.contextmanager
+    def temp_config(self):
+        with core_temp_config() as tmp:
+            i = tmp['integrations']
+            S3 = Configuration.S3_INTEGRATION
+            i[S3] = {
+                Configuration.S3_OPEN_ACCESS_CONTENT_BUCKET : 'test-open-access-s3-bucket',
+                Configuration.S3_BOOK_COVERS_BUCKET : 'test-book-covers-s3-bucket'
+            }
+            yield tmp
+
+    def test_content_root(self):
+        with self.temp_config():
+            eq_("http://s3.amazonaws.com/test-open-access-s3-bucket/",
+                S3Uploader.content_root())
+
+    def test_cover_image_root(self):
+        with self.temp_config():
+            gutenberg_illustrated = DataSource.lookup(
+                self._db, DataSource.GUTENBERG_COVER_GENERATOR)
+            overdrive = DataSource.lookup(
+                self._db, DataSource.OVERDRIVE)
+            eq_("http://s3.amazonaws.com/test-book-covers-s3-bucket/Gutenberg%20Illustrated/",
+                S3Uploader.cover_image_root(gutenberg_illustrated))
+            eq_("http://s3.amazonaws.com/test-book-covers-s3-bucket/Overdrive/",
+                S3Uploader.cover_image_root(overdrive))
+            eq_("http://s3.amazonaws.com/test-book-covers-s3-bucket/scaled/300/Overdrive/", 
+                S3Uploader.cover_image_root(overdrive, 300))


### PR DESCRIPTION
~*movin' thangs, passin' tests*~

(In other words, this is just a code placement change, per a TODO in `tests/test_coverage.py`.)