### PR TITLE
fixed unicode error

### DIFF
--- a/model.py
+++ b/model.py
@@ -2764,7 +2764,7 @@ class Edition(Base):
         # Now that everything's calculated, log it.
         msg = "Calculated presentation for %s (by %s, pub=%s, ident=%r, pwid=%s, language=%s, cover=%r)"
         args = [self.title, self.author, self.publisher, 
-                self.primary_identifier, self.permanent_work_id, self.language]
+                self.primary_identifier.identifier, self.permanent_work_id, self.language]
         if self.cover and self.cover.representation:
             args.append(self.cover.representation.mirror_url)
         else:


### PR DESCRIPTION
calculate_presentation() in Edition passes the primary identifier as an argument to logging.info(), which attempts to convert it to unicode using ascii, which causes an error when the identifier contains non-ascii text. Passing the identifier's identifier property, which is a unicode string already, avoids this error.