### PR TITLE
Improve searches for exact titles/authors

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -230,21 +230,6 @@ class ExternalSearchIndex(object):
             'imprint'
         ]
 
-        minimal_query_string_fields = [
-            # These fields have been minimally stemmed, so they have
-            # a higher weight than the stemmed fields.
-            'title.minimal^5',
-            "series.minimal^5", 
-            'subtitle.minimal^4',
-            'summary.minimal^3',
-
-            # These fields only use the standard analyzer and are closer to the
-            # original text.
-            'author^6',
-            'publisher',
-            'imprint'
-        ]
-
         fuzzy_fields = [
             # Only minimal stemming should be used with fuzzy queries.
             'title.minimal^4',
@@ -285,12 +270,9 @@ class ExternalSearchIndex(object):
         # fields.
 
         # Query string operators like "AND", "OR", "-", and quotation marks will
-        # work in the query string queries, but not the fuzzy query. There are two
-        # query string queries so that stemmed matches will have lower weight, but
-        # things won't match one field stemmed and minimally stemmed in the same query.
+        # work in the query string queries, but not the fuzzy query.
         match_full_query_stemmed = make_query_string_query(query_string, stemmed_query_string_fields)
-        match_full_query_minimal = make_query_string_query(query_string, minimal_query_string_fields)
-        must_match_options = [match_full_query_stemmed, match_full_query_minimal]
+        must_match_options = [match_full_query_stemmed]
 
         match_phrase = make_phrase_query(query_string, ['title.minimal', 'author', 'series.minimal'])
         must_match_options.append(match_phrase)

--- a/external_search.py
+++ b/external_search.py
@@ -96,7 +96,7 @@ class ExternalSearchIndex(object):
                                     "type": "custom",
                                     "char_filter": ["html_strip"],
                                     "tokenizer": "standard",
-                                    "filter": ["lowercase", "asciifolding", "en_stem_minimal_filter"]
+                                    "filter": ["lowercase", "asciifolding", "en_stop_filter", "en_stem_minimal_filter"]
                                 },
                             }
                         }
@@ -105,7 +105,7 @@ class ExternalSearchIndex(object):
             )
         
             mapping = {"properties": {}}
-            for field in ["title", "series", "subtitle", "summary"]:
+            for field in ["title", "series", "subtitle", "summary", "classifications.term"]:
                 mapping["properties"][field] = {
                     "type": "string",
                     "analyzer": "en_analyzer",
@@ -163,6 +163,23 @@ class ExternalSearchIndex(object):
                 }
             }
 
+        def make_phrase_query(query_string, fields):
+            field_queries = []
+            for field in fields:
+                field_query = {
+                  'match_phrase': {
+                    field: query_string
+                  }
+                }
+                field_queries.append(field_query)
+            return {
+                'bool': {
+                  'should': field_queries,
+                  'minimum_should_match': 1,
+                  'boost': 100,
+                }
+              }
+
         def make_fuzzy_query(query_string, fields):
             return {
                 'multi_match': {
@@ -204,10 +221,10 @@ class ExternalSearchIndex(object):
             "series^4", 
             'subtitle^3',
             'summary^2',
+            "classifications.term^2",
 
             # These fields only use the standard analyzer and are closer to the
             # original text.
-            "classifications.term^2",
             'author^6',
             'publisher',
             'imprint'
@@ -223,7 +240,6 @@ class ExternalSearchIndex(object):
 
             # These fields only use the standard analyzer and are closer to the
             # original text.
-            "classifications.term^3",
             'author^6',
             'publisher',
             'imprint'
@@ -236,7 +252,6 @@ class ExternalSearchIndex(object):
             "subtitle.minimal^3",
             "summary.minimal^2",
 
-            "classifications.term^2",
             'author^4',
             'publisher',
             'imprint'
@@ -245,11 +260,26 @@ class ExternalSearchIndex(object):
         # These words will fuzzy match other common words that aren't relevant,
         # so if they're present and correctly spelled we shouldn't use a
         # fuzzy query.
-        fuzzy_exceptions = [
+        fuzzy_blacklist = [
             "baseball", "basketball", # These fuzzy match each other
+
             "soccer", # Fuzzy matches "saucer", "docker", "sorcery"
+
+            "football", "softball", "software", "postwar",
+
+            "hamlet", "harlem", "amulet", "tablet",
+
+            "biology", "ecology", "zoology", "geology",
+
+            "joke", "jokes" # "jake"
+
+            "cat", "cats",
+            "car", "cars",
+            "war", "wars",
+
+            "away", "stay",
         ]
-        fuzzy_exception_re = re.compile(r'\b(%s)\b' % "|".join(fuzzy_exceptions), re.I)
+        fuzzy_blacklist_re = re.compile(r'\b(%s)\b' % "|".join(fuzzy_blacklist), re.I)
 
         # Find results that match the full query string in one of the main
         # fields.
@@ -262,7 +292,10 @@ class ExternalSearchIndex(object):
         match_full_query_minimal = make_query_string_query(query_string, minimal_query_string_fields)
         must_match_options = [match_full_query_stemmed, match_full_query_minimal]
 
-        if not fuzzy_exception_re.search(query_string):
+        match_phrase = make_phrase_query(query_string, ['title.minimal', 'author', 'series.minimal'])
+        must_match_options.append(match_phrase)
+
+        if not fuzzy_blacklist_re.search(query_string):
             fuzzy_query = make_fuzzy_query(query_string, fuzzy_fields)
             must_match_options.append(fuzzy_query)
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -266,13 +266,6 @@ class TestExternalSearch(DatabaseTest):
         eq_(unicode(self.moby_dick.id), hits[0]["_id"])
 
 
-        # Handles negation operator
-
-        results = self.search.query_works("moby -dick", None, None, None, None, None, None, None)
-        hits = results["hits"]["hits"]
-        eq_(unicode(self.moby_duck.id), hits[0]["_id"])
-
-
         # Matches stemmed word
 
         results = self.search.query_works("runs", None, None, None, None, None, None, None)
@@ -607,7 +600,7 @@ class TestSearchQuery(DatabaseTest):
 
         must = query['dis_max']['queries']
 
-        eq_(3, len(must))
+        eq_(4, len(must))
         stemmed_query = must[0]['simple_query_string']
         eq_("test", stemmed_query['query'])
         assert "title^4" in stemmed_query['fields']
@@ -618,26 +611,31 @@ class TestSearchQuery(DatabaseTest):
         assert "title.minimal^5" in minimal_query['fields']
         assert 'publisher' in minimal_query['fields']
 
+        phrase_queries = must[2]['bool']['should']
+        eq_(3, len(phrase_queries))
+        title_phrase_query = phrase_queries[0]['match_phrase']
+        assert 'title.minimal' in title_phrase_query
+        eq_("test", title_phrase_query['title.minimal'])
 
-        # Query with fuzzy exception
+        # Query with fuzzy blacklist keyword
         query = search.make_query("basketball")
 
         must = query['dis_max']['queries']
 
-        eq_(2, len(must))
+        eq_(3, len(must))
 
         # Query with genre
         query = search.make_query("test romance")
 
         must = query['dis_max']['queries']
 
-        eq_(4, len(must))
+        eq_(5, len(must))
         full_query = must[0]['simple_query_string']
         eq_("test romance", full_query['query'])
         assert "title^4" in full_query['fields']
         assert 'publisher' in full_query['fields']
 
-        classification_query = must[3]['bool']['must']
+        classification_query = must[4]['bool']['must']
         eq_(2, len(classification_query))
         genre_query = classification_query[0]['match']
         assert 'genres.name' in genre_query
@@ -653,9 +651,9 @@ class TestSearchQuery(DatabaseTest):
         
         must = query['dis_max']['queries']
 
-        eq_(4, len(must))
+        eq_(5, len(must))
 
-        classification_query = must[3]['bool']['must']
+        classification_query = must[4]['bool']['must']
         eq_(2, len(classification_query))
         fiction_query = classification_query[0]['match']
         assert 'fiction' in fiction_query
@@ -671,9 +669,9 @@ class TestSearchQuery(DatabaseTest):
 
         must = query['dis_max']['queries']
 
-        eq_(4, len(must))
+        eq_(5, len(must))
 
-        classification_query = must[3]['bool']['must']
+        classification_query = must[4]['bool']['must']
         eq_(3, len(classification_query))
         genre_query = classification_query[0]['match']
         assert 'genres.name' in genre_query
@@ -692,11 +690,11 @@ class TestSearchQuery(DatabaseTest):
 
         must = query['dis_max']['queries']
 
-        eq_(4, len(must))
+        eq_(5, len(must))
         full_query = must[0]['simple_query_string']
         eq_("test young adult", full_query['query'])
 
-        classification_query = must[3]['bool']['must']
+        classification_query = must[4]['bool']['must']
         eq_(2, len(classification_query))
         audience_query = classification_query[0]['match']
         assert 'audience' in audience_query
@@ -710,11 +708,11 @@ class TestSearchQuery(DatabaseTest):
         
         must = query['dis_max']['queries']
 
-        eq_(4, len(must))
+        eq_(5, len(must))
         full_query = must[0]['simple_query_string']
         eq_("test grade 6", full_query['query'])
 
-        classification_query = must[3]['bool']['must']
+        classification_query = must[4]['bool']['must']
         eq_(2, len(classification_query))
         grade_query = classification_query[0]['bool']
         assert 'must' in grade_query
@@ -733,11 +731,11 @@ class TestSearchQuery(DatabaseTest):
 
         must = query['dis_max']['queries']
 
-        eq_(4, len(must))
+        eq_(5, len(must))
         full_query = must[0]['simple_query_string']
         eq_("test 5-10 years", full_query['query'])
 
-        classification_query = must[3]['bool']['must']
+        classification_query = must[4]['bool']['must']
         eq_(2, len(classification_query))
         grade_query = classification_query[0]['bool']
         assert 'must' in grade_query

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -600,18 +600,13 @@ class TestSearchQuery(DatabaseTest):
 
         must = query['dis_max']['queries']
 
-        eq_(4, len(must))
+        eq_(3, len(must))
         stemmed_query = must[0]['simple_query_string']
         eq_("test", stemmed_query['query'])
         assert "title^4" in stemmed_query['fields']
         assert 'publisher' in stemmed_query['fields']
 
-        minimal_query = must[1]['simple_query_string']
-        eq_("test", minimal_query['query'])
-        assert "title.minimal^5" in minimal_query['fields']
-        assert 'publisher' in minimal_query['fields']
-
-        phrase_queries = must[2]['bool']['should']
+        phrase_queries = must[1]['bool']['should']
         eq_(3, len(phrase_queries))
         title_phrase_query = phrase_queries[0]['match_phrase']
         assert 'title.minimal' in title_phrase_query
@@ -622,20 +617,20 @@ class TestSearchQuery(DatabaseTest):
 
         must = query['dis_max']['queries']
 
-        eq_(3, len(must))
+        eq_(2, len(must))
 
         # Query with genre
         query = search.make_query("test romance")
 
         must = query['dis_max']['queries']
 
-        eq_(5, len(must))
+        eq_(4, len(must))
         full_query = must[0]['simple_query_string']
         eq_("test romance", full_query['query'])
         assert "title^4" in full_query['fields']
         assert 'publisher' in full_query['fields']
 
-        classification_query = must[4]['bool']['must']
+        classification_query = must[3]['bool']['must']
         eq_(2, len(classification_query))
         genre_query = classification_query[0]['match']
         assert 'genres.name' in genre_query
@@ -651,9 +646,9 @@ class TestSearchQuery(DatabaseTest):
         
         must = query['dis_max']['queries']
 
-        eq_(5, len(must))
+        eq_(4, len(must))
 
-        classification_query = must[4]['bool']['must']
+        classification_query = must[3]['bool']['must']
         eq_(2, len(classification_query))
         fiction_query = classification_query[0]['match']
         assert 'fiction' in fiction_query
@@ -669,9 +664,9 @@ class TestSearchQuery(DatabaseTest):
 
         must = query['dis_max']['queries']
 
-        eq_(5, len(must))
+        eq_(4, len(must))
 
-        classification_query = must[4]['bool']['must']
+        classification_query = must[3]['bool']['must']
         eq_(3, len(classification_query))
         genre_query = classification_query[0]['match']
         assert 'genres.name' in genre_query
@@ -690,11 +685,11 @@ class TestSearchQuery(DatabaseTest):
 
         must = query['dis_max']['queries']
 
-        eq_(5, len(must))
+        eq_(4, len(must))
         full_query = must[0]['simple_query_string']
         eq_("test young adult", full_query['query'])
 
-        classification_query = must[4]['bool']['must']
+        classification_query = must[3]['bool']['must']
         eq_(2, len(classification_query))
         audience_query = classification_query[0]['match']
         assert 'audience' in audience_query
@@ -708,11 +703,11 @@ class TestSearchQuery(DatabaseTest):
         
         must = query['dis_max']['queries']
 
-        eq_(5, len(must))
+        eq_(4, len(must))
         full_query = must[0]['simple_query_string']
         eq_("test grade 6", full_query['query'])
 
-        classification_query = must[4]['bool']['must']
+        classification_query = must[3]['bool']['must']
         eq_(2, len(classification_query))
         grade_query = classification_query[0]['bool']
         assert 'must' in grade_query
@@ -731,11 +726,11 @@ class TestSearchQuery(DatabaseTest):
 
         must = query['dis_max']['queries']
 
-        eq_(5, len(must))
+        eq_(4, len(must))
         full_query = must[0]['simple_query_string']
         eq_("test 5-10 years", full_query['query'])
 
-        classification_query = must[4]['bool']['must']
+        classification_query = must[3]['bool']['must']
         eq_(2, len(classification_query))
         grade_query = classification_query[0]['bool']
         assert 'must' in grade_query


### PR DESCRIPTION
Changes on this branch:

- Replaced the query_string_query with minimally analyzed fields with a phrase query that considers the order of the words. The phrase query has a higher weight than the stemmed query and the fuzzy query. This means the search operators like the negation operator from the query string won't really work anymore, since results from the phrase query will come first, but I don't think that's too important.
- Added a bunch of things to the fuzzy search blacklist
- Added the subjects to the fields that get analyzed. I'd noticed that stop words like "and" from the subjects were matching in some cases, so now they'll get removed. I also added the stop words filter to the minimal analyzer - the phrase queries seem to work well even without stop words.