### PR TITLE
After refreshing the materialized views, vacuum the database.

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -2,6 +2,7 @@ import os
 import logging
 import sys
 from nose.tools import set_trace
+from sqlalchemy import create_engine
 from sqlalchemy.sql.functions import func
 from sqlalchemy.orm.session import Session
 import time
@@ -321,18 +322,33 @@ class RefreshMaterializedViewsScript(Script):
     
     def do_run(self):
         # Initialize database
-        db = self._db
         from model import (
             MaterializedWork,
             MaterializedWorkWithGenre,
         )
+        db = self._db
         for i in (MaterializedWork, MaterializedWorkWithGenre):
             view_name = i.__table__.name
             a = time.time()
             db.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY %s" % view_name)
             b = time.time()
-            print "%s refreshed in %.2f sec" % (view_name, b-a)
+            print "%s refreshed in %.2f sec." % (view_name, b-a)
+        # Close out this session because we're about to create another one.
+        db.commit()
+        db.close()
 
+        # The normal database connection (which we want almost all the
+        # time) wraps everything in a big transaction, but VACUUM
+        # can't be executed within a transaction block. So create a
+        # separate connection that uses autocommit.
+        url = Configuration.database_url()
+        engine = create_engine(url, isolation_level="AUTOCOMMIT")
+        engine.autocommit = True
+        a = time.time()
+        engine.execute("VACUUM (VERBOSE, ANALYZE)")
+        b = time.time()
+        print "Vacuumed in %.2f sec." % (b-a)
+        
 
 class Explain(Script):
     """Explain everything known about a given work."""


### PR DESCRIPTION
It turns out the real problem behind https://github.com/NYPL-Simplified/circulation/issues/82 is that we keep changing the database, messing with indexes, refreshing the materialized views, etc. without running the VACUUM command. So I've changed the script that refreshes the materialized views to immediately follow up with a VACUUM.

Since VACUUM can't be executed inside a transaction block, and all our connections set up a transaction block automatically, this requires creating a brand new database connection, but this is at the very end of one script, so I think it's a better solution than changing the whole way we get connections.