### PR TITLE
Handle subjects better in search

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -17,6 +17,7 @@ import json
 import os
 import pkgutil
 import re
+from functools import partial
 from collections import (
     Counter,
     defaultdict,
@@ -1660,16 +1661,6 @@ class LCCClassifier(Classifier):
         # Everything else is implicitly for adults.
         return cls.AUDIENCE_ADULT
 
-def match_kw(*l):
-    """Turn a list of strings into a regular expression which matches
-    any of those strings, so long as there's a word boundary on both ends.
-    """
-    if not l:
-        return None
-    any_keyword = "|".join([keyword for keyword in l])
-    with_boundaries = r'\b(%s)\b' % any_keyword
-    return re.compile(with_boundaries, re.I)
-
 class AgeOrGradeClassifier(Classifier):
 
     @classmethod
@@ -1692,20 +1683,57 @@ class AgeOrGradeClassifier(Classifier):
             age = GradeLevelClassifier.target_age(identifier, name, True)
         return age
 
+def match_term(l, term, exclude_examples=False):
+    if not l:
+        return None
+    if exclude_examples:
+        keywords = [keyword for keyword in l if not isinstance(keyword, Eg)]
+    else:
+        keywords = [str(keyword) for keyword in l]
+
+    if not keywords:
+        return None
+    any_keyword = "|".join(keywords)
+    with_boundaries = r'\b(%s)\b' % any_keyword
+    return re.compile(with_boundaries, re.I).search(term)
+
+
+def match_kw(*l):
+    """Turn a list of strings into a function which uses a regular expression
+    to match any of those strings, so long as there's a word boundary on both ends.
+    The function will match all the strings by default, or can exclude the strings
+    that are examples of the classification.
+    """
+    # This is a dictionary so it can be used as a class variable
+    return {"search": partial(match_term, l)}
+
+class Eg(object):
+    """Mark this string as an example of a classification, rather than
+    an exact identifier for that classification. For example, basketball
+    is an an example of a sport, but athletics is an identifier for the sports
+    classification.
+    """
+
+    def __init__(self, term):
+        self.term = term
+
+    def __str__(self):
+        return self.term
+
 class KeywordBasedClassifier(AgeOrGradeClassifier):
 
     """Classify a book based on keywords."""
     
     FICTION_INDICATORS = match_kw(
-        "fiction", "stories", "tales", "literature",
-        "bildungsromans", "fictitious",
+        "fiction", Eg("stories"), Eg("tales"), Eg("literature"),
+        Eg("bildungsromans"), "fictitious",
     )
     NONFICTION_INDICATORS = match_kw(
-        "history", "biography", "histories", "biographies", "autobiography",
-        "autobiographies", "nonfiction", "essays", "letters")
+        Eg("history"), Eg("biography"), Eg("histories"), Eg("biographies"), Eg("autobiography"),
+        Eg("autobiographies"), "nonfiction", Eg("essays"), Eg("letters"))
     JUVENILE_INDICATORS = match_kw(
         "for children", "children's", "juvenile",
-        "nursery rhymes", "9-12")
+        Eg("nursery rhymes"), Eg("9-12"))
     YOUNG_ADULT_INDICATORS = match_kw(
         "young adult", 
         "ya", 
@@ -1713,7 +1741,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
         "teenage .*fiction", 
         "teens .*fiction",
         "teen books",
-        "teenage romance",
+        Eg("teenage romance"),
     )
 
     # Children's books don't generally deal with romance, so although
@@ -1745,9 +1773,9 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
             "adventure stories",
             "adventure fiction", 
             "adventurers",
-            "sea stories",
-            "war stories", 
-            "men's adventure",
+            Eg("sea stories"),
+            Eg("war stories"), 
+            Eg("men's adventure"),
         ), 
                
         African_History: match_kw(
@@ -1801,10 +1829,10 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
             "cocktail",
             "cocktails",
             "bartending",
-            "beer",
+            Eg("beer"),
             "alcoholic beverages",
-            "wine",
-            "wine & spirits",
+            Eg("wine"),
+            Eg("wine & spirits"),
             "spirits & cocktails",
         ),
                
@@ -1836,24 +1864,24 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "sales",
                    "selling",
                    "sales & selling",
-                   "nonprofit",
+                   Eg("nonprofit"),
                ),
                
                Christianity : match_kw(
                    "schema:creativework:bible",
                    "bible",
-                   "sermons",
-                   "devotional",
-                   "theological",
-                   "theology",
+                   Eg("sermons"),
+                   Eg("devotional"),
+                   Eg("theological"),
+                   Eg("theology"),
                    'biblical',
                    "christian",
                    "christianity",
-                   "catholic",
-                   "protestant",
-                   "catholicism",
-                   "protestantism",
-                   "church",
+                   Eg("catholic"),
+                   Eg("protestant"),
+                   Eg("catholicism"),
+                   Eg("protestantism"),
+                   Eg("church"),
                ),
                
                Civil_War_History: match_kw(
@@ -1871,14 +1899,14 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "computational",
                    "computers",
                    "computing",
-                   "data",
-                   "database",
-                   "hardware",
-                   "software",
-                   "software development",
-                   "information technology",
-                   "web",
-                   "world wide web",
+                   Eg("data"),
+                   Eg("database"),
+                   Eg("hardware"),
+                   Eg("software"),
+                   Eg("software development"),
+                   Eg("information technology"),
+                   Eg("web"),
+                   Eg("world wide web"),
                ),
                
                Contemporary_Romance: match_kw(
@@ -1889,62 +1917,63 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                ),
                
                Cooking : match_kw(
-                   "non-alcoholic",
-                   "baking",
+                   Eg("non-alcoholic"),
+                   Eg("baking"),
                    "cookbook",
                    "cooking",
                    "food",
-                   "health & healing",
+                   Eg("health & healing"),
                    "home economics",
                    "cuisine",
                ),
                              
                Crafts_Hobbies: match_kw(
                    "arts & crafts",
-                   "arts, crafts"
-                   "beadwork",
-                   "candle crafts",
-                   "candle making",
-                   "carving",
-                   "ceramics",
+                   "arts, crafts",
+                   Eg("beadwork"),
+                   Eg("candle crafts"),
+                   Eg("candle making"),
+                   Eg("carving"),
+                   Eg("ceramics"),
                    "crafts & hobbies",
                    "crafts",
-                   "crocheting",
-                   "cross-stitch",
+                   Eg("crochet"),
+                   Eg("crocheting"),
+                   Eg("cross-stitch"),
                    "decorative arts",
-                   "flower arranging",
+                   Eg("flower arranging"),
                    "folkcrafts",
                    "handicrafts",
                    "hobbies",
                    "hobby",
                    "hobbyist",
                    "hobbyists",
-                   "jewelry",
-                   "knitting",
-                   "metal work",
-                   "needlework",
-                   "origami",
-                   "paper crafts",
-                   "pottery",
-                   "quilting",
-                   "quilts",
-                   "scrapbooking",
-                   "sewing",
-                   "soap making",
-                   "stamping",
-                   "stenciling",
-                   "textile crafts",
-                   "toymaking",
-                   "weaving",
-                   "woodwork",
+                   Eg("jewelry"),
+                   Eg("knitting"),
+                   Eg("metal work"),
+                   Eg("needlework"),
+                   Eg("origami"),
+                   Eg("paper crafts"),
+                   Eg("pottery"),
+                   Eg("quilting"),
+                   Eg("quilts"),
+                   Eg("scrapbooking"),
+                   Eg("sewing"),
+                   Eg("soap making"),
+                   Eg("stamping"),
+                   Eg("stenciling"),
+                   Eg("textile crafts"),
+                   Eg("toymaking"),
+                   Eg("weaving"),
+                   Eg("woodwork"),
                ),
 
                Design: match_kw(
                    "design",
                    "designer",
                    "designers",
-                   "graphic design",
-                   "typography"
+                   Eg("graphic design"),
+                   Eg("typography")
                ),
                
                Dictionaries: match_kw(
@@ -1953,19 +1982,19 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                ),              
                
                Drama : match_kw(
-                   "comedies",
+                   Eg("comedies"),
                    "drama",
                    "dramatist",
                    "dramatists",
-                   "operas",
-                   "plays",
-                   "shakespeare",
-                   "tragedies",
-                   "tragedy",
+                   Eg("operas"),
+                   Eg("plays"),
+                   Eg("shakespeare"),
+                   Eg("tragedies"),
+                   Eg("tragedy"),
                ),
                
                Economics: match_kw(
-                   "banking",
+                   Eg("banking"),
                    "economy",
                    "economies",
                    "economic",
@@ -1981,7 +2010,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "educational",
                    "educator",
                    "educators",
-                   "principals",
+                   Eg("principals"),
                    "teacher",
                    "teachers",
                    "teaching",
@@ -1991,8 +2020,8 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    #"student",
                    #"students",
                    #"college",
-                   "university",
-                   "universities",
+                   Eg("university"),
+                   Eg("universities"),
                ),
                
                Epic_Fantasy: match_kw(
@@ -2022,14 +2051,14 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
         European_History: match_kw(
             "europe.*history",
             "history.*europe",
-            "france.*history",
-            "history.*france",
-            "england.*history",
-            "history.*england",
-            "ireland.*history",
-            "history.*ireland",
-            "germany.*history",
-            "history.*germany",
+            Eg("france.*history"),
+            Eg("history.*france"),
+            Eg("england.*history"),
+            Eg("history.*england"),
+            Eg("ireland.*history"),
+            Eg("history.*ireland"),
+            Eg("germany.*history"),
+            Eg("history.*germany"),
             # etc. etc. etc.
         ),
                
@@ -2041,14 +2070,14 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                
                Fantasy : match_kw(
                    "fantasy",
-                   "magic",
-                   "wizards",
-                   "fairies",
-                   "witches",
-                   "dragons",
-                   "sorcery",
-                   "witchcraft",
-                   "wizardry",
+                   Eg("magic"),
+                   Eg("wizards"),
+                   Eg("fairies"),
+                   Eg("witches"),
+                   Eg("dragons"),
+                   Eg("sorcery"),
+                   Eg("witchcraft"),
+                   Eg("wizardry"),
                ),
                
                Fashion: match_kw(
@@ -2058,8 +2087,8 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                ),
                
                Film_TV: match_kw(
-                   "director",
-                   "directors",
+                   Eg("director"),
+                   Eg("directors"),
                    "film",
                    "films",
                    "movies",
@@ -2068,26 +2097,26 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "motion pictures",
                    "moviemaker",
                    "moviemakers",
-                   "producer",
-                   "producers",
+                   Eg("producer"),
+                   Eg("producers"),
                    "television",
                    "tv",
                    "video",
                ),
                
                Foreign_Language_Study: match_kw(
-                   "english as a foreign language",
-                   "english as a second language",
-                   "esl",
+                   Eg("english as a foreign language"),
+                   Eg("english as a second language"),
+                   Eg("esl"),
                    "foreign language study",
-                   "multi-language dictionaries",
+                   Eg("multi-language dictionaries"),
                ),
 
                Games : match_kw(
                    "games",
-                   "video games",
+                   Eg("video games"),
                    "gaming",
-                   "gambling",
+                   Eg("gambling"),
                ),
                
                Gardening: match_kw(
@@ -2104,14 +2133,14 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "graphic novels",
 
                    # Formerly in 'Superhero'
-                   "superhero",
-                   "superheroes",
+                   Eg("superhero"),
+                   Eg("superheroes"),
 
                    # Formerly in 'Manga'
-                   "japanese comic books",
-                   "japanese comics",
-                   "manga",
-                   "yaoi",
+                   Eg("japanese comic books"),
+                   Eg("japanese comics"),
+                   Eg("manga"),
+                   Eg("yaoi"),
 
                ),
                
@@ -2146,8 +2175,8 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                
                Historical_Romance: match_kw(
                    "historical romance",
-                   "regency romance",
-                   "romance.*regency",
+                   Eg("regency romance"),
+                   Eg("romance.*regency"),
                ),
                
                History : match_kw(
@@ -2156,20 +2185,20 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                ),
                
                Horror : match_kw(
-                   "ghost stories",
+                   Eg("ghost stories"),
                    "horror",
-                   "vampires",
-                   "paranormal fiction",
-                   "occult fiction",
+                   Eg("vampires"),
+                   Eg("paranormal fiction"),
+                   Eg("occult fiction"),
                ),
                
                House_Home: match_kw(
                    "house and home",
                    "house & home",
-                   "remodeling",
-                   "renovation",
-                   "caretaking",
-                   "interior decorating",
+                   Eg("remodeling"),
+                   Eg("renovation"),
+                   Eg("caretaking"),
+                   Eg("interior decorating"),
                ),
                
         Humorous_Fiction : match_kw(
@@ -2179,7 +2208,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
             "humorous",
             "humourous",
             "humour",
-            "satire",
+            Eg("satire"),
             "wit",
         ),
         Humorous_Nonfiction : match_kw(
@@ -2200,23 +2229,25 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                # These might be a problem because they might pick up
         # hateful books. Not sure if this will be a problem.
         Islam : match_kw(
-            'islam', 'islamic', 'muslim', 'muslims', 'halal',
+            'islam', 'islamic', 'muslim', 'muslims', Eg('halal'),
             'islamic studies',
         ),
                
                Judaism: match_kw(
-                   'judaism', 'jewish', 'kosher', 'jews',
+                   'judaism', 'jewish', Eg('kosher'), 'jews',
                    'jewish studies',
                ),
                
                LGBTQ_Fiction: match_kw(
-                   'lesbian',
-                   'lesbians',
+                   'lgbt',
+                   'lgbtq',
+                   Eg('lesbian'),
+                   Eg('lesbians'),
                    'gay',
-                   'bisexual',
-                   'transgender',
-                   'transsexual',
-                   'transsexuals',
+                   Eg('bisexual'),
+                   Eg('transgender'),
+                   Eg('transsexual'),
+                   Eg('transsexuals'),
                    'homosexual',
                    'homosexuals',
                    'homosexuality',
@@ -2242,7 +2273,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                              
                Literary_Criticism: match_kw(
                    "criticism, interpretation",
-                   "literary collections",
+                   Eg("literary collections"),
                ),
                
                Literary_Fiction: match_kw(
@@ -2261,39 +2292,39 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                ),
                
                Mathematics : match_kw(
-                   "algebra",
-                   "arithmetic",
-                   "calculus",
-                   "chaos theory",
-                   "game theory",
-                   "geometry",
-                   "group theory",
-                   "logic",
+                   Eg("algebra"),
+                   Eg("arithmetic"),
+                   Eg("calculus"),
+                   Eg("chaos theory"),
+                   Eg("game theory"),
+                   Eg("geometry"),
+                   Eg("group theory"),
+                   Eg("logic"),
                    "math",
                    "mathematical",
                    "mathematician",
                    "mathematicians",
                    "mathematics",
-                   "probability",
-                   "statistical",
-                   "statistics",
-                   "trigonometry",
+                   Eg("probability"),
+                   Eg("statistical"),
+                   Eg("statistics"),
+                   Eg("trigonometry"),
                ),
                
                Medical : match_kw(
-                   "anatomy",
-                   "disease",
-                   "diseases",
-                   "disorders",
-                   "epidemiology",
-                   "illness",
-                   "illnesses",
+                   Eg("anatomy"),
+                   Eg("disease"),
+                   Eg("diseases"),
+                   Eg("disorders"),
+                   Eg("epidemiology"),
+                   Eg("illness"),
+                   Eg("illnesses"),
                    "medical",
                    "medicine", 
-                   "neuroscience",
-                   "physiology",
-                   "vaccines",
-                   "virus",
+                   Eg("neuroscience"),
+                   Eg("physiology"),
+                   Eg("vaccines"),
+                   Eg("virus"),
                ),
                
                Medieval_History: match_kw(
@@ -2312,20 +2343,20 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "military science",
                    "warfare",
                    "military",
-                   "1914-1918",
-                   "1939-1945",
-                   "world war",
+                   Eg("1914-1918"),
+                   Eg("1939-1945"),
+                   Eg("world war"),
                ),
                              
                Modern_History: match_kw(
-                   "1900 - 1999",
-                   "2000-2099",
+                   Eg("1900 - 1999"),
+                   Eg("2000-2099"),
                    "modern history",
                    "history, modern",
                    "history (modern)",
                    "history--modern",
-                   "history.*20th century",
-                   "history.*21st century",
+                   Eg("history.*20th century"),
+                   Eg("history.*21st century"),
                ),
                
                # This is SF movie tie-ins, not movies & gaming per se.
@@ -2334,9 +2365,9 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
         # "fantasy"
         Media_Tie_in_SF: match_kw(
             "science fiction & fantasy gaming",
-            "star trek",
-            "star wars",
-            "jedi",
+            Eg("star trek"),
+            Eg("star wars"),
+            Eg("jedi"),
         ),
                
                Music: match_kw(
@@ -2344,26 +2375,26 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "musician",
                    "musicians",
                    "musical",
-                   "genres & styles"
-                   "blues",
-                   "jazz",
-                   "rap",
-                   "hip-hop",
-                   "rock.*roll",
-                   "rock music",
-                   "punk rock",
+                   Eg("genres & styles"),
+                   Eg("blues"),
+                   Eg("jazz"),
+                   Eg("rap"),
+                   Eg("hip-hop"),
+                   Eg("rock.*roll"),
+                   Eg("rock music"),
+                   Eg("punk rock"),
                ),
                
                Mystery : match_kw(
-                   "crime",
-                   "detective",
-                   "murder",
+                   Eg("crime"),
+                   Eg("detective"),
+                   Eg("murder"),
                    "mystery",
                    "mysteries",
-                   "private investigators",
-                   "holmes, sherlock",
-                   "poirot, hercule",
-                   "schema:person:holmes, sherlock",
+                   Eg("private investigators"),
+                   Eg("holmes, sherlock"),
+                   Eg("poirot, hercule"),
+                   Eg("schema:person:holmes, sherlock"),
                ),
                
                Nature : match_kw(
@@ -2391,8 +2422,8 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "parenting",
                    "parent",
                    "parents",
-                   "motherhood",
-                   "fatherhood",
+                   Eg("motherhood"),
+                   Eg("fatherhood"),
                ),
                
                Parenting_Family: match_kw(
@@ -2415,14 +2446,14 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "personal finance",
                    "financial planning",
                    "investing",
-                   "retirement planning",
+                   Eg("retirement planning"),
                    "money management",
                ),
                
                Pets: match_kw(
                    "pets",
-                   "dogs",
-                   "cats",
+                   Eg("dogs"),
+                   Eg("cats"),
                ),
                
                Philosophy : match_kw(
@@ -2450,42 +2481,39 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "poets",
                    "poem",
                    "poems",
-                   "sonnet",
-                   "sonnets",
+                   Eg("sonnet"),
+                   Eg("sonnets"),
                ),
                
                Political_Science : match_kw(
-                   "american government",
-                   "anarchism",
-                   "censorship",
-                   "citizenship",
-                   "civics",
-                   "communism",
-                   "corruption",
-                   "corrupt practices",
-                   "democracy",
-                   "geopolitics",
+                   Eg("american government"),
+                   Eg("anarchism"),
+                   Eg("censorship"),
+                   Eg("citizenship"),
+                   Eg("civics"),
+                   Eg("communism"),
+                   Eg("corruption"),
+                   Eg("corrupt practices"),
+                   Eg("democracy"),
+                   Eg("geopolitics"),
                    "goverment",
-                   "human rights",
-                   "international relations",
-                   "political economy",
+                   Eg("human rights"),
+                   Eg("international relations"),
+                   Eg("political economy"),
                    "political ideologies",
                    "political process",
                    "political science",
-                   "public affairs",
-                   "public policy",
-               ),
-               
-               Political_Science: match_kw(
+                   Eg("public affairs"),
+                   Eg("public policy"),
                    "politics",
-                   "current events",
+                   Eg("current events"),
                ),
                
                Psychology: match_kw(
                    "psychology",
-                   "psychiatry",
+                   Eg("psychiatry"),
                    "psychological aspects",
-                   "psychiatric",
+                   Eg("psychiatric"),
                ),
                
                Real_Estate: match_kw(
@@ -2493,40 +2521,40 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                ),
                
                Reference_Study_Aids : match_kw(
-                   "catalogs",
-                   "handbooks",
-                   "manuals",
+                   Eg("catalogs"),
+                   Eg("handbooks"),
+                   Eg("manuals"),
 
                    # Formerly in 'Encyclopedias'
-                   "encyclopaedias",
-                   "encyclopaedia",
-                   "encyclopedias",
-                   "encyclopedia",            
+                   Eg("encyclopaedias"),
+                   Eg("encyclopaedia"),
+                   Eg("encyclopedias"),
+                   Eg("encyclopedia"),            
 
                    # Formerly in 'Language Arts & Disciplines'
-                   "alphabets",
-                   "communication studies",
-                   "composition",
-                   "creative writing",
-                   "grammar",
-                   "handwriting",
-                   "information sciences",
-                   "journalism",
-                   "language arts & disciplines",
-                   "language arts and disciplines",
-                   "language arts",
-                   "library & information sciences",
-                   "linguistics",
-                   "literacy",
-                   "public speaking",
-                   "rhetoric",
-                   "sign language",
-                   "speech",
-                   "spelling",
-                   "style manuals",
-                   "syntax",
-                   "vocabulary",
-                   "writing systems",
+                   Eg("alphabets"),
+                   Eg("communication studies"),
+                   Eg("composition"),
+                   Eg("creative writing"),
+                   Eg("grammar"),
+                   Eg("handwriting"),
+                   Eg("information sciences"),
+                   Eg("journalism"),
+                   Eg("language arts & disciplines"),
+                   Eg("language arts and disciplines"),
+                   Eg("language arts"),
+                   Eg("library & information sciences"),
+                   Eg("linguistics"),
+                   Eg("literacy"),
+                   Eg("public speaking"),
+                   Eg("rhetoric"),
+                   Eg("sign language"),
+                   Eg("speech"),
+                   Eg("spelling"),
+                   Eg("style manuals"),
+                   Eg("syntax"),
+                   Eg("vocabulary"),
+                   Eg("writing systems"),
                ),
                
                Religion_Spirituality : match_kw(
@@ -2551,41 +2579,41 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                ),
                
                Science : match_kw(
-                   "aeronautics",
-                   "astronomy",
-                   "biology",
-                   "biophysics",
-                   "biochemistry", 
-                   "botany",
-                   "chemistry",
-                   "ecology",
-                   "entomology",
-                   "evolution",
-                   "geology",
-                   "genetics",
-                   "genetic engineering",
-                   "genomics",
-                   "ichthyology",
-                   "herpetology", 
-                   "life sciences",
-                   "microbiology",
-                   "microscopy",
-                   "mycology",
-                   "ornithology",
-                   "natural history",
-                   "natural history",
-                   "physics",
+                   Eg("aeronautics"),
+                   Eg("astronomy"),
+                   Eg("biology"),
+                   Eg("biophysics"),
+                   Eg("biochemistry"), 
+                   Eg("botany"),
+                   Eg("chemistry"),
+                   Eg("ecology"),
+                   Eg("entomology"),
+                   Eg("evolution"),
+                   Eg("geology"),
+                   Eg("genetics"),
+                   Eg("genetic engineering"),
+                   Eg("genomics"),
+                   Eg("ichthyology"),
+                   Eg("herpetology"), 
+                   Eg("life sciences"),
+                   Eg("microbiology"),
+                   Eg("microscopy"),
+                   Eg("mycology"),
+                   Eg("ornithology"),
+                   Eg("natural history"),
+                   Eg("natural history"),
+                   Eg("physics"),
                    "science",
                    "scientist",
                    "scientists",
-                   "zoology",
-                   "virology",
-                   "cytology",
+                   Eg("zoology"),
+                   Eg("virology"),
+                   Eg("cytology"),
                ),
                
                Science_Fiction : match_kw(
                    "science fiction",
-                   "time travel",
+                   Eg("time travel"),
                ),
                
                #Science_Fiction_Fantasy: match_kw(
@@ -2608,58 +2636,58 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                Social_Sciences: match_kw(
                    "social sciences",
                    "social science",
-                   "anthropology",
-                   "archaology",
-                   "sociology",
-                   "ethnic studies",
-                   "gender studies",
-                   "media studies",
-                   "minority studies",
-                   "men's studies",
-                   "regional studies",
-                   "women's studies",
-                   "demography",
-                   'lesbian studies',
-                   'gay studies',
-                   "black studies",
-                   "african-american studies",
+                   Eg("anthropology"),
+                   Eg("archaology"),
+                   Eg("sociology"),
+                   Eg("ethnic studies"),
+                   Eg("gender studies"),
+                   Eg("media studies"),
+                   Eg("minority studies"),
+                   Eg("men's studies"),
+                   Eg("regional studies"),
+                   Eg("women's studies"),
+                   Eg("demography"),
+                   Eg('lesbian studies'),
+                   Eg('gay studies'),
+                   Eg("black studies"),
+                   Eg("african-american studies"),
                ),               
                
                Sports: match_kw(
                    # Ton of specific sports here since 'players'
                    # doesn't work. TODO: Why? I don't remember.
                    "sports",
-                   "baseball",
-                   "football",
-                   "hockey",
-                   "soccer",
-                   "skating",
+                   Eg("baseball"),
+                   Eg("football"),
+                   Eg("hockey"),
+                   Eg("soccer"),
+                   Eg("skating"),
                ),
                
                Study_Aids: match_kw(
-                   "act",
-                   "advanced placement",
-                   "bar exam",
-                   "clep",
-                   "college entrance",
-                   "college guides",
-                   "financial aid",
-                   "certification",
-                   "ged",
-                   "gmat",
-                   "gre",
-                   "lsat",
-                   "mat",
-                   "mcat",
-                   "nmsqt",
-                   "nte",
-                   "psat",
-                   "sat",
+                   Eg("act"),
+                   Eg("advanced placement"),
+                   Eg("bar exam"),
+                   Eg("clep"),
+                   Eg("college entrance"),
+                   Eg("college guides"),
+                   Eg("financial aid"),
+                   Eg("certification"),
+                   Eg("ged"),
+                   Eg("gmat"),
+                   Eg("gre"),
+                   Eg("lsat"),
+                   Eg("mat"),
+                   Eg("mcat"),
+                   Eg("nmsqt"),
+                   Eg("nte"),
+                   Eg("psat"),
+                   Eg("sat"),
                    "school guides",
                    "study guide",
                    "study guides",
                    "study aids",
-                   "toefl",
+                   Eg("toefl"),
                    "workbooks",
                ),
                             
@@ -2674,16 +2702,16 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                
                Technology: match_kw(
                    "technology",
-                   "engineering",
-                   "bioengineering",
+                   Eg("engineering"),
+                   Eg("bioengineering"),
 
                    # Formerly in 'Transportation'
-                   "transportation",
-                   "railroads",
-                   "trains",
-                   "automotive",
-                   "ships & shipbuilding",
-                   "cars & trucks",
+                   Eg("transportation"),
+                   Eg("railroads"),
+                   Eg("trains"),
+                   Eg("automotive"),
+                   Eg("ships & shipbuilding"),
+                   Eg("cars & trucks"),
                ),
                
                Suspense_Thriller: match_kw(
@@ -2699,7 +2727,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                ),
 
                Travel : match_kw(
-                   "discovery",
+                   Eg("discovery"),
                    "exploration",
                    "travel",
                    "travels.*voyages",
@@ -2716,8 +2744,8 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                United_States_History: match_kw(
                    "united states history",
                    "u.s. history",
-                   "american revolution",
-                   "1775-1783",
+                   Eg("american revolution"),
+                   Eg("1775-1783"),
                ),
                
                Urban_Fantasy: match_kw(
@@ -2727,15 +2755,15 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                
                Urban_Fiction: match_kw(
                    "urban fiction",
-                   "fiction.*african american.*urban",
+                   Eg("fiction.*african american.*urban"),
                    "fiction / urban",
                    "fiction/urban",
                ),
                
                Vegetarian_Vegan: match_kw(
                    "vegetarian",
-                   "vegan",
-                   "veganism",
+                   Eg("vegan"),
+                   Eg("veganism"),
                    "vegetarianism",
                ),
 
@@ -2769,23 +2797,23 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
             "arts and crafts movement",
         ),
         Drama : match_kw(
-            "opera",
+            Eg("opera"),
         ),
 
         Erotica : match_kw(
-            "erotic poetry",
-            "gay erotica",
-            "lesbian erotica",
-            "erotic photography",
+            Eg("erotic poetry"),
+            Eg("gay erotica"),
+            Eg("lesbian erotica"),
+            Eg("erotic photography"),
         ),
 
         Games : match_kw(
-            "games.*fantasy"
+            Eg("games.*fantasy")
         ),
 
         Literary_Criticism : match_kw(
-            "literary history", # Not History
-            "romance language", # Not Romance
+            Eg("literary history"), # Not History
+            Eg("romance language"), # Not Romance
         ),
 
         Media_Tie_in_SF : match_kw(
@@ -2797,8 +2825,8 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
         Military_SF: match_kw(
             "science fiction.*military",
             "military.*science fiction",
-            "space warfare",            # Thankfully
-            "interstellar warfare",
+            Eg("space warfare"),            # Thankfully
+            Eg("interstellar warfare"),
         ),
         Military_Thriller: match_kw(
             "military thrillers",
@@ -2808,13 +2836,13 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
             "human-animal relationships",
         ),
         Political_Science : match_kw(
-            "health care reform",
+            Eg("health care reform"),
         ),
 
         # Stop the 'religious' from matching Religion/Spirituality.
         Religious_Fiction: match_kw(
-            "christian fiction",
-            "fiction.*christian",
+            Eg("christian fiction"),
+            Eg("fiction.*christian"),
             "religious fiction",
             "fiction.*religious",
         ),
@@ -2856,22 +2884,22 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
     
 
     @classmethod
-    def is_fiction(cls, identifier, name):
+    def is_fiction(cls, identifier, name, exclude_examples=False):
         if not name:
             return None
-        if (cls.FICTION_INDICATORS.search(name)):
+        if (cls.FICTION_INDICATORS["search"](name, exclude_examples)):
             return True
-        if (cls.NONFICTION_INDICATORS.search(name)):
+        if (cls.NONFICTION_INDICATORS["search"](name, exclude_examples)):
             return False
         return None
 
     @classmethod
-    def audience(cls, identifier, name):
+    def audience(cls, identifier, name, exclude_examples=False):
         if name is None:
             return None
-        if cls.YOUNG_ADULT_INDICATORS.search(name):
+        if cls.YOUNG_ADULT_INDICATORS["search"](name, exclude_examples):
             use = cls.AUDIENCE_YOUNG_ADULT
-        elif cls.JUVENILE_INDICATORS.search(name):
+        elif cls.JUVENILE_INDICATORS["search"](name, exclude_examples):
             use = cls.AUDIENCE_CHILDREN
         else:
             return None
@@ -2892,17 +2920,17 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
     def audience_match(cls, query):
         audience = None
         audience_words = None
-        audience = cls.audience(None, query)
+        audience = cls.audience(None, query, exclude_examples=True)
         if audience:
             for audience_keywords in [cls.JUVENILE_INDICATORS, cls.YOUNG_ADULT_INDICATORS]:
-                match = audience_keywords.search(query)
+                match = audience_keywords["search"](query, exclude_examples=True)
                 if match:
                     audience_words = match.group()
                     break
         return (audience, audience_words)
 
     @classmethod
-    def genre(cls, identifier, name, fiction=None, audience=None):
+    def genre(cls, identifier, name, fiction=None, audience=None, exclude_examples=False):
         matches = Counter()
         match_against = [name]
         for l in [cls.LEVEL_3_KEYWORDS, cls.LEVEL_2_KEYWORDS, cls.CATCHALL_KEYWORDS]:
@@ -2912,7 +2940,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                 if (genre and audience and genre.audience_restriction
                     and audience not in genre.audience_restriction):
                     continue
-                if keywords and keywords.search(name):
+                if keywords and keywords["search"](name, exclude_examples):
                     matches[genre] += 1
             most_specific_genre = None
             most_specific_count = 0
@@ -2934,12 +2962,12 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
     def genre_match(cls, query):
         genre = None
         genre_words = None
-        genre = cls.genre(None, query)
+        genre = cls.genre(None, query, exclude_examples=True)
         if genre:
             for kwlist in [cls.LEVEL_3_KEYWORDS, cls.LEVEL_2_KEYWORDS, cls.CATCHALL_KEYWORDS]:
                 if genre in kwlist.keys():
                     genre_keywords = kwlist[genre]
-                    match = genre_keywords.search(query)
+                    match = genre_keywords["search"](query, exclude_examples=True)
                     if match:
                         genre_words = match.group()
                         break

--- a/classifier.py
+++ b/classifier.py
@@ -17,7 +17,6 @@ import json
 import os
 import pkgutil
 import re
-from functools import partial
 from collections import (
     Counter,
     defaultdict,
@@ -1683,29 +1682,29 @@ class AgeOrGradeClassifier(Classifier):
             age = GradeLevelClassifier.target_age(identifier, name, True)
         return age
 
-def match_term(l, term, exclude_examples=False):
-    if not l:
-        return None
-    if exclude_examples:
-        keywords = [keyword for keyword in l if not isinstance(keyword, Eg)]
-    else:
-        keywords = [str(keyword) for keyword in l]
-
-    if not keywords:
-        return None
-    any_keyword = "|".join(keywords)
-    with_boundaries = r'\b(%s)\b' % any_keyword
-    return re.compile(with_boundaries, re.I).search(term)
-
-
 def match_kw(*l):
     """Turn a list of strings into a function which uses a regular expression
     to match any of those strings, so long as there's a word boundary on both ends.
     The function will match all the strings by default, or can exclude the strings
     that are examples of the classification.
     """
+    def match_term(term, exclude_examples=False):
+        if not l:
+            return None
+        if exclude_examples:
+            keywords = [keyword for keyword in l if not isinstance(keyword, Eg)]
+        else:
+            keywords = [str(keyword) for keyword in l]
+
+        if not keywords:
+            return None
+        any_keyword = "|".join(keywords)
+        with_boundaries = r'\b(%s)\b' % any_keyword
+        return re.compile(with_boundaries, re.I).search(term)
+
+
     # This is a dictionary so it can be used as a class variable
-    return {"search": partial(match_term, l)}
+    return {"search": match_term}
 
 class Eg(object):
     """Mark this string as an example of a classification, rather than

--- a/external_search.py
+++ b/external_search.py
@@ -214,6 +214,7 @@ class ExternalSearchIndex(object):
             'series.minimal^5',
             "subtitle.minimal^4",
             "summary.minimal^3",
+            "classifications.term^3",
             'publisher',
             'imprint'
         ]
@@ -267,7 +268,7 @@ class ExternalSearchIndex(object):
                 return re.compile(word_boundary_pattern % match.strip(), re.IGNORECASE).sub("", original_string)
 
             if genre:
-                match_genre = make_match_query(genre.name, 'classifications.name')
+                match_genre = make_match_query(genre.name, 'genres.name')
                 classification_queries.append(match_genre)
                 remaining_string = without_match(remaining_string, genre_match)
 
@@ -334,7 +335,7 @@ class ExternalSearchIndex(object):
             clauses.append({'not': dict(terms=dict(language=exclude_languages))})
         if genres:
             genre_ids = [genre.id for genre in genres]
-            clauses.append(dict(terms={"classifications.term": genre_ids}))
+            clauses.append(dict(terms={"genres.term": genre_ids}))
         if media:
             media = [_f(medium) for medium in media]
             clauses.append(dict(terms=dict(medium=media)))

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -400,6 +400,24 @@ class TestKeyword(object):
             Keyword.audience(None, "teenage romance")
         )
 
+    def test_audience_match(self):
+        (audience, match) = Keyword.audience_match("teen books")
+        eq_(Classifier.AUDIENCE_YOUNG_ADULT, audience)
+        eq_("teen books", match)
+
+        # This is a search for a specific example so it doesn't match
+        (audience, match) = Keyword.audience_match("teen romance")
+        eq_(None, audience)
+
+    def test_genre_match(self):
+        (genre, match) = Keyword.genre_match("pets")
+        eq_(classifier.Pets, genre)
+        eq_("pets", match)
+
+        # This is a search for a specific example so it doesn't match
+        (genre, match) = Keyword.genre_match("cats")
+        eq_(None, genre)
+
     def test_improvements(self):
         """A place to put tests for miscellaneous improvements added 
         since the original work.

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -629,8 +629,8 @@ class TestSearchQuery(DatabaseTest):
         classification_query = must[2]['bool']['must']
         eq_(2, len(classification_query))
         genre_query = classification_query[0]['match']
-        assert 'classifications.name' in genre_query
-        eq_('Romance', genre_query['classifications.name'])
+        assert 'genres.name' in genre_query
+        eq_('Romance', genre_query['genres.name'])
         remaining_query = classification_query[1]['simple_query_string']
         assert "test" in remaining_query['query']
         assert "romance" not in remaining_query['query']
@@ -665,8 +665,8 @@ class TestSearchQuery(DatabaseTest):
         classification_query = must[2]['bool']['must']
         eq_(3, len(classification_query))
         genre_query = classification_query[0]['match']
-        assert 'classifications.name' in genre_query
-        eq_('Romance', genre_query['classifications.name'])
+        assert 'genres.name' in genre_query
+        eq_('Romance', genre_query['genres.name'])
         fiction_query = classification_query[1]['match']
         assert 'fiction' in fiction_query
         eq_('Fiction', fiction_query['fiction'])


### PR DESCRIPTION
This connects to #144 

There are two changes on this branch:
- Subjects are now stored in the search index and searched, separately from genres.
- Keywords that are specific examples of a classification rather than an exact identifier are excluded when used from search queries, so a search for "cats" won't match "pets" and return books about all pets.