### PR TITLE
Work coverage record

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -205,7 +205,7 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
                     self._db, Identifier.AXIS_360_ID, identifier_string
                 )
                 result = CoverageFailure(
-                    self, identifier, "Book not in collection", transient=True
+                    self, identifier, "Book not in collection", transient=False
                 )
                 batch_results.append(result)
         return batch_results

--- a/classifier.py
+++ b/classifier.py
@@ -155,7 +155,7 @@ class Classifier(object):
         """
         if 'juvenile' in name:
             return cls.AUDIENCE_CHILDREN
-        elif 'young adult' in name or 'YA' in name.original:
+        elif 'young adult' in name or "YA" in name.original:
             return cls.AUDIENCE_YOUNG_ADULT
         return None
 
@@ -3199,7 +3199,7 @@ class WorkClassifier(object):
     nonfiction_publishers = set(["Wiley"])
     fiction_publishers = set([])
 
-    def __init__(self, work, test_session=None, debug=True):
+    def __init__(self, work, test_session=None, debug=False):
         self._db = Session.object_session(work)
         if test_session:
             self._db = test_session
@@ -3362,21 +3362,12 @@ class WorkClassifier(object):
         # contrary.
         audience = Classifier.AUDIENCE_ADULT
 
-        # There are two cases when a book will be classified as a
-        # young adult or childrens' book:
-        #
-        # 1. The weight of that audience is more than twice the
+        # A book will be classified as a young adult or childrens'
+        # book when the weight of that audience is more than twice the
         # combined weight of the 'adult' and 'adults only' audiences.
-        #
-        # 2. The weight of that audience is greater than 0, and
-        # the 'adult' and 'adults only' audiences have no weight
-        # whatsoever.
-        #
-        # Either way, we have a numeric threshold that must be met.
-        if total_adult_weight > 0:
-            threshold = total_adult_weight * 2
-        else:
-            threshold = 0
+        # If that combined weight is zero, then any amount of evidence
+        # is sufficient.
+        threshold = total_adult_weight * 2
 
         # If both the 'children' weight and the 'YA' weight pass the
         # threshold, we go with the one that weighs more.

--- a/classifier.py
+++ b/classifier.py
@@ -155,7 +155,7 @@ class Classifier(object):
         """
         if 'juvenile' in name:
             return cls.AUDIENCE_CHILDREN
-        elif 'young adult' in name or "YA" in name.original:
+        elif 'young adult' in name or 'YA' in name.original:
             return cls.AUDIENCE_YOUNG_ADULT
         return None
 
@@ -1153,6 +1153,18 @@ class BISACClassifier(ThreeMClassifier):
     def scrub_identifier(cls, identifier):
         identifier = identifier.replace(' / ', '/')
         return ThreeMClassifier.scrub_identifier(identifier)
+
+    @classmethod
+    def audience(cls, identifier, name):
+        if not identifier:
+            return Classifier.audience(identifier, name)
+        identifier = Lowercased(identifier)
+        if 'juvenile' in identifier:
+            return Classifier.AUDIENCE_CHILDREN
+        elif 'young adult' in identifier:
+            return Classifier.AUDIENCE_YOUNG_ADULT
+        else:
+            return Classifier.AUDIENCE_ADULT
 
 
 class OverdriveClassifier(Classifier):
@@ -3187,7 +3199,7 @@ class WorkClassifier(object):
     nonfiction_publishers = set(["Wiley"])
     fiction_publishers = set([])
 
-    def __init__(self, work, test_session=None, debug=False):
+    def __init__(self, work, test_session=None, debug=True):
         self._db = Session.object_session(work)
         if test_session:
             self._db = test_session
@@ -3356,7 +3368,7 @@ class WorkClassifier(object):
         # 1. The weight of that audience is more than twice the
         # combined weight of the 'adult' and 'adults only' audiences.
         #
-        # 2. The weight of that audience is greater than 10, and
+        # 2. The weight of that audience is greater than 0, and
         # the 'adult' and 'adults only' audiences have no weight
         # whatsoever.
         #
@@ -3364,7 +3376,7 @@ class WorkClassifier(object):
         if total_adult_weight > 0:
             threshold = total_adult_weight * 2
         else:
-            threshold = 10
+            threshold = 0
 
         # If both the 'children' weight and the 'YA' weight pass the
         # threshold, we go with the one that weighs more.

--- a/model.py
+++ b/model.py
@@ -2816,9 +2816,11 @@ class Edition(Base):
                 changed_status = "unchanged"
                 level = logging.debug
 
-            msg = "Presentation %s for Edition %s (by %s, pub=%s, ident=%r, pwid=%s, language=%s, cover=%r)"
+            msg = u"Presentation %s for Edition %s (by %s, pub=%s, ident=%s/%s, pwid=%s, language=%s, cover=%r)"
             args = [changed_status, self.title, self.author, self.publisher, 
-                    self.primary_identifier, self.permanent_work_id, self.language]
+                    self.primary_identifier.type, self.primary_identifier.identifier,
+                    self.permanent_work_id, self.language
+            ]
             if self.cover and self.cover.representation:
                 args.append(self.cover.representation.mirror_url)
             else:

--- a/opds.py
+++ b/opds.py
@@ -140,11 +140,6 @@ class Annotator(object):
                 thumb = work.cover_thumbnail_url
                 old_thumb = thumb
                 thumbnails = [cdnify(thumb, cdn_host)]
-                if old_thumb != thumbnails[0]:
-                    logging.debug(
-                        "Thumbnail URL changed %s => %s",
-                        old_thumb, thumbnails[0]
-                    )
 
             if work.cover_full_url:
                 full = work.cover_full_url


### PR DESCRIPTION
This branch introduces WorkCoverageRecord, which is like CoverageRecord for works. 

I also change CoverageRecord.date (a Date) to a DateTime called CoverageRecord.timestamp, because it's sometimes important to keep track of exactly when, within a single day, a coverage record was updated.

And I add 'operation' to CoverageRecord, because we're at a point where sometimes there are two types of coverage we might want to give an Identifier, both of which come from the same data source.
