### PR TITLE
Fix identifier resolution monitor

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -163,7 +163,12 @@ class CoverageProvider(object):
         if force or coverage_record is None:
             result = self.process_item(identifier)
             if isinstance(result, CoverageFailure):
-                return result.to_coverage_record()
+                coverage_record = result.to_coverage_record()
+                if coverage_record:
+                    return coverage_record
+                # Returns a CoverageFailure if the CoverageRecord
+                # can't be created.
+                return result
             else:
                 coverage_record, ignore = self.add_coverage_record_for(
                     identifier

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -81,7 +81,7 @@ class TestCoverageProvider(DatabaseTest):
             "Transient failure", self.input_identifier_types, self.output_source
         )
         result = provider.ensure_coverage(self.edition)
-        eq_(None, result)
+        eq_(True, isinstance(result, CoverageFailure))
 
         # Because the error is transient we have no coverage record.
         eq_([], self._db.query(CoverageRecord).all())


### PR DESCRIPTION
Allowing CoverageProviders to return their failures when `ensure_coverage` is called. This is necessary for NYPL-Simplified/metadata_wrangler#22.