### PR TITLE
Subjects classified under Erotica must also have an audience of "Adults Only"

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -2674,6 +2674,14 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
         Drama : match_kw(
             "opera",
         ),
+
+        Erotica : match_kw(
+            "erotic poetry",
+            "gay erotica",
+            "lesbian erotica",
+            "erotic photography",
+        ),
+
         Literary_Criticism : match_kw(
             "literary history", # Not History
             "romance language", # Not Romance

--- a/model.py
+++ b/model.py
@@ -4454,7 +4454,7 @@ class Subject(Base):
 
         # If the genre is erotica, the audience will always be ADULTS_ONLY,
         # no matter what the classifier says.
-        if genredata and genredata == Erotica:
+        if genredata == Erotica:
             audience = Classifier.AUDIENCE_ADULTS_ONLY
 
         if audience in Classifier.AUDIENCES_ADULT:

--- a/model.py
+++ b/model.py
@@ -92,6 +92,7 @@ from external_search import ExternalSearchIndex
 import classifier
 from classifier import (
     Classifier,
+    Erotica,
     COMICS_AND_GRAPHIC_NOVELS,
     GenreData,
     WorkClassifier,
@@ -4450,6 +4451,12 @@ class Subject(Base):
         log = logging.getLogger("Subject-genre assignment")
 
         genredata, audience, target_age, fiction = classifier.classify(self)
+
+        # If the genre is erotica, the audience will always be ADULTS_ONLY,
+        # no matter what the classifier says.
+        if genredata and genredata == Erotica:
+            audience = Classifier.AUDIENCE_ADULTS_ONLY
+
         if audience in Classifier.AUDIENCES_ADULT:
             target_age = (None, None)
         lower, upper = target_age

--- a/scripts.py
+++ b/scripts.py
@@ -267,7 +267,7 @@ class WorkProcessingScript(IdentifierInputScript):
         works = True
         offset = 0
         while works:
-            works = self.query.offset(offset).limit(self.batch_size)
+            works = self.query.offset(offset).limit(self.batch_size).all()
             for work in works:
                 self.process_work(work)
             offset += self.batch_size
@@ -376,7 +376,7 @@ class WorkClassificationScript(WorkPresentationScript):
     classify = True
     choose_summary = False
     calculate_quality = False
-  
+
 
 class CustomListManagementScript(Script):
     """Maintain a CustomList whose membership is determined by a


### PR DESCRIPTION
I noticed that books classified under Erotica were also being classified as audience=Adult. They should be audience=Adults Only, in fact this is the only reason the Adults Only audience exists. But that only happened for Overdrive books, where the classifier's implementation of `.audience` was set up to work this way.

Rather than change all the individual classifiers, I changed the model code to add this restriction to all Subject objects.