### PR TITLE
Remove Axis 360 integration dependency

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -66,15 +66,19 @@ class Axis360API(object):
 
     @classmethod
     def environment_values(cls):
-        value = Configuration.integration('Axis 360')
-        return [
-            value[var] for var in [
+        config = Configuration.integration('Axis 360')
+        values = []
+        for name in [
                 'library_id',
                 'username',
                 'password',
                 'server',
-            ]
-        ]
+        ]:
+            value = config.get(name)
+            if value:
+                value = value.encode("utf8")
+            values.append(value)
+        return values
 
     @classmethod
     def from_environment(cls, _db):

--- a/overdrive.py
+++ b/overdrive.py
@@ -118,7 +118,6 @@ class OverdriveAPI(object):
     def from_environment(cls, _db):
         # Make sure all environment values are present. If any are missing,
         # return None. Otherwise return an OverdriveAPI object.
-        values = cls.environment_values()
         try:
             return cls(_db)
         except CannotLoadConfiguration, e:


### PR DESCRIPTION
This mirrors what we're doing with the Overdrive and 3M objects right now and allows the app to load when there's no Axis 360 integration configured.

Fixes NYPL-Simplified/circulation#153.