### PR TITLE
Show collection updates

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -436,23 +436,3 @@ class ComplaintController(object):
             )
 
         return make_response("Success", 201, {"Content-Type": "text/plain"})
-
-
-class CollectionController(object):
-    """A controller to manage collections and their assets"""
-
-    def __init__(self, _db):
-        self._db = _db
-
-    def authenticated_collection_from_request(self):
-        header = flask.request.authorization
-        if header:
-            client_id, client_secret = header.username, header.password
-            collection = Collection.authenticate(client_id, client_secret)
-            if collection:
-                return collection
-
-            # If inaccurate authorization details were sent, return error.
-            return INVALID_CREDENTIALS.response
-        return None
-

--- a/migration/20160422-add-last-checked-to-collections.sql
+++ b/migration/20160422-add-last-checked-to-collections.sql
@@ -1,1 +1,0 @@
-ALTER TABLE collections add COLUMN last_checked timestamp;

--- a/migration/20160422-add-last-checked-to-collections.sql
+++ b/migration/20160422-add-last-checked-to-collections.sql
@@ -1,0 +1,1 @@
+ALTER TABLE collections add COLUMN last_checked timestamp;

--- a/model.py
+++ b/model.py
@@ -6915,7 +6915,7 @@ class Collection(Base):
         client_id_chars = ('abcdefghijklmnopqrstuvwxyz'
                            'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
                            '0123456789')
-        client_secret_chars = client_id_chars + '!"#$%&()*+,-./[]^_`{}|~'
+        client_secret_chars = client_id_chars + '!#$%&*+,-._'
 
         def make_client_string(chars, length):
             return u"".join([random.choice(chars) for x in range(length)])
@@ -6926,7 +6926,7 @@ class Collection(Base):
 
     @classmethod
     def authenticate(cls, _db, client_id, plaintext_client_secret):
-        collection = get_one(_db, cls, client_id=client_id)
+        collection = get_one(_db, cls, client_id=unicode(client_id))
         if (collection and
             collection._correct_secret(plaintext_client_secret)):
             return collection

--- a/model.py
+++ b/model.py
@@ -6928,21 +6928,18 @@ class Collection(Base):
     def works_updated(self, _db):
         """Returns all of a collection's works that have been updated since the
         last time the collection was checked"""
-        if self.catalog:
-            catalog_identifier_ids = [identifier.id for identifier in self.catalog]
 
-            # Find the works in the catalog that have been created or updated
-            # since the collection last checked.
-            query = _db.query(Work).join(Work.coverage_records)
-            query = query.join(Work.license_pools).join(Identifier)
-            query = query.filter(Identifier.id.in_(catalog_identifier_ids))
-            if self.last_checked:
-                query = query.filter(
-                    WorkCoverageRecord.timestamp > self.last_checked
-                )
+        query = _db.query(Work).join(Work.coverage_records)
+        query = query.join(Work.license_pools).join(Identifier)
+        query = query.join(Identifier.collections).filter(
+            Collection.id==self.id
+        )
+        if self.last_checked:
+            query = query.filter(
+                WorkCoverageRecord.timestamp > self.last_checked
+            )
 
-            return query.all()
-        return []
+        return query
 
 
 collections_identifiers = Table(

--- a/model.py
+++ b/model.py
@@ -6831,7 +6831,6 @@ class Collection(Base):
     name = Column(Unicode, unique=True, nullable=False)
     client_id = Column(Unicode, unique=True, index=True)
     _client_secret = Column(Unicode, nullable=False)
-    last_checked = Column(DateTime)
 
     # A collection can have one DataSource
     data_source_id = Column(
@@ -6925,7 +6924,7 @@ class Collection(Base):
             self.catalog.append(identifier)
             _db.commit()
 
-    def works_updated(self, _db):
+    def works_updated_since(self, _db, timestamp):
         """Returns all of a collection's works that have been updated since the
         last time the collection was checked"""
 
@@ -6934,9 +6933,9 @@ class Collection(Base):
         query = query.join(Identifier.collections).filter(
             Collection.id==self.id
         )
-        if self.last_checked:
+        if timestamp:
             query = query.filter(
-                WorkCoverageRecord.timestamp > self.last_checked
+                WorkCoverageRecord.timestamp > timestamp
             )
 
         return query

--- a/model.py
+++ b/model.py
@@ -1326,20 +1326,11 @@ class Identifier(Base):
                 # in the next round.
                 new_working_set.add(e.input_id)
 
-        #logging.debug("At level %d.", levels)
-        #logging.debug(" Original working set: %r", sorted(original_working_set))
-        #logging.debug(" New working set: %r", sorted(new_working_set))
-        #logging.debug(" %d equivalencies seen so far.",  len(seen_equivalency_ids))
-        #logging.debug(" %d identifiers seen so far.", len(seen_identifier_ids))
-        #logging.debug(" %d equivalents", len(equivalents))
-
         if new_working_set:
 
             q = _db.query(Identifier).filter(Identifier.id.in_(new_working_set))
             new_identifiers = [repr(i) for i in q]
             new_working_set_repr = ", ".join(new_identifiers)
-            #logging.debug(
-            #    " Here's the new working set: %r", new_working_set_repr)
 
         surviving_working_set = set()
         for id in original_working_set:
@@ -1363,10 +1354,6 @@ class Identifier(Base):
                             equivalents[id][new_id] = (new_weight, o2n_votes + n2new_votes)
                             surviving_working_set.add(new_id)
 
-        #logging.debug(
-        #    "Pruned %d from working set",
-        #    len(surviving_working_set.intersection(new_working_set))
-        #)
         return (surviving_working_set, seen_equivalency_ids, seen_identifier_ids,
                 equivalents)
 

--- a/model.py
+++ b/model.py
@@ -6938,6 +6938,26 @@ class Collection(Base):
             self.catalog.append(identifier)
             _db.commit()
 
+    def works_updated(self, _db):
+        """Returns all of a collection's works that have been updated since the
+        last time the collection was checked"""
+        if self.catalog:
+            catalog_identifier_ids = [identifier.id for identifier in self.catalog]
+
+            # Find the works in the catalog that have been created or updated
+            # since the collection last checked.
+            query = _db.query(Work).join(Work.coverage_records)
+            query = query.join(Work.license_pools).join(Identifier)
+            query = query.filter(Identifier.id.in_(catalog_identifier_ids))
+            if self.last_checked:
+                query = query.filter(
+                    WorkCoverageRecord.timestamp > self.last_checked
+                )
+
+            return query.all()
+        return []
+
+
 collections_identifiers = Table(
     'collectionsidentifiers', Base.metadata,
     Column(

--- a/model.py
+++ b/model.py
@@ -6844,6 +6844,7 @@ class Collection(Base):
     name = Column(Unicode, unique=True, nullable=False)
     client_id = Column(Unicode, unique=True, index=True)
     _client_secret = Column(Unicode, nullable=False)
+    last_checked = Column(DateTime)
 
     # A collection can have one DataSource
     data_source_id = Column(

--- a/testing.py
+++ b/testing.py
@@ -433,8 +433,8 @@ def _setup(dbinfo):
     SessionManager.initialize_data(db)
     # Test data: Create the patron used by the dummy authentication
     # mechanism.
-    get_one_or_create(db, Patron, authorization_identifier="200",
-                      create_method_kwargs=dict(external_identifier="200200200"))
+    get_one_or_create(db, Patron, authorization_identifier=u"200",
+                      create_method_kwargs=dict(external_identifier=u"200200200"))
     db.commit()
 
     print "Connection is now %r" % dbinfo.connection

--- a/testing.py
+++ b/testing.py
@@ -322,8 +322,9 @@ class DatabaseTest(object):
         return complaint
 
     def _collection(self, name=u"Faketown Public Library"):
+        source, ignore = get_one_or_create(self._db, DataSource, name=name)
         return get_one_or_create(
-            self._db, Collection, name=name,
+            self._db, Collection, name=name, data_source=source,
             client_id=u"abc", client_secret=u"def"
         )[0]
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2481,3 +2481,27 @@ class TestCollection(DatabaseTest):
         collection.catalog_identifier(self._db, identifier)
         eq_(1, len(collection.catalog))
         eq_(identifier, collection.catalog[0])
+
+    def test_works_updated(self):
+
+        collection = self._collection()
+        w1 = self._work(with_license_pool=True)
+        w2 = self._work(with_license_pool=True)
+        w3 = self._work(with_license_pool=True)
+
+        collection.catalog_identifier(self._db, w1.license_pools[0].identifier)
+        collection.catalog_identifier(self._db, w2.license_pools[0].identifier)
+        updated_works = collection.works_updated(self._db)
+        eq_(2, len(updated_works))
+        assert w1 in updated_works
+        assert w2 in updated_works
+        assert w3 not in updated_works
+
+        # Once the collection has checked, known works don't get returned.
+        collection.last_checked = datetime.datetime.utcnow()
+        eq_([], collection.works_updated(self._db))
+
+        # But if the work is updated, we get it back.
+        w1.coverage_records[0].timestamp = datetime.datetime.utcnow()
+        eq_([w1], collection.works_updated(self._db))
+        pass

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2489,9 +2489,14 @@ class TestCollection(DatabaseTest):
         w2 = self._work(with_license_pool=True)
         w3 = self._work(with_license_pool=True)
 
+        # A collection with no catalog returns nothing.
+        eq_([], collection.works_updated(self._db).all())
+
+        # A collection with a catalog returns updated works in the catalog
         collection.catalog_identifier(self._db, w1.license_pools[0].identifier)
         collection.catalog_identifier(self._db, w2.license_pools[0].identifier)
-        updated_works = collection.works_updated(self._db)
+        updated_works = collection.works_updated(self._db).all()
+
         eq_(2, len(updated_works))
         assert w1 in updated_works
         assert w2 in updated_works
@@ -2499,9 +2504,9 @@ class TestCollection(DatabaseTest):
 
         # Once the collection has checked, known works don't get returned.
         collection.last_checked = datetime.datetime.utcnow()
-        eq_([], collection.works_updated(self._db))
+        eq_([], collection.works_updated(self._db).all())
 
         # But if the work is updated, we get it back.
         w1.coverage_records[0].timestamp = datetime.datetime.utcnow()
-        eq_([w1], collection.works_updated(self._db))
+        eq_([w1], collection.works_updated(self._db).all())
         pass


### PR DESCRIPTION
- Moves the CollectionController to the metadata wrangler: NYPL-Simplified/metadata_wrangler#52
- Removes some of the more special characters from the `client_secret`, since they were getting in way of effortlessly `curl`ing the route
- Adds the column `last_checked` to collections, so we can:
- Return(s) works updated since a collection's last visit.
- Creates a datasource for a collection made during testing (like `Collection.register` does all the time)

Also: tests, removal of some commenty cruft, and the use of unicode encoding where it was immediately apparent.

Fixes NYPL-Simplified/metadata_wrangler#51.