### PR TITLE
Improved use of metadata policy

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -177,11 +177,12 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
     not normally necessary because the Axis 360 API combines
     bibliographic and availability data.
     """
-    def __init__(self, _db):
+    def __init__(self, _db, metadata_replacement_policy=None):
         self.parser = BibliographicParser()
         super(Axis360BibliographicCoverageProvider, self).__init__(
             _db, Axis360API(_db), DataSource.AXIS_360,
-            workset_size=25
+            workset_size=25, 
+            metadata_replacement_policy=metadata_replacement_policy
         )
 
     def process_batch(self, identifiers):

--- a/coverage.py
+++ b/coverage.py
@@ -13,7 +13,6 @@ from model import (
     Edition,
     Identifier,
     LicensePool,
-    PresentationCalculationPolicy,
     Timestamp,
 )
 from metadata_layer import (

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -34,6 +34,7 @@ from model import (
     LicensePool,
     Subject,
     Hyperlink,
+    PresentationCalculationPolicy,
     RightsStatus,
     Representation,
 )
@@ -53,6 +54,7 @@ class ReplacementPolicy(object):
             mirror=None,
             http_get=None,
             even_if_not_apparently_updated=False,
+            presentation_calculation_policy=None
     ):
         self.identifiers = identifiers
         self.subjects = subjects
@@ -63,6 +65,10 @@ class ReplacementPolicy(object):
         self.even_if_not_apparently_updated = even_if_not_apparently_updated
         self.mirror = mirror
         self.http_get = http_get
+        self.presentation_calculation_policy = (
+            presentation_calculation_policy or
+            PresentationCalculationPolicy()
+        )
 
     @classmethod
     def from_license_source(self, mirror=None, even_if_not_apparently_updated=False):
@@ -808,13 +814,13 @@ class Metadata(object):
     # instead of passing in individual `replace` arguments. Once that's done,
     # we can get rid of the `replace` arguments.
     def apply(self, edition, metadata_client=None, replace=None,
-            replace_identifiers=False,
-            replace_subjects=False, 
-            replace_contributions=False,
-            replace_links=False,
-            replace_formats=False,
-            replace_rights=False,
-            force=False,
+              replace_identifiers=False,
+              replace_subjects=False, 
+              replace_contributions=False,
+              replace_links=False,
+              replace_formats=False,
+              replace_rights=False,
+              force=False,
     ):
         """Apply this metadata to the given edition.
 
@@ -1021,9 +1027,13 @@ class Metadata(object):
 
         # Make sure the work we just did shows up.
         if edition.work:
-            edition.work.calculate_presentation()
+            edition.work.calculate_presentation(
+                policy=replace.presentation_calculation_policy
+            )
         else:
-            edition.calculate_presentation()
+            edition.calculate_presentation(
+                policy=replace.presentation_calculation_policy
+            )
 
         if not edition.sort_author:
             # This may be a situation like the NYT best-seller list where

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -71,7 +71,7 @@ class ReplacementPolicy(object):
         )
 
     @classmethod
-    def from_license_source(self, mirror=None, even_if_not_apparently_updated=False):
+    def from_license_source(self, **args):
         """When gathering data from the license source, overwrite all old data
         from this source with new data from the same source. Also
         overwrite an old rights status with an updated status and update
@@ -84,12 +84,11 @@ class ReplacementPolicy(object):
             links=True, 
             rights=True,
             formats=True,
-            mirror=mirror,
-            even_if_not_apparently_updated=even_if_not_apparently_updated
+            **args
         )
 
     @classmethod
-    def from_metadata_source(self, mirror=None, even_if_not_apparently_updated=False):
+    def from_metadata_source(self, **args):
         """When gathering data from a metadata source, overwrite all old data
         from this source, but do not overwrite the rights status or
         the available formats. License sources are the authority on rights
@@ -102,12 +101,11 @@ class ReplacementPolicy(object):
             links=True, 
             rights=False,
             formats=False,
-            mirror=mirror,
-            even_if_not_apparently_updated=even_if_not_apparently_updated
+            **args
         )
 
     @classmethod
-    def append_only(self, even_if_not_apparently_updated=False):
+    def append_only(self, **args):
         """Don't overwrite any information, just append it.
 
         This should probably never be used.
@@ -119,7 +117,7 @@ class ReplacementPolicy(object):
             links=False, 
             rights=False,
             formats=False,
-            even_if_not_apparently_updated=even_if_not_apparently_updated
+            **args
         )
 
 class SubjectData(object):

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1103,6 +1103,12 @@ class Metadata(object):
         representation.mirror_url = mirror_url
         mirror.mirror_one(representation)
 
+        # The metadata may have some idea about the media type for this
+        # LinkObject, but the media type we actually just saw takes 
+        # precedence.
+        if representation.media_type:
+            link.media_type = representation.media_type
+
         if link_obj.rel == Hyperlink.IMAGE:
             # Create and mirror a thumbnail.
             thumbnail_filename = representation.default_filename(

--- a/model.py
+++ b/model.py
@@ -2981,6 +2981,7 @@ class PresentationCalculationPolicy(object):
                  regenerate_opds_entries=False, 
                  update_search_index=False,
                  verbose=True,
+                 post_hook=None,
     ):
         self.choose_edition = choose_edition
         self.set_edition_metadata = set_edition_metadata
@@ -2999,6 +3000,7 @@ class PresentationCalculationPolicy(object):
         self.update_search_index = update_search_index
 
         self.verbose = verbose
+        self.post_hook = post_hook
 
     @classmethod
     def recalculate_everything(cls):

--- a/model.py
+++ b/model.py
@@ -2981,7 +2981,6 @@ class PresentationCalculationPolicy(object):
                  regenerate_opds_entries=False, 
                  update_search_index=False,
                  verbose=True,
-                 post_hook=None,
     ):
         self.choose_edition = choose_edition
         self.set_edition_metadata = set_edition_metadata
@@ -3000,7 +2999,6 @@ class PresentationCalculationPolicy(object):
         self.update_search_index = update_search_index
 
         self.verbose = verbose
-        self.post_hook = post_hook
 
     @classmethod
     def recalculate_everything(cls):

--- a/model.py
+++ b/model.py
@@ -3000,6 +3000,17 @@ class PresentationCalculationPolicy(object):
 
         self.verbose = verbose
 
+    @classmethod
+    def recalculate_everything(cls):
+        """A PresentationCalculationPolicy that always recalculates
+        everything, even when it doesn't seem necessary.
+        """
+        return PresentationCalculationPolicy(
+            regenerate_opds_entries=True,
+            update_search_index=True,
+        )
+
+        
 
 class Work(Base):
 

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -110,7 +110,7 @@ class TestOverdriveRepresentationExtractor(object):
         eq_(DeliveryMechanism.ADOBE_DRM, pdf.drm_scheme)
 
         # Links to various resources.
-        shortd, image, thumbnail, longd = sorted(
+        shortd, image, longd = sorted(
             metadata.links, key=lambda x:x.rel
         )
 
@@ -123,6 +123,8 @@ class TestOverdriveRepresentationExtractor(object):
 
         eq_(Hyperlink.IMAGE, image.rel)
         eq_('http://images.contentreserve.com/ImageType-100/0128-1/%7B3896665D-9D81-4CAC-BD43-FFC5066DE1F5%7DImg100.jpg', image.href)
+
+        thumbnail = image.thumbnail
 
         eq_(Hyperlink.THUMBNAIL_IMAGE, thumbnail.rel)
         eq_('http://images.contentreserve.com/ImageType-200/0128-1/%7B3896665D-9D81-4CAC-BD43-FFC5066DE1F5%7DImg200.jpg', thumbnail.href)

--- a/threem.py
+++ b/threem.py
@@ -322,10 +322,10 @@ class ItemListParser(XMLParser):
 class ThreeMBibliographicCoverageProvider(BibliographicCoverageProvider):
     """Fill in bibliographic metadata for 3M records."""
 
-    def __init__(self, _db):
+    def __init__(self, _db, metadata_replacement_policy=None):
         super(ThreeMBibliographicCoverageProvider, self).__init__(
             _db, ThreeMAPI(_db), DataSource.THREEM,
-            workset_size=25
+            workset_size=25, metadata_replacement_policy=metadata_replacement_policy
         )
 
     def process_batch(self, identifiers):


### PR DESCRIPTION
This branch is kind of obnoxious but I was able to come up with decent tests for it. Basically, I was having problems with the CoverageProviders' interactions with the metadata layer.

1. When the circ manager first hears about an Overdrive book it's supposed to start using Overdrive's thumbnail image until it gets our version of the thumbnail from the metadata wrangler. This wasn't happening. The full-size image (which we don't use) was being recorded, but its thumbnail was not. I determined this was because although we identify the thumbnail image as such, we don't record the fact that it's a thumbnail _of the main image_, so the metadata layer ignores it. I fixed this, and I also noticed that Overdrive now provides some larger-size thumbnails that are closer to the size we use, so I check for those before settling for the (greatly inferior) "thumbnail" image.

2. When the metadata wrangler's IdentifierResolutionMonitor hears about cover images from 3M and Overdrive, it's supposed to automatically mirror and scale them. This was not happening because although the IRM creates an OverdriveBibliographicCoverageProvider and a ThreeMBibliographicCoverageProvider, it wasn't passing in the custom MetadataReplacementPolicy that includes the essential information about how to 'mirror' an image. That was because Overdrive and TheeMBibliographicCoverageProvider didn't accept that constructor argument. I added the constructor argument to those classes and made sure the MetadataReplacementPolicy was used in the crucial set_metadata() call.

3. Once I fixed #1 and #2, re-running the scripts would solve the database problem, but the OPDS entries for the broken books wouldn't get updated, because the metadata layer didn't see that anything had changed. So I changed MetadataReplacementPolicy to take a PresentationCalculationPolicy object as an argument, and changed Metadata.apply() to use the PresentationCalculationPolicy when it calls Work.calculate_presentation() or Edition.calculate_presentation().

This lets me set up a repair script that fixes the data for a book and then forces an update for its OPDS entry and search index entry. Previously this would have required two different scripts.