### PR TITLE
Don't boost 'adult' audience if there's an 'adults only' indicator in the data

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -3187,7 +3187,7 @@ class WorkClassifier(object):
     nonfiction_publishers = set(["Wiley"])
     fiction_publishers = set([])
 
-    def __init__(self, work, test_session=None):
+    def __init__(self, work, test_session=None, debug=True):
         self._db = Session.object_session(work)
         if test_session:
             self._db = test_session
@@ -3198,10 +3198,14 @@ class WorkClassifier(object):
         self.genre_weights = Counter()
         self.direct_from_license_source = set()
         self.prepared = False
+        self.debug = debug
+        self.classifications = []
 
     def add(self, classification):
         """Prepare a single Classification for consideration."""
         # Make sure the Subject is ready to be used in calculations.
+        if self.debug:
+            self.classifications.append(classification)
         if not classification.subject.checked:
             classification.subject.assign_to_genre()
 
@@ -3279,22 +3283,23 @@ class WorkClassifier(object):
         """
         self.weigh_metadata()
 
-        children_and_ya = (Classifier.AUDIENCE_CHILDREN, Classifier.AUDIENCE_YOUNG_ADULT)
+        explicitly_indicated_audiences = (Classifier.AUDIENCE_CHILDREN, Classifier.AUDIENCE_YOUNG_ADULT, Classifier.AUDIENCE_ADULTS_ONLY)
         audiences = [classification.subject.audience
             for classification in self.direct_from_license_source]
         if self.direct_from_license_source and not any(
-                audience in children_and_ya for audience in audiences
+                audience in explicitly_indicated_audiences for audience in audiences
         ):
-            # If this was a book for children or young adults, the
-            # distributor would have given some indication of that
-            # fact. In the absense of any such indication, we can
-            # assume very strongly that this is a book for adults.
+            # If this was erotica, or a book for children or young
+            # adults, the distributor would have given some indication
+            # of that fact. In the absense of any such indication, we
+            # can assume very strongly that this is a regular old book
+            # for adults.
             #
             # 3M is terrible at distinguishing between childrens'
             # books and YA books, but books for adults can be
-            # distinguished by their lack of childrens/YA
+            # distinguished by their _lack_ of childrens/YA
             # classifications.
-            self.audience_weights[Classifier.AUDIENCE_ADULT] += 500
+            self.audience_weights[classifier.AUDIENCE_ADULT] += 500
         else:
             for audience in audiences:
                 self.audience_weights[audience] += 100

--- a/classifier.py
+++ b/classifier.py
@@ -3299,7 +3299,7 @@ class WorkClassifier(object):
             # books and YA books, but books for adults can be
             # distinguished by their _lack_ of childrens/YA
             # classifications.
-            self.audience_weights[classifier.AUDIENCE_ADULT] += 500
+            self.audience_weights[Classifier.AUDIENCE_ADULT] += 500
         else:
             for audience in audiences:
                 self.audience_weights[audience] += 100

--- a/classifier.py
+++ b/classifier.py
@@ -3187,7 +3187,7 @@ class WorkClassifier(object):
     nonfiction_publishers = set(["Wiley"])
     fiction_publishers = set([])
 
-    def __init__(self, work, test_session=None, debug=True):
+    def __init__(self, work, test_session=None, debug=False):
         self._db = Session.object_session(work)
         if test_session:
             self._db = test_session

--- a/model.py
+++ b/model.py
@@ -2762,9 +2762,9 @@ class Edition(Base):
         #    AcquisitionFeed.single_entry(_db, self, Annotator))
 
         # Now that everything's calculated, log it.
-        msg = "Calculated presentation for %s (by %s, pub=%s, pwid=%s, language=%s, cover=%r)"
+        msg = "Calculated presentation for %s (by %s, pub=%s, ident=%r, pwid=%s, language=%s, cover=%r)"
         args = [self.title, self.author, self.publisher, 
-                self.permanent_work_id, self.language]
+                self.primary_identifier, self.permanent_work_id, self.language]
         if self.cover and self.cover.representation:
             args.append(self.cover.representation.mirror_url)
         else:
@@ -3369,6 +3369,12 @@ class Work(Base):
         l = ["%s (by %s)" % (self.title, self.author)]
         l.append(" language=%s" % self.language)
         l.append(" quality=%s" % self.quality)
+
+        if self.primary_edition and self.primary_edition.primary_identifier:
+            primary_identifier = self.primary_edition.primary_identifier
+        else:
+            primary_identifier=None
+        l.append(" primary id=%s" % primary_identifier)
         if self.fiction:
             fiction = "Fiction"
         elif self.fiction == False:


### PR DESCRIPTION
This branch fixes at least one situation where bug #112 happens. I think it fixes the whole thing but I don't yet have ironclad evidence of this.

Currently, if the distributor of a book gives classifications, and none of them are assigned to the 'children' or 'young adult' audience, we give 'adult' a big boost. This is to handle the situation with 3M, which tells you when a book is a 'juvenile' book but says nothing in particular when a book is for adults.

But consider a book of erotica. 3M classifies the book under the Erotica genre, which is 'adults only'. But since there are no classifications under 'children' or 'young adult', we give 'adult' that big boost--a boost that outweighs the 'adults only' classification 3M explicitly gave us. This is how a book that is clearly erotica can end up being classified as 'adult' instead of 'adults only'.

This branch adds 'adults only' to the list of audiences that will stop the 'adult' boost from happening. The rest of the branch is minor stuff I added to make this scenario easier to debug.