### PR TITLE
Run on identifiers

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -102,6 +102,16 @@ class CoverageProvider(object):
         self._db.commit()
         return offset
 
+    def run_on_identifiers(self, identifiers):
+        # Split a specific set of identifiers into batches and
+        # process one batch at a time.
+        index = 0
+        while index < len(identifiers):
+            batch = identifiers[index:index+self.workset_size]
+            self.process_batch(batch)
+            self._db.commit()
+            index += self.workset_size
+
     def run_once(self, offset):
         batch = self.items_that_need_coverage.limit(
             self.workset_size).offset(offset)

--- a/scripts.py
+++ b/scripts.py
@@ -194,11 +194,9 @@ class RunCoverageProviderScript(IdentifierInputScript):
         self.name = self.provider.service_name
 
     def do_run(self):
-
         identifiers = self.parse_identifiers()
         if identifiers:
-            self.provider.process_batch(identifiers)
-            self._db.commit()
+            self.provider.run_on_identifiers(identifiers)
         else:
             self.provider.run()
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -89,6 +89,20 @@ class TestCoverageProvider(DatabaseTest):
         # Timestamp was not updated.
         eq_([], self._db.query(Timestamp).all())
 
+    def test_run_on_identifiers(self):
+        provider = AlwaysSuccessfulCoverageProvider(
+            "Always successful", self.input_identifier_types, self.output_source
+        )
+        provider.workset_size = 6
+        
+        to_be_tested = [self._identifier() for i in range(6)]
+        not_to_be_tested = [self._identifier() for i in range(6)]
+        provider.run_on_identifiers(to_be_tested)
+        for i in to_be_tested:
+            assert i in provider.attempts
+        for i in not_to_be_tested:
+            assert i not in provider.attempts
+
     def test_always_successful(self):
 
         # We start with no CoverageRecords and no Timestamp.


### PR DESCRIPTION
This branch defines a new method of CoverageProvider, run_on_identifiers, which splits a predefined set of identifiers into batches and runs process_batch() on each batch. I implemented this after trying to  run a CoverageProvider script with a huge list of identifiers, which failed as it tried to process all the identifiers in one huge batch.