### PR TITLE
Implemented and tested LicensePool.open_access_links.

### DIFF
--- a/files/materialized_view_works.sql
+++ b/files/materialized_view_works.sql
@@ -44,6 +44,14 @@ as
 
 create unique index mv_works_editions_work_id on mv_works_editions_datasources_identifiers (works_id);
 
+-- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
+
+create index mv_works_editions_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id);
+
+-- Similarly, an index on everything, sorted by descending update time.
+
+create index mv_works_editions_by_modification on mv_works_editions_datasources_identifiers (last_update_time DESC, sort_author, sort_title, works_id);
+
 -- We need three versions of each index:
 --- One that orders by sort_author, sort_title, and works_id
 --- One that orders by sort_title, sort_author, and works_id

--- a/files/materialized_view_works_workgenres.sql
+++ b/files/materialized_view_works_workgenres.sql
@@ -43,6 +43,14 @@ as
 -- Create a work/genre lookup.
 create unique index mv_works_genres_work_id_genre_id on mv_works_editions_workgenres_datasources_identifiers (works_id, genre_id);
 
+-- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
+
+create index mv_works_genres_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id);
+
+-- Similarly, an index on everything, sorted by descending update time.
+
+create index mv_works_genres_by_modification on mv_works_editions_workgenres_datasources_identifiers (last_update_time DESC, sort_author, sort_title, works_id);
+
 -- We need three versions of each index:
 --- One that orders by sort_author, sort_title, and works_id
 --- One that orders by sort_title, sort_author, and works_id

--- a/migration/20160209-materialized-view-indexes.sql
+++ b/migration/20160209-materialized-view-indexes.sql
@@ -1,0 +1,15 @@
+-- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
+
+create index mv_works_editions_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id);
+
+-- Similarly, an index on everything, sorted by descending update time.
+
+create index mv_works_editions_by_modification on mv_works_editions_datasources_identifiers (last_update_time DESC, sort_author, sort_title, works_id);
+
+-- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
+
+create index mv_works_genres_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id);
+
+-- Similarly, an index on everything, sorted by descending update time.
+
+create index mv_works_genres_by_modification on mv_works_editions_workgenres_datasources_identifiers (last_update_time DESC, sort_author, sort_title, works_id);

--- a/model.py
+++ b/model.py
@@ -5192,8 +5192,6 @@ class LicensePool(Base):
 
         open_access = Hyperlink.OPEN_ACCESS_DOWNLOAD
         _db = Session.object_session(self)
-        best = None
-        best_priority = None
         q = Identifier.resources_for_identifier_ids(
             _db, [self.identifier.id], open_access
         )

--- a/opds.py
+++ b/opds.py
@@ -614,6 +614,7 @@ class AcquisitionFeed(OPDSFeed):
         else:
             works_q = lane.works(facets, pagination)
         works = works_q.all()
+
         feed = cls(_db, title, url, works, annotator)
 
         # Add URLs to change faceted views of the collection.
@@ -639,7 +640,6 @@ class AcquisitionFeed(OPDSFeed):
 
         content = unicode(feed)
         cached.update(content)
-
         return cached
 
     @classmethod

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -812,6 +812,32 @@ class TestLicensePool(DatabaseTest):
         eq_(uri2, status3.uri)
         eq_(None, status3.name)
 
+    def test_open_access_links(self):
+        edition, pool = self._edition(with_open_access_download=True)
+        source = DataSource.lookup(self._db, DataSource.GUTENBERG)
+
+        [oa1] = list(pool.open_access_links)
+
+        # We have one open-access download, let's
+        # add another.
+        url = self._url
+        media_type = Representation.EPUB_MEDIA_TYPE
+        link2, new = pool.identifier.add_link(
+            Hyperlink.OPEN_ACCESS_DOWNLOAD, url,
+            source, pool
+        )
+        oa2 = link2.resource
+
+        # And let's add a link that's not an open-access download.
+        url = self._url
+        image, new = pool.identifier.add_link(
+            Hyperlink.IMAGE, url, source, pool
+        )
+        self._db.commit()
+
+        # Only the two open-access download links show up.
+        eq_(set([oa1, oa2]), set(pool.open_access_links))
+
 class TestWork(DatabaseTest):
 
     def test_calculate_presentation(self):


### PR DESCRIPTION
This branch fixes https://github.com/NYPL-Simplified/content_server/issues/42 by adding indexes to the materialized views. These indexes optimize a query for all books ordered by date added to the collection.

I also refactored a bit of code to create a method called LicensePool.open_access_links, a generator which yields every open-access link available for a LicensePool. This is necessary because open-access books from unglue.it might have books in multiple formats, and the content server doesn't necessarily know which one is the best.