### PR TITLE
Pk for four year olds

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -196,6 +196,7 @@ class GradeLevelClassifier(Classifier):
         'preschool' : 3,
         'pre-school' : 3,
         'p' : 3,
+        'pk' : 4,
 
         # Easy readers
         'kindergarten' : 5,

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -66,6 +66,7 @@ class TestTargetAge(object):
         def f(t):
             return GradeLevelClassifier.target_age(t, None)
         eq_((5,6), GradeLevelClassifier.target_age(None, "grades 0-1"))
+        eq_((4,7), f("pk - 2"))
         eq_((5,7), f("grades k-2"))
         eq_((6,6), f("first grade"))
         eq_((6,6), f("1st grade"))


### PR DESCRIPTION
This branch makes the grade level classifier recognize the abbreviation 'pk', for pre-kindergarten.