### PR TITLE
Improve metadata import

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -272,7 +272,7 @@ class URNLookupController(object):
 
         license_sources = DataSource.license_sources_for(
             self._db, identifier)
-        if license_sources.count():
+        if identifier.type != Identifier.ISBN and license_sources.count():
             return self.register_identifier_as_unresolved(identifier)
         else:
             entry = self.make_opds_entry_from_metadata_lookups(identifier)

--- a/coverage.py
+++ b/coverage.py
@@ -229,7 +229,10 @@ class CoverageProvider(object):
             return CoverageFailure(self, identifier, e, transient=True)
 
         try:
-            metadata.apply(edition)
+            metadata.apply(
+                edition, replace_subjects=True, replace_links=True,
+                replace_contributions=True, force=True
+            )
         except Exception as e:
             return CoverageFailure(self, identifier, repr(e), transient=True)
 

--- a/coverage.py
+++ b/coverage.py
@@ -237,7 +237,7 @@ class CoverageProvider(object):
             return CoverageFailure(self, identifier, e, transient=True)
 
         try:
-            metadata.apply(edition, replace=self.replacement_policy)
+            metadata.apply(edition, replace=self.metadata_replacement_policy)
         except Exception as e:
             return CoverageFailure(self, identifier, repr(e), transient=True)
 

--- a/external_list.py
+++ b/external_list.py
@@ -9,7 +9,10 @@ from sqlalchemy.orm.session import Session
 from opds_import import SimplifiedOPDSLookup
 import logging
 from config import Configuration
-from metadata_layer import CSVMetadataImporter
+from metadata_layer import (
+    CSVMetadataImporter,
+    ReplacementPolicy,
+)
 from model import (
     get_one,
     get_one_or_create,
@@ -229,12 +232,18 @@ class TitleFromExternalList(object):
                 "Ignoring %s, no corresponding edition.", self.metadata.title
             )
             return None
+        if overwrite_old_data:
+            policy = ReplacementPolicy.from_metadata_source(
+                even_if_not_apparently_updated=True
+            )
+        else:
+            policy = ReplacementPolicy.append_only(
+                even_if_not_apparently_updated=True
+            )
         self.metadata.apply(
             edition=edition, 
             metadata_client=metadata_client,
-            replace_identifiers=overwrite_old_data,
-            replace_subjects=overwrite_old_data, 
-            replace_contributions=overwrite_old_data
+            replace=policy,
         )
         self.metadata.associate_with_identifiers_based_on_permanent_work_id(_db)
         return edition

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -823,7 +823,6 @@ class Metadata(object):
             # Remove any old Subjects from this data source, unless they
             # are also in the list of new subjects.
             surviving_classifications = []
-            dirty = False
 
             def _key(classification):
                 s = classification.subject
@@ -835,11 +834,8 @@ class Metadata(object):
                     if not key in new_subjects:
                         # The data source has stopped claiming that
                         # this classification should exist.
-                        print "Removing %r" % classification.subject
                         _db.delete(classification)
-                        dirty = True
                     else:
-                        print "Preserving %r" % classification.subject
                         # The data source maintains that this
                         # classification is a good idea. We don't have
                         # to do anything.

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -56,13 +56,15 @@ class ReplacementPolicy(object):
         self.contributions = contributions
         self.links = links
         self.rights = rights
+        self.formats = formats
         self.even_if_not_apparently_updated = even_if_not_apparently_updated
         
     @classmethod
     def from_license_source(self, even_if_not_apparently_updated=False):
         """When gathering data from the license source, overwrite all old data
         from this source with new data from the same source. Also
-        overwrite an old rights status with an updated status.
+        overwrite an old rights status with an updated status and update
+        the list of available formats.
         """
         return ReplacementPolicy(
             identifiers=True, 
@@ -70,15 +72,16 @@ class ReplacementPolicy(object):
             contributions=True, 
             links=True, 
             rights=True,
+            formats=True,
             even_if_not_apparently_updated=even_if_not_apparently_updated
         )
 
     @classmethod
     def from_metadata_source(self, even_if_not_apparently_updated=False):
         """When gathering data from a metadata source, overwrite all old data
-        from this source, but do not overwrite the rights
-        status--metadata sources have no authority to specify a rights
-        status.
+        from this source, but do not overwrite the rights status or
+        the available formats. License sources are the authority on rights
+        and formats, and metadata sources have no say in the matter.
         """
         return ReplacementPolicy(
             identifiers=True, 
@@ -86,6 +89,7 @@ class ReplacementPolicy(object):
             contributions=True, 
             links=True, 
             rights=False,
+            formats=False,
             even_if_not_apparently_updated=even_if_not_apparently_updated
         )
 
@@ -101,6 +105,7 @@ class ReplacementPolicy(object):
             contributions=False, 
             links=False, 
             rights=False,
+            formats=False,
             even_if_not_apparently_updated=even_if_not_apparently_updated
         )
 

--- a/model.py
+++ b/model.py
@@ -3617,7 +3617,6 @@ class Work(Base):
         elif ya_score > threshold:
             audience = Classifier.AUDIENCE_YOUNG_ADULT
 
-
         # Remove any genres whose fiction status is inconsistent with the
         # (independently determined) fiction status of the book.
         #
@@ -4515,7 +4514,9 @@ class Subject(Base):
             genre = ' genre="%s"' % self.genre.name
         else:
             genre = ""
-        if self.target_age is not None:
+        if (self.target_age is not None
+            and (self.target_age.lower or self.target_age.upper)
+        ):
             age_range= " " + self.target_age_string
         else:
             age_range = ""

--- a/monitor.py
+++ b/monitor.py
@@ -139,15 +139,19 @@ class IdentifierResolutionMonitor(Monitor):
         )
 
         for unresolved_identifier in unresolved_identifiers:
-            success = False
-            try:
-                self.resolve(unresolved_identifier)
-                success = True
-            except Exception, e:
-                self.process_failure(unresolved_identifier, e)
-            if success:
-                self._db.delete(unresolved_identifier)
-            self._db.commit()
+            self.resolve_and_handle_result(unresolved_identifier)
+
+    def resolve_and_handle_result(self, unresolved_identifier):
+        success = False
+        try:
+            self.resolve(unresolved_identifier)
+            success = True
+        except Exception, e:
+            self.process_failure(unresolved_identifier, e)
+        if success:
+            self._db.delete(unresolved_identifier)
+        self._db.commit()
+        return success
 
     def resolve(self, unresolved_identifier):
         """Resolve one UnresolvedIdentifier."""

--- a/opds_import.py
+++ b/opds_import.py
@@ -167,7 +167,10 @@ class OPDSImporter(object):
                 # before that date. There's no reason to do anything.
                 continue
 
-            metadata.apply(edition, self.metadata_client)
+            metadata.apply(edition, self.metadata_client, 
+                           replace_subjects=True,
+                           replace_links=True, replace_contributions=True,
+                           force=True)
             if license_pool is None:
                 # Without a LicensePool, we can't create a Work.
                 self.log.warn(

--- a/scripts.py
+++ b/scripts.py
@@ -137,8 +137,30 @@ class RunCoverageProviderScript(Script):
         self.provider = provider
         self.name = self.provider.service_name
 
+    def parse_identifiers(self):
+        potential_identifiers = sys.argv[1:]
+        identifiers = self.parse_identifier_list(
+            self._db, potential_identifiers
+        )
+        if potential_identifiers and not identifiers:
+            self.log.warn("Could not extract any identifiers from command-line arguments, falling back to default behavior.")
+        return identifiers
+
     def do_run(self):
-        self.provider.run()
+
+        identifiers = self.parse_identifiers()
+        if identifiers:
+            self.process_batch(identifiers)
+        else:
+            self.provider.run()
+
+    def process_batch(self, identifiers):
+        results = []
+        for identifier in identifiers:
+            result = self.provider.ensure_coverage(identifier, force=True)
+            if result:
+                results.append(result)
+        return results
 
 class WorkProcessingScript(Script):
 

--- a/scripts.py
+++ b/scripts.py
@@ -47,6 +47,27 @@ class Script(object):
     def data_directory(self):
         return Configuration.data_directory()
 
+    @classmethod
+    def parse_identifier_list(self, _db, arguments):
+        """Turn a list of arguments into a list of identifiers.
+
+        This makes it easy to identify specific identifiers on the
+        command line. Examples:
+
+        "Gutenberg ID" 1 2
+        
+        "Overdrive ID" a b c
+
+        Basic but effective.
+        """
+        current_identifier_type = None
+        identifier_type = arguments[0]
+        for arg in arguments[1:]:
+            identifier, ignore = Identifier.for_foreign_id(
+                _db, identifier_type, arg, autocreate=False)
+            if identifier:
+                yield identifier
+
     def run(self):
         self.load_configuration()
         DataSource.well_known_sources(self._db)

--- a/tests/test_external_list.py
+++ b/tests/test_external_list.py
@@ -187,10 +187,9 @@ class TestCustomListFromCSV(DatabaseTest):
 
         eq_(list_entry_1.annotation, list_entry_2.annotation)
 
-        # There are six classifications instead of 12.
+        # There are still six classifications.
         i = list_entry_1.edition.primary_identifier
-        descriptions = i.classifications
-        eq_(6, len(descriptions))
+        eq_(6, len(i.classifications))
 
         # Now import from the third row, but with
         # overwrite_old_data set to False.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,19 @@
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+
+from . import (
+    DatabaseTest,
+)
+from scripts import Script
+
+class TestScript(DatabaseTest):
+
+    def test_parse_list_as_identifiers(self):
+
+        i1 = self._identifier()
+        i2 = self._identifier()
+        args = [i1.type, i1.identifier, 'no-such-identifier', i2.identifier]
+        identifiers = list(Script.parse_identifier_list(self._db, args))
+        eq_([i1, i2], identifiers)


### PR DESCRIPTION
This branch offers a number of small improvements to improve the process of metadata import and debugging problems with metadata:

* By default, a CoverageProvider that calls metadata.apply() will completely replace the old set of subjects, links, and contributors previously obtained from the CoverageProvider. Without this branch, it's additive, so there's no way to get rid of bad data.

* Previously, the no-op when a book's classifications had not changed was achieved by deleting all the classifications and recreating them. This branch speeds things up by only deleting a classification if it's no longer in the list.

* Make it possible for a script to take a number of specific identifiers as command-line arguments and operate just on those Identifiers.

* Create a BibliographicRefreshScript which takes identifiers as command-line arguments and asks   Overdrive or 3M about those Identifiers, refreshing the local metadata to fit.
