### PR TITLE
Improve audience classification

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -205,7 +205,7 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
                     self._db, Identifier.AXIS_360_ID, identifier_string
                 )
                 result = CoverageFailure(
-                    self, identifier, "Book not in collection", transient=True
+                    self, identifier, "Book not in collection", transient=False
                 )
                 batch_results.append(result)
         return batch_results

--- a/classifier.py
+++ b/classifier.py
@@ -155,7 +155,7 @@ class Classifier(object):
         """
         if 'juvenile' in name:
             return cls.AUDIENCE_CHILDREN
-        elif 'young adult' in name or 'YA' in name.original:
+        elif 'young adult' in name or "YA" in name.original:
             return cls.AUDIENCE_YOUNG_ADULT
         return None
 
@@ -3199,7 +3199,7 @@ class WorkClassifier(object):
     nonfiction_publishers = set(["Wiley"])
     fiction_publishers = set([])
 
-    def __init__(self, work, test_session=None, debug=True):
+    def __init__(self, work, test_session=None, debug=False):
         self._db = Session.object_session(work)
         if test_session:
             self._db = test_session
@@ -3362,21 +3362,12 @@ class WorkClassifier(object):
         # contrary.
         audience = Classifier.AUDIENCE_ADULT
 
-        # There are two cases when a book will be classified as a
-        # young adult or childrens' book:
-        #
-        # 1. The weight of that audience is more than twice the
+        # A book will be classified as a young adult or childrens'
+        # book when the weight of that audience is more than twice the
         # combined weight of the 'adult' and 'adults only' audiences.
-        #
-        # 2. The weight of that audience is greater than 0, and
-        # the 'adult' and 'adults only' audiences have no weight
-        # whatsoever.
-        #
-        # Either way, we have a numeric threshold that must be met.
-        if total_adult_weight > 0:
-            threshold = total_adult_weight * 2
-        else:
-            threshold = 0
+        # If that combined weight is zero, then any amount of evidence
+        # is sufficient.
+        threshold = total_adult_weight * 2
 
         # If both the 'children' weight and the 'YA' weight pass the
         # threshold, we go with the one that weighs more.

--- a/classifier.py
+++ b/classifier.py
@@ -155,7 +155,7 @@ class Classifier(object):
         """
         if 'juvenile' in name:
             return cls.AUDIENCE_CHILDREN
-        elif 'young adult' in name or "YA" in name.original:
+        elif 'young adult' in name or 'YA' in name.original:
             return cls.AUDIENCE_YOUNG_ADULT
         return None
 
@@ -1153,6 +1153,18 @@ class BISACClassifier(ThreeMClassifier):
     def scrub_identifier(cls, identifier):
         identifier = identifier.replace(' / ', '/')
         return ThreeMClassifier.scrub_identifier(identifier)
+
+    @classmethod
+    def audience(cls, identifier, name):
+        if not identifier:
+            return Classifier.audience(identifier, name)
+        identifier = Lowercased(identifier)
+        if 'juvenile' in identifier:
+            return Classifier.AUDIENCE_CHILDREN
+        elif 'young adult' in identifier:
+            return Classifier.AUDIENCE_YOUNG_ADULT
+        else:
+            return Classifier.AUDIENCE_ADULT
 
 
 class OverdriveClassifier(Classifier):
@@ -3187,7 +3199,7 @@ class WorkClassifier(object):
     nonfiction_publishers = set(["Wiley"])
     fiction_publishers = set([])
 
-    def __init__(self, work, test_session=None, debug=False):
+    def __init__(self, work, test_session=None, debug=True):
         self._db = Session.object_session(work)
         if test_session:
             self._db = test_session
@@ -3356,7 +3368,7 @@ class WorkClassifier(object):
         # 1. The weight of that audience is more than twice the
         # combined weight of the 'adult' and 'adults only' audiences.
         #
-        # 2. The weight of that audience is greater than 10, and
+        # 2. The weight of that audience is greater than 0, and
         # the 'adult' and 'adults only' audiences have no weight
         # whatsoever.
         #
@@ -3364,7 +3376,7 @@ class WorkClassifier(object):
         if total_adult_weight > 0:
             threshold = total_adult_weight * 2
         else:
-            threshold = 10
+            threshold = 0
 
         # If both the 'children' weight and the 'YA' weight pass the
         # threshold, we go with the one that weighs more.

--- a/opds.py
+++ b/opds.py
@@ -140,11 +140,6 @@ class Annotator(object):
                 thumb = work.cover_thumbnail_url
                 old_thumb = thumb
                 thumbnails = [cdnify(thumb, cdn_host)]
-                if old_thumb != thumbnails[0]:
-                    logging.debug(
-                        "Thumbnail URL changed %s => %s",
-                        old_thumb, thumbnails[0]
-                    )
 
             if work.cover_full_url:
                 full = work.cover_full_url


### PR DESCRIPTION
In addition to minor debug-message changes, this branch makes some improvements to classification based on real-world experience.

1. If there is absolutely no evidence that a book is for adults, then any amount of information that it's for YA / children is enough to determine its audience classification. We had a problem where books were being classified as 'adult' because although the evidence clearly indicated YA or children, the evidence didn't rise to the arbitrary level we set in the code.

The goal of the old system was to err against marking books that are for adults as children's books, and we need to be careful that doesn't happen on other collections, but now that we have better classifications, better data, and easy ways to complain about misclassification, I don't think it's as much of an issue.

2. The BISAC classifier (used by Axis 360) was based on the 3M classifier. It should probably be the other way around, but that's for later. The problem here is that 3M uses BISAC in such a way that both children's and YA books are filed under "Juvenile Fiction". Axis 360 uses BISAC properly, filing children's books under "Juvenile" and YA books under "Young Adult". But since we were using the broken 3M logic, "Young Adult" books had no implied audience and "Juvenile" books had an implied audience of Young ADult.

So I implemented BISACClassifier.audience to classify BISAC classifications properly, assuming they're being used properly.