### PR TITLE
Enable authenticated libraries

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -400,7 +400,7 @@ class URNLookupController(object):
 
         return feed_response(opds_feed)
 
-    
+
 class ComplaintController(object):
     """A controller to register complaints against objects."""
 
@@ -433,4 +433,4 @@ class ComplaintController(object):
             )
 
         return make_response("Success", 201, {"Content-Type": "text/plain"})
-        
+

--- a/model.py
+++ b/model.py
@@ -6821,6 +6821,40 @@ class Admin(Base):
         _db.commit()
 
 
+class Library(Base):
+
+    __tablename__ = 'libraries'
+
+    id = Column(Integer, primary_key=True)
+    name = Column(Unicode, unique=True)
+    client_id = Column(Unicode, unique=True)
+    client_secret = Column(Unicode, unique=True, nullable=False)
+
+    CLIENT_ID_CHARS = ('abcdefghijklmnopqrstuvwxyz'
+                       'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                       '0123456789')
+
+    CLIENT_SECRET_CHARS = '!"#$%&()*+,-./[]^_`{}|~'
+
+    @classmethod
+    def generate(cls, _db, name):
+        library = get_one(_db, cls, name=name)
+        if not library:
+            def make_client_string(chars, length):
+                return u"".join([random.choice(chars) for x in range(length)])
+
+            full_client_secret_chars = cls.CLIENT_ID_CHARS + cls.CLIENT_SECRET_CHARS
+            client_id = make_client_string(cls.CLIENT_ID_CHARS, 25)
+            client_secret = make_client_string(full_client_secret_chars, 40)
+
+            library, new = create(
+                _db, cls, name=unicode(name), client_id=client_id,
+                client_secret=client_secret
+            )
+            return library, new
+        return library, False
+
+
 from sqlalchemy.sql import compiler
 from psycopg2.extensions import adapt as sqlescape
 

--- a/model.py
+++ b/model.py
@@ -283,7 +283,6 @@ def get_one(db, model, on_multiple='error', **kwargs):
     except NoResultFound:
         return None
 
-
 def get_one_or_create(db, model, create_method='',
                       create_method_kwargs=None,
                       **kwargs):
@@ -1811,7 +1810,6 @@ class UnresolvedIdentifier(Base):
             q = q.order_by(func.random())
         return q
 
-
     def set_attempt(self, time=None):
         """Set most_recent_attempt (and possibly first_attempt) to the given
         time.
@@ -1820,6 +1818,7 @@ class UnresolvedIdentifier(Base):
         self.most_recent_attempt = time
         if not self.first_attempt:
             self.first_attempt = time
+
 
 class Contributor(Base):
 
@@ -3011,7 +3010,6 @@ class PresentationCalculationPolicy(object):
             update_search_index=True,
         )
 
-        
 
 class Work(Base):
 

--- a/opds.py
+++ b/opds.py
@@ -783,7 +783,6 @@ class AcquisitionFeed(OPDSFeed):
     def _create_entry(self, work, license_pool, edition, identifier, lane_link,
                       force_create=False):
 
-        before = time.time()
         xml = None
         cache_hit = False
         field = self.annotator.opds_cache_field
@@ -813,8 +812,6 @@ class AcquisitionFeed(OPDSFeed):
                 xml, rel=OPDSFeed.GROUP_REL, href=group_uri,
                 title=group_title)
 
-
-        after = time.time()
         if edition:
             title = (edition.title or "") + " "
         else:

--- a/problem_details.py
+++ b/problem_details.py
@@ -13,3 +13,10 @@ UNRECOGNIZED_DATA_SOURCE = pd(
       "Unrecognized data source.",
       "I don't know anything about that data source.",
 )
+
+INVALID_CREDENTIALS = pd(
+      "http://librarysimplified.org/terms/problem/credentials-invalid",
+      401,
+      "Invalid credentials",
+      "A valid library card barcode number and PIN are required.",
+)


### PR DESCRIPTION
This is a simple way to keep track of libraries for the metadata wrangler. While the client_id and client_secret arrangement mimics OAuth, at this point library authentication is extremely insecure, in part because both the client_id and client_secret are being held in the database as plaintext. We could--and maybe should?!--use Bcrypt to encrypt the client_secret, but that means we'd only have one opportunity to see and share the client secret, at the moment we create the library.

Maybe this is fine. We're responsible people.

Or maybe - since Library's don't currently have any special privileges at all right now - this is temporarily acceptable?

Also, whitespace changes.