### PR TITLE
NYT ISBNs are less trustworthy than previously though

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -252,8 +252,8 @@ class ContributorData(object):
 class IdentifierData(object):
     def __init__(self, type, identifier, weight=1):
         self.type = type
+        self.weight = weight
         self.identifier = identifier
-        self.weight = 1
 
     def __repr__(self):
         return '<IdentifierData type="%s" identifier="%s" weight="%s">' % (
@@ -889,6 +889,8 @@ class Metadata(object):
 
         if self.identifiers is not None:
             for identifier_data in self.identifiers:
+                if not identifier_data.identifier:
+                    continue
                 new_identifier, ignore = Identifier.for_foreign_id(
                     _db, identifier_data.type, identifier_data.identifier)
                 identifier.equivalent_to(

--- a/nyt.py
+++ b/nyt.py
@@ -242,11 +242,18 @@ class NYTBestSellerListTitle(TitleFromExternalList):
             annotation = d.get('description', None)
             primary_isbn10 = d.get('primary_isbn10', None)
             primary_isbn13 = d.get('primary_isbn13', None)
-            for isbn in d.get('isbns', []):
+
+            # The list of other ISBNs frequently contains ISBNs for
+            # other books in the same series, as well as ISBNs that
+            # are just wrong. Assign these equivalencies at a low
+            # level of confidence.
+            for isbn in d.get('isbns', []): 
                 isbn13 = isbn.get('isbn13', None)
-                other_isbns.append(
-                    IdentifierData(Identifier.ISBN, isbn13, 0.80)
-                )
+                if isbn13:
+                    other_isbns.append( 
+                        IdentifierData(Identifier.ISBN, isbn13, 0.50) 
+                    )
+
 
         primary_isbn = primary_isbn13 or primary_isbn10
         if primary_isbn:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -14,6 +14,7 @@ from metadata_layer import (
     FormatData,
     LinkData,
     Metadata,
+    IdentifierData,
 )
 
 import os
@@ -30,6 +31,14 @@ from model import (
 from . import (
     DatabaseTest,
 )
+
+class TestIdentifierData(object):
+
+    def test_constructor(self):
+        data = IdentifierData(Identifier.ISBN, "foo", 0.5)
+        eq_(Identifier.ISBN, data.type)
+        eq_("foo", data.identifier)
+        eq_(0.5, data.weight)
 
 class TestMetadataImporter(DatabaseTest):
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -73,11 +73,11 @@ class TestMetadataImporter(DatabaseTest):
 
         eq_(Identifier.OVERDRIVE_ID, overdrive.type)
         eq_('eae60d41-e0b8-4f9d-90b5-cbc43d433c2f', overdrive.identifier)
-        eq_(1, overdrive.weight)
+        eq_(0.75, overdrive.weight)
 
         eq_(Identifier.THREEM_ID, threem.type)
         eq_('eswhyz9', threem.identifier)
-        eq_(1, threem.weight)
+        eq_(0.75, threem.weight)
 
         # Now let's check out subjects.
         eq_(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -63,7 +63,7 @@ class TestMetadataImporter(DatabaseTest):
         [overdrive] = m1.identifiers
         eq_(Identifier.OVERDRIVE_ID, overdrive.type)
         eq_('504BA8F6-FF4E-4B57-896E-F1A50CFFCA0C', overdrive.identifier)
-        eq_(1, overdrive.weight)
+        eq_(0.75, overdrive.weight)
 
         # The second book has no ID at all.
         eq_([], m2.identifiers)

--- a/tests/test_nyt.py
+++ b/tests/test_nyt.py
@@ -172,11 +172,18 @@ class TestNYTBestSellerListTitle(NYTBestSellerAPITest):
         edition = title.to_edition(self._db, self.metadata_client)
         eq_("9780698185395", edition.primary_identifier.identifier)
 
+        # The alternate ISBN is markes as equivalent to the primary identifier,
+        # but at a greatly reduced strength.
+        [equivalency] = [x for x in edition.primary_identifier.equivalencies]
+        eq_("9781594633669", equivalency.output.identifier)
+        eq_(0.5, equivalency.strength)
+
+        # That strength is not enough to make the alternate ISBN an equivalent
+        # identifier for the edition.
         equivalent_identifiers = [
-            (x.type, x.identifier) for x in edition.equivalent_identifiers()]
-        eq_([("ISBN", "9780698185395"),
-             ("ISBN", "9781594633669"),
-         ], sorted(equivalent_identifiers))
+            (x.type, x.identifier) for x in edition.equivalent_identifiers()
+        ]
+        eq_([("ISBN", "9780698185395")], sorted(equivalent_identifiers))
 
         eq_(datetime.datetime(2015, 2, 1, 0, 0), edition.published)
         # The list said the author was 'Paula Hawkins', but we couldn't


### PR DESCRIPTION
This branch fixes a trivial but really bad bug where the metadata layer was treating all IdentifierData as having a confidence level of 1, instead of whatever confidence level was passed in originally.

This branch also lowers the confidence level of the list of `isbns` provided as part of the NYT best-seller list data. As per https://github.com/NYPL-Simplified/server_core/issues/102 I've discovered that that data frequently conflates multiple books in a series, and sometimes claims that totally unrelated books are the same. Given that this data is _usually_ accurate and we don't use it for very much, I think keeping it but giving it a lower confidence level is the best way to solve the problem.