### PR TITLE
Make it possible to set works presentation-ready immediately upon imp…

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -590,7 +590,7 @@ class Metadata(object):
         for format in self.formats:
             if format.link:
                 link = format.link
-                if self.rights_uri == None and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
+                if self.rights_uri in (None, RightsStatus.UNKNOWN) and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
                     # We haven't determined rights from the metadata or the data source, but there's an
                     # open access download link, so we'll consider it generic open access.
                     self.rights_uri = RightsStatus.GENERIC_OPEN_ACCESS

--- a/model.py
+++ b/model.py
@@ -3402,7 +3402,9 @@ class Work(Base):
         self.presentation_ready_attempt = as_of
         self.random = random.random()
 
-    def set_presentation_ready_based_on_content(self):
+    def set_presentation_ready_based_on_content(
+            self, require_author=True, require_thumbnail=True
+    ):
         """Set this work as presentation ready, if it appears to
         be ready based on its data.
 
@@ -3418,11 +3420,15 @@ class Work(Base):
         if (not self.primary_edition
             or not self.license_pools
             or not self.title
-            or not self.primary_edition.author
+            or (require_author and not self.primary_edition.author)
             or not self.language
             or not self.work_genres
-            or (not self.cover_thumbnail_url
-                and not self.primary_edition.no_known_cover)
+            or (
+                require_thumbnail and not (
+                    self.cover_thumbnail_url
+                    or self.primary_edition.no_known_cover
+                )
+            )
         ):
             self.presentation_ready = False
         else:

--- a/opds.py
+++ b/opds.py
@@ -524,6 +524,11 @@ class AcquisitionFeed(OPDSFeed):
             # We did not find any works whatsoever. The groups feed is
             # useless. Instead we need to display a flat feed--the
             # contents of what would have been the 'all' feed.
+            if not isinstance(lane, Lane):
+                # This is probably a top-level controller or
+                # application object.  Create a dummy lane that
+                # contains everything.
+                lane = Lane(_db, "Everything")
             cached = cls.page(
                 _db, title, url, lane, annotator, 
                 force_refresh=force_refresh,

--- a/scripts.py
+++ b/scripts.py
@@ -271,16 +271,19 @@ class WorkPresentationScript(WorkProcessingScript):
 class OPDSImportScript(Script):
     """Import all books from an OPDS feed."""
     def __init__(self, feed_url, default_data_source, importer_class, 
-                 keep_timestamp=True):
+                 keep_timestamp=True, immediately_presentation_ready=False):
         self.feed_url = feed_url
         self.default_data_source = default_data_source
         self.importer_class = importer_class
         self.keep_timestamp = keep_timestamp
+        self.immediately_presentation_ready = immediately_presentation_ready
 
     def do_run(self):
         monitor = OPDSImportMonitor(
             self._db, self.feed_url, self.default_data_source, 
-            self.importer_class, keep_timestamp=self.keep_timestamp)
+            self.importer_class, keep_timestamp=self.keep_timestamp,
+            immediately_presentation_ready = self.immediately_presentation_ready
+        )
         monitor.run()
         
 

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -188,16 +188,17 @@ class TestOPDSImporter(DatabaseTest):
         [crow, mouse] = sorted(imported, key=lambda x: x.title)
 
         # By default, this feed is treated as though it came from the
-        # metadata wrangler.
+        # metadata wrangler. No Work has been created for the 'crow'
+        # book because the metadat wrangler doesn't know who actually
+        # provides copies of this book.
         eq_(DataSource.METADATA_WRANGLER, crow.data_source.name)
-        eq_(Edition.BOOK_MEDIUM, crow.medium)
-        eq_(Edition.PERIODICAL_MEDIUM, mouse.medium)
-
-        # Because of this, no works have been created for the books,
-        # because there's no expectation that we actually have a copy
-        # of the book.
         eq_(None, crow.work)
-        eq_(None, mouse.work)
+        eq_(Edition.BOOK_MEDIUM, crow.medium)
+
+        # But the 'mouse' book is known to come from Project Gutenberg,
+        # so a Work has been created for that book.
+        assert mouse.work is not None
+        eq_(Edition.PERIODICAL_MEDIUM, mouse.medium)
 
         editions, popularity, quality, rating = sorted(
             [x for x in mouse.primary_identifier.measurements


### PR DESCRIPTION
…ort from an OPDS feed, assuming the OPDS feed provides a license for the book and basic metadata.

The motivating use case is to be allow a circulation manager to import a subset of books from the content server. If the content server publishes enough information to fit the book into an OPDS feed and make it available to the client, the books can be made presentation-ready immediately, without going to the metadata wrangler first. (Besides which, the metadata wrangler currently can't resolve a lot of the books that come from the content server.)

There's also a small unrelated change in opds.py, which handles the case where you try to generate a grouped OPDS feed for the top level of the site, but there aren't enough books on the whole site to generate a grouped feed. Previously the code crashed; now it shows you a paginated list of every book on the whole site. It's still not a great solution, but at least it doesn't crash. 