### PR TITLE
Create search index client from calculate_presentation if it's not passed in.

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -17,9 +17,6 @@ from model import (
 from metadata_layer import (
     ReplacementPolicy
 )
-from external_search import (
-    ExternalSearchIndex,
-)
 
 import log # This sets the appropriate log format.
 
@@ -214,7 +211,6 @@ class CoverageProvider(object):
             return CoverageFailure(self, identifier, e, transient=True)
         work, created = license_pool.calculate_work(
             even_if_no_author=True,
-            search_index_client=self.search_index
         )
         if not work:
             e = "Work could not be calculated"
@@ -282,7 +278,6 @@ class BibliographicCoverageProvider(CoverageProvider):
     def __init__(self, _db, api, datasource, workset_size=10):
         self._db = _db
         self.api = api
-        self.search_index = ExternalSearchIndex()
         output_source = DataSource.lookup(_db, datasource)
         input_identifier_types = [output_source.primary_identifier_type]
         service_name = "%s Bibliographic Monitor" % datasource

--- a/external_search.py
+++ b/external_search.py
@@ -14,25 +14,24 @@ class ExternalSearchIndex(Elasticsearch):
     
     work_document_type = 'work-type'
 
-    def __init__(self, url=None, works_index=None, fallback_to_dummy=True):
+    def __init__(self, url=None, works_index=None):
     
         integration = Configuration.integration(
             Configuration.ELASTICSEARCH_INTEGRATION, 
-            required=not fallback_to_dummy
         )
         self.log = logging.getLogger("External search index")
         self.works_index = works_index or integration.get(
             Configuration.ELASTICSEARCH_INDEX_KEY
         ) or None
 
-        if fallback_to_dummy and not integration:
+        if not integration:
             return
 
         url = integration[Configuration.URL]
         use_ssl = url and url.startswith('https://')
         self.log.info("Connecting to Elasticsearch cluster at %s", url)
         super(ExternalSearchIndex, self).__init__(url, use_ssl=use_ssl)
-        if not url and not fallback_to_dummy:
+        if not url:
             raise Exception("Cannot connect to Elasticsearch cluster.")
         if self.works_index and not self.indices.exists(self.works_index):
             self.log.info("Creating index %s", self.works_index)
@@ -287,7 +286,7 @@ class ExternalSearchIndex(Elasticsearch):
             return {}
 
 
-class DummyExternalSearchIndex(object):
+class DummyExternalSearchIndex(ExternalSearchIndex):
 
     work_document_type = 'work-type'
 

--- a/model.py
+++ b/model.py
@@ -3355,8 +3355,10 @@ class Work(Base):
         if calculate_opds_entry:
             self.calculate_opds_entries()
 
-        if search_index_client:
-            self.update_external_index(search_index_client)
+        if not search_index_client:
+            search_index_client = ExternalSearchIndex()
+
+        self.update_external_index(search_index_client)
 
         # Now that everything's calculated, print it out.
         if debug:
@@ -4988,8 +4990,7 @@ class LicensePool(Base):
             if a and not a % 100:
                 _db.commit()
 
-    def calculate_work(self, even_if_no_author=False, known_edition=None,
-                       search_index_client=None):
+    def calculate_work(self, even_if_no_author=False, known_edition=None):
         """Try to find an existing Work for this LicensePool.
 
         If there are no Works for the permanent work ID associated
@@ -5085,7 +5086,7 @@ class LicensePool(Base):
 
         # Recalculate the display information for the Work, since the
         # associated Editions have changed.
-        work.calculate_presentation(search_index_client=search_index_client)
+        work.calculate_presentation()
 
         if created:
             logging.info("Created a new work: %r", work)

--- a/monitor.py
+++ b/monitor.py
@@ -25,9 +25,6 @@ from model import (
     UnresolvedIdentifier,
     Work,
 )
-from external_search import (
-    ExternalSearchIndex,
-)
 
 class Monitor(object):
 
@@ -43,14 +40,6 @@ class Monitor(object):
         self.interval_seconds = interval_seconds
         self.stop_running = False
         self.keep_timestamp = keep_timestamp
-
-        search = Configuration.integration(
-            Configuration.ELASTICSEARCH_INTEGRATION)
-        if search:
-            search_index_client = ExternalSearchIndex()
-        else:
-            search_index_client = None
-        self.search_index_client=search_index_client
 
         if not default_start_time:
              default_start_time = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ elasticsearch
 python-dateutil
 uwsgi
 loggly-python-handler
+mock

--- a/testing.py
+++ b/testing.py
@@ -34,6 +34,9 @@ from coverage import (
     CoverageProvider,
     CoverageFailure,
 )
+from external_search import DummyExternalSearchIndex
+import mock
+import model
 
 class DatabaseTest(object):
 
@@ -49,11 +52,13 @@ class DatabaseTest(object):
         self.counter = 0
         self.time_counter = datetime(2014, 1, 1)
         self.isbns = ["9780674368279", "0636920028468", "9781936460236"]
+        self.search_mock = mock.patch(model.__name__ + ".ExternalSearchIndex", DummyExternalSearchIndex)
+        self.search_mock.start()
 
     def teardown(self):
         self._db.close()
         self.__transaction.rollback()
-
+        self.search_mock.stop()
 
     @property
     def _id(self):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -3,13 +3,13 @@ from nose.tools import (
     set_trace,
 )
 
-from external_search import ExternalSearchIndex
+from external_search import DummyExternalSearchIndex
 
 class TestExternalSearch(object):
 
     def test_make_query(self):
 
-        search = ExternalSearchIndex(fallback_to_dummy=True)
+        search = DummyExternalSearchIndex()
 
         # Basic query
         query = search.make_query("test")['bool']

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -47,7 +47,6 @@ from model import (
     Edition,
     get_one_or_create,
 )
-
 from external_search import (
     DummyExternalSearchIndex,
 )


### PR DESCRIPTION
I changed work.calculate_presentation to create an ExternalSearchIndex, so we won't forget to pass one in and end up with an outdated index. 

I also don't want to accidentally mess up a real search index by running tests without passing in the dummy one, so I'm using mock.patch to replace the ExternalSearchIndex class used by model for all tests.