### PR TITLE
Fix a bug that occured when a work had measurements of rating and qua…

### DIFF
--- a/model.py
+++ b/model.py
@@ -4084,12 +4084,15 @@ class Measurement(Base):
             # Our idea of the quality depends entirely on the work's quality scores.
             return quality
 
-        # We have both popularity and rating.
+        # We have at least two of the three... but which two?
         if popularity is None:
+            # We have rating and quality but not popularity.
             final = rating
-        if rating is None:
+        elif rating is None:
+            # We have quality and popularity but not rating.
             final = popularity
         else:
+            # We have popularity and rating but not quality.
             final = (popularity * popularity_weight) + (rating * rating_weight)
             logging.debug(
                 "(%.2f * %.2f) + (%.2f * %.2f) = %.2f", 


### PR DESCRIPTION
…lity but not popularity.

The bug was pretty simple: an 'if' instead of an 'elif'. If `popularity` is None but `rating` and `quality` are not, we ended up trying to calculate `(popularity * popularity_weight) + (rating * rating_weight)`, and multiplying None by a number gave a TypeError.

I added a test for this case and a few related cases because I thought the coverage here was a little light.