### PR TITLE
Reduce our dependence on foreign medians

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -19,6 +19,7 @@ import csv
 import datetime
 import logging
 from util import LanguageCodes
+from util.median import median
 from model import (
     get_one,
     get_one_or_create,
@@ -749,11 +750,10 @@ class Metadata(object):
         for i in self.identifiers:
             by_weight[(i.type, i.identifier)].append(i.weight)
         new_identifiers = []
-        import numpy
         for (type, identifier), weights in by_weight.items():
             new_identifiers.append(
                 IdentifierData(type=type, identifier=identifier,
-                               weight=numpy.median(weights))
+                               weight=median(weights))
             )
         self.identifiers = new_identifiers
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -15,6 +15,7 @@ from util import (
     TitleProcessor,
 )
 from util.opds_authentication_document import OPDSAuthenticationDocument
+from util.median import median
 
 class TestLanguageCodes(object):
 
@@ -456,3 +457,16 @@ class TestOPDSAuthenticationDocument(object):
             "A title", "An ID", links=links)
 
         eq_(doc['links'], {'complex-link': {'href': 'http://baz', 'type': 'text/html'}, 'double-link': [{'href': 'http://bar1'}, {'href': 'http://bar2'}], 'single-link': {'href': 'http://foo'}, 'complex-links': [{'href': 'http://comp1', 'type': 'text/html'}, {'href': 'http://comp2', 'type': 'text/plain'}]})
+
+class TestMedian(object):
+
+    def test_median(self):
+        test_set = [228.56, 205.50, 202.64, 190.15, 188.86, 187.97, 182.49,
+                    181.44, 172.46, 171.91]
+        eq_(188.41500000000002, median(test_set))
+
+        test_set = [90, 94, 53, 68, 79, 84, 87, 72, 70, 69, 65, 89, 85, 83]
+        eq_(81.0, median(test_set))
+
+        test_set = [8, 82, 781233, 857, 290, 7, 8467]
+        eq_(290, median(test_set))

--- a/util/median.py
+++ b/util/median.py
@@ -1,0 +1,9 @@
+def median(numbers):
+    numbers = sorted(numbers)
+    length = len(numbers)
+    if length % 2 == 0:
+        high_middle = numbers[length/2]
+        low_middle = numbers[length/2 - 1]
+        return (high_middle + low_middle) / 2.0
+    else:
+        return numbers[length/2]


### PR DESCRIPTION
Numpy is a huge library that takes a really long time to load, lengthening test and deploy times everywhere. And we only use it in one place in our code base. Well, **no more**! Here's a median of our own design, with our *own* best interests in mind.

The expected values in the test were created by running the same sets of data in numpy's median function.