### PR TITLE
Pass keyword args to monitors

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -120,9 +120,9 @@ class Script(object):
 
 class RunMonitorScript(Script):
 
-    def __init__(self, monitor):
+    def __init__(self, monitor, **kwargs):
         if callable(monitor):
-            monitor = monitor(self._db)
+            monitor = monitor(self._db, **kwargs)
         self.monitor = monitor
         self.name = self.monitor.service_name
 

--- a/threem.py
+++ b/threem.py
@@ -55,8 +55,7 @@ class ThreeMAPI(object):
 
     log = logging.getLogger("3M API")
 
-    def __init__(self, _db, account_id=None, library_id=None, account_key=None,
-                 base_url = "https://cloudlibraryapi.3m.com/",
+    def __init__(self, _db, base_url = "https://cloudlibraryapi.3m.com/",
                  version="2.0", testing=False):
         self._db = _db
         self.version = version
@@ -67,17 +66,10 @@ class ThreeMAPI(object):
         if testing:
             return
 
-        if not account_id or not library_id or not account_key:
-            values = self.environment_values()
-            if len([x for x in values if not x]):
-                raise CannotLoadConfiguration(
-                    "3M integration has incomplete configuration.")
-
-        (env_library_id, env_account_id, 
-         env_account_key) = values
-        self.library_id = library_id or env_library_id
-        self.account_id = account_id or env_account_id
-        self.account_key = account_key or env_account_key
+        values = self.environment_values()
+        if len([x for x in values if not x]):
+            raise CannotLoadConfiguration("3M integration has incomplete configuration.")
+        (self.library_id, self.account_id, self.account_key) = values
 
     @classmethod
     def environment_values(


### PR DESCRIPTION
This allows scripts to pass along keyword arguments when initialized and removes passed authentication values from ThreeMAPI initialization. Config files fo' life.

Related to NYPL-Simplified/circulation#108.