### PR TITLE
A book doesn't have to be in a genre to be presentation-ready, it just has to have a fiction setting.

### DIFF
--- a/model.py
+++ b/model.py
@@ -3446,13 +3446,16 @@ class Work(Base):
         since many public domain books have no summary.
 
         A work with no cover can be presentation ready 
+
+        A work with no genres can be presentation ready, but we do
+        at least need to know whether it's fiction or nonfiction.
         """
         if (not self.primary_edition
             or not self.license_pools
             or not self.title
             or (require_author and not self.primary_edition.author)
             or not self.language
-            or not self.work_genres
+            or self.fiction is None
             or (
                 require_thumbnail and not (
                     self.cover_thumbnail_url

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -975,6 +975,16 @@ class TestWork(DatabaseTest):
         work.set_presentation_ready_based_on_content()
         eq_(True, work.presentation_ready)        
 
+        # Remove the fiction setting, and the work stops being
+        # presentation ready.
+        work.fiction = None
+        work.set_presentation_ready_based_on_content()
+        eq_(False, work.presentation_ready)        
+
+        work.fiction = False
+        work.set_presentation_ready_based_on_content()
+        eq_(True, work.presentation_ready)        
+
         # Remove the author's presentation string, and the work stops
         # being presentation ready.
         primary.author = None


### PR DESCRIPTION
This is old code from back when I assumed that if a book couldn't be placed into a genre, its metadata was incomplete. But there are lots of books where we don't have any information beyond 'fiction' or 'nonfiction', so I loosened the restriction.
