### PR TITLE
Overdrive ignore empty asin

### DIFF
--- a/model.py
+++ b/model.py
@@ -3495,7 +3495,7 @@ class Work(Base):
         genre_weights, fiction, audience, target_age = classifier.classify
 
         # Assign WorkGenre objects to the remainder.
-        total_genre_weight = sum(genre_weights.values())
+        total_genre_weight = float(sum(genre_weights.values()))
         workgenres = []
         for g, score in genre_weights.items():
             affinity = score / total_genre_weight

--- a/overdrive.py
+++ b/overdrive.py
@@ -630,7 +630,7 @@ class OverdriveRepresentationExtractor(object):
                     type_key = Identifier.UPC
                 elif t == 'PublisherCatalogNumber':
                     continue
-                if type_key:
+                if type_key and v:
                     identifiers.append(
                         IdentifierData(type_key, v, 1)
                     )

--- a/tests/files/overdrive/overdrive_metadata.json
+++ b/tests/files/overdrive/overdrive_metadata.json
@@ -52,6 +52,10 @@
                 {
                     "type": "ASIN",
                     "value": "B000VI88N2"
+                },
+                {
+                    "type": "ASIN",
+                    "value": ""
                 }
             ],
             "name": "Kindle Book",

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -89,6 +89,9 @@ class TestOverdriveRepresentationExtractor(object):
             (metadata.primary_identifier.type, metadata.primary_identifier.identifier))
 
         ids = [(x.type, x.identifier) for x in metadata.identifiers]
+
+        # The original data contains a blank ASIN in addition to the
+        # actual ASIN, but it doesn't show up here.
         eq_(
             [
                 (Identifier.ASIN, "B000VI88N2"), 


### PR DESCRIPTION
Fixes https://github.com/NYPL-Simplified/server_core/issues/103

Get the Overdrive bibliographic data gatherer to ignore identifiers if the string associated with the identifier is empty.

Incidentally changed Work.assign_genres() to use float math instead of integer math.