### PR TITLE
Create bibliographic coverage providers

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -176,3 +176,23 @@ class CoverageProvider(object):
         e.g. uploading a bunch of assets to S3.
         """
         pass
+
+
+class IdentifierBasedCoverageProvider(CoverageProvider):
+    """Run Identifiers from one DataSource (the input DataSource) through
+    code associated with another DataSource (the output
+    DataSource). If the code returns success, add a CoverageRecord for
+    the Identifier and the output DataSource, so that the record
+    doesn't get processed next time.
+    """
+
+    @property
+    def editions_that_need_coverage(self):
+        """Find all Identifiers lacking coverage from this CoverageProvider.
+
+        Identifiers are selected randomly to reduce the effect of
+        persistent errors.
+        """
+        return Identifier.missing_coverage_from(
+            self._db, self.input_sources, self.output_source).order_by(
+                func.random())

--- a/overdrive.py
+++ b/overdrive.py
@@ -743,7 +743,7 @@ class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
         info = self.api.metadata_lookup(identifier)
         if info.get('errorCode') == 'NotFound':
             e = "ID not recognized by Overdrive"
-            return CoverageFailure(self, identifier, e, transient=True)
+            return CoverageFailure(self, identifier, e, transient=False)
         metadata = OverdriveRepresentationExtractor.book_info_to_metadata(
             info
         )

--- a/overdrive.py
+++ b/overdrive.py
@@ -744,15 +744,14 @@ class OverdriveBibliographicMonitor(IdentifierBasedCoverageProvider):
     def process_identifier(self, identifier):
         info = self.api.metadata_lookup(identifier)
         if info.get('errorCode') == 'NotFound':
-            return CoverageFailure(self, identifier,
-                    exception="ID not recognized by Overdrive", transient=False)
+            e = "ID not recognized by Overdrive"
+            return CoverageFailure(self, identifier, e, transient=False)
         metadata = OverdriveRepresentationExtractor.book_info_to_metadata(
             info
         )
         if not metadata:
             e = "Could not extract metadata from Overdrive data: %r" % info
-            return CoverageFailure(self, identifier, exception=e,
-                    transient=True)
+            return CoverageFailure(self, identifier, e, transient=True)
 
         license_pool = identifier.licensed_through
         work, created = license_pool.calculate_work()

--- a/overdrive.py
+++ b/overdrive.py
@@ -731,8 +731,6 @@ class OverdriveRepresentationExtractor(object):
 class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
     """Fill in bibliographic metadata for Overdrive records."""
 
-    cls_log = logging.getLogger("Overdrive Bibliographic Monitor")
-
     def __init__(self, _db):
         super(OverdriveBibliographicCoverageProvider, self).__init__(_db,
                 OverdriveAPI(_db), DataSource.OVERDRIVE)


### PR DESCRIPTION
- Creates a Bibliographic Coverage Provider template class.
- Moves the OverdriveBibliographicMonitor to core and alters it to use the template.
- Also: Test! :sparkles: 

Related to NYPL-Simplified/circulation#46..... sorta.