### PR TITLE
Improve classifications

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -92,45 +92,6 @@ class Classifier(object):
         return NumericRange(lower, upper, '[]')
 
     @classmethod
-    def default_audience_for_target_age(cls, nr):
-        if nr is None:
-            return None
-        lower = nr.lower
-        upper = nr.upper
-        if not lower and not upper:
-            return None
-        if lower and not nr.lower_inc:
-            lower += 1
-        if upper and not nr.upper_inc:
-            upper += 1
-        if not lower:
-            if upper > 18:
-                # e.g. "up to 20 years", though that doesn't
-                # make much sense.
-                return cls.AUDIENCE_ADULT
-            elif upper > cls.YOUNG_ADULT_AGE_CUTOFF:
-                # e.g. "up to 15 years"
-                return cls.AUDIENCE_YOUNG_ADULT
-            else:
-                # e.g. "up to 14 years"
-                return cls.AUDIENCE_CHILDREN
-
-        # At this point we can assume that lower is not None.
-        if lower >= 18:
-            return cls.AUDIENCE_ADULT
-        elif lower >= cls.YOUNG_ADULT_AGE_CUTOFF:
-            return cls.AUDIENCE_YOUNG_ADULT
-        elif lower >= 12 and (not upper or upper >= cls.YOUNG_ADULT_AGE_CUTOFF):
-            # Although we treat "Young Adult" as starting at 14, many
-            # outside sources treat it as starting at 12. As such we
-            # treat "12 and up" or "12-14" as an indicator of a Young
-            # Adult audience, with a target age that overlaps what we
-            # consider a Children audience.
-            return cls.AUDIENCE_YOUNG_ADULT
-        else:
-            return cls.AUDIENCE_CHILDREN
-
-    @classmethod
     def lookup(cls, scheme):
         """Look up a classifier for a classification scheme."""
         return cls.classifiers.get(scheme, None)
@@ -239,6 +200,45 @@ class Classifier(object):
         ):
             return cls.nr(18, None)
         return cls.nr(None, None)
+
+    @classmethod
+    def default_audience_for_target_age(cls, nr):
+        if nr is None:
+            return None
+        lower = nr.lower
+        upper = nr.upper
+        if not lower and not upper:
+            return None
+        if lower and not nr.lower_inc:
+            lower += 1
+        if upper and not nr.upper_inc:
+            upper += 1
+        if not lower:
+            if upper > 18:
+                # e.g. "up to 20 years", though that doesn't
+                # make much sense.
+                return cls.AUDIENCE_ADULT
+            elif upper > cls.YOUNG_ADULT_AGE_CUTOFF:
+                # e.g. "up to 15 years"
+                return cls.AUDIENCE_YOUNG_ADULT
+            else:
+                # e.g. "up to 14 years"
+                return cls.AUDIENCE_CHILDREN
+
+        # At this point we can assume that lower is not None.
+        if lower >= 18:
+            return cls.AUDIENCE_ADULT
+        elif lower >= cls.YOUNG_ADULT_AGE_CUTOFF:
+            return cls.AUDIENCE_YOUNG_ADULT
+        elif lower >= 12 and (not upper or upper >= cls.YOUNG_ADULT_AGE_CUTOFF):
+            # Although we treat "Young Adult" as starting at 14, many
+            # outside sources treat it as starting at 12. As such we
+            # treat "12 and up" or "12-14" as an indicator of a Young
+            # Adult audience, with a target age that overlaps what we
+            # consider a Children audience.
+            return cls.AUDIENCE_YOUNG_ADULT
+        else:
+            return cls.AUDIENCE_CHILDREN
 
     @classmethod
     def and_up(cls, young, keyword):

--- a/classifier.py
+++ b/classifier.py
@@ -3393,11 +3393,11 @@ class WorkClassifier(object):
             scaled_weight = classification.weight_as_indicator_of_target_age
             target_min = subject.target_age.lower
             target_max = subject.target_age.upper
-            if target_min:
+            if target_min is not None:
                 if not subject.target_age.lower_inc:
                     target_min += 1
                 self.target_age_lower_weights[target_min] += scaled_weight
-            if target_max:
+            if target_max is not None:
                 if not subject.target_age.upper_inc:
                     target_max += 1
                 self.target_age_upper_weights[target_max] += scaled_weight

--- a/classifier.py
+++ b/classifier.py
@@ -3315,7 +3315,7 @@ class WorkClassifier(object):
     nonfiction_publishers = set(["Wiley"])
     fiction_publishers = set([])
 
-    def __init__(self, work, test_session=None, debug=False):
+    def __init__(self, work, test_session=None, debug=True):
         self._db = Session.object_session(work)
         if test_session:
             self._db = test_session
@@ -3334,7 +3334,7 @@ class WorkClassifier(object):
         """Prepare a single Classification for consideration."""
         # Make sure the Subject is ready to be used in calculations.
         if self.debug:
-            classification.subject.assign_to_genre()
+            # classification.subject.assign_to_genre()
             self.classifications.append(classification)
         if not classification.subject.checked:
             classification.subject.assign_to_genre()

--- a/classifier.py
+++ b/classifier.py
@@ -3316,7 +3316,7 @@ class WorkClassifier(object):
     nonfiction_publishers = set(["Wiley"])
     fiction_publishers = set([])
 
-    def __init__(self, work, test_session=None, debug=True):
+    def __init__(self, work, test_session=None, debug=False):
         self._db = Session.object_session(work)
         if test_session:
             self._db = test_session

--- a/classifier.py
+++ b/classifier.py
@@ -3650,7 +3650,7 @@ class WorkClassifier(object):
 
         # Err on the side of setting the minimum age too high.
         if target_age_min > target_age_max:
-            target_age_min = target_age_max
+            target_age_max = target_age_min
         return Classifier.nr(target_age_min, target_age_max)
 
     def genres(self, fiction, cutoff=0.15):

--- a/classifier.py
+++ b/classifier.py
@@ -256,7 +256,9 @@ class Classifier(object):
         ):
             return None
 
-        if young >= 12:
+        if young >= 18:
+            old = young
+        elif young >= 12:
             # "12 and up", "14 and up", etc.  are
             # generally intended to cover the entire
             # YA span.

--- a/classifier.py
+++ b/classifier.py
@@ -92,14 +92,13 @@ class Classifier(object):
         return NumericRange(lower, upper, '[]')
 
     @classmethod
-    def audience_from_target_age(self, nr):
+    def audience_from_target_age(cls, nr):
         if nr is None:
             return None
         lower = nr.lower
-
+        upper = nr.upper
         if not lower and not upper:
             return None
-        upper = nr.upper
         if lower and not nr.lower_inc:
             lower += 1
         if upper and not nr.upper_inc:
@@ -108,26 +107,28 @@ class Classifier(object):
             if upper > 18:
                 # e.g. "up to 20 years", though that doesn't
                 # make much sense.
-                return Classifier.ADULT
+                return cls.ADULT
             elif upper > cls.YOUNG_ADULT_AGE_CUTOFF:
                 # e.g. "up to 15 years"
-                return Classifier.AUDIENCE_YOUNG_ADULT
+                return cls.AUDIENCE_YOUNG_ADULT
             else:
                 # e.g. "up to 14 years"
-                return Classifier.AUDIENCE_CHILDREN
+                return cls.AUDIENCE_CHILDREN
 
         # At this point we can assume that lower is not None.
         if lower >= 18:
-            return Classifier.AUDIENCE_ADULT
+            return cls.AUDIENCE_ADULT
+        elif lower >= cls.YOUNG_ADULT_AGE_CUTOFF:
+            return cls.AUDIENCE_YOUNG_ADULT
         elif lower >= 12 and (not upper or upper >= cls.YOUNG_ADULT_AGE_CUTOFF):
             # Although we treat "Young Adult" as starting at 14, many
             # outside sources treat it as starting at 12. As such we
             # treat "12 and up" or "12-14" as an indicator of a Young
             # Adult audience, with a target age that overlaps what we
             # consider a Children audience.
-            return Classifier.AUDIENCE_YOUNG_ADULT
+            return cls.AUDIENCE_YOUNG_ADULT
         else:
-            return Classifier.AUDIENCE_YOUNG_ADULT
+            return cls.AUDIENCE_CHILDREN
 
 
     @classmethod

--- a/classifier.py
+++ b/classifier.py
@@ -92,7 +92,7 @@ class Classifier(object):
         return NumericRange(lower, upper, '[]')
 
     @classmethod
-    def audience_from_target_age(cls, nr):
+    def default_audience_for_target_age(cls, nr):
         if nr is None:
             return None
         lower = nr.lower
@@ -107,7 +107,7 @@ class Classifier(object):
             if upper > 18:
                 # e.g. "up to 20 years", though that doesn't
                 # make much sense.
-                return cls.ADULT
+                return cls.AUDIENCE_ADULT
             elif upper > cls.YOUNG_ADULT_AGE_CUTOFF:
                 # e.g. "up to 15 years"
                 return cls.AUDIENCE_YOUNG_ADULT
@@ -241,44 +241,6 @@ class Classifier(object):
             return cls.nr(18, None)
         return cls.nr(None, None)
 
-    @classmethod
-    def default_audience_for_target_age(cls, target_age):
-        """The default audience for a given target age.
-
-        Inverse of default_target_age_for_audience.
-        """
-        if not target_age:
-            # We were not passed a NumericRange
-            return None
-
-        lower = target_age.lower
-        upper = target_age.upper
-
-        if not lower and not upper:
-            # We have no information.
-            return None
-
-        # Sometimes we can determine audience given only a lower bound.
-        if lower:
-            if lower < cls.YOUNG_ADULT_AGE_CUTOFF:
-                return Classifier.AUDIENCE_CHILDREN
-            elif lower < 18:
-                return Classifier.AUDIENCE_YOUNG_ADULT
-            else:
-                return Classifier.AUDIENCE_ADULT
-
-        # Sometimes we can determine audience given only an upper
-        # bound.
-        if upper:
-            if upper < cls.YOUNG_ADULT_AGE_CUTOFF:
-                return Classifier.AUDIENCE_CHILDREN
-            elif upper < 18:
-                return Classifier.AUDIENCE_YOUNG_ADULT
-
-        # This will happen if lower is null and upper is greater than 18.
-        # This is a pretty weird case and we don't have a good answer.
-        return None
-
 class GradeLevelClassifier(Classifier):
     # How old a kid is when they start grade N in the US.
     american_grade_to_age = {
@@ -342,7 +304,7 @@ class GradeLevelClassifier(Classifier):
     @classmethod
     def audience(cls, identifier, name, require_explicit_age_marker=False):
         target_age = cls.target_age(identifier, name, require_explicit_age_marker)
-        return cls.audience_from_target_age(target_age)
+        return cls.default_audience_for_target_age(target_age)
         
 
     @classmethod
@@ -462,7 +424,7 @@ class AgeClassifier(Classifier):
     @classmethod
     def audience(cls, identifier, name, require_explicit_age_marker=False):
         target_age = cls.target_age(identifier, name, require_explicit_age_marker)
-        return cls.audience_from_target_age(target_age)
+        return cls.default_audience_for_target_age(target_age)
 
     @classmethod
     def target_age(cls, identifier, name, require_explicit_age_marker=False):

--- a/model.py
+++ b/model.py
@@ -4917,6 +4917,10 @@ class Classification(Base):
         return 0.1
 
     @property
+    def weight_as_indicator_of_target_age(self):
+        return self.weight * self.quality_as_indicator_of_target_age
+
+    @property
     def comes_from_license_source(self):
         if not self.identifier.licensed_through:
             return False

--- a/model.py
+++ b/model.py
@@ -4839,11 +4839,11 @@ class Classification(Base):
         # These measure age appropriateness.
         (DataSource.METADATA_WRANGLER, Subject.AGE_RANGE) : 100,
         Subject.AXIS_360_AUDIENCE : 30,
-        (DataSource.OVERDRIVE, Subject.GRADE_LEVEL) : 20,
         (DataSource.OVERDRIVE, Subject.INTEREST_LEVEL) : 20,
-        Subject.OVERDRIVE : 15,
+        (DataSource.OVERDRIVE, Subject.OVERDRIVE) : 15, # But see below
         (DataSource.AMAZON, Subject.AGE_RANGE) : 10,
         (DataSource.AMAZON, Subject.GRADE_LEVEL) : 9,
+
 
         # These measure reading level, except for TAG, which measures
         # who-knows-what.
@@ -4851,6 +4851,12 @@ class Classification(Base):
         Subject.TAG : 2,
         Subject.LEXILE_SCORE : 1,
         Subject.ATOS_SCORE: 1,
+
+        # Although Overdrive usually reserves Fiction and Nonfiction
+        # for books for adults, it's not as reliable an indicator as
+        # other Overdrive classifications.
+        (DataSource.OVERDRIVE, Subject.OVERDRIVE, "Fiction") : 5,
+        (DataSource.OVERDRIVE, Subject.OVERDRIVE, "Nonfiction") : 5,
 
         Subject.AGE_RANGE : 10,
         Subject.GRADE_LEVEL : 10,
@@ -4873,10 +4879,16 @@ class Classification(Base):
         data_source = self.data_source.name
         subject_type = self.subject.type
         q = self._quality_as_indicator_of_target_age
-        if (data_source, subject_type) in q:
-            return q[(data_source, subject_type)]
-        if subject_type in q:
-            return q[subject_type]
+
+        keys = [
+            (data_source, subject_type, self.subject.identifier),
+            (data_source, subject_type),
+            subject_type
+        ]
+        for key in keys:
+            if key in q:
+                print "Found %s from %s" % (repr(key), data_source)
+                return q[key]
         return 0.1
 
     @property

--- a/overdrive.py
+++ b/overdrive.py
@@ -552,11 +552,15 @@ class OverdriveRepresentationExtractor(object):
 
         extra = dict()
         if 'grade_levels' in book:
+            # n.b. Grade levels are measurements of reading level, not
+            # age appropriateness. We can use them as a measure of age
+            # appropriateness in a pinch, but we weight them less
+            # heavily than other information from Overdrive.
             for i in book['grade_levels']:
                 subject = SubjectData(
                     type=Subject.GRADE_LEVEL,
                     identifier=i['value'],
-                    weight=100
+                    weight=10
                 )
                 subjects.append(subject)
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -1119,6 +1119,20 @@ class TestWorkClassifier(DatabaseTest):
         [[g1, weight], [g2, weight]] = self.classifier.genres(True).items()
         eq_(set([g1, g2]), set([romance.genredata, sf.genredata]))
 
+    def test_classify_sets_minimum_age_high_if_minimum_lower_than_maximum(self):
+
+        # We somehow end up in a situation where the proposed low end
+        # of the target age is higher than the proposed high end.
+        self.classifier.audience_weights[Classifier.AUDIENCE_CHILDREN] = 1
+        self.classifier.target_age_lower_weights[10] = 1
+        self.classifier.target_age_upper_weights[4] = 1
+        
+        # We set the low end equal to the high end, erring on the side
+        # of making the book available to fewer people.
+        genres, fiction, audience, target_age = self.classifier.classify
+        eq_(10, target_age.lower)
+        eq_(10, target_age.upper)
+
     def test_classify(self):
         # At this point we've tested all the components of classify, so just
         # do an overall test to verify that classify() returns a 4-tuple

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -61,13 +61,20 @@ class TestClassifier(object):
         aud(None, None, None)
         aud(None, 17, Classifier.AUDIENCE_YOUNG_ADULT)
         aud(None, 4, Classifier.AUDIENCE_CHILDREN)
-        aud(None, 44, None)
+        aud(None, 44, Classifier.AUDIENCE_ADULT)
         aud(18, 44, Classifier.AUDIENCE_ADULT)
-        aud(12, 15, Classifier.AUDIENCE_CHILDREN)
         aud(14, 14, Classifier.AUDIENCE_YOUNG_ADULT)
         aud(14, 19, Classifier.AUDIENCE_YOUNG_ADULT)
         aud(2, 14, Classifier.AUDIENCE_CHILDREN)
         aud(2, 8, Classifier.AUDIENCE_CHILDREN)
+
+        # We treat this as YA because its target age range overlaps
+        # our YA age range, and many external sources consider books
+        # for twelve-year-olds to be "YA".
+        aud(12, 15, Classifier.AUDIENCE_YOUNG_ADULT)
+
+        # Whereas this is unambiguously 'Children' as far as we're concerned.
+        aud(12, 13, Classifier.AUDIENCE_CHILDREN)
 
 class TestClassifierLookup(object):
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -78,8 +78,16 @@ class TestClassifier(object):
 
     def test_and_up(self):
 
-        def u(self, young, keyword):
+        def u(young, keyword):
             return Classifier.and_up(young, keyword)
+
+        eq_(None, u(None, None))
+        eq_(None, u(6, "6 years old only"))
+        eq_(5, u(3, "3 and up"))
+        eq_(8, u(6, "6+"))
+        eq_(17, u(12, "12 and up"))
+        eq_(17, u(14, "14+."))
+        eq_(18, u(18, "18+"))
 
 class TestClassifierLookup(object):
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -77,7 +77,7 @@ class TestClassifier(object):
         aud(12, 13, Classifier.AUDIENCE_CHILDREN)
 
     def test_and_up(self):
-
+        """Test the code that determines what "x and up" actually means."""
         def u(young, keyword):
             return Classifier.and_up(young, keyword)
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -76,6 +76,11 @@ class TestClassifier(object):
         # Whereas this is unambiguously 'Children' as far as we're concerned.
         aud(12, 13, Classifier.AUDIENCE_CHILDREN)
 
+    def test_and_up(self):
+
+        def u(self, young, keyword):
+            return Classifier.and_up(young, keyword)
+
 class TestClassifierLookup(object):
 
     def test_lookup(self):
@@ -176,7 +181,7 @@ class TestTargetAge(object):
         eq_((0,3), f("0-3"))
         eq_((5,8), f("05 - 08"))
         eq_((None,None), f("K-3"))
-        eq_((18, 20), f("Age 18+"))
+        eq_((18, 18), f("Age 18+"))
 
         # This could be improved but I've never actually seen a
         # classification like this.


### PR DESCRIPTION
Another big batch of improvements to the way target ages are calculated and the target age for a work is determined. This fixes issue #162 and does a lot of work for issue #163.

The biggest change is that when calculating target age we now consider all Classifications that have an opinion about target age, instead of only considering the "most reliable subset" of classifications. However, this doesn't mean we suddenly consider all classifications equally reliable. The numbers associated with the old hierarchy of reliable/unreliable classifications have been turned into coefficients. We consider all classifications, but we multiply the weight of each classification by the coefficient associated with its source. This lets us make the right decision in situations where the "most reliable subset" is wrong about something and all the "less reliable" data points in a different direction.