### PR TITLE
Classify YOUNG ADULT FICTION as fiction

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -1183,6 +1183,8 @@ class ThreeMClassifier(Classifier):
             return True
         if identifier.startswith('JUVENILE FICTION'):
             return True
+        if identifier.startswith('YOUNG ADULT FICTION'):
+            return True
         return False
 
     @classmethod
@@ -3344,7 +3346,7 @@ class WorkClassifier(object):
     nonfiction_publishers = set(["Wiley"])
     fiction_publishers = set([])
 
-    def __init__(self, work, test_session=None, debug=False):
+    def __init__(self, work, test_session=None, debug=True):
         self._db = Session.object_session(work)
         if test_session:
             self._db = test_session

--- a/classifier.py
+++ b/classifier.py
@@ -3346,7 +3346,7 @@ class WorkClassifier(object):
     nonfiction_publishers = set(["Wiley"])
     fiction_publishers = set([])
 
-    def __init__(self, work, test_session=None, debug=True):
+    def __init__(self, work, test_session=None, debug=False):
         self._db = Session.object_session(work)
         if test_session:
             self._db = test_session

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -501,6 +501,7 @@ class TestBISAC(object):
 
         eq_(True, fic("FICTION / Classics"))
         eq_(True, fic("JUVENILE FICTION / Concepts / Date & Time"))
+        eq_(True, fic("YOUNG ADULT FICTION / Lifestyles / Country Life"))
         eq_(False, fic("HISTORY / General"))
 
 


### PR DESCRIPTION
This branch corrects the classification of YOUNG ADULT FICTION as fiction. It's a BISAC classification that 3M never uses, so until we started working with Axis 360 data we didn't notice that it's misclassified as nonfiction.