### PR TITLE
Moved in Axis 360 bibliographic coverage provider from circulation.

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -10,6 +10,7 @@ import re
 
 from util import LanguageCodes
 from util.xmlparser import XMLParser
+from coverage import CoverageFailure
 from model import (
     Contributor,
     DataSource,
@@ -31,6 +32,7 @@ from metadata_layer import (
 )
 
 from config import Configuration
+from coverage import BibliographicCoverageProvider
 
 class Axis360API(object):
 
@@ -145,6 +147,18 @@ class Axis360API(object):
         return response
 
     @classmethod
+    def create_identifier_strings(cls, identifiers):
+        identifier_strings = []
+        for i in identifiers:
+            if isinstance(i, Identifier):
+                value = i.identifier
+            else:
+                value = i
+            identifier_strings.append(value)
+
+        return identifier_strings
+
+    @classmethod
     def parse_token(cls, token):
         data = json.loads(token)
         return data['access_token']
@@ -155,6 +169,38 @@ class Axis360API(object):
         return requests.request(
             url=url, method=method, headers=headers, data=data,
             params=params)
+
+class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
+    """Fill in bibliographic metadata for Axis 360 records.
+
+    Currently this is only used by BibliographicRefreshScript. It's
+    not normally necessary because the Axis 360 API combines
+    bibliographic and availability data.
+    """
+    def __init__(self, _db):
+        self.parser = BibliographicParser()
+        super(Axis360BibliographicCoverageProvider, self).__init__(
+            _db, Axis360API(_db), DataSource.AXIS_360,
+            workset_size=25
+        )
+
+    def process_batch(self, identifiers):
+        identifier_strings = self.api.create_identifier_strings(identifiers)
+        response = self.api.availability(title_ids=identifier_strings)
+        batch_results = []
+        for metadata, availability in self.parser.process_all(response.content):
+            identifier, is_new = metadata.primary_identifier.load(self._db)
+            set_trace()
+            result = self.set_metadata(identifier, metadata)
+            if not isinstance(result, CoverageFailure):
+                result = self.set_presentation_ready(identifier)
+            batch_results.append(result)
+        return batch_results
+
+    def process_item(self, identifier):
+        results = self.process_batch([identifier])
+        return results[0]
+
 
 class Axis360Parser(XMLParser):
 

--- a/axis.py
+++ b/axis.py
@@ -191,7 +191,7 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
         batch_results = []
         for metadata, availability in self.parser.process_all(response.content):
             identifier, is_new = metadata.primary_identifier.load(self._db)
-            seen_identifiers.append(identifier.identifier)
+            seen_identifiers.add(identifier.identifier)
             result = self.set_metadata(identifier, metadata)
             if not isinstance(result, CoverageFailure):
                 result = self.set_presentation_ready(identifier)

--- a/axis.py
+++ b/axis.py
@@ -187,14 +187,27 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
     def process_batch(self, identifiers):
         identifier_strings = self.api.create_identifier_strings(identifiers)
         response = self.api.availability(title_ids=identifier_strings)
+        seen_identifiers = set()
         batch_results = []
         for metadata, availability in self.parser.process_all(response.content):
             identifier, is_new = metadata.primary_identifier.load(self._db)
-            set_trace()
+            seen_identifiers.append(identifier.identifier)
             result = self.set_metadata(identifier, metadata)
             if not isinstance(result, CoverageFailure):
                 result = self.set_presentation_ready(identifier)
             batch_results.append(result)
+
+        # Create a CoverageFailure object for each original identifier
+        # not mentioned in the results.
+        for identifier_string in identifier_strings:
+            if identifier_string not in seen_identifiers:
+                identifier, ignore = Identifier.for_foreign_id(
+                    self._db, Identifier.AXIS_360_ID, identifier_string
+                )
+                result = CoverageFailure(
+                    self, identifier, "Book not in collection", transient=True
+                )
+                batch_results.append(result)
         return batch_results
 
     def process_item(self, identifier):

--- a/scripts.py
+++ b/scripts.py
@@ -37,6 +37,8 @@ from threem import (
     ThreeMBibliographicCoverageProvider,
 )
 
+from axis import Axis360BibliographicCoverageProvider
+
 class Script(object):
 
     @property
@@ -219,6 +221,8 @@ class BibliographicRefreshScript(IdentifierInputScript):
             provider = ThreeMBibliographicCoverageProvider
         elif identifier.type==Identifier.OVERDRIVE_ID:
             provider = OverdriveBibliographicCoverageProvider
+        elif identifier.type==Identifier.AXIS_360_ID:
+            provider = Axis360BibliographicCoverageProvider
         else:
             self.log.warn("Cannot update coverage for %r" % identifier)
         if provider:

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -14,8 +14,18 @@ from model import (
 )
 
 from axis import (
+    Axis360API,
     BibliographicParser,
 )
+
+from . import DatabaseTest
+
+class TestAxis360API(DatabaseTest):
+
+    def test_create_identifier_strings(self):
+        identifier = self._identifier()
+        values = Axis360API.create_identifier_strings(["foo", identifier])
+        eq_(["foo", identifier.identifier], values)
 
 class TestParsers(object):
 


### PR DESCRIPTION
This branch moves the Axis 360 bibliographic coverage provider from circulation into core. The only reason we need this coverage provider is for the bibliographic repair script, and since that script is in core, this code needs to be in core as well--even though the circ manager is the only component that we'd reasonably expect to have Axis 360 credentials.

I've added a simple test for the helper method create_identifier_strings.
