### PR TITLE
Redo some subjects

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -403,9 +403,12 @@ class SimpleOPDSEntryCacheMonitor(OPDSEntryCacheMonitor):
 
 class SubjectAssignmentMonitor(SubjectSweepMonitor):
 
-    def __init__(self, _db, interval_seconds=None):
+    def __init__(self, _db, subject_type=None, filter_string=None,
+                 interval_seconds=None):
         super(SubjectAssignmentMonitor, self).__init__(
-            _db, "Subject assignment monitor", interval_seconds)
+            _db, "Subject assignment monitor", subject_type, filter_string,
+            interval_seconds
+        )
 
     def process_batch(self, subjects):
         highest_id = 0

--- a/monitor.py
+++ b/monitor.py
@@ -273,6 +273,14 @@ class IdentifierSweepMonitor(Monitor):
 
 class SubjectSweepMonitor(IdentifierSweepMonitor):
 
+    def __init__(self, _db, name, subject_type=None, filter_string=None,
+                 batch_size=500):
+        super(SubjectSweepMonitor, self).__init__(
+            _db, name, batch_size=batch_size
+        )
+        self.subject_type = subject_type
+        self.filter_string = filter_string
+
     def run_once(self, offset):
         q = self.subject_query().filter(
             Subject.id > offset).order_by(
@@ -285,7 +293,17 @@ class SubjectSweepMonitor(IdentifierSweepMonitor):
             return 0
 
     def subject_query(self):
-        return self._db.query(Subject)
+        qu = self._db.query(Subject)
+        if self.subject_type:
+            qu = qu.filter(Subject.type==self.subject_type)
+        if self.filter_string:
+            filter_string = '%' + self.filter_string + '%'
+            or_clause = or_(
+                Subject.identifier.ilike(filter_string),
+                Subject.name.ilike(filter_string)
+            )
+            qu = qu.filter(or_clause)
+        return qu
 
 class CustomListEntrySweepMonitor(IdentifierSweepMonitor):
 

--- a/scripts.py
+++ b/scripts.py
@@ -29,7 +29,7 @@ from external_search import (
 )
 from nyt import NYTBestSellerAPI
 from opds_import import OPDSImportMonitor
-from nyt import NYTBestSellerAPI
+from monitor import SubjectAssignmentMonitor
 
 from overdrive import (
     OverdriveBibliographicCoverageProvider,
@@ -185,6 +185,26 @@ class IdentifierInputScript(Script):
         return self.parse_identifier_list_or_data_source(
             self._db, sys.argv[1:]
         )
+
+class SubjectInputScript(Script):
+    """A script whose command line filters the set of Subjects.
+
+    :return: a 2-tuple (subject type, subject filter) that can be
+    passed into the SubjectSweepMonitor constructor.
+    """
+
+    @classmethod
+    def parse_command_line(cls):
+        subject_type = None
+        if len(sys.argv) < 2:
+            return None, None
+        subject_type = sys.argv[1]
+
+        if len(sys.argv) < 3:
+            subject_filter = None
+        else:
+            subject_filter = sys.argv[2]
+        return subject_type, subject_filter
 
 class RunCoverageProviderScript(IdentifierInputScript):
     """Run a single coverage provider."""
@@ -607,3 +627,12 @@ class Explain(IdentifierInputScript):
         print " %s genres." % (len(work.genres))
         for genre in work.genres:
             print " ", genre
+
+class SubjectAssignmentScript(SubjectInputScript):
+
+    def run(self):
+        subject_type, subject_filter = self.parse_command_line()
+        monitor = SubjectAssignmentMonitor(
+            self._db, subject_type, subject_filter
+        )
+        monitor.run()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -18,6 +18,7 @@ from model import (
     CoverageRecord,
     DataSource,
     Identifier,
+    Subject,
     Timestamp,
     UnresolvedIdentifier,
 )
@@ -27,6 +28,7 @@ from monitor import (
     PresentationReadyMonitor,
     IdentifierResolutionMonitor,
     ResolutionFailed,
+    SubjectSweepMonitor,
 )
 
 class DummyMonitor(Monitor):
@@ -257,3 +259,26 @@ class TestIdentifierResolutionMonitor(DatabaseTest):
         eq_(success, True)
 
 
+class TestSubjectSweepMonitor(DatabaseTest):
+
+    def test_subject_query(self):
+        s1, ignore = Subject.lookup(self._db, Subject.DDC, "100", None)
+        s2, ignore = Subject.lookup(
+            self._db, Subject.TAG, None, "100 Years of Solitude"
+        )
+
+        dewey_monitor = SubjectSweepMonitor(
+            self._db, "Test Monitor", Subject.DDC
+        )
+        eq_([s1], dewey_monitor.subject_query().all())
+
+        one_hundred_monitor = SubjectSweepMonitor(
+            self._db, "Test Monitor", None, "100"
+        )
+        eq_([s1, s2], one_hundred_monitor.subject_query().all())
+
+        specific_tag_monitor = SubjectSweepMonitor(
+            self._db, "Test Monitor", Subject.TAG, "Years"
+        )
+        eq_([s2], specific_tag_monitor.subject_query().all())
+        


### PR DESCRIPTION
This branch makes it possible to get the SubjectAssignmentMonitor to operate on a subset of subjects, rather than all of them. It creates a new script class, SubjectAssignmentScript, which retrieves command line options and uses them to instantiate an appropriate SubjectAssignmentMonitor.