### PR TITLE
Made it possible to remove a work's summary.

### DIFF
--- a/model.py
+++ b/model.py
@@ -3250,6 +3250,8 @@ class Work(Base):
         # TODO: clean up the content
         if resource:
             self.summary_text = resource.representation.unicode_content
+        else:
+            self.summary_text = ""
         WorkCoverageRecord.add_for(
             self, operation=WorkCoverageRecord.SUMMARY_OPERATION
         )

--- a/model.py
+++ b/model.py
@@ -3248,7 +3248,7 @@ class Work(Base):
     def set_summary(self, resource):
         self.summary = resource
         # TODO: clean up the content
-        if resource:
+        if resource and resource.representation:
             self.summary_text = resource.representation.unicode_content
         else:
             self.summary_text = ""

--- a/opds.py
+++ b/opds.py
@@ -220,9 +220,9 @@ class Annotator(object):
         """Return an HTML summary of this work."""
         summary = ""
         if work: 
-            if work.summary_text:
+            if work.summary_text != None:
                 summary = work.summary_text
-            elif work.summary:
+            elif work.summary and work.summary.content:
                 work.summary_text = work.summary.content
                 summary = work.summary_text
         return summary

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -759,7 +759,7 @@ class TestEdition(DatabaseTest):
         eq_("Kelly Accumulator, Bob A. Bitshifter", wr.author)
         eq_("Accumulator, Kelly ; Bitshifter, Bob", wr.sort_author)
 
-    def test_calculate_presentation_summary(self):
+    def test_set_summary(self):
         e, pool = self._edition(with_license_pool=True)
         work = self._work(primary_edition=e)
         overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -759,6 +759,25 @@ class TestEdition(DatabaseTest):
         eq_("Kelly Accumulator, Bob A. Bitshifter", wr.author)
         eq_("Accumulator, Kelly ; Bitshifter, Bob", wr.sort_author)
 
+    def test_calculate_presentation_summary(self):
+        e, pool = self._edition(with_license_pool=True)
+        work = self._work(primary_edition=e)
+        overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
+
+        # Set the work's summmary.
+        l1, new = pool.add_link(Hyperlink.DESCRIPTION, None, overdrive, "text/plain",
+                      "F")
+        work.set_summary(l1.resource)
+
+        eq_(l1.resource, work.summary)
+        eq_("F", work.summary_text)
+
+        # Remove the summary.
+        work.set_summary(None)
+        
+        eq_(None, work.summary)
+        eq_("", work.summary_text)
+
     def test_calculate_evaluate_summary_quality_with_privileged_data_source(self):
         e, pool = self._edition(with_license_pool=True)
         oclc = DataSource.lookup(self._db, DataSource.OCLC_LINKED_DATA)


### PR DESCRIPTION
Previously, you could set a work's summary to None, but it would retain the summary_text from the previous summary.

For the admin interface, I think it will be useful to remove an incorrect summary even if you don't have a new summary to replace it with.

I'm not sure how this will change with composite editions, but it works for now.

This connects to https://github.com/NYPL-Simplified/circulation/issues/146