### PR TITLE
Stop following the 'next' link in an OPDS feed for books when we encounter the place we left off

### DIFF
--- a/config.py
+++ b/config.py
@@ -48,6 +48,7 @@ class Configuration(object):
     PRIVACY_POLICY = "privacy_policy"
     TERMS_OF_SERVICE = "terms_of_service"
     COPYRIGHT = "copyright"
+    ABOUT = "about"
 
     # Logging
     LOGGING = "logging"
@@ -232,6 +233,10 @@ class Configuration(object):
     @classmethod
     def acknowledgements_url(cls):
         return cls.link(cls.COPYRIGHT)
+
+    @classmethod
+    def about_url(cls):
+        return cls.link(cls.ABOUT)
 
     @classmethod
     def privacy_policy_url(cls):

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -258,12 +258,14 @@ class CirculationData(object):
             licenses_available, 
             licenses_reserved,
             patrons_in_hold_queue,
+            first_appearance=None,
             last_checked=None,
     ):
         self.licenses_owned = licenses_owned
         self.licenses_available = licenses_available
         self.licenses_reserved = licenses_reserved
         self.patrons_in_hold_queue = patrons_in_hold_queue
+        self.first_appearance = first_appearance
         self.last_checked = last_checked or datetime.datetime.utcnow()
         self.log = logging.getLogger(
             "Abstract metadata layer - Circulation data"
@@ -355,6 +357,7 @@ class Metadata(object):
             formats=None,
             rights_uri=None,
             last_update_time=None,
+            circulation=None,
     ):
         # data_source is where the data comes from.
         self._data_source = data_source
@@ -396,6 +399,7 @@ class Metadata(object):
         self.measurements = measurements or []
         self.formats = formats or []
         self.rights_uri = rights_uri
+        self.circulation = circulation
 
         self.last_update_time = last_update_time
         for link in self.links:

--- a/tests/files/opds/content_server_mini.opds
+++ b/tests/files/opds/content_server_mini.opds
@@ -15,6 +15,7 @@
     </author>
     <summary>This is a summary!</summary>
     <updated>2015-01-02T16:56:40Z</updated>
+    <published>2014-01-02T16:56:40Z</published>
     <simplified:pwid>6db4cf90-0129-0eaf-410a-502b20a45e67</simplified:pwid>
     <schema:Rating schema:ratingValue="0.3333" schema:additionalType="http://librarysimplified.org/terms/rel/quality"/>
     <schema:Rating schema:ratingValue="0.6000"/>
@@ -41,6 +42,7 @@
     </author>
     <summary></summary>
     <updated>2015-01-02T16:56:40Z</updated>
+    <published>2014-01-02T16:56:40Z</published>
     <simplified:pwid>9acabf17-cea8-c7dd-8440-f12dfa75caa9</simplified:pwid>
     <category term="Animals -- Juvenile poetry" scheme="http://purl.org/dc/terms/LCSH"/>
     <category term="Nursery rhymes" scheme="http://purl.org/dc/terms/LCSH"/>

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -1,4 +1,5 @@
 import os
+import datetime
 from StringIO import StringIO
 from nose.tools import (
     set_trace,
@@ -96,6 +97,9 @@ class TestOPDSImporter(DatabaseTest):
         eq_('en', metadata['language'])
         eq_('Project Gutenberg', metadata['publisher'])
         eq_(DataSource.GUTENBERG, metadata['license_data_source'])
+
+        circulation = metadata['circulation']
+        eq_(datetime.datetime(2014, 1, 2, 16, 56, 40), circulation.first_appearance)
 
         message = status_messages['http://www.gutenberg.org/ebooks/1984']
         eq_(202, message.status_code)


### PR DESCRIPTION
Previously the OPDS importer kept following the 'next' link until there was no more link. This made it impractical for the circulation manager to import from the content server more than once. This code changes things so that we stop following the 'next' link when we encounter a full page of books that we've already encountered.

This does assume that the feed is ordered by the date books were added to the collection, but that's true of all the feeds we're importing from so far.
