### PR TITLE
Don't delete author information just because metadata wrangler doesn't have any new information

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1032,7 +1032,7 @@ class Metadata(object):
 
     def update_contributions(self, _db, edition, metadata_client=None, 
                              replace=True):
-        if replace and self.contributors is not None:
+        if replace and self.contributors:
             dirty = False
             # Remove any old Contributions from this data source --
             # we're about to add a new set

--- a/scripts.py
+++ b/scripts.py
@@ -214,6 +214,7 @@ class BibliographicRefreshScript(IdentifierInputScript):
             )
         for identifier in identifiers:
             self.refresh_metadata(identifier)
+        self._db.commit()
 
     def refresh_metadata(self, identifier):
         provider = None


### PR DESCRIPTION
This branch fixes two minor problems that add up to big trouble.

1. In the OPDS feed importer, we had code for not deleting author information if the OPDS feed turned the list of authors into None, but if the list of authors was an empty list we went ahead and deleted all the authors. This screwed up the metadata import of Axis 360 books (where the metadata wrangler has no author information).

2. When I tried to fix the problem with the repair script `bibliographic_coverage`, the problem was apparently fixed, but because the database session was never committed, the changes weren't written to the database.