### PR TITLE
Some CoverageProviders can autocreate missing LicensePools

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -60,7 +60,7 @@ class Script(object):
         return Configuration.data_directory()
 
     @classmethod
-    def parse_identifier_list(cls, _db, arguments):
+    def parse_identifier_list(cls, _db, arguments, autocreate=False):
         """Turn a list of arguments into a list of identifiers.
 
         This makes it easy to identify specific identifiers on the
@@ -79,7 +79,7 @@ class Script(object):
         identifiers = []
         for arg in arguments[1:]:
             identifier, ignore = Identifier.for_foreign_id(
-                _db, identifier_type, arg, autocreate=False
+                _db, identifier_type, arg, autocreate=autocreate
             )
             if not identifier:
                 logging.warn(
@@ -90,11 +90,11 @@ class Script(object):
         return identifiers
 
     @classmethod
-    def parse_identifier_list_or_data_source(cls, _db, arguments):
+    def parse_identifier_list_or_data_source(cls, _db, arguments, autocreate=False):
         """Try to parse `arguments` as a list of identifiers.
         If that fails, try to interpret it as a data source.
         """
-        identifiers = cls.parse_identifier_list(_db, arguments)
+        identifiers = cls.parse_identifier_list(_db, arguments, autocreate)
         if identifiers:
             return identifiers
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -10,6 +10,7 @@ from model import (
     get_one,
     CustomList,
     DataSource,
+    Identifier,
 )
 from scripts import (
     Script,
@@ -26,6 +27,13 @@ class TestScript(DatabaseTest):
         identifiers = Script.parse_identifier_list(self._db, args)
         eq_([i1, i2], identifiers)
         eq_([], Script.parse_identifier_list(self._db, []))
+
+    def test_parse_list_as_identifiers_with_autocreate(self):
+
+        args = [Identifier.OVERDRIVE_ID, 'brand-new-identifier']
+        [i] = Script.parse_identifier_list(self._db, args, autocreate=True)
+        eq_(Identifier.OVERDRIVE_ID, i.type)
+        eq_('brand-new-identifier', i.identifier)
 
     def test_parse_list_as_identifiers_or_data_source(self):
 


### PR DESCRIPTION
Currently if a CoverageProvider tries to figure out the Edition for an Identifier it's processing, and there is no LicensePool for that Identifier, the CoverageProvider automatically fails, because we can't get from Identifier to Edition unless we also have a DataSource, which we currently get through LicensePool.

This isn't a problem on circulation managers, where we create a LicensePool as soon as we find out about the book. But it's a problem on the metadata wrangler, where we find out about books through UnresolvedIdentifier objects. LicensePools are only necessary on metadata because the data model currently requires them, but making sure they exist is a lot simpler than making the data model not require them.

This branch changes certain CoverageProviders -- in particular, the BibliographicCoverageProviders that ask Overdrive and 3M about books -- so that they can autocreate missing LicensePools for the Identifiers they process. This makes the identifier resolution process work on the metadata wrangler, so long as the BibliographicCoverageProvider is the first one to run. Since only the BibliographicCoverageProviders have this power, there's no risk that we'll create LicensePools for an Identifier with a DataSource that doesn't actually offer licenses.

This branch also changes `Script.parse_identifier_list` so that certain scripts can autocreate _identifiers_ that are mentioned on the command line but not already in the database. For most scripts, an unrecognized identifier on the command line is probably a typo. But I sometimes use a script like metadata/bin/identifiers_resolve to stick a new identifier into the system, so that script needs to autocreate identifiers if they don't exist.