### PR TITLE
Enable authenticated collections

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -400,7 +400,7 @@ class URNLookupController(object):
 
         return feed_response(opds_feed)
 
-    
+
 class ComplaintController(object):
     """A controller to register complaints against objects."""
 
@@ -433,4 +433,4 @@ class ComplaintController(object):
             )
 
         return make_response("Success", 201, {"Content-Type": "text/plain"})
-        
+

--- a/app_server.py
+++ b/app_server.py
@@ -453,7 +453,6 @@ class CollectionController(object):
                 return collection
 
             # If inaccurate authorization details were sent, return error.
-            error = INVALID_CREDENTIALS
-            return problem(error.uri, error.status_code, error.title)
+            return INVALID_CREDENTIALS.response
         return None
 

--- a/app_server.py
+++ b/app_server.py
@@ -235,7 +235,7 @@ class URNLookupController(object):
 
         return (400, self.UNRESOLVABLE_URN)
 
-    def process_urn(self, urn):
+    def process_urn(self, urn, collection=None):
         """Turn a URN into a Work suitable for use in an OPDS feed.
 
         :return: If a Work is found, the return value is None.
@@ -246,6 +246,9 @@ class URNLookupController(object):
         if not isinstance(identifier, Identifier):
             # Error.
             return identifier
+
+        if collection:
+            collection.track_asset(self._db, identifier)
 
         if identifier.licensed_through:
             # There is a LicensePool for this identifier!
@@ -360,14 +363,14 @@ class URNLookupController(object):
         # We made it!
         return entry
 
-    def work_lookup(self, annotator, controller_name='lookup'):
+    def work_lookup(self, annotator, controller_name='lookup', collection=None):
         """Generate an OPDS feed describing works identified by identifier."""
         urns = flask.request.args.getlist('urn')
 
         messages_by_urn = dict()
         this_url = cdn_url_for(controller_name, _external=True, urn=urns)
         for urn in urns:
-            code, message = self.process_urn(urn)
+            code, message = self.process_urn(urn, collection=collection)
             if code:
                 messages_by_urn[urn] = (code, message)
 

--- a/app_server.py
+++ b/app_server.py
@@ -434,3 +434,23 @@ class ComplaintController(object):
 
         return make_response("Success", 201, {"Content-Type": "text/plain"})
 
+
+class CollectionController(object):
+    """A controller to manage collections and their assets"""
+
+    def __init__(self, _db):
+        self._db = _db
+
+    def authenticated_collection_from_request(self):
+        header = flask.request.authorization
+        if header:
+            client_id, client_secret = header.username, header.password
+            collection = Collection.authenticate(client_id, client_secret)
+            if collection:
+                return collection
+
+            # If inaccurate authorization details were sent, return error.
+            error = INVALID_CREDENTIALS
+            return problem(error.uri, error.status_code, error.title)
+        return None
+

--- a/app_server.py
+++ b/app_server.py
@@ -248,7 +248,7 @@ class URNLookupController(object):
             return identifier
 
         if collection:
-            collection.track_asset(self._db, identifier)
+            collection.catalog_identifier(self._db, identifier)
 
         if identifier.licensed_through:
             # There is a LicensePool for this identifier!

--- a/coverage.py
+++ b/coverage.py
@@ -212,6 +212,11 @@ class CoverageProvider(object):
                 )
             else:
                 return None
+        if not license_pool.data_source:
+            # This license pool was created to track a collection's
+            # holdings before its source was known.
+            license_pool.data_source = self.output_source
+            self._db.commit()
         return license_pool
 
     def edition(self, identifier):

--- a/coverage.py
+++ b/coverage.py
@@ -214,11 +214,6 @@ class CoverageProvider(object):
                 )
             else:
                 return None
-        if not license_pool.data_source:
-            # This license pool was created to track a collection's
-            # holdings before its source was known.
-            license_pool.data_source = self.output_source
-            self._db.commit()
         return license_pool
 
     def edition(self, identifier):

--- a/model.py
+++ b/model.py
@@ -6821,6 +6821,40 @@ class Admin(Base):
         _db.commit()
 
 
+class Library(Base):
+
+    __tablename__ = 'libraries'
+
+    id = Column(Integer, primary_key=True)
+    name = Column(Unicode, unique=True)
+    client_id = Column(Unicode, unique=True)
+    client_secret = Column(Unicode, unique=True, nullable=False)
+
+    CLIENT_ID_CHARS = ('abcdefghijklmnopqrstuvwxyz'
+                       'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                       '0123456789')
+
+    CLIENT_SECRET_CHARS = '!"#$%&()*+,-./[]^_`{}|~'
+
+    @classmethod
+    def generate(cls, _db, name):
+        library = get_one(_db, cls, name=name)
+        if not library:
+            def make_client_string(chars, length):
+                return u"".join([random.choice(chars) for x in range(length)])
+
+            full_client_secret_chars = cls.CLIENT_ID_CHARS + cls.CLIENT_SECRET_CHARS
+            client_id = make_client_string(cls.CLIENT_ID_CHARS, 25)
+            client_secret = make_client_string(full_client_secret_chars, 40)
+
+            library, new = create(
+                _db, cls, name=unicode(name), client_id=client_id,
+                client_secret=client_secret
+            )
+            return library, new
+        return library, False
+
+
 from sqlalchemy.sql import compiler
 from psycopg2.extensions import adapt as sqlescape
 

--- a/model.py
+++ b/model.py
@@ -6895,10 +6895,10 @@ class Collection(Base):
             _db, DataSource, name=name, offers_licenses=False
         )
 
-        client_id, plaintext_client_secret = cls.generate_client_details()
+        client_id, plaintext_client_secret = cls._generate_client_details()
         # Generate a new client_id if it's not unique initially.
         while get_one(_db, cls, client_id=client_id):
-            client_id, plaintext_client_secret = cls.generate_client_details()
+            client_id, plaintext_client_secret = cls._generate_client_details()
 
         collection, ignore = get_one_or_create(
             _db, cls, name=name, client_id=unicode(client_id),
@@ -6910,7 +6910,7 @@ class Collection(Base):
         return collection, plaintext_client_secret
 
     @classmethod
-    def generate_client_details(cls):
+    def _generate_client_details(cls):
         client_id_chars = ('abcdefghijklmnopqrstuvwxyz'
                            'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
                            '0123456789')

--- a/model.py
+++ b/model.py
@@ -283,7 +283,6 @@ def get_one(db, model, on_multiple='error', **kwargs):
     except NoResultFound:
         return None
 
-
 def get_one_or_create(db, model, create_method='',
                       create_method_kwargs=None,
                       **kwargs):
@@ -1811,7 +1810,6 @@ class UnresolvedIdentifier(Base):
             q = q.order_by(func.random())
         return q
 
-
     def set_attempt(self, time=None):
         """Set most_recent_attempt (and possibly first_attempt) to the given
         time.
@@ -1820,6 +1818,7 @@ class UnresolvedIdentifier(Base):
         self.most_recent_attempt = time
         if not self.first_attempt:
             self.first_attempt = time
+
 
 class Contributor(Base):
 
@@ -3011,7 +3010,6 @@ class PresentationCalculationPolicy(object):
             update_search_index=True,
         )
 
-        
 
 class Work(Base):
 

--- a/model.py
+++ b/model.py
@@ -6879,7 +6879,7 @@ class Collection(Base):
                 == self.client_secret)
 
     @classmethod
-    def register(cls, _db, name, is_source=True):
+    def register(cls, _db, name):
         """Creates a new collection with client details and a datasource."""
 
         name = unicode(name)
@@ -6890,28 +6890,22 @@ class Collection(Base):
                 name, collection)
             )
 
-        collection_data_source = None
-        if is_source:
-            collection_data_source, ignore = get_one_or_create(
-                _db, DataSource, name=name, offers_licenses=False
-            )
+        collection_data_source, ignore = get_one_or_create(
+            _db, DataSource, name=name, offers_licenses=False
+        )
 
         client_id, plaintext_client_secret = cls.generate_client_details()
         # Generate a new client_id if it's not unique initially.
         while get_one(_db, cls, client_id=client_id):
             client_id, plaintext_client_secret = cls.generate_client_details()
 
-        kw = dict(
-            client_id=unicode(client_id),
-            client_secret=unicode(plaintext_client_secret)
+        collection, ignore = get_one_or_create(
+            _db, cls, name=name, client_id=unicode(client_id),
+            client_secret=unicode(plaintext_client_secret),
+            data_source=collection_data_source
         )
 
-        if collection_data_source:
-            kw['data_source'] = collection_data_source
-
-        collection, ignore = get_one_or_create(_db, cls, name=name, **kw)
         _db.commit()
-
         return collection, plaintext_client_secret
 
     @classmethod

--- a/model.py
+++ b/model.py
@@ -6938,6 +6938,11 @@ class Collection(Base):
         if license_pool not in self.license_pools:
             self.license_pools.append(license_pool)
 
+    def catalog(self, _db):
+        qu = _db.query(Identifier).join(LicensePool)
+        qu = qu.filter(LicensePool.collections.any(id=self.id))
+        return qu
+
 
 collections_license_pools = Table(
     'collectionslicensepools', Base.metadata,

--- a/model.py
+++ b/model.py
@@ -6836,10 +6836,9 @@ class Collection(Base):
     client_id = Column(Unicode, unique=True, index=True)
     _client_secret = Column(Unicode, nullable=False)
 
-    # A collection has one DataSource
+    # A collection can have one DataSource
     data_source_id = Column(
-        Integer, ForeignKey('datasources.id'), index=True, unique=True,
-        nullable=False
+        Integer, ForeignKey('datasources.id'), index=True
     )
 
     # A collection can have many LicensePools

--- a/model.py
+++ b/model.py
@@ -6876,11 +6876,10 @@ class Collection(Base):
         name = unicode(name)
         collection = get_one(_db, cls, name=name)
         if collection:
-            logging.error(
-                "A collection with the name '%s' already exists: %r",
-                name, collection
+            raise ValueError(
+                "A collection with the name '%s' already exists: %r" % (
+                name, collection)
             )
-            return None, None
 
         collection_data_source = None
         if is_source:

--- a/opds.py
+++ b/opds.py
@@ -783,7 +783,6 @@ class AcquisitionFeed(OPDSFeed):
     def _create_entry(self, work, license_pool, edition, identifier, lane_link,
                       force_create=False):
 
-        before = time.time()
         xml = None
         cache_hit = False
         field = self.annotator.opds_cache_field
@@ -813,8 +812,6 @@ class AcquisitionFeed(OPDSFeed):
                 xml, rel=OPDSFeed.GROUP_REL, href=group_uri,
                 title=group_title)
 
-
-        after = time.time()
         if edition:
             title = (edition.title or "") + " "
         else:

--- a/problem_details.py
+++ b/problem_details.py
@@ -13,3 +13,10 @@ UNRECOGNIZED_DATA_SOURCE = pd(
       "Unrecognized data source.",
       "I don't know anything about that data source.",
 )
+
+INVALID_CREDENTIALS = pd(
+      "http://librarysimplified.org/terms/problem/credentials-invalid",
+      401,
+      "Invalid credentials",
+      "A valid library card barcode number and PIN are required.",
+)

--- a/problem_details.py
+++ b/problem_details.py
@@ -18,5 +18,5 @@ INVALID_CREDENTIALS = pd(
       "http://librarysimplified.org/terms/problem/credentials-invalid",
       401,
       "Invalid credentials",
-      "A valid library card barcode number and PIN are required.",
+      "Valid credentials are required.",
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ uwsgi
 loggly-python-handler
 cairosvg
 mock
+py-bcrypt

--- a/testing.py
+++ b/testing.py
@@ -11,6 +11,7 @@ from config import Configuration
 os.environ['TESTING'] = 'true'
 from model import (
     Base,
+    Collection,
     Complaint,
     Contributor,
     CoverageRecord,
@@ -319,6 +320,9 @@ class DatabaseTest(object):
             resolved
         )
         return complaint
+
+    def _collection(self):
+        return Collection.register(self._db, "Faketown Public Library")[0]
 
 class InstrumentedCoverageProvider(CoverageProvider):
     """A CoverageProvider that keeps track of every item it tried

--- a/testing.py
+++ b/testing.py
@@ -321,8 +321,11 @@ class DatabaseTest(object):
         )
         return complaint
 
-    def _collection(self):
-        return Collection.register(self._db, "Faketown Public Library")[0]
+    def _collection(self, name=u"Faketown Public Library"):
+        return get_one_or_create(
+            self._db, Collection, name=name,
+            client_id=u"abc", client_secret=u"def"
+        )[0]
 
 class InstrumentedCoverageProvider(CoverageProvider):
     """A CoverageProvider that keeps track of every item it tried

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -111,6 +111,15 @@ class TestURNLookupController(DatabaseTest):
         eq_(404, code)
         eq_(controller.UNRECOGNIZED_IDENTIFIER, message)
 
+    def test_process_urn_with_collection(self):
+        identifier = self._identifier()
+        collection = self._collection()
+
+        eq_([], collection.assets)
+        self.controller.process_urn(identifier.urn, collection=collection)
+        eq_(1, len(collection.assets))
+        eq_(identifier, collection.assets[0].identifier)
+
 
 class TestComplaintController(DatabaseTest):
     

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -108,11 +108,10 @@ class TestURNLookupController(DatabaseTest):
         identifier = self._identifier()
         collection = self._collection()
 
-        eq_([], collection.license_pools)
+        eq_([], collection.catalog)
         self.controller.process_urn(identifier.urn, collection=collection)
-        eq_(1, len(collection.license_pools))
-        [lp] = collection.license_pools
-        eq_(identifier, lp.identifier)
+        eq_(1, len(collection.catalog))
+        eq_([identifier], collection.catalog)
 
 
 class TestComplaintController(DatabaseTest):

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -41,13 +41,6 @@ class TestURNLookupController(DatabaseTest):
         eq_(400, code)
         eq_(URNLookupController.INVALID_URN, message)
 
-    # We can't run this test at the moment because we actually can
-    # get info from an ISBN.
-    #def test_process_urn_unresolvable_urn(self):
-    #    code, message = self.controller.process_urn("urn:isbn:9781449358068")
-    #    eq_(400, code)
-    #    eq_(URNLookupController.UNRESOLVABLE_URN, message)
-
     def test_process_urn_initial_registration(self):
         identifier = self._identifier(Identifier.GUTENBERG_ID)
         code, message = self.controller.process_urn(identifier.urn)

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -105,13 +105,24 @@ class TestURNLookupController(DatabaseTest):
         eq_(controller.UNRECOGNIZED_IDENTIFIER, message)
 
     def test_process_urn_with_collection(self):
-        identifier = self._identifier()
         collection = self._collection()
+        i1 = self._identifier()
+        i2 = self._identifier()
 
         eq_([], collection.catalog)
-        self.controller.process_urn(identifier.urn, collection=collection)
+        self.controller.process_urn(i1.urn, collection=collection)
         eq_(1, len(collection.catalog))
-        eq_([identifier], collection.catalog)
+        eq_([i1], collection.catalog)
+
+        # Adds new identifiers to an existing catalog
+        self.controller.process_urn(i2.urn, collection=collection)
+        eq_(2, len(collection.catalog))
+        eq_([i1, i2], collection.catalog)
+
+        # Does not duplicate identifiers in the catalog
+        self.controller.process_urn(i1.urn, collection=collection)
+        eq_(2, len(collection.catalog))
+        eq_([i1, i2], collection.catalog)
 
 
 class TestComplaintController(DatabaseTest):

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -108,10 +108,11 @@ class TestURNLookupController(DatabaseTest):
         identifier = self._identifier()
         collection = self._collection()
 
-        eq_([], collection.assets)
+        eq_([], collection.license_pools)
         self.controller.process_urn(identifier.urn, collection=collection)
-        eq_(1, len(collection.assets))
-        eq_(identifier, collection.assets[0].identifier)
+        eq_(1, len(collection.license_pools))
+        [lp] = collection.license_pools
+        eq_(identifier, lp.identifier)
 
 
 class TestComplaintController(DatabaseTest):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2455,3 +2455,12 @@ class TestCollection(DatabaseTest):
         # It doesn't duplicate identifiers in the catalog.
         collection.catalog_identifier(self._db, identifier)
         eq_(1, len(collection.license_pools))
+
+    def test_catalog(self):
+        collection = self._collection()
+        i1, i2, i3 = self._identifier(), self._identifier(), self._identifier()
+
+        for identifier in [i1, i2, i3]:
+            collection.catalog_identifier(self._db, identifier)
+
+        eq_([i1, i2, i3], collection.catalog(self._db).all())

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2422,8 +2422,7 @@ class TestCollection(DatabaseTest):
         assert collection.client_secret
 
         # It returns nothing if the name is already taken.
-        result = Collection.register(self._db, u"A Library")
-        eq_((None, None), result)
+        assert_raises(ValueError, Collection.register, self._db, u"A Library")
 
         # It creates a DataSource for the Collection by default.
         source = get_one(self._db, DataSource, name=collection.name)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2470,24 +2470,11 @@ class TestCollection(DatabaseTest):
         eq_(None, result)
 
     def test_catalog_identifier(self):
+        """#catalog_identifier associates an identifier with the collection"""
+
         identifier = self._identifier()
         collection = self._collection()
 
-        # It creates a license_pool and associates it with the collection
-        eq_(None, identifier.licensed_through)
         collection.catalog_identifier(self._db, identifier)
-        eq_(1, len(collection.license_pools))
-        eq_(identifier, collection.license_pools[0].identifier)
-
-        # It doesn't duplicate identifiers in the catalog.
-        collection.catalog_identifier(self._db, identifier)
-        eq_(1, len(collection.license_pools))
-
-    def test_catalog(self):
-        collection = self._collection()
-        i1, i2, i3 = self._identifier(), self._identifier(), self._identifier()
-
-        for identifier in [i1, i2, i3]:
-            collection.catalog_identifier(self._db, identifier)
-
-        eq_([i1, i2, i3], collection.catalog(self._db).all())
+        eq_(1, len(collection.catalog))
+        eq_(identifier, collection.catalog[0])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2469,6 +2469,9 @@ class TestCollection(DatabaseTest):
         result = Collection.authenticate(self._db, u"abc", u"bad_secret")
         eq_(None, result)
 
+        result = Collection.authenticate(self._db, u"bad_id", u"def")
+        eq_(None, result)
+
     def test_catalog_identifier(self):
         """#catalog_identifier associates an identifier with the collection"""
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2453,21 +2453,12 @@ class TestCollection(DatabaseTest):
             self._db, u"A Library"
         )
 
-        # It creates a collection with client_details.
+        # It creates client details and a DataSource for the collection
         assert collection.client_id and collection.client_secret
+        assert get_one(self._db, DataSource, name=collection.name)
 
         # It returns nothing if the name is already taken.
         assert_raises(ValueError, Collection.register, self._db, u"A Library")
-
-        # It creates a DataSource for the Collection by default.
-        assert get_one(self._db, DataSource, name=collection.name)
-
-        # It can also create a Collection without a Data Source.
-        collection, plaintext_secret = Collection.register(
-            self._db, u"A Non-Library", is_source=False
-        )
-        source = get_one(self._db, DataSource, name=collection.name)
-        eq_(None, source)
 
     def test_authenticate(self):
         collection = self._collection()


### PR DESCRIPTION
This branch:
- creates collections (née libraries) as user-type objects for the Metadata Wrangler
- encrypts their `client_secret`
- authenticates requests from true-blue collections
- tracks the lookups of authenticated collections in the database

PHEW!

The content server and circulation manager are going to need their `requirements.txt` updated to include bcrypt before they can submodule update past this point.