### PR TITLE
Make WorkProcessingScript an IdentifierInputScript

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -376,39 +376,6 @@ class PresentationReadyWorkSweepMonitor(WorkSweepMonitor):
     def work_query(self):
         return self._db.query(Work).filter(Work.presentation_ready==True)
 
-class ReclassifierMonitor(PresentationReadyWorkSweepMonitor):
-
-    """Reclassifies works using (one hopes) new data or updated
-    classification rules.
-    """
-
-    def __init__(self, _db, interval_seconds=3600*24):
-        super(ReclassifierMonitor, self).__init__(
-            _db, "Reclassifier", interval_seconds)
-
-    def run_once(self, offset):
-        new_offset = super(ReclassifierMonitor, self).run_once(offset)
-        if new_offset == 0:
-            self.stop_running = True
-        return new_offset
-
-    def process_work(self, work):
-        work.calculate_presentation(
-        choose_edition=False, classify=True,
-        choose_summary=False,
-        calculate_quality=False, debug=True,
-        search_index_client=self.search_index_client
-    )
-
-class OverdriveReclassifierMonitor(ReclassifierMonitor):
-    """Reclassify only Overdrive books."""
-
-    def work_query(self):
-        return self._db.query(Work).join(Work.primary_edition).join(
-            Edition.data_source).filter(
-                DataSource.name==DataSource.OVERDRIVE).filter(
-                    Work.presentation_ready==True)
-
 
 class OPDSEntryCacheMonitor(PresentationReadyWorkSweepMonitor):
 

--- a/scripts.py
+++ b/scripts.py
@@ -354,10 +354,27 @@ class WorkConsolidationScript(WorkProcessingScript):
 class WorkPresentationScript(WorkProcessingScript):
     """Calculate the presentation for Work objects."""
 
+    choose_edition = True
+    classify = True
+    choose_summary = True
+    calculate_quality = True
+
     def process_work(self, work):
         work.calculate_presentation(
-            choose_edition=True, classify=True, choose_summary=True,
-            calculate_quality=True)
+            choose_edition=self.choose_edition, 
+            classify=self.classify,
+            choose_summary=self.choose_summary,
+            calculate_quality=self.calculate_quality
+        )
+
+class WorkClassificationScript(WorkPresentationScript):
+    """Recalculate the classification for Work objects.
+    Just the classification, not the rest of calculate_presentation.
+    """
+    choose_edition = False
+    classify = True
+    choose_summary = False
+    calculate_quality = False
   
 
 class CustomListManagementScript(Script):

--- a/scripts.py
+++ b/scripts.py
@@ -234,6 +234,7 @@ class WorkProcessingScript(IdentifierInputScript):
         identifiers_or_source = self.parse_identifiers_or_data_source()
         self.batch_size = batch_size
         self.query = self.make_query(identifiers_or_source)
+        self.force = force
 
     def make_query(self, identifiers):
         query = self._db.query(Work)

--- a/scripts.py
+++ b/scripts.py
@@ -486,11 +486,14 @@ class RefreshMaterializedViewsScript(Script):
         print "Vacuumed in %.2f sec." % (b-a)
 
 
-class Explain(Script):
+class Explain(IdentifierInputScript):
     """Explain everything known about a given work."""
     def run(self):
-        title = sys.argv[1]
-        editions = self._db.query(Edition).filter(Edition.title.ilike(title))
+        identifiers = self.parse_identifiers()
+        identifier_ids = [x.id for x in identifiers]
+        editions = self._db.query(Edition).filter(
+            Edition.primary_identifier_id.in_(identifier_ids)
+        )
         for edition in editions:
             self.explain(self._db, edition)
             print "-" * 80

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -25,3 +25,20 @@ class TestScript(DatabaseTest):
         args = [i1.type, i1.identifier, 'no-such-identifier', i2.identifier]
         identifiers = list(Script.parse_identifier_list(self._db, args))
         eq_([i1, i2], identifiers)
+
+        eq_([], Script.parse_identifiers_list(self._db, []))
+
+    def test_parse_list_as_identifiers_or_data_source(self):
+
+        i1 = self._identifier()
+        i2 = self._identifier()
+        args = [i1.type, i1.identifier, 'no-such-identifier', i2.identifier]
+        identifiers = list(Script.parse_identifier_list(self._db, args))
+        eq_([i1, i2], identifiers)
+
+        args = [DataSource.OVERDRIVE]
+        data_source = Script.parse_identifiers_list(self._db, args)
+        overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
+        eq_(overdrive, data_source)
+
+        eq_([], Script.parse_identifiers_list(self._db, []))

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -23,22 +23,23 @@ class TestScript(DatabaseTest):
         i1 = self._identifier()
         i2 = self._identifier()
         args = [i1.type, i1.identifier, 'no-such-identifier', i2.identifier]
-        identifiers = list(Script.parse_identifier_list(self._db, args))
+        identifiers = Script.parse_identifier_list(self._db, args)
         eq_([i1, i2], identifiers)
-
-        eq_([], Script.parse_identifiers_list(self._db, []))
+        eq_([], Script.parse_identifier_list(self._db, []))
 
     def test_parse_list_as_identifiers_or_data_source(self):
 
         i1 = self._identifier()
         i2 = self._identifier()
         args = [i1.type, i1.identifier, 'no-such-identifier', i2.identifier]
-        identifiers = list(Script.parse_identifier_list(self._db, args))
+        identifiers = Script.parse_identifier_list_or_data_source(
+            self._db, args
+        )
         eq_([i1, i2], identifiers)
 
         args = [DataSource.OVERDRIVE]
-        data_source = Script.parse_identifiers_list(self._db, args)
+        data_source = Script.parse_identifier_list_or_data_source(self._db, args)
         overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
         eq_(overdrive, data_source)
 
-        eq_([], Script.parse_identifiers_list(self._db, []))
+        eq_([], Script.parse_identifier_list(self._db, []))


### PR DESCRIPTION
This branch changes WorkProcessingScript (an abstract superclass that does _something_ to individual works, all works from a given data source, or all works in the system) so that it subclasses IdentifierInputScript (an abstract superclass that takes identifiers as command-line arguments and does _something_ to those identifiers). To get this to work I defined a method `parse_identifier_list_or_data_source` which lets you put _either_ a set of identifiers _or_ a single data source like "Overdrive" on the command line.

This improves the usability of WorkProcessingScript and lets me consolidate several scripts in metadata and circulation which do the same thing in different ways.