### PR TITLE
Fix juvenile classifications

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -1533,6 +1533,9 @@ class DeweyDecimalClassifier(Classifier):
         if isinstance(identifier, basestring) and identifier.startswith('Y'):
             return cls.AUDIENCE_YOUNG_ADULT
 
+        if isinstance(identifier, basestring) and identifier=='FIC':
+            # FIC is used for all types of fiction.
+            return None
         return cls.AUDIENCE_ADULT
 
     @classmethod

--- a/classifier.py
+++ b/classifier.py
@@ -425,7 +425,9 @@ class AgeClassifier(Classifier):
         if not lower and not upper:
             return None
 
-        if lower >= 12 and (not upper or upper >= cls.YOUNG_ADULT_AGE_CUTOFF):
+        if lower >= 18:
+            return Classifier.AUDIENCE_ADULT
+        elif lower >= 12 and (not upper or upper >= cls.YOUNG_ADULT_AGE_CUTOFF):
             # Although we treat "Young Adult" as starting at 14, many
             # outside sources treat it as starting at 12. As such we
             # treat "12 and up" or "12-14" as an indicator of a Young
@@ -434,10 +436,8 @@ class AgeClassifier(Classifier):
             return Classifier.AUDIENCE_YOUNG_ADULT
         elif lower < cls.YOUNG_ADULT_AGE_CUTOFF:
             return Classifier.AUDIENCE_CHILDREN
-        elif lower < 18:
-            return Classifier.AUDIENCE_YOUNG_ADULT
         else:
-            return Classifier.AUDIENCE_ADULT
+            return Classifier.AUDIENCE_YOUNG_ADULT
 
     @classmethod
     def target_age(cls, identifier, name, require_explicit_age_marker=False):
@@ -3305,7 +3305,7 @@ class WorkClassifier(object):
     nonfiction_publishers = set(["Wiley"])
     fiction_publishers = set([])
 
-    def __init__(self, work, test_session=None, debug=True):
+    def __init__(self, work, test_session=None, debug=False):
         self._db = Session.object_session(work)
         if test_session:
             self._db = test_session

--- a/coverage.py
+++ b/coverage.py
@@ -271,7 +271,7 @@ class CoverageProvider(object):
                 edition, replace=metadata_replacement_policy,
             )
         except Exception as e:
-            self.log.debug(
+            self.log.warn(
                 "Error applying metadata to edition %d: %s",
                 edition.id, e
             )

--- a/coverage.py
+++ b/coverage.py
@@ -271,6 +271,10 @@ class CoverageProvider(object):
                 edition, replace=metadata_replacement_policy,
             )
         except Exception as e:
+            self.log.debug(
+                "Error applying metadata to edition %d: %s",
+                edition.id, e
+            )
             return CoverageFailure(self, identifier, repr(e), transient=True)
 
         work = self.work(identifier)

--- a/overdrive.py
+++ b/overdrive.py
@@ -619,7 +619,7 @@ class OverdriveRepresentationExtractor(object):
             grade_level = grade_level_info.get('value')
             subjects.append(
                 SubjectData(type=Subject.GRADE_LEVEL, identifier=grade_level,
-                            weight=1)
+                            weight=100)
             )
 
         identifiers = []

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -778,6 +778,14 @@ class TestWorkClassifier(DatabaseTest):
             weight=100
         )
         self.classifier.add(c)
+
+        # (This classification has no bearing on audience and its
+        # weight will be ignored.)
+        c2 = i.classify(
+            source, Subject.TAG, "Pets", 
+            weight=1000
+        )
+        self.classifier.add(c2)
         self.classifier.prepare_to_classify
         genres, fiction, audience, target_age = self.classifier.classify
 

--- a/threem.py
+++ b/threem.py
@@ -209,7 +209,7 @@ class ItemListParser(XMLParser):
             if not i:
                 continue
             i = i.replace("&amp;amp;", "&amp;").replace("&amp;", "&").replace("&#39;", "'")
-            genres.append(SubjectData(Subject.THREEM, i, weight=30))
+            genres.append(SubjectData(Subject.THREEM, i, weight=15))
         return genres
 
     def process_one(self, tag, namespaces):

--- a/threem.py
+++ b/threem.py
@@ -209,7 +209,7 @@ class ItemListParser(XMLParser):
             if not i:
                 continue
             i = i.replace("&amp;amp;", "&amp;").replace("&amp;", "&").replace("&#39;", "'")
-            genres.append(SubjectData(Subject.THREEM, i))
+            genres.append(SubjectData(Subject.THREEM, i, weight=30))
         return genres
 
     def process_one(self, tag, namespaces):


### PR DESCRIPTION
This branch fixes a couple of problems we had classifying 3M books. The biggest one is that certain classifications are now treated as generic 'juvenile' classifications. Their weight is divided up between the 'children' and 'YA' audiences (instead of all being assigned to YA). This makes it easier for data from some other source to set the record straight if it is in fact a children's book.

I also added a fair amount of debug code that's useful when tracking down this sort of problem. None of this code runs unless you change debug=False in the WorkClassifier constructor.