### PR TITLE
Custom list from classification

### DIFF
--- a/external_list.py
+++ b/external_list.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+from collections import defaultdict
 from nose.tools import set_trace
 import datetime
 from dateutil.parser import parse
@@ -16,6 +17,7 @@ from metadata_layer import (
 from model import (
     get_one,
     get_one_or_create,
+    Classification,
     CustomList,
     CustomListEntry,
     Contributor,
@@ -247,3 +249,90 @@ class TitleFromExternalList(object):
         )
         self.metadata.associate_with_identifiers_based_on_permanent_work_id(_db)
         return edition
+
+
+class MembershipManager(object):
+    """Manage the membership of a custom list based on some criteria."""
+
+    def __init__(self, custom_list, log=None):
+        self.log = log or logging.getLogger(
+            "Membership manager for %s" % custom_list.name
+        )
+        self._db = Session.object_session(custom_list)
+        self.custom_list = custom_list
+
+    def update(self, update_time=None):
+        update_time = update_time or datetime.datetime.utcnow()
+
+        # Map each Edition currently in this list to the corresponding
+        # CustomListEntry.
+        current_membership = defaultdict(list)
+        for entry in self.custom_list.entries:
+            if not entry.edition:
+                continue
+            current_membership[entry.edition].append(entry)
+
+        # Find the new membership of the list.
+        for new_edition in self.new_membership:
+            if new_edition in current_membership:
+                # This entry was in the list before, and is still in
+                # the list. Update its .most_recent_appearance.
+                self.log.debug("Maintaining %s" % new_edition.title)
+                entry_list = current_membership[new_edition]
+                for entry in entry_list:
+                    entry.most_recent_appearance = update_time
+                del current_membership[new_edition]
+            else:
+                # This is a new list entry.
+                self.log.debug("Adding %s" % new_edition.title)
+                self.custom_list.add_entry(
+                    edition=new_edition, first_appearance=update_time
+                )
+
+        # Anything still left in current_membership used to be in the
+        # list but is no longer. Remove these entries from the list.
+        for entry_list in current_membership.values():
+            for entry in entry_list:
+                self.log.debug("Deleting %s" % entry.edition.title)
+                self._db.delete(entry)
+
+    @property
+    def new_membership(self):
+        """Iterate over the new membership of the list.
+
+        :yield: a sequence of Edition objects
+        """
+        raise NotImplementedError()
+
+
+class SubjectBasedMembershipManager(MembershipManager):
+    """Manage a custom list containing all Editions whose primary
+    Identifier is classified under one of the given subject fragments.
+    """
+    def __init__(self, custom_list, subject_fragments):
+        super(SubjectBasedMembershipManager, self).__init__(custom_list)
+        self.subject_fragments = subject_fragments
+
+    @property
+    def new_membership(self):
+        """Iterate over the new membership of the list.
+
+        :yield: a sequence of Edition objects
+        """
+        subject_clause = None
+        for i in self.subject_fragments:
+            c = Subject.identifier.ilike('%' + i + '%')
+            if subject_clause is None:
+                subject_clause = c
+            else:
+                subject_clause = or_(subject_clause, c)
+        qu = self._db.query(Edition).distinct(Edition.id).join(
+            Edition.primary_identifier
+        ).join(
+            Identifier.classifications
+        ).join(
+            Classification.subject
+        )
+        qu = qu.filter(subject_clause)
+        return qu
+

--- a/external_list.py
+++ b/external_list.py
@@ -5,6 +5,7 @@ import datetime
 from dateutil.parser import parse
 import csv
 import os
+from sqlalchemy import or_
 from sqlalchemy.orm.session import Session
 
 from opds_import import SimplifiedOPDSLookup
@@ -305,12 +306,12 @@ class MembershipManager(object):
         raise NotImplementedError()
 
 
-class SubjectBasedMembershipManager(MembershipManager):
+class ClassificationBasedMembershipManager(MembershipManager):
     """Manage a custom list containing all Editions whose primary
     Identifier is classified under one of the given subject fragments.
     """
     def __init__(self, custom_list, subject_fragments):
-        super(SubjectBasedMembershipManager, self).__init__(custom_list)
+        super(ClassificationBasedMembershipManager, self).__init__(custom_list)
         self.subject_fragments = subject_fragments
 
     @property

--- a/scripts.py
+++ b/scripts.py
@@ -2,10 +2,7 @@ import os
 import logging
 import sys
 from nose.tools import set_trace
-from sqlalchemy import (
-    create_engine,
-    or_,
-)
+from sqlalchemy import create_engine
 from sqlalchemy.sql.functions import func
 from sqlalchemy.orm.session import Session
 import time

--- a/scripts.py
+++ b/scripts.py
@@ -13,7 +13,6 @@ import random
 from model import (
     get_one_or_create,
     production_session,
-    Classification,
     CustomList,
     DataSource,
     Edition,

--- a/tests/test_external_list.py
+++ b/tests/test_external_list.py
@@ -21,6 +21,7 @@ from model import (
 from external_list import (
     CustomListFromCSV,
     MembershipManager,
+    ClassificationBasedMembershipManager,
 )
 
 class TestCustomListFromCSV(DatabaseTest):
@@ -261,3 +262,28 @@ class TestMembershipManager(DatabaseTest):
         eq_(new_update_time, new_entry.first_appearance)
         eq_(new_update_time, new_entry.most_recent_appearance)
         
+    def test_classification_based_membership_manager(self):
+        e1 = self._edition()
+        e2 = self._edition()
+        e3 = self._edition()
+        source = e1.data_source
+        e1.primary_identifier.classify(source, Subject.TAG, "GOOD FOOD")
+        e2.primary_identifier.classify(source, Subject.TAG, "barflies")
+        e3.primary_identifier.classify(source, Subject.TAG, "irrelevant")
+
+        custom_list, ignore = self._customlist()
+        fragments = ["foo", "bar"]
+        manager = ClassificationBasedMembershipManager(custom_list, fragments)
+        members = list(manager.new_membership)
+        eq_(2, len(members))
+
+        # e1 is a member of the list because its primary identifier is
+        # classified under a subject that matches %foo%.
+        # 
+        # e2 is a member of the list because its primary identifier is
+        # classified under a subject that matches %bar%.
+        #
+        # e3 is not a member of the list.
+        assert e1 in members
+        assert e2 in members
+

--- a/tests/test_external_list.py
+++ b/tests/test_external_list.py
@@ -14,11 +14,13 @@ from . import (
 
 from model import (
     DataSource,
+    Edition,
     Identifier,
     Subject,
 )
 from external_list import (
     CustomListFromCSV,
+    MembershipManager,
 )
 
 class TestCustomListFromCSV(DatabaseTest):
@@ -203,3 +205,59 @@ class TestCustomListFromCSV(DatabaseTest):
         # Now there are 12 classifications.
         eq_(12, len(i.classifications))
 
+
+class BooksInSeries(MembershipManager):
+    """A sample implementation of MembershipManager that makes a CustomList
+    out of all books that are in some series.
+    """
+
+    @property
+    def new_membership(self):
+        """Only books that are part of a series should be in this list."""
+        return self._db.query(Edition).filter(Edition.series != None)
+
+class TestMembershipManager(DatabaseTest):
+
+    def test_update(self):
+        # Create two books that are part of series, and one book that
+        # is not.
+        series1 = self._edition()
+        series1.series = "Series 1"
+
+        series2 = self._edition()
+        series2.series = "Series Two"
+
+        no_series = self._edition()
+        eq_(None, no_series.series)
+
+        update_time = datetime.datetime(2015, 1, 1)
+
+        custom_list, ignore = self._customlist()
+        manager = BooksInSeries(custom_list)
+        manager.update(update_time)
+
+        [entry1] = [x for x in custom_list.entries if x.edition.series == "Series 1"] 
+        [entry2] = [x for x in custom_list.entries if x.edition.series == "Series Two"] 
+        
+        eq_(update_time, entry1.first_appearance)
+        eq_(update_time, entry1.most_recent_appearance)
+
+        # In a shocking twist, one of the entries turns out not to
+        # have a series, while the entry previously thought not to
+        # have a series actually does.
+        series2.series = None
+        no_series.series = "Actually I do have a series."
+        self._db.commit()
+
+        new_update_time = datetime.datetime(2016, 1,1)
+
+        manager.update(new_update_time)
+
+        # Entry #2 has been removed from the list, and a new entry added.
+        [old_entry] = [x for x in custom_list.entries if x.edition.series == "Series 1"] 
+        [new_entry] = [x for x in custom_list.entries if x.edition.series == "Actually I do have a series."] 
+        eq_(update_time, old_entry.first_appearance)
+        eq_(new_update_time, old_entry.most_recent_appearance)
+        eq_(new_update_time, new_entry.first_appearance)
+        eq_(new_update_time, new_entry.most_recent_appearance)
+        

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -6,7 +6,15 @@ from nose.tools import (
 from . import (
     DatabaseTest,
 )
-from scripts import Script
+from model import (
+    get_one,
+    CustomList,
+    DataSource,
+)
+from scripts import (
+    Script,
+    CustomListManagementScript,
+)
 
 class TestScript(DatabaseTest):
 


### PR DESCRIPTION
This branch makes it possible to take all Editions whose primary Identifiers are classified a certain way, and put them on a CustomList. This will eventually make it possible to set up lanes for subject matter classifications like 'animals' which we don't and won't support as full-fledged Genres.

First there's MembershipManager. This class gets a list of Editions from... somewhere, and makes sure that exactly those Editions are on a CustomList.

Then we have ClassificationBasedMembershipManager, a subclass which gets its list of Editions from a list of identifier fragments. It finds all Editions whose primary Identifiers are classified under a Subject that matches one of the fragments.

Finally we have CustomListManagementScript, which takes a MembershipManager class (plus constructor args) and a description of a CustomList. It makes sure the list exists, instantiates the MembershipManager class, and ensures that the CustomList contains all the entries the MembershipManager says it should.