### PR TITLE
Move basic IdentifierResolutionMonitor code into core

### DIFF
--- a/model.py
+++ b/model.py
@@ -1656,13 +1656,8 @@ class UnresolvedIdentifier(Base):
         has_metadata_lookup = DataSource.metadata_sources_for(_db, identifier)
 
         if not has_metadata_lookup:
-            try:
-                datasource = DataSource.license_source_for(_db, identifier)
-            except MultipleResultsFound:
-                # This is fine--we'll just try every source we know of until
-                # we find one.
-                pass
-            except NoResultFound:
+            datasources = DataSource.license_sources_for(_db, identifier)
+            if datasources.count() == 0:
                 # This is not okay--we have no way of resolving this identifier.
                 raise Identifier.UnresolvableIdentifierException()
 
@@ -1670,6 +1665,15 @@ class UnresolvedIdentifier(Base):
             _db, UnresolvedIdentifier, identifier=identifier,
             create_method_kwargs=dict(status=202), on_multiple='interchangeable'
         )
+
+    def set_attempt(self, time=None):
+        """Set most_recent_attempt (and possibly first_attempt) to the given
+        time.
+        """
+        time = time or datetime.utcnow()
+        self.most_recent_attempt = now
+        if not self.first_attempt:
+            self.first_attempt = now
 
 class Contributor(Base):
 

--- a/model.py
+++ b/model.py
@@ -1670,10 +1670,10 @@ class UnresolvedIdentifier(Base):
         """Set most_recent_attempt (and possibly first_attempt) to the given
         time.
         """
-        time = time or datetime.utcnow()
-        self.most_recent_attempt = now
+        time = time or datetime.datetime.utcnow()
+        self.most_recent_attempt = time
         if not self.first_attempt:
-            self.first_attempt = now
+            self.first_attempt = time
 
 class Contributor(Base):
 
@@ -5542,6 +5542,8 @@ class Representation(Base):
     TEXT_XML_MEDIA_TYPE = u"text/xml"
     APPLICATION_XML_MEDIA_TYPE = u"application/xml"
     JPEG_MEDIA_TYPE = u"image/jpeg"
+    PNG_MEDIA_TYPE = u"image/png",
+    GIF_MEDIA_TYPE = u"image/gif",
     MP3_MEDIA_TYPE = u"audio/mpeg"
     TEXT_PLAIN = u"text/plain"
 
@@ -5549,6 +5551,12 @@ class Representation(Base):
         EPUB_MEDIA_TYPE,
         PDF_MEDIA_TYPE,
         MP3_MEDIA_TYPE,
+    ]
+
+    IMAGE_MEDIA_TYPES = [
+        JPEG_MEDIA_TYPE,
+        PNG_MEDIA_TYPE,
+        GIF_MEDIA_TYPE,
     ]
 
     SUPPORTED_BOOK_MEDIA_TYPES = [
@@ -5559,6 +5567,9 @@ class Representation(Base):
         EPUB_MEDIA_TYPE: "epub",
         PDF_MEDIA_TYPE: "pdf",
         MP3_MEDIA_TYPE: "mp3",
+        JPEG_MEDIA_TYPE: "jpg",
+        PNG_MEDIA_TYPE: "png",
+        GIF_MEDIA_TYPE: "gif",
     }
 
     __tablename__ = 'representations'

--- a/monitor.py
+++ b/monitor.py
@@ -11,6 +11,7 @@ from sqlalchemy.sql.expression import (
 
 import log # This sets the appropriate log format and level.
 from config import Configuration
+from coverage import CoverageFailure
 from model import (
     get_one_or_create,
     CoverageRecord,
@@ -21,6 +22,7 @@ from model import (
     LicensePool,
     Subject,
     Timestamp,
+    UnresolvedIdentifier,
     Work,
 )
 from external_search import (
@@ -31,6 +33,7 @@ class Monitor(object):
 
     ONE_MINUTE_AGO = datetime.timedelta(seconds=60)
     ONE_YEAR_AGO = datetime.timedelta(seconds=60*60*24*365)
+    NEVER = object()
 
     def __init__(
             self, _db, name, interval_seconds=1*60,
@@ -52,6 +55,8 @@ class Monitor(object):
         if not default_start_time:
              default_start_time = (
                  datetime.datetime.utcnow() - self.ONE_MINUTE_AGO)
+        if default_start_time is self.NEVER:
+            default_start_time = None
         self.default_start_time = default_start_time
 
     @property
@@ -110,12 +115,11 @@ class IdentifierResolutionMonitor(Monitor):
     """
 
     def __init__(
-            self, _db, name, 
-            required_coverage_providers, optional_coverage_providers,
-            interval_seconds=1*60,
-            default_start_time=None, keep_timestamp=True,
+            self, _db, name, interval_seconds=1*60, default_start_time=None, 
+            keep_timestamp=True, required_coverage_providers=[], 
+            optional_coverage_providers=[],
     ):
-        super(IdentifierResolutionMonitor).__init__(
+        super(IdentifierResolutionMonitor, self).__init__(
             _db, name, interval_seconds, default_start_time,
             keep_timestamp
         )

--- a/opds_import.py
+++ b/opds_import.py
@@ -625,10 +625,11 @@ class OPDSImportMonitor(Monitor):
         self.importer = import_class(_db, default_data_source)
         super(OPDSImportMonitor, self).__init__(
             _db, "OPDS Import %s" % feed_url, interval_seconds,
-            keep_timestamp=keep_timestamp)
+            keep_timestamp=keep_timestamp, default_start_time=Monitor.NEVER
+        )
 
     def follow_one_link(self, link, start):
-        self.log.info("Following next link: %s", link)
+        self.log.info("Following next link: %s, cutoff=%s", link, start)
         response = requests.get(link)
         imported, messages, next_links = self.importer.import_from_feed(
             response.content, cutoff_date=start

--- a/opds_import.py
+++ b/opds_import.py
@@ -631,7 +631,7 @@ class OPDSImportMonitor(Monitor):
         self.log.info("Following next link: %s", link)
         response = requests.get(link)
         imported, messages, next_links = self.importer.import_from_feed(
-            response.content, even_if_no_author=True, cutoff_date=start
+            response.content, cutoff_date=start
         )
         self._db.commit()
         

--- a/testing.py
+++ b/testing.py
@@ -315,6 +315,9 @@ class NeverSuccessfulCoverageProvider(InstrumentedCoverageProvider):
         self.attempts.append(item)
         return CoverageFailure(self, item, "What did you expect?", False)
 
+class BrokenCoverageProvider(InstrumentedCoverageProvider):
+    def process_item(self, item):
+        raise Exception("I'm too broken to even return a CoverageFailure.")
 
 class TransientFailureCoverageProvider(InstrumentedCoverageProvider):
     def process_item(self, item):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -309,7 +309,22 @@ class TestUnresolvedIdentifier(DatabaseTest):
         assert_raises(
             Identifier.UnresolvableIdentifierException,
             UnresolvedIdentifier.register, self._db, identifier)
-            
+
+    def test_set_attempt(self):
+        i, ignore = self._unresolved_identifier()
+        eq_(None, i.first_attempt)
+        eq_(None, i.most_recent_attempt)
+        
+        now = datetime.datetime.utcnow()
+        i.set_attempt()
+        eq_(i.first_attempt, i.most_recent_attempt)
+        first_attempt = i.first_attempt
+        assert abs(first_attempt-now).seconds < 2
+
+        future = now + datetime.timedelta(days=1)
+        i.set_attempt(future)
+        eq_(first_attempt, i.first_attempt)
+        eq_(future, i.most_recent_attempt)
 
 class TestContributor(DatabaseTest):
 


### PR DESCRIPTION
The content server is about to get its own IdentifierResolutionMonitor, so I've copied some of the basic code out of metadata and into core. The IdentifierResolutionMonitor finds UnresolvedIdentifiers and runs the corresponding Identifiers through a series of CoverageProviders. If all the mandatory CoverageProviders succeed, the UnresolvedIdentifier is removed.
