### PR TITLE
Fixed searching from lane with exclude_languages set. (Fixes #190)

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -383,9 +383,9 @@ class ExternalSearchIndex(object):
 
         clauses = []
         if languages:
-            clauses.append(dict(terms=dict(language=languages)))
+            clauses.append(dict(terms=dict(language=list(languages))))
         if exclude_languages:
-            clauses.append({'not': dict(terms=dict(language=exclude_languages))})
+            clauses.append({'not': dict(terms=dict(language=list(exclude_languages)))})
         if genres:
             genre_ids = [genre.id for genre in genres]
             clauses.append(dict(terms={"genres.term": genre_ids}))


### PR DESCRIPTION
This makes sure exclude_languages is a list before it gets serialized by elasticsearch. languages was already a list, but I did the same just in case.