### PR TITLE
Remove typo from index command

### DIFF
--- a/migration/20160229-suppress-licensepool.sql
+++ b/migration/20160229-suppress-licensepool.sql
@@ -1,2 +1,2 @@
 ALTER TABLE licensepools ADD COLUMN suppressed boolean default false;
-create index "ix_licensepools_suppressed" btree on licensepools (suppressed);
+create index "ix_licensepools_suppressed" on licensepools (suppressed);


### PR DESCRIPTION
The `btree` command in the index was creating a syntax error, and it looks like _btree_ is the default method for Postgres indices anyway.