### PR TITLE
Control what data gets recalculated with a PresentationCalculationPolicy

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -1676,6 +1676,15 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
     YOUNG_ADULT_INDICATORS = match_kw("young adult", "ya", "12-Up", 
                                       "teenage fiction")
 
+    # Children's books don't generally deal with romance, so although
+    # "Juvenile Fiction" generally refers to children's fiction,
+    # "Juvenile Fiction / Love & Romance" is almost certainly YA.
+    JUVENILE_TERMS_THAT_IMPLY_YOUNG_ADULT = set([
+        "love & romance",
+        "romance",
+        "romantic",
+    ])        
+
     # These identifiers indicate that the string "children" or
     # "juvenile" in the identifier does not actually mean the work is
     # _for_ children.
@@ -2804,12 +2813,17 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
     def audience(cls, identifier, name):
         if name is None:
             return None
-        if cls.JUVENILE_INDICATORS.search(name):
-            use = cls.AUDIENCE_CHILDREN
-        elif cls.YOUNG_ADULT_INDICATORS.search(name):
+        if cls.YOUNG_ADULT_INDICATORS.search(name):
             use = cls.AUDIENCE_YOUNG_ADULT
+        elif cls.JUVENILE_INDICATORS.search(name):
+            use = cls.AUDIENCE_CHILDREN
         else:
             return None
+
+        if use == cls.AUDIENCE_CHILDREN:
+            for i in cls.JUVENILE_TERMS_THAT_IMPLY_YOUNG_ADULT:
+                if i in name:
+                    use = cls.AUDIENCE_YOUNG_ADULT
 
         # It may be for kids, or it may be about kids, e.g. "juvenile
         # delinquency".
@@ -3233,7 +3247,7 @@ class WorkClassifier(object):
     nonfiction_publishers = set(["Wiley"])
     fiction_publishers = set([])
 
-    def __init__(self, work, test_session=None, debug=False):
+    def __init__(self, work, test_session=None, debug=True):
         self._db = Session.object_session(work)
         if test_session:
             self._db = test_session

--- a/classifier.py
+++ b/classifier.py
@@ -3166,11 +3166,11 @@ class FreeformAudienceClassifier(AgeOrGradeClassifier):
             return cls.nr(13, 15)
 
         strict_age = AgeClassifier.target_age(identifier, name, True)
-        if any(strict_age):
+        if strict_age.lower or strict_age.upper:
             return strict_age
 
         strict_grade = GradeLevelClassifier.target_age(identifier, name, True)
-        if any(strict_grade):
+        if strict_grade.lower or strict_grade.upper:
             return strict_grade
 
         # Default to assuming it's an unmarked age.

--- a/external_search.py
+++ b/external_search.py
@@ -19,6 +19,9 @@ class ExternalSearchIndex(object):
     
         self.log = logging.getLogger("External search index")
 
+        # By default, assume that there is no search index.
+        self.works_index = None
+
         if not ExternalSearchIndex.__client:
             integration = Configuration.integration(
                 Configuration.ELASTICSEARCH_INTEGRATION, 

--- a/external_search.py
+++ b/external_search.py
@@ -76,7 +76,7 @@ class ExternalSearchIndex(Elasticsearch):
             }
 
         def make_target_age_query(target_age):
-            (lower, upper) = target_age
+            (lower, upper) = target_age.lower, target_age.upper
             return { 
                 "bool" : {
                     # There must be some overlap with the range in the query
@@ -120,12 +120,12 @@ class ExternalSearchIndex(Elasticsearch):
 
         # Get the grade level and the words in the query that matched it, if any
         age_from_grade, grade_match = GradeLevelClassifier.target_age_match(query_string)
-        if age_from_grade and age_from_grade[0] == None:
+        if age_from_grade and age_from_grade.lower == None:
             age_from_grade = None
 
         # Get the age range and the words in the query that matched it, if any
         age, age_match = AgeClassifier.target_age_match(query_string)
-        if age and age[0] == None:
+        if age and age.lower == None:
             age = None
 
         if fiction or genre or audience or age_from_grade or age:
@@ -248,8 +248,8 @@ class ExternalSearchIndex(Elasticsearch):
                 audience = [_f(aud) for aud in audience]
                 clauses.append(dict(terms=dict(audience=audience)))
         if age_range:
-            lower = age_range[0]
-            upper = age_range[-1]
+            lower = age_range.lower
+            upper = age_range.upper
 
             age_clause = {
                 "and": [

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -840,13 +840,9 @@ class Metadata(object):
         if self.last_update_time and not replace.even_if_not_apparently_updated:
             coverage_record = CoverageRecord.lookup(edition, data_source)
             if coverage_record:
-                check_date = coverage_record.date
-                if not isinstance(check_date, datetime.date):
-                    check_date = check_date.date()
-                last_date = self.last_update_time
-                if isinstance(last_date, datetime.datetime):
-                    last_date = last_date.date()
-                if check_date >= last_date:
+                check_time = coverage_record.timestamp
+                last_time = self.last_update_time
+                if check_time >= last_time:
                     # The metadata has not changed since last time. Do nothing.
                     return
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1027,7 +1027,9 @@ class Metadata(object):
 
         # Finally, update the coverage record for this edition
         # and data source.
-        CoverageRecord.add_for(edition, data_source, self.last_update_time)
+        CoverageRecord.add_for(
+            edition, data_source, timestamp=self.last_update_time
+        )
         return edition
 
     def update_contributions(self, _db, edition, metadata_client=None, 

--- a/migration/20160324-coverage-record-operation.sql
+++ b/migration/20160324-coverage-record-operation.sql
@@ -1,4 +1,5 @@
-ALTER TABLE coveragerecords RENAME COLUMN date timestamp;
+ALTER TABLE coveragerecords RENAME date TO timestamp;
 ALTER TABLE coveragerecords ALTER COLUMN timestamp SET DATA TYPE timestamp;
 ALTER TABLE coveragerecords ADD COLUMN operation varchar(255) DEFAULT NULL;
 CREATE UNIQUE INDEX "ix_coveragerecords_data_source_id_operation_identifier_id" ON coveragerecords (data_source_id, operation, identifier_id);
+ALTER TABLE ONLY coveragerecords ADD CONSTRAINT coveragerecords_identifier_id_data_source_id_operation_key UNIQUE (identifier_id, data_source_id, operation);

--- a/migration/20160324-coverage-record-operation.sql
+++ b/migration/20160324-coverage-record-operation.sql
@@ -1,0 +1,4 @@
+ALTER TABLE coveragerecords RENAME COLUMN date timestamp;
+ALTER TABLE coveragerecords ALTER COLUMN timestamp SET DATA TYPE timestamp;
+ALTER TABLE coveragerecords ADD COLUMN operation varchar(255) DEFAULT NULL;
+CREATE UNIQUE INDEX "ix_coveragerecords_data_source_id_operation_identifier_id" ON coveragerecords (data_source_id, operation, identifier_id);

--- a/model.py
+++ b/model.py
@@ -1301,7 +1301,8 @@ class Identifier(Base):
                 cls._update_equivalents(
                     equivalents, e.input_id, e.output_id, e.strength, e.votes)
             else:
-                logging.debug("Ignoring signal below threshold: %r", e)
+                # logging.debug("Ignoring signal below threshold: %r", e)
+                pass
 
             if e.output_id not in seen_identifier_ids:
                 # This is our first time encountering the
@@ -2963,8 +2964,8 @@ class PresentationCalculationPolicy(object):
         self.choose_edition = choose_edition
         self.set_edition_metadata = set_edition_metadata
         self.classify = classify
-        self.choose_summary=choose_summary, 
-        self.calculate_quality=calculate_quality,
+        self.choose_summary=choose_summary
+        self.calculate_quality=calculate_quality
         self.choose_cover = choose_cover
 
         # We will regenerate OPDS entries if any of the metadata
@@ -4750,7 +4751,7 @@ class Subject(Base):
                 )
         self.fiction = fiction
 
-        if self.target_age != target_age:
+        if numericrange_to_tuple(self.target_age) != numericrange_to_tuple(target_age):
             log.info(
                 "%s:%s target_age %r=>%r", self.type, self.identifier,
                 self.target_age, target_age

--- a/model.py
+++ b/model.py
@@ -810,6 +810,10 @@ class CoverageRecord(Base):
     timestamp = Column(DateTime, index=True)
     exception = Column(Unicode, index=True)
 
+    __table_args__ = (
+        UniqueConstraint('identifier_id', 'data_source_id', 'operation'),
+    )
+
     @classmethod
     def lookup(self, edition_or_identifier, data_source, operation=None):
         _db = Session.object_session(edition_or_identifier)
@@ -868,6 +872,10 @@ class WorkCoverageRecord(Base):
         
     timestamp = Column(DateTime, index=True)
     exception = Column(Unicode, index=True)
+
+    __table_args__ = (
+        UniqueConstraint('work_id', 'operation'),
+    )
 
     @classmethod
     def lookup(self, work, operation):

--- a/model.py
+++ b/model.py
@@ -829,7 +829,7 @@ class CoverageRecord(Base):
         )
 
     @classmethod
-    def add_for(self, edition, data_source, operation=None, date=None):
+    def add_for(self, edition, data_source, operation=None, timestamp=None):
         _db = Session.object_session(edition)
         if isinstance(edition, Identifier):
             identifier = edition
@@ -838,7 +838,7 @@ class CoverageRecord(Base):
         else:
             raise ValueError(
                 "Cannot create a coverage record for %r." % edition) 
-        date = date or datetime.datetime.utcnow()
+        timestamp = timestamp or datetime.datetime.utcnow()
         coverage_record, is_new = get_one_or_create(
             _db, CoverageRecord,
             identifier=identifier,
@@ -846,7 +846,7 @@ class CoverageRecord(Base):
             operation=operation,
             on_multiple='interchangeable'
         )
-        coverage_record.timestamp = date
+        coverage_record.timestamp = timestamp
         return coverage_record, is_new
 
 Index("ix_coveragerecords_data_source_id_operation_identifier_id", CoverageRecord.data_source_id, CoverageRecord.operation, CoverageRecord.identifier_id)

--- a/model.py
+++ b/model.py
@@ -2383,6 +2383,8 @@ class Edition(Base):
         self.open_access_download_url = url
 
     def set_cover(self, resource):
+        old_cover = self.cover
+        old_cover_full_url = self.cover_full_url
         self.cover = resource
         self.cover_full_url = resource.representation.mirror_url
 
@@ -2399,11 +2401,12 @@ class Edition(Base):
                 if scaled_down.mirror_url and scaled_down.mirrored_at:
                     self.cover_thumbnail_url = scaled_down.mirror_url
                     break
-        logging.debug(
-            "Setting cover for %s/%s: full=%s thumb=%s", 
-            self.primary_identifier.type, self.primary_identifier.identifier,
-            self.cover_full_url, self.cover_thumbnail_url
-        )
+        if old_cover != self.cover or old_cover_full_url != self.cover_full_url:
+            logging.debug(
+                "Setting cover for %s/%s: full=%s thumb=%s", 
+                self.primary_identifier.type, self.primary_identifier.identifier,
+                self.cover_full_url, self.cover_thumbnail_url
+            )
 
     def add_contributor(self, name, roles, aliases=None, lc=None, viaf=None,
                         **kwargs):

--- a/model.py
+++ b/model.py
@@ -3422,7 +3422,6 @@ class Work(Base):
                 )
             self.calculate_quality(flattened_data, default_quality)
 
-        # TODO: This still isn't working
         if self.summary_text:
             if isinstance(self.summary_text, unicode):
                 new_summary_text = self.summary_text
@@ -3435,7 +3434,7 @@ class Work(Base):
             primary_edition != self.primary_edition or
             summary != self.summary or
             summary_text != new_summary_text or
-            quality != self.quality
+            float(quality) != float(self.quality)
         )
 
         if changed:

--- a/model.py
+++ b/model.py
@@ -2976,6 +2976,9 @@ class Work(Base):
     primary_edition = relationship(
         "Edition", primaryjoin=clause, uselist=False, lazy='joined')
 
+    # One Work may have many asosciated WorkCoverageRecords.
+    coverage_records = relationship("WorkCoverageRecord", backref="work")
+
     # One Work may participate in many WorkGenre assignments.
     genres = association_proxy('work_genres', 'genre',
                                creator=WorkGenre.from_genre)

--- a/model.py
+++ b/model.py
@@ -2816,9 +2816,11 @@ class Edition(Base):
                 changed_status = "unchanged"
                 level = logging.debug
 
-            msg = "Presentation %s for Edition %s (by %s, pub=%s, ident=%r, pwid=%s, language=%s, cover=%r)"
+            msg = u"Presentation %s for Edition %s (by %s, pub=%s, ident=%s/%s, pwid=%s, language=%s, cover=%r)"
             args = [changed_status, self.title, self.author, self.publisher, 
-                    self.primary_identifier, self.permanent_work_id, self.language]
+                    self.primary_identifier.type, self.primary_identifier.identifier,
+                    self.permanent_work_id, self.language
+            ]
             if self.cover and self.cover.representation:
                 args.append(self.cover.representation.mirror_url)
             else:

--- a/model.py
+++ b/model.py
@@ -3427,6 +3427,8 @@ class Work(Base):
                 new_summary_text = self.summary_text
             else:
                 new_summary_text = self.summary_text.decode("utf8")
+        else:
+            new_summary_text = self.summary_text
 
         changed = (
             edition_metadata_changed or

--- a/model.py
+++ b/model.py
@@ -797,6 +797,9 @@ class CoverageRecord(Base):
     """A record of a Identifier being used as input into some process."""
     __tablename__ = 'coveragerecords'
 
+    SET_EDITION_METADATA_OPERATION = 'set-edition-metadata'
+    CHOOSE_COVER_OPERATION = 'choose-cover'
+
     id = Column(Integer, primary_key=True)
     identifier_id = Column(
         Integer, ForeignKey('identifiers.id'), index=True)
@@ -864,6 +867,13 @@ class WorkCoverageRecord(Base):
     and as such there is no data_source_id.
     """
     __tablename__ = 'workcoveragerecords'
+
+    CHOOSE_EDITION_OPERATION = 'choose-edition'
+    CLASSIFY_OPERATION = 'classify'
+    SUMMARY_OPERATION = 'summary'
+    QUALITY_OPERATION = 'quality'
+    OPDS_OPERATION = 'opds'
+    SEARCH_INDEX_OPERATION = 'search-index'
 
     id = Column(Integer, primary_key=True)
     work_id = Column(

--- a/model.py
+++ b/model.py
@@ -817,6 +817,25 @@ class CoverageRecord(Base):
         UniqueConstraint('identifier_id', 'data_source_id', 'operation'),
     )
 
+    def __repr__(self):
+        if self.operation:
+            operation = ' operation="%s"' % self.operation
+        else:
+            operation = ''
+        if self.exception:
+            exception = ' exception="%s"' % self.exception
+        else:
+            exception = ''
+        template = '<CoverageRecord: identifier=%s/%s data_source="%s"%s timestamp="%s"%s>'
+        return template % (
+            self.identifier.type, 
+            self.identifier.identifier,
+            self.data_source.name,
+            operation, 
+            self.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+            exception
+        )
+
     @classmethod
     def lookup(self, edition_or_identifier, data_source, operation=None):
         _db = Session.object_session(edition_or_identifier)
@@ -872,8 +891,8 @@ class WorkCoverageRecord(Base):
     CLASSIFY_OPERATION = 'classify'
     SUMMARY_OPERATION = 'summary'
     QUALITY_OPERATION = 'quality'
-    OPDS_OPERATION = 'opds'
-    SEARCH_INDEX_OPERATION = 'search-index'
+    GENERATE_OPDS_OPERATION = 'generate-opds'
+    UPDATE_SEARCH_INDEX_OPERATION = 'update-search-index'
 
     id = Column(Integer, primary_key=True)
     work_id = Column(
@@ -886,6 +905,18 @@ class WorkCoverageRecord(Base):
     __table_args__ = (
         UniqueConstraint('work_id', 'operation'),
     )
+
+    def __repr__(self):
+        if self.exception:
+            exception = ' exception="%s"' % self.exception
+        else:
+            exception = ''
+        template = '<WorkCoverageRecord: work_id=%s operation="%s" timestamp="%s"%s>'
+        return template % (
+            self.work_id, self.operation, 
+            self.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+            exception
+        )
 
     @classmethod
     def lookup(self, work, operation):
@@ -2795,6 +2826,10 @@ class Edition(Base):
             self.sort_title = TitleProcessor.sort_title_for(self.title)
             self.calculate_permanent_work_id()
             self.set_open_access_link()
+            CoverageRecord.add_for(
+                self, data_source=self.data_source, 
+                operation=CoverageRecord.SET_EDITION_METADATA_OPERATION
+            )
 
         if policy.choose_cover:
             self.choose_cover()
@@ -2812,9 +2847,6 @@ class Edition(Base):
         if changed:
             # last_update_time tracks the last time the data 
             # actually changed.
-            #
-            # TODO: We need CoverageProviders to track the last time
-            # we _checked_ whether or not to change the data.
             self.last_update_time = datetime.datetime.utcnow()
 
         # Now that everything's calculated, log it.
@@ -2882,6 +2914,14 @@ class Edition(Base):
                         )
                 self.set_cover(best_cover)
                 break
+
+        # Whether or not we succeeded in setting the cover,
+        # record the fact that we tried.
+        CoverageRecord.add_for(
+            self, data_source=self.data_source, 
+            operation=CoverageRecord.CHOOSE_COVER_OPERATION
+        )
+
 
 Index("ix_editions_data_source_id_identifier_id", Edition.data_source_id, Edition.primary_identifier_id, unique=True)
 Index("ix_editions_work_id_is_primary_for_work_id", Edition.work_id, Edition.is_primary_for_work)
@@ -3167,6 +3207,9 @@ class Work(Base):
         # TODO: clean up the content
         if resource:
             self.summary_text = resource.representation.content
+        WorkCoverageRecord.add_for(
+            self, operation=WorkCoverageRecord.SUMMARY_OPERATION
+        )
 
     @classmethod
     def feed_query(cls, _db, languages, availability=CURRENTLY_AVAILABLE):
@@ -3442,6 +3485,10 @@ class Work(Base):
 
         if policy.choose_edition or not self.primary_edition:
             self.set_primary_edition()
+            WorkCoverageRecord.add_for(
+                self, operation=WorkCoverageRecord.CHOOSE_EDITION_OPERATION
+            )
+
 
         # The privileged data source may short-circuit the process of
         # finding a good cover or description.
@@ -3474,6 +3521,9 @@ class Work(Base):
 
         if policy.classify:
             classification_changed = self.assign_genres(flattened_data)
+            WorkCoverageRecord.add_for(
+                self, operation=WorkCoverageRecord.CLASSIFY_OPERATION
+            )
 
         if policy.choose_summary:
             summary, summaries = Identifier.evaluate_summary_quality(
@@ -3512,9 +3562,6 @@ class Work(Base):
             # last_update_time tracks the last time the data actually
             # changed, not the last time we checked whether or not to
             # change it.
-            #
-            # TODO: We need WorkCoverageProviders for the various checks
-            # we ran to determine whether or not to change something.
             self.last_update_time = datetime.datetime.utcnow()
 
         if changed or policy.regenerate_opds_entries:
@@ -3593,6 +3640,9 @@ class Work(Base):
                                                force_create=True)
         if verbose is not None:
             self.verbose_opds_entry = etree.tostring(verbose)
+        WorkCoverageRecord.add_for(
+            self, operation=WorkCoverageRecord.GENERATE_OPDS_OPERATION
+        )
         # print self.id, self.simple_opds_entry, self.verbose_opds_entry
 
 
@@ -3622,7 +3672,9 @@ class Work(Base):
         else:
             if client.exists(**args):
                 client.delete(**args)
-
+        WorkCoverageRecord.add_for(
+            self, operation=WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION
+        )
 
     def set_presentation_ready(self, as_of=None):
         as_of = as_of or datetime.datetime.utcnow()
@@ -3677,6 +3729,9 @@ class Work(Base):
 
         self.quality = Measurement.overall_quality(
             measurements, default_value=default_quality)
+        WorkCoverageRecord.add_for(
+            self, operation=WorkCoverageRecord.QUALITY_OPERATION
+        )
 
     def assign_genres(self, identifier_ids, cutoff=0.15):
         """Set classification information for this work based on the

--- a/monitor.py
+++ b/monitor.py
@@ -20,6 +20,7 @@ from model import (
     CustomListEntry,
     Identifier,
     LicensePool,
+    PresentationCalculationPolicy,
     Subject,
     Timestamp,
     UnresolvedIdentifier,
@@ -467,7 +468,10 @@ class PresentationReadyMonitor(WorkSweepMonitor):
             if exception:
                 work.presentation_ready_exception = exception
             else:
-                work.calculate_presentation(choose_edition=False)
+                policy = PresentationCalculationPolicy(
+                    choose_edition=False
+                )
+                work.calculate_presentation(policy)
                 work.set_presentation_ready()                    
                 one_success = True
         self.finalize_batch()

--- a/scripts.py
+++ b/scripts.py
@@ -273,7 +273,6 @@ class WorkProcessingScript(IdentifierInputScript):
                 self.process_work(work)
             offset += self.batch_size
             self._db.commit()
-            break
         self._db.commit()
 
     def process_work(self, work):

--- a/scripts.py
+++ b/scripts.py
@@ -242,7 +242,7 @@ class WorkProcessingScript(IdentifierInputScript):
 
     def make_query(self, identifiers):
         query = self._db.query(Work)
-        if identifiers is None:
+        if not identifiers:
             self.log.info(
                 "Processing all %d works.", query.count()
             )
@@ -378,7 +378,6 @@ class WorkClassificationScript(WorkPresentationScript):
         regenerate_opds_entries=False, 
         update_search_index=False,
     )
-
 
 class CustomListManagementScript(Script):
     """Maintain a CustomList whose membership is determined by a

--- a/testing.py
+++ b/testing.py
@@ -26,6 +26,7 @@ from model import (
     Identifier,
     Edition,
     Work,
+    WorkCoverageRecord,
     UnresolvedIdentifier,
     get_one_or_create
 )
@@ -198,6 +199,15 @@ class DatabaseTest(object):
             data_source=coverage_source,
             operation=operation,
             create_method_kwargs = dict(timestamp=datetime.utcnow()))
+        return record
+
+    def _work_coverage_record(self, work, operation=None):
+        record, ignore = get_one_or_create(
+            self._db, WorkCoverageRecord,
+            work=work,
+            operation=operation,
+            create_method_kwargs = dict(timestamp=datetime.utcnow())
+        )
         return record
 
     def _licensepool(self, edition, open_access=True, 

--- a/testing.py
+++ b/testing.py
@@ -191,12 +191,13 @@ class DatabaseTest(object):
             work.calculate_opds_entries(verbose=False)
         return work
 
-    def _coverage_record(self, edition, coverage_source):
+    def _coverage_record(self, edition, coverage_source, operation=None):
         record, ignore = get_one_or_create(
             self._db, CoverageRecord,
             identifier=edition.primary_identifier,
             data_source=coverage_source,
-            create_method_kwargs = dict(date=datetime.utcnow()))
+            operation=operation,
+            create_method_kwargs = dict(timestamp=datetime.utcnow()))
         return record
 
     def _licensepool(self, edition, open_access=True, 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -362,6 +362,16 @@ class TestKeyword(object):
     def test_children_audience_implies_no_genre(self):
         eq_(None, self.genre("Children's Books"))
 
+    def test_young_adult_wins_over_children(self):
+        eq_(Classifier.AUDIENCE_YOUNG_ADULT, 
+            Keyword.audience(None, "children's books - young adult fiction")
+        )
+
+    def test_juvenile_romance_means_young_adult(self):
+        eq_(Classifier.AUDIENCE_YOUNG_ADULT, 
+            Keyword.audience(None, "juvenile fiction / love & romance")
+        )
+
 class TestBISAC(object):
 
     def test_is_fiction(self):

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -85,8 +85,12 @@ class TestClassifierLookup(object):
 class TestTargetAge(object):
     def test_age_from_grade_classifier(self):
         def f(t):
-            return GradeLevelClassifier.target_age(t, None)
-        eq_((5,6), GradeLevelClassifier.target_age(None, "grades 0-1"))
+            v = GradeLevelClassifier.target_age(t, None)
+            return v.lower, v.upper
+        eq_(
+            Classifier.nr(5,6), 
+            GradeLevelClassifier.target_age(None, "grades 0-1")
+        )
         eq_((4,7), f("pk - 2"))
         eq_((5,7), f("grades k-2"))
         eq_((6,6), f("first grade"))
@@ -107,19 +111,20 @@ class TestTargetAge(object):
         # target_age() will assume that a number it sees is talking
         # about a grade level, unless require_explicit_grade_marker is
         # True.
-        eq_((7,9), GradeLevelClassifier.target_age("2-4", None, False))
-        eq_((None,None), GradeLevelClassifier.target_age("2-4", None, True))
         eq_((14,17), f("Children's Audio - 9-12"))
-        eq_((None,None), GradeLevelClassifier.target_age(
+        eq_(Classifier.nr(7,9), GradeLevelClassifier.target_age("2-4", None, False))
+        eq_(Classifier.nr(None,None), GradeLevelClassifier.target_age("2-4", None, True))
+        eq_(Classifier.nr(None,None), GradeLevelClassifier.target_age(
             "Children's Audio - 9-12", None, True))
 
-        eq_((None,None), GradeLevelClassifier.target_age("grade 50", None))
-        eq_((None,None), GradeLevelClassifier.target_age("road grades -- history", None))
-        eq_((None,None), GradeLevelClassifier.target_age(None, None))
+        eq_(Classifier.nr(None,None), GradeLevelClassifier.target_age("grade 50", None))
+        eq_(Classifier.nr(None,None), GradeLevelClassifier.target_age("road grades -- history", None))
+        eq_(Classifier.nr(None,None), GradeLevelClassifier.target_age(None, None))
 
     def test_age_from_age_classifier(self):
         def f(t):
-            return AgeClassifier.target_age(t, None)
+            v = AgeClassifier.target_age(t, None)
+            return v.lower, v.upper
         eq_((9,12), f("Ages 9-12"))
         eq_((9,11), f("9 and up"))
         eq_((9,11), f("9 and up."))
@@ -134,14 +139,15 @@ class TestTargetAge(object):
         eq_((0,3), f("0-3"))
         eq_((None,None), f("K-3"))
 
-        eq_((None,None), AgeClassifier.target_age("K-3", None, True))
-        eq_((None,None), AgeClassifier.target_age("9-12", None, True))
-        eq_((9,11), AgeClassifier.target_age("9 and up", None, True))
-        eq_((7,9), AgeClassifier.target_age("7 years and up.", None, True))
+        eq_(Classifier.nr(None,None), AgeClassifier.target_age("K-3", None, True))
+        eq_(Classifier.nr(None,None), AgeClassifier.target_age("9-12", None, True))
+        eq_(Classifier.nr(9,11), AgeClassifier.target_age("9 and up", None, True))
+        eq_(Classifier.nr(7,9), AgeClassifier.target_age("7 years and up.", None, True))
 
     def test_age_from_keyword_classifier(self):
         def f(t):
-            return LCSH.target_age(t, None)
+            v = LCSH.target_age(t, None)
+            return v.lower, v.upper
         eq_((5,5), f("Interest age: from c 5 years"))
         eq_((9,12), f("Children's Books / 9-12 Years"))
         eq_((9,12), f("Ages 9-12"))
@@ -170,7 +176,8 @@ class TestTargetAge(object):
     def test_age_from_age_or_grade_classifier(self):
         def f(t):
             t = AgeOrGradeClassifier.scrub_identifier(t)
-            return AgeOrGradeClassifier.target_age(t, None)
+            v = AgeOrGradeClassifier.target_age(t, None)
+            return v.lower, v.upper
         eq_((5,6), f("Children's - Kindergarten, Age 5-6"))
         eq_((5,5), f("Children's - Kindergarten"))
         eq_((9,12), f("Ages 9-12"))
@@ -188,7 +195,8 @@ class TestInterestLevelClassifier(object):
 
     def test_target_age(self):
         def f(t):
-            return InterestLevelClassifier.target_age(t, None)
+            v = InterestLevelClassifier.target_age(t, None)
+            return v.lower, v.upper
         eq_((5,8), f("lg"))
         eq_((9,13), f("mg"))
         eq_((9,13), f("mg+"))
@@ -383,7 +391,8 @@ class TestBISAC(object):
 
         def target(bisac):
             dummy = DummySubject(bisac)
-            return BISAC.classify(dummy)[2]
+            v = BISAC.classify(dummy)[2]
+            return v.lower, v.upper
         
         eq_((14,17), target("JUVENILE FICTION / Action & Adventure / General"))
         eq_((18, None), target("Erotica / General"))
@@ -435,7 +444,8 @@ class TestAxis360Classifier(object):
 
     def test_age(self):
         def f(t):
-            return Axis360AudienceClassifier.target_age(t, None)
+            v = Axis360AudienceClassifier.target_age(t, None)
+            return v.lower, v.upper
         eq_((5,6), f("Children's - Kindergarten, Age 5-6"))
         eq_((7,8), f("Children's - Grade 2-3, Age 7-8"))
         eq_((9,11), f("Children's - Grade 4-6, Age 9-11"))
@@ -527,7 +537,9 @@ class TestOverdriveClassifier(object):
             Overdrive.scrub_identifier("Foreign Language Study - Italian"))
 
     def test_target_age(self):
-        a = Overdrive.target_age
+        def a(x, y):
+            v = Overdrive.target_age(x,y)
+            return v.lower, v.upper
         eq_((0,4), a("Picture Book Nonfiction", None))
         eq_((5,8), a("Beginning Reader", None))
         eq_((None,None), a("Fiction", None))
@@ -778,7 +790,7 @@ class TestWorkClassifier(DatabaseTest):
         self.classifier.add(c1)
 
         target_age = self.classifier.target_age(Classifier.AUDIENCE_ADULT)
-        eq_((18, None), target_age)
+        eq_(Classifier.nr(18, None), target_age)
 
     def test_most_reliable_target_age_subset(self):
         # We have a very weak but reliable signal that this is a book for
@@ -804,8 +816,9 @@ class TestWorkClassifier(DatabaseTest):
 
         # And only most_reliable_target_age_subset is used to calculate
         # the target age.
+        a = self.classifier.target_age(Classifier.AUDIENCE_CHILDREN)
         eq_(
-            NumericRange(0,3, '[]'),  
+            Classifier.nr(0,4),
             self.classifier.target_age(Classifier.AUDIENCE_CHILDREN)
         )
 
@@ -825,7 +838,7 @@ class TestWorkClassifier(DatabaseTest):
         genres, fiction, audience, target_age = self.classifier.classify
 
         eq_(Classifier.AUDIENCE_CHILDREN, audience)
-        eq_(NumericRange(6,9, '[]'), target_age)
+        eq_(Classifier.nr(6,9), target_age)
 
     def test_fiction_status_restricts_genre(self):
         # Classify a book to imply that it's 50% science fiction and
@@ -913,8 +926,6 @@ class TestWorkClassifier(DatabaseTest):
             self.classifier.add(classification)
         self.classifier.prepare_to_classify()
 
-        self.classifier.audience
-
         genres, fiction, audience, target_age = self.classifier.classify
 
         # This work really looks like science fiction (w=100), but it
@@ -924,7 +935,7 @@ class TestWorkClassifier(DatabaseTest):
         eq_(u"History", genres.keys()[0].name)
         eq_(False, fiction)
         eq_(Classifier.AUDIENCE_YOUNG_ADULT, audience)
-        eq_(NumericRange(14,17, '[]'), target_age)
+        eq_(Classifier.nr(14,17), target_age)
 
     def test_top_tier_values(self):
         c = Counter()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -213,17 +213,17 @@ class TestMetadataImporter(DatabaseTest):
         coverage = CoverageRecord.lookup(edition, data_source)
         eq_(coverage, None)
         
-        last_update = datetime.date(2015, 1, 1)
+        last_update = datetime.datetime(2015, 1, 1)
 
         m = Metadata(data_source=data_source,
                      title=u"New title", last_update_time=last_update)
         m.apply(edition)
         
         coverage = CoverageRecord.lookup(edition, data_source)
-        eq_(last_update, coverage.date)
+        eq_(last_update, coverage.timestamp)
         eq_(u"New title", edition.title)
 
-        older_last_update = datetime.date(2014, 1, 1)
+        older_last_update = datetime.datetime(2014, 1, 1)
         m = Metadata(data_source=data_source,
                      title=u"Another new title", 
                      last_update_time=older_last_update
@@ -232,9 +232,9 @@ class TestMetadataImporter(DatabaseTest):
         eq_(u"New title", edition.title)
 
         coverage = CoverageRecord.lookup(edition, data_source)
-        eq_(last_update, coverage.date)
+        eq_(last_update, coverage.timestamp)
 
         m.apply(edition, force=True)
         eq_(u"Another new title", edition.title)
         coverage = CoverageRecord.lookup(edition, data_source)
-        eq_(older_last_update, coverage.date)
+        eq_(older_last_update, coverage.timestamp)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -377,7 +377,7 @@ class TestSubject(DatabaseTest):
         # But calling assign_to_genre() will fix it.
         subject.assign_to_genre()
         eq_(Classifier.AUDIENCE_CHILDREN, subject.audience)
-        eq_(NumericRange(None, None), subject.target_age)
+        eq_(NumericRange(None, None, '[]'), subject.target_age)
         eq_(None, subject.genre)
         eq_(None, subject.fiction)
         

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -827,7 +827,6 @@ class TestEdition(DatabaseTest):
         # Edition, not just the Identifier, because each
         # CoverageRecord's DataSource is set to this Edition's
         # DataSource.
-        set_trace()
         eq_(
             [edition.data_source, edition.data_source], 
             [x.data_source for x in records]

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -200,10 +200,11 @@ class TestOPDSImporter(DatabaseTest):
         assert mouse.work is not None
         eq_(Edition.PERIODICAL_MEDIUM, mouse.medium)
 
-        editions, popularity, quality, rating = sorted(
+        popularity, quality, rating = sorted(
             [x for x in mouse.primary_identifier.measurements
              if x.is_most_recent],
-            key=lambda x: x.quantity_measured)
+            key=lambda x: x.quantity_measured
+        )
 
         eq_(DataSource.OCLC_LINKED_DATA, editions.data_source.name)
         eq_(Measurement.PUBLISHED_EDITIONS, editions.quantity_measured)

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -206,10 +206,6 @@ class TestOPDSImporter(DatabaseTest):
             key=lambda x: x.quantity_measured
         )
 
-        eq_(DataSource.OCLC_LINKED_DATA, editions.data_source.name)
-        eq_(Measurement.PUBLISHED_EDITIONS, editions.quantity_measured)
-        eq_(1, editions.value)
-
         eq_(DataSource.METADATA_WRANGLER, popularity.data_source.name)
         eq_(Measurement.POPULARITY, popularity.quantity_measured)
         eq_(0.25, popularity.value)


### PR DESCRIPTION
This branch introduces PresentationCalculationPolicy, a class similar to the metadata layer's ReplacementPolicy, which lets you specify exactly which parts of a Work's (or Edition's) policy you would like to recalculate.

This branch also changes calculate_presentation() and all the methods it calls so that it keeps track of whether or not any of the presentation _actually changed_. Work.last_update_time and Edition.last_update_time now track the last time the presentation actually changed, not the last time we _tried_ to change something.

The follow-up to this branch will introduce coverage providers that keep track of when we last _tried_ to change something about a Work or Edition.

Don't merge this branch yet; I'm getting it reviewed because it's approaching the maximum reasonable size for a reviewable branch.

Other, smaller changes:
- Choosing a cover is now controlled by a separate policy from setting other types of metadata associated with the Edition such as sort_title and permanent_work_id.
- The output of Classifier.target_age is now always supposed to be a NumericRange object. I created Classifier.nr as a helper method to make this easier.
- I moved some code out of the presentation calculation method and implemented it more fully as Classifier.default_audience_for_target_age.
- I took out some code for adding a measurement of the total number of OCLC editions associated with a work. That code belongs in the metadata wrangler.
