### PR TITLE
Fix age range search

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -263,8 +263,8 @@ class ExternalSearchIndex(object):
                 audience = [_f(aud) for aud in audience]
                 clauses.append(dict(terms=dict(audience=audience)))
         if age_range:
-            lower = age_range.lower
-            upper = age_range.upper
+            lower = age_range[0]
+            upper = age_range[-1]
 
             age_clause = {
                 "and": [


### PR DESCRIPTION
This branch fixes bug #138 and adds a test to detect a future reversion, which makes sure that Lane data is properly converted into a search filter. The test isn't great--it would be better if there were a method you could pass the Lane into and get back the search filter--but I think it's good enough for now.
