### PR TITLE
Remove Edition.no_known_cover

### DIFF
--- a/migration/20160324-coverage-record-operation.sql
+++ b/migration/20160324-coverage-record-operation.sql
@@ -1,5 +1,1 @@
-ALTER TABLE coveragerecords RENAME date TO timestamp;
-ALTER TABLE coveragerecords ALTER COLUMN timestamp SET DATA TYPE timestamp;
-ALTER TABLE coveragerecords ADD COLUMN operation varchar(255) DEFAULT NULL;
-CREATE UNIQUE INDEX "ix_coveragerecords_data_source_id_operation_identifier_id" ON coveragerecords (data_source_id, operation, identifier_id);
-ALTER TABLE ONLY coveragerecords ADD CONSTRAINT coveragerecords_identifier_id_data_source_id_operation_key UNIQUE (identifier_id, data_source_id, operation);
+ALTER TABLE editions DROP COLUMN no_known_cover;

--- a/migration/20160324-coverage-record-operation.sql
+++ b/migration/20160324-coverage-record-operation.sql
@@ -1,1 +1,5 @@
-ALTER TABLE editions DROP COLUMN no_known_cover;
+ALTER TABLE coveragerecords RENAME date TO timestamp;
+ALTER TABLE coveragerecords ALTER COLUMN timestamp SET DATA TYPE timestamp;
+ALTER TABLE coveragerecords ADD COLUMN operation varchar(255) DEFAULT NULL;
+CREATE UNIQUE INDEX "ix_coveragerecords_data_source_id_operation_identifier_id" ON coveragerecords (data_source_id, operation, identifier_id);
+ALTER TABLE ONLY coveragerecords ADD CONSTRAINT coveragerecords_identifier_id_data_source_id_operation_key UNIQUE (identifier_id, data_source_id, operation);

--- a/model.py
+++ b/model.py
@@ -2279,12 +2279,6 @@ class Edition(Base):
     # access link for this Edition.
     open_access_download_url = Column(Unicode)
 
-    # This is set to True if we know there just isn't a cover for this
-    # edition. That lets us know it's okay to set the corresponding
-    # work to presentation ready even in the absence of a cover for
-    # its primary edition.
-    no_known_cover = Column(Boolean, default=False)
-
     # An OPDS entry containing all metadata about this entry that
     # would be relevant to display to a library patron.
     simple_opds_entry = Column(Unicode, default=None)
@@ -3706,9 +3700,7 @@ class Work(Base):
         self.presentation_ready_attempt = as_of
         self.random = random.random()
 
-    def set_presentation_ready_based_on_content(
-            self, require_author=True, require_thumbnail=True
-    ):
+    def set_presentation_ready_based_on_content(self):
         """Set this work as presentation ready, if it appears to
         be ready based on its data.
 
@@ -3716,26 +3708,15 @@ class Work(Base):
         patrons and (pending availability) checked out. It doesn't
         necessarily mean the presentation is complete.
 
-        A work with no summary can still be presentation ready,
-        since many public domain books have no summary.
-
-        A work with no cover can be presentation ready 
-
-        A work with no genres can be presentation ready, but we do
-        at least need to know whether it's fiction or nonfiction.
+        The absolute minimum data necessary is a title, a language,
+        and a fiction/nonfiction status. We don't need a cover or an
+        author -- we can fill in that info later if it exists.
         """
         if (not self.primary_edition
             or not self.license_pools
             or not self.title
-            or (require_author and not self.primary_edition.author)
             or not self.language
             or self.fiction is None
-            or (
-                require_thumbnail and not (
-                    self.cover_thumbnail_url
-                    or self.primary_edition.no_known_cover
-                )
-            )
         ):
             self.presentation_ready = False
         else:

--- a/opds_import.py
+++ b/opds_import.py
@@ -224,12 +224,10 @@ class OPDSImporter(object):
                 work.calculate_presentation()
                 if immediately_presentation_ready:
                     # We want this book to be presentation-ready
-                    # immediately upon import. It's okay if it
-                    # doesn't have an author or thumbnail
-                    # image--we'll fill that in later.
-                    work.set_presentation_ready_based_on_content(
-                        require_author=False, require_thumbnail=False,
-                    )
+                    # immediately upon import. As long as no crucial
+                    # information is missing (like language or title),
+                    # this will do it.
+                    work.set_presentation_ready_based_on_content()
         return edition
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1108,31 +1108,22 @@ class TestWork(DatabaseTest):
         work = self._work(with_license_pool=True)
         primary = work.primary_edition
         work.set_presentation_ready_based_on_content()
-        eq_(False, work.presentation_ready)
+        eq_(True, work.presentation_ready)
         
-        # This work is not presentation ready because it has no
-        # cover. If we record the fact that we tried and failed to
-        # find a cover, it will be considered presentation ready.
-        work.primary_edition.no_known_cover = True
-        work.set_presentation_ready_based_on_content()
-        eq_(True, work.presentation_ready)
-
-        # It would also work to add a cover, of course.
-        work.primary_edition.cover_thumbnail_url = "http://example.com/"
-        work.primary_edition.no_known_cover = False
-        work.set_presentation_ready_based_on_content()
-        eq_(True, work.presentation_ready)
+        # This work is presentation ready because it has a title
+        # and a fiction status.
 
         # Remove the title, and the work stops being presentation
         # ready.
         primary.title = None
         work.set_presentation_ready_based_on_content()
         eq_(False, work.presentation_ready)        
+
         primary.title = u"foo"
         work.set_presentation_ready_based_on_content()
         eq_(True, work.presentation_ready)        
 
-        # Remove the fiction setting, and the work stops being
+        # Remove the fiction status, and the work stops being
         # presentation ready.
         work.fiction = None
         work.set_presentation_ready_based_on_content()
@@ -1141,18 +1132,6 @@ class TestWork(DatabaseTest):
         work.fiction = False
         work.set_presentation_ready_based_on_content()
         eq_(True, work.presentation_ready)        
-
-        # Remove the author's presentation string, and the work stops
-        # being presentation ready.
-        primary.author = None
-        work.set_presentation_ready_based_on_content()
-        eq_(False, work.presentation_ready)        
-        primary.author = u"foo"
-        work.set_presentation_ready_based_on_content()
-        eq_(True, work.presentation_ready)        
-
-        # TODO: there are some other things you can do to stop a work
-        # being presentation ready, and they should all be tested.
 
     def test_assign_genres_from_weights(self):
         work = self._work()


### PR DESCRIPTION
At one point our rules for when a work was 'presentation-ready' (i.e. would be shown to patrons for checkout) were pretty strict. In particular, you either had to have a cover image or Edition.no_known_cover had to be set. no_known_cover meant that we had tried really hard to look for a cover image and come up short.

But recently we changed the rules so that works are made presentation-ready much sooner. If there's a problem completing the metadata for a book, we want a) the book to be loanable during the period when the problem happens, and b) the problem to be visible (e.g. by bad metadata), not invisible (e.g. by a book not showing up in the collection). So we effectively stopped using no_known_cover.

I'm about to do some work that changes the relationship between Edition and Work, and as cleanup I'm getting rid of no_known_cover, which complicates that relationship and is no longer used.