### PR TITLE
Dont remove classifications from another source

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -937,7 +937,11 @@ class Metadata(object):
                         # to do anything.
                         del new_subjects[key]
                         surviving_classifications.append(classification)
-                identifier.classifications = surviving_classifications
+                else:
+                    # This classification comes from some other data
+                    # source.  Don't mess with it.
+                    surviving_classifications.append(classification)
+            identifier.classifications = surviving_classifications
 
         # Apply all new subjects to the identifier.
         for subject in new_subjects.values():


### PR DESCRIPTION
This branch fixes a bug that only showed up when you got classifications from two different sources. Calling metadata.apply() on the second data source would destroy all the classifications created by the first source, and vice versa.