### PR TITLE
Introduce the concept of 'suppressed' licensepools

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -858,6 +858,8 @@ class Lane(object):
 
         * Have a delivery mechanism that can be rendered by the
           default client.
+
+        * Have an unsuppressed license pool.
         """
 
         q = self._db.query(Work).join(Work.primary_edition)
@@ -1021,15 +1023,15 @@ class Lane(object):
         return q
 
     @classmethod
-    def only_show_ready_deliverable_works(cls, query, work_model):
+    def only_show_ready_deliverable_works(
+            cls, query, work_model, show_suppressed=False
+    ):
         """Restrict a query to show only unmerged presentation-ready
         works which the default client can fulfill.
 
         Note that this assumes the query has an active join against
         LicensePool.
         """
-        # TODO: Only find works with unsuppressed LicensePools.
-
         # Only find unmerged presentation-ready works.
         #
         # Such works are automatically filtered out of 
@@ -1044,6 +1046,10 @@ class Lane(object):
         query = query.filter(LicensePool.delivery_mechanisms.any(
             DeliveryMechanism.default_client_can_fulfill==True)
         )
+
+        # Only find books with unsuppressed LicensePools.
+        if not show_suppressed:
+            query = query.filter(LicensePool.suppressed==False)
 
         # If we don't allow holds, hide any books with no available copies.
         hold_policy = Configuration.hold_policy()

--- a/model.py
+++ b/model.py
@@ -4906,6 +4906,10 @@ class LicensePool(Base):
         "LicensePoolDeliveryMechanism", backref="license_pool"
     )
 
+    # A LicensePool that seemingly looks fine may be manually suppressed
+    # to be temporarily or permanently removed from the collection.
+    suppressed = Column(Boolean, default=False, index=True)
+
     # Index the combination of DataSource and Identifier to make joins easier.
 
     clause = "and_(Edition.data_source_id==LicensePool.data_source_id, Edition.primary_identifier_id==LicensePool.identifier_id)"


### PR DESCRIPTION
A 'suppressed' LicensePool is one that for whatever reason we just don't want to use until we perform a manual intervention to restore it. Maybe the book doesn't render, maybe the metadata is horribly broken, maybe we got a copy of a book that's not technically published yet... whatever. At some point, someone decides we need to temporarily remove a book from the collection. Suppressing the licensepool allows us to hide the book (at least from the bad source) without deleting it or creating inaccurate information about its presentation or licensing.

Up to this point we've been handling this kind of intervention by blanking out the available copies, marking works that are presentation ready as not presentation ready, etc. It's confusing and it causes unwanted side effects. This gives us an officially supported path to hiding individual books.

By default, a Work will not show up in lanes or search results unless it has at least one un-suppressed LicensePool.