### PR TITLE
Store Unicode in Work.summary_text

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -113,7 +113,7 @@ class CoverageProvider(object):
         batch = self.items_that_need_coverage.limit(
             self.workset_size).offset(offset)
 
-        if not batch:
+        if not batch.count():
             # The batch is empty. We're done.
             return None
 

--- a/model.py
+++ b/model.py
@@ -3228,7 +3228,7 @@ class Work(Base):
         self.summary = resource
         # TODO: clean up the content
         if resource:
-            self.summary_text = resource.representation.content
+            self.summary_text = resource.representation.unicode_content
         WorkCoverageRecord.add_for(
             self, operation=WorkCoverageRecord.SUMMARY_OPERATION
         )
@@ -6077,6 +6077,20 @@ class Representation(Base):
             if content_path.startswith('/'):
                 content_path = content_path[1:]
         return content_path
+
+    @property
+    def unicode_content(self):
+        """Attempt to convert the content into Unicode.
+        
+        If all attempts fail, we will return None rather than raise an exception.
+        """
+        content = None
+        for encoding in ('utf-8', 'windows-1252'):
+            try:
+                content = self.content.decode(encoding)
+            except UnicodeDecodeError, e:
+                pass
+        return content
 
     def set_fetched_content(self, content, content_path=None):
         """Simulate a successful HTTP request for this representation.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import datetime
 import os
 import sys
@@ -1757,6 +1758,32 @@ class TestRepresentation(DatabaseTest):
         representation.set_fetched_content(None, filename)
         fh = representation.content_fh()
         eq_("some text", fh.read())
+
+    def test_unicode_content_utf8_default(self):
+        unicode_content = u"A “love” story"
+        utf8_content = unicode_content.encode("utf8")
+
+        representation, ignore = self._representation(self._url, "text/plain")
+        representation.set_fetched_content(unicode_content, None)
+        eq_(utf8_content, representation.content)
+        eq_(unicode_content, representation.unicode_content)
+
+    def test_unicode_content_windows_1252(self):
+        unicode_content = u"A “love” story"
+        windows_1252_content = unicode_content.encode("windows-1252")
+
+        representation, ignore = self._representation(self._url, "text/plain")
+        representation.set_fetched_content(windows_1252_content)
+        eq_(windows_1252_content, representation.content)
+        eq_(unicode_content, representation.unicode_content)
+
+    def test_unicode_content_is_none_when_decoding_is_impossible(self):
+        byte_content = b"\x81\x02\x03"
+        representation, ignore = self._representation(self._url, "text/plain")
+        representation.set_fetched_content(byte_content)
+        eq_(byte_content, representation.content)
+        eq_(None, representation.unicode_content)
+
 
     def test_404_creates_cachable_representation(self):
         h = DummyHTTPClient()


### PR DESCRIPTION
This branch fixes a bug where Work.summary_text, despite being a Unicode field, was being filled with binary data from Representation.content. This caused a crash when we tried to index the binary data in Elasticsearch.

This branch ensures that Work.summary_text is set to a Unicode value. If we can't figure out a Unicode value from Representation.content, we would have no value at all then a value that can't be indexed.