### PR TITLE
assign_to_genre() can actually remove a subject's genre, not just set it

### DIFF
--- a/model.py
+++ b/model.py
@@ -4448,15 +4448,18 @@ class Subject(Base):
                 audience = Classifier.AUDIENCE_YOUNG_ADULT
             else:
                 audience = Classifier.AUDIENCE_CHILDREN
+
         if genredata:
             _db = Session.object_session(self)
             genre, was_new = Genre.lookup(_db, genredata.name, True)
-            if genre != self.genre:
-                log.info(
-                    "%s:%s genre %r=>%r", self.type, self.identifier,
-                    self.genre, genre
-                )
-            self.genre = genre
+        else:
+            genre = None
+        if genre != self.genre:
+            log.info(
+                "%s:%s genre %r=>%r", self.type, self.identifier,
+                self.genre, genre
+            )
+        self.genre = genre
 
         if audience:
             if self.audience != audience:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -362,6 +362,27 @@ class TestUnresolvedIdentifier(DatabaseTest):
         assert never_tried in ready
         assert tried_a_long_time_ago in ready
 
+class TestSubject(DatabaseTest):
+
+    def test_assign_to_genre_can_remove_genre(self):
+        # Here's a Subject that identifies children's books.
+        subject, was_new = Subject.lookup(self._db, Subject.TAG, "Children's books", None)
+
+        # The genre and audience data for this Subject is totally wrong.
+        subject.audience = Classifier.AUDIENCE_ADULT
+        subject.target_age = NumericRange(1,10)
+        subject.fiction = False
+        sf, ignore = Genre.lookup(self._db, "Science Fiction")
+        subject.genre = sf
+
+        # But calling assign_to_genre() will fix it.
+        subject.assign_to_genre()
+        eq_(Classifier.AUDIENCE_CHILDREN, subject.audience)
+        eq_(NumericRange(None, None), subject.target_age)
+        eq_(None, subject.genre)
+        eq_(None, subject.fiction)
+        
+
 class TestContributor(DatabaseTest):
 
     def test_lookup_by_viaf(self):


### PR DESCRIPTION
I tried to use assign_to_genre() to clear out the genre association of Subjects like 'Children's Books' which had been incorrectly assigned to the Parenting genre. Although assign_to_genre() works properly when assigning a Subject's initial genre, or changing a Subject from one genre to another, it doesn't work when removing a Subject's genre. This branch fixes that and also adds a basic test.
