### PR TITLE
Tell metadata layer to mirror and scale resources

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1107,7 +1107,7 @@ class Metadata(object):
 
         # The thumbnail and image are different. Make sure there's a
         # separate link to the thumbnail.
-        thumbnail_obj, ignore = identifier.add_link(
+        thumbnail_obj, ignore = link_obj.identifier.add_link(
             rel=thumbnail.rel, href=thumbnail.href, 
             data_source=data_source, 
             license_pool=pool, media_type=thumbnail.media_type,

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -960,6 +960,10 @@ class Metadata(object):
                 license_pool=pool, media_type=link.media_type,
                 content=link.content
             )
+            # TODO: We do not properly handle the (unlikely) case
+            # where there is an IMAGE_THUMBNAIL link but no IMAGE
+            # link. In such a case we should treat the IMAGE_THUMBNAIL
+            # link as though it were an IMAGE link.
             if replace.mirror:
                 # We need to mirror this resource. If it's an image, a
                 # thumbnail may be provided as a side effect.
@@ -1048,8 +1052,7 @@ class Metadata(object):
         mirror that too.
         """
         if link_obj.rel not in (
-                Hyperlink.IMAGE, Hyperlink.THUMBNAIL_IMAGE,
-                Hyperlink.OPEN_ACCESS_DOWNLOAD
+                Hyperlink.IMAGE, Hyperlink.OPEN_ACCESS_DOWNLOAD
         ):
             return
         mirror = policy.mirror

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -50,7 +50,8 @@ class ReplacementPolicy(object):
             links=False,
             formats=False,
             rights=False,
-            even_if_not_apparently_updated=False
+            mirror=None,
+            even_if_not_apparently_updated=False,
     ):
         self.identifiers = identifiers
         self.subjects = subjects
@@ -59,9 +60,10 @@ class ReplacementPolicy(object):
         self.rights = rights
         self.formats = formats
         self.even_if_not_apparently_updated = even_if_not_apparently_updated
-        
+        self.mirror = mirror
+
     @classmethod
-    def from_license_source(self, even_if_not_apparently_updated=False):
+    def from_license_source(self, mirror=None, even_if_not_apparently_updated=False):
         """When gathering data from the license source, overwrite all old data
         from this source with new data from the same source. Also
         overwrite an old rights status with an updated status and update
@@ -74,11 +76,12 @@ class ReplacementPolicy(object):
             links=True, 
             rights=True,
             formats=True,
+            mirror=mirror,
             even_if_not_apparently_updated=even_if_not_apparently_updated
         )
 
     @classmethod
-    def from_metadata_source(self, even_if_not_apparently_updated=False):
+    def from_metadata_source(self, mirror=None, even_if_not_apparently_updated=False):
         """When gathering data from a metadata source, overwrite all old data
         from this source, but do not overwrite the rights status or
         the available formats. License sources are the authority on rights
@@ -91,6 +94,7 @@ class ReplacementPolicy(object):
             links=True, 
             rights=False,
             formats=False,
+            mirror=mirror,
             even_if_not_apparently_updated=even_if_not_apparently_updated
         )
 
@@ -807,7 +811,6 @@ class Metadata(object):
             replace_formats=False,
             replace_rights=False,
             force=False,
-            mirror=None,
     ):
         """Apply this metadata to the given edition.
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1078,7 +1078,7 @@ class Metadata(object):
         # representation.
         if link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
             if pool and pool.edition and pool.edition.title:
-                title = edition.title
+                title = pool.edition.title
             else:
                 title = None
             extension = representation.extension()

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -804,6 +804,9 @@ class Metadata(object):
                 success = True
         return success
 
+    # TODO: We need to change all calls to apply() to use a ReplacementPolicy
+    # instead of passing in individual `replace` arguments. Once that's done,
+    # we can get rid of the `replace` arguments.
     def apply(self, edition, metadata_client=None, replace=None,
             replace_identifiers=False,
             replace_subjects=False, 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -18,7 +18,6 @@ from sqlalchemy.orm.exc import (
 import csv
 import datetime
 import logging
-import urlparse
 from util import LanguageCodes
 from model import (
     get_one,

--- a/model.py
+++ b/model.py
@@ -5919,12 +5919,12 @@ class Representation(Base):
         # Do we already have a usable representation?
         #
         # 'Usable' means we tried it and either got some data or
-        # received a status code outside the 2xx series.
+        # received a status code that's not in the 5xx series.
         usable_representation = (
             representation and not representation.fetch_exception
             and (
                 representation.content or representation.local_path
-                or representation.status_code and representation.status_code / 100 != 2
+                or representation.status_code and representation.status_code / 100 != 5
             )
         )
 

--- a/model.py
+++ b/model.py
@@ -4226,14 +4226,18 @@ class Hyperlink(Base):
             l.append(m.hexdigest())
         return ":".join(l)
 
+    @classmethod
+    def _default_filename(self, rel):
+        if rel == self.OPEN_ACCESS_DOWNLOAD:
+            return 'content'
+        elif rel == self.IMAGE:
+            return 'cover'
+        elif rel == self.THUMBNAIL_IMAGE:
+            return 'cover-thumbnail'
+
     @property
     def default_filename(self):
-        if self.rel == self.OPEN_ACCESS_DOWNLOAD:
-            return 'content'
-        elif self.rel == self.IMAGE:
-            return 'cover'
-        elif self.rel == self.THUMBNAIL_IMAGE:
-            return 'cover-thumbnail'
+        return self._default_filename(self.rel)
 
 class Resource(Base):
     """An external resource that may be mirrored locally."""

--- a/model.py
+++ b/model.py
@@ -4228,11 +4228,11 @@ class Hyperlink(Base):
 
     @property
     def default_filename(self):
-        if self.rel == self.OPEN_ACCESS_CONTENT:
+        if self.rel == self.OPEN_ACCESS_DOWNLOAD:
             return 'content'
         elif self.rel == self.IMAGE:
             return 'cover'
-        elif self.rel == self.THUMBNAIL:
+        elif self.rel == self.THUMBNAIL_IMAGE:
             return 'cover-thumbnail'
 
 class Resource(Base):

--- a/model.py
+++ b/model.py
@@ -6147,6 +6147,8 @@ class Representation(Base):
 
     @classmethod
     def _clean_media_type(cls, media_type):
+        if not media_type:
+            return media_type
         if ';' in media_type:
             media_type = media_type[:media_type.index(';')].strip()
         return media_type
@@ -6169,10 +6171,15 @@ class Representation(Base):
 
         if not filename and link:
             filename = link.default_filename
+        if not filename:
+            # This is the absolute last-ditch filename solution, and
+            # it's basically only used when we try to mirror the root
+            # URL of a domain.
+            filename = 'resource'
 
         default_extension = self.extension()
         extension = self.extension(destination_type)
-        if default_extension != extension and filename.endswith(default_extension):
+        if default_extension and default_extension != extension and filename.endswith(default_extension):
             filename = filename[:-len(default_extension)] + extension
         elif extension and not filename.endswith(extension):
             filename += extension

--- a/opds_import.py
+++ b/opds_import.py
@@ -177,10 +177,10 @@ class OPDSImporter(object):
                 links=True,
                 contributions=True,
                 even_if_not_apparently_updated=True,
+                mirror=self.mirror
             )
             metadata.apply(
-                edition, self.metadata_client, mirror=self.mirror,
-                policy=policy
+                edition, self.metadata_client, policy=policy
             )
 
             if license_pool is None:

--- a/opds_import.py
+++ b/opds_import.py
@@ -129,18 +129,22 @@ class OPDSImporter(object):
     communicates with a content server. It ignores author and subject
     information, under the assumption that it will get better author
     and subject information from the metadata wrangler.
+
+    :param mirror: Use this MirrorUploader object to mirror all
+    incoming open-access books and cover images.
     """
     COULD_NOT_CREATE_LICENSE_POOL = (
         "No existing license pool for this identifier and no way of creating one.")
    
     def __init__(self, _db, data_source_name=DataSource.METADATA_WRANGLER,
-                 identifier_mapping=None, force=True):
+                 identifier_mapping=None, mirror=None, force=True):
         self._db = _db
         self.force = True
         self.log = logging.getLogger("OPDS Importer")
         self.data_source_name = data_source_name
         self.identifier_mapping = identifier_mapping
         self.metadata_client = SimplifiedOPDSLookup.from_config()
+        self.mirror = mirror
 
     def import_from_feed(self, feed, even_if_no_author=False, 
                          cutoff_date=None, 
@@ -167,7 +171,7 @@ class OPDSImporter(object):
                 # before that date. There's no reason to do anything.
                 continue
 
-            metadata.apply(edition, self.metadata_client)
+            metadata.apply(edition, self.metadata_client, mirror=self.mirror)
             if license_pool is None:
                 # Without a LicensePool, we can't create a Work.
                 self.log.warn(

--- a/opds_import.py
+++ b/opds_import.py
@@ -180,7 +180,7 @@ class OPDSImporter(object):
                 mirror=self.mirror
             )
             metadata.apply(
-                edition, self.metadata_client, policy=policy
+                edition, self.metadata_client, replace=policy
             )
 
             if license_pool is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ elasticsearch
 python-dateutil
 uwsgi
 loggly-python-handler
+cairosvg

--- a/s3.py
+++ b/s3.py
@@ -201,5 +201,7 @@ class DummyS3Uploader(S3Uploader):
 
     def mirror_batch(self, representations):
         self.uploaded.extend(representations)
-        for r in representations:
-            r.set_as_mirrored()
+        for representation in representations:
+            if not representation.mirror_url:
+                representation.mirror_url = representation.url
+            representation.set_as_mirrored()

--- a/s3.py
+++ b/s3.py
@@ -79,10 +79,12 @@ class S3Uploader(MirrorUploader):
         return cls.url(bucket, '/')
 
     @classmethod
-    def book_url(cls, identifier, extension='epub', open_access=True, 
+    def book_url(cls, identifier, extension='.epub', open_access=True, 
                  data_source=None, title=None):
         """The path to the hosted EPUB file for the given identifier."""
         root = cls.content_root(open_access)
+        if not extension.startswith('.'):
+            extension = '.' + extension
         if title:
             filename = "%s/%s" % (identifier.identifier, title)
         else:
@@ -91,9 +93,9 @@ class S3Uploader(MirrorUploader):
         args = [urllib.quote(x.encode('utf-8')) for x in args]
         if data_source:
             args.insert(0, urllib.quote(data_source.name))
-            template = "%s/%s/%s.%s"
+            template = "%s/%s/%s%s"
         else:
-            template = "%s/%s.%s"
+            template = "%s/%s%s"
         return root + template % tuple(args + [extension])
 
     @classmethod

--- a/testing.py
+++ b/testing.py
@@ -382,6 +382,7 @@ class DummyHTTPClient(object):
 
     def __init__(self):
         self.responses = []
+        self.requests = []
 
     def queue_response(self, response_code, media_type="text/html",
                        other_headers=None, content=''):
@@ -392,6 +393,7 @@ class DummyHTTPClient(object):
         self.responses.append((response_code, headers, content))
 
     def do_get(self, url, headers, **kwargs):
+        self.requests.append(url)
         return self.responses.pop()
 
 import os

--- a/tests/files/opds/content_server_mini.opds
+++ b/tests/files/opds/content_server_mini.opds
@@ -21,7 +21,7 @@
     <schema:Rating schema:ratingValue="0.6000"/>
     <schema:Rating schema:ratingValue="0.2500" schema:additionalType="http://librarysimplified.org/terms/rel/popularity"/>
     <link href="https://s3.amazonaws.com/book-covers.nypl.org/Gutenberg-Illustrated/10441/cover_10441_9.png" rel="http://opds-spec.org/image"/>
-    <link href="https://s3.amazonaws.com/book-covers.nypl.org/Gutenberg-Illustrated/10441/cover_10441_9.png" rel="http://opds-spec.org/image/thumbnail"/>
+    <link href="https://s3.amazonaws.com/book-covers.nypl.org/Gutenberg-Illustrated/10441/cover_10441_9.thumb.png" rel="http://opds-spec.org/image/thumbnail"/>
     <category term="sh2008100298" label="Courtship -- Fiction" scheme="http://purl.org/dc/terms/LCSH"/>
     <category term="sh2008108377" label="New York (N.Y.) -- Fiction" scheme="http://purl.org/dc/terms/LCSH"/>
     <category term="sh85047114" label="Fantasy fiction" scheme="http://purl.org/dc/terms/LCSH"/>

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -180,7 +180,7 @@ class TestMetadataImporter(DatabaseTest):
 
         # The thumbnail image has been converted to PNG.
         assert thumbnail.mirror_url.startswith('http://s3.amazonaws.com/test.cover.bucket/scaled/300/')
-        assert image.mirror_url.endswith('cover.png')
+        assert thumbnail.mirror_url.endswith('cover.png')
 
     def test_open_access_content_mirrored(self):
         mirror = DummyS3Uploader()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -217,7 +217,6 @@ class TestMetadataImporter(DatabaseTest):
         )
 
         # It's been 'mirrored' to the appropriate S3 bucket.
-        set_trace()
         assert book.mirror_url.startswith('http://s3.amazonaws.com/test.content.bucket/')
         expect = '/%s/%s.epub' % (
             edition.primary_identifier.identifier,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1698,6 +1698,22 @@ class TestRepresentation(DatabaseTest):
         eq_(".jpg", m("image/jpeg"))
         eq_("", m("no/such-media-type"))
 
+    def test_as_image_converts_svg_to_png(self):
+        svg = """<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
+    <ellipse cx="50" cy="25" rx="50" ry="25" style="fill:blue;"/>
+</svg>"""
+        edition = self._edition()
+        pool = self._licensepool(edition)
+        source = DataSource.lookup(self._db, DataSource.OVERDRIVE)
+        hyperlink, ignore = pool.add_link(
+            Hyperlink.IMAGE, None, source, Representation.SVG_MEDIA_TYPE,
+            content=svg)
+        image = hyperlink.resource.representation.as_image()
+        eq_("PNG", image.format)
+
 class TestScaleRepresentation(DatabaseTest):
 
     def test_set_cover(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1859,6 +1859,18 @@ class TestRepresentation(DatabaseTest):
         image = hyperlink.resource.representation.as_image()
         eq_("PNG", image.format)
 
+        # Even though the SVG image is smaller than the thumbnail
+        # size, thumbnailing it will create a separate PNG-format
+        # Representation, because we want all the thumbnails to be
+        # bitmaps.
+        thumbnail, is_new = hyperlink.resource.representation.scale(
+            Edition.MAX_THUMBNAIL_HEIGHT, Edition.MAX_THUMBNAIL_WIDTH,
+            self._url, Representation.PNG_MEDIA_TYPE
+        )
+        eq_(True, is_new)
+        assert thumbnail != hyperlink.resource.representation
+        eq_(Representation.PNG_MEDIA_TYPE, thumbnail.media_type)
+
 class TestScaleRepresentation(DatabaseTest):
 
     def test_set_cover(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1786,6 +1786,19 @@ class TestRepresentation(DatabaseTest):
         eq_(True, cached)
         eq_(representation, representation2)
 
+    def test_500_creates_uncachable_representation(self):
+        h = DummyHTTPClient()
+        h.queue_response(500)
+        url = self._url
+        representation, cached = Representation.get(
+            self._db, url, do_get=h.do_get)
+        eq_(False, cached)
+
+        h.queue_response(500)
+        representation, cached = Representation.get(
+            self._db, url, do_get=h.do_get)
+        eq_(False, cached)
+
     def test_clean_media_type(self):
         m = Representation._clean_media_type
         eq_("image/jpeg", m("image/jpeg"))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1724,7 +1724,12 @@ class TestHyperlink(DatabaseTest):
             identifier.add_link,
             Hyperlink.DESCRIPTION, "http://foo.com/", data_source, 
             pool, "text/plain", "The content")
-        
+
+    def test_default_filename(self):
+        m = Hyperlink._default_filename
+        eq_("content", m(Hyperlink.OPEN_ACCESS_DOWNLOAD))
+        eq_("cover", m(Hyperlink.IMAGE))
+        eq_("cover-thumbnail", m(Hyperlink.THUMBNAIL_IMAGE))
 
 class TestRepresentation(DatabaseTest):
 
@@ -1756,6 +1761,20 @@ class TestRepresentation(DatabaseTest):
     def test_404_creates_cachable_representation(self):
         h = DummyHTTPClient()
         h.queue_response(404)
+
+        url = self._url
+        representation, cached = Representation.get(
+            self._db, url, do_get=h.do_get)
+        eq_(False, cached)
+
+        representation2, cached = Representation.get(
+            self._db, url, do_get=h.do_get)
+        eq_(True, cached)
+        eq_(representation, representation2)
+
+    def test_302_creates_cachable_representation(self):
+        h = DummyHTTPClient()
+        h.queue_response(302)
 
         url = self._url
         representation, cached = Representation.get(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1686,6 +1686,18 @@ class TestRepresentation(DatabaseTest):
         eq_(True, cached)
         eq_(representation, representation2)
 
+    def test_clean_media_type(self):
+        m = Representation._clean_media_type
+        eq_("image/jpeg", m("image/jpeg"))
+        eq_("application/atom+xml",
+            m("application/atom+xml;profile=opds-catalog;kind=acquisition")
+        )
+
+    def test_extension(self):
+        m = Representation._extension
+        eq_(".jpg", m("image/jpeg"))
+        eq_("", m("no/such-media-type"))
+
 class TestScaleRepresentation(DatabaseTest):
 
     def test_set_cover(self):

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -16,6 +16,7 @@ from . import (
 
 from opds_import import (
     OPDSImporter,
+    OPDSImporterWithS3Mirror,
     StatusMessage,
 )
 from metadata_layer import (
@@ -33,6 +34,9 @@ from model import (
     RightsStatus,
     Subject,
 )
+
+from s3 import DummyS3Uploader
+from testing import DummyHTTPClient
 
 class TestStatusMessage(object):
 
@@ -55,16 +59,18 @@ class TestStatusMessage(object):
         eq_(False, message.transient)
 
 
-class TestOPDSImporter(DatabaseTest):
+class OPDSImporterTest(DatabaseTest):
 
     def setup(self):
-        super(TestOPDSImporter, self).setup()
+        super(OPDSImporterTest, self).setup()
         base_path = os.path.split(__file__)[0]
         self.resource_path = os.path.join(base_path, "files", "opds")
         self.content_server_feed = open(
             os.path.join(self.resource_path, "content_server.opds")).read()
         self.content_server_mini_feed = open(
             os.path.join(self.resource_path, "content_server_mini.opds")).read()
+
+class TestOPDSImporter(OPDSImporterTest):
 
     def test_extract_metadata(self):
 
@@ -428,3 +434,69 @@ class TestOPDSImporter(DatabaseTest):
              Hyperlink.IMAGE], [x.rel for x in links])
         eq_(t1, i1.thumbnail)
         eq_(None, i2.thumbnail)
+
+class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
+
+    def test_resources_are_mirrored_on_import(self):
+
+        svg = """<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
+    <ellipse cx="50" cy="25" rx="50" ry="25" style="fill:blue;"/>
+</svg>"""
+
+        http = DummyHTTPClient()
+        http.queue_response(
+            200, content='I am 10557.epub.images',
+            media_type=Representation.EPUB_MEDIA_TYPE,
+        )
+        http.queue_response(
+            200, content=svg, media_type=Representation.SVG_MEDIA_TYPE
+        )
+        http.queue_response(
+            200, content='I am 10441.epub.images',
+            media_type=Representation.EPUB_MEDIA_TYPE
+        )
+
+        s3 = DummyS3Uploader()
+
+        importer = OPDSImporter(
+            self._db, data_source_name=DataSource.OA_CONTENT_SERVER,
+            mirror=s3, http_get=http.do_get
+        )
+        [e1, e2], messages, next_link = importer.import_from_feed(self.content_server_mini_feed)
+
+        # The import process requested each remote resource in the
+        # order they appeared in the OPDS feed.
+        eq_(http.requests, [
+            'http://www.gutenberg.org/ebooks/10557.epub.images',
+            'https://s3.amazonaws.com/book-covers.nypl.org/Gutenberg-Illustrated/10441/cover_10441_9.png', 
+            'http://www.gutenberg.org/ebooks/10441.epub.images',
+        ])
+
+        [e1_oa_link] = e1.primary_identifier.links
+        [e2_oa_link, e2_image_link, e2_description_link] = sorted(
+            e2.primary_identifier.links, key=lambda x: x.rel
+        )
+
+        # The two open-access links were mirrored to S3, as was the
+        # original SVG image and its PNG thumbnail.
+        eq_(
+            [e1_oa_link.resource.representation,
+             e2_image_link.resource.representation,
+             e2_image_link.resource.representation.thumbnails[0],
+             e2_oa_link.resource.representation,
+         ],
+            s3.uploaded
+        )
+
+        # Each resource was 'mirrored' to an Amazon S3 bucket.
+        eq_(
+            ['http://s3.amazonaws.com/test.content.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10557.epub',
+             'http://s3.amazonaws.com/test.cover.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441/cover_10441_9.png.svg', 
+             'http://s3.amazonaws.com/test.cover.bucket/scaled/300/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441/cover_10441_9.png', 
+             'http://s3.amazonaws.com/test.content.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441.epub'
+         ],
+            [x.mirror_url for x in s3.uploaded]
+        )

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -468,7 +468,9 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
         [e1, e2], messages, next_link = importer.import_from_feed(self.content_server_mini_feed)
 
         # The import process requested each remote resource in the
-        # order they appeared in the OPDS feed.
+        # order they appeared in the OPDS feed. The thumbnail
+        # image was not requested, since we were going to make our own
+        # thumbnail anyway.
         eq_(http.requests, [
             'http://www.gutenberg.org/ebooks/10557.epub.images',
             'https://s3.amazonaws.com/book-covers.nypl.org/Gutenberg-Illustrated/10441/cover_10441_9.png', 


### PR DESCRIPTION
This branch makes the metadata layer capable of automatically downloading the resources mentioned in LinkData objects and mirroring them to an S3 bucket. Cover images are automatically thumbnailed, and the thumbnails are also mirrored.

Previously, downloading these resources and mirroring them was the responsibility of the code that called Metadata.apply(). This led to duplicate code, since this process--download, scale, mirror--always works the same way. Now all you have to do is pass your S3Uploader (or other mirror) object into your ReplacementPolicy constructor.

There are two smaller changes I made in the interests of having something that works in general:

1. The code for determining the filename to use when mirroring a resource has been made much more robust. It will give the best filename possible, depending on the original URL of the resource, the media type of the resource, or the link relation between the main Metadata object and the resource. If the resource is an open-access book, the filename is the title of the book (assuming we know that).

2. The code now uses CairoSVG to scale SVG cover images and convert them to PNG thumbnails. "But SVGs auto-scale!" you say. This is true, but SVGs can get really huge, and we find it useful to use tiny PNG thumbnails instead.