### PR TITLE
Added fiction status to opds entries and removed it as a genre. (Fixes #187)

### DIFF
--- a/model.py
+++ b/model.py
@@ -4565,9 +4565,11 @@ class Subject(Base):
     PERSON = Classifier.PERSON
     ORGANIZATION = Classifier.ORGANIZATION
     SIMPLIFIED_GENRE = "http://librarysimplified.org/terms/genres/Simplified/"
+    SIMPLIFIED_FICTION_STATUS = "http://librarysimplified.org/terms/fiction/"
 
     by_uri = {
         SIMPLIFIED_GENRE : SIMPLIFIED_GENRE,
+        SIMPLIFIED_FICTION_STATUS : SIMPLIFIED_FICTION_STATUS,
         "http://librarysimplified.org/terms/genres/Overdrive/" : OVERDRIVE,
         "http://librarysimplified.org/terms/genres/3M/" : THREEM,
         "http://id.worldcat.org/fast/" : FAST, # I don't think this is official.

--- a/opds.py
+++ b/opds.py
@@ -157,19 +157,25 @@ class Annotator(object):
         """
         if not work:
             return {}
+
+        categories = {}
+
+        fiction_term = None
+        if work.fiction == True:
+            fiction_term = 'Fiction'
+        elif work.fiction == False:
+            fiction_term = 'Nonfiction'
+        if fiction_term:
+            fiction_scheme = simplified_ns + "fiction/"
+            categories[fiction_scheme] = [
+                dict(term=fiction_scheme + fiction_term,
+                     label=fiction_term)
+            ]
+
         simplified_genres = []
         for wg in work.work_genres:
             simplified_genres.append(wg.genre.name)
-        if not simplified_genres:
-            sole_genre = None
-            if work.fiction == True:
-                sole_genre = 'Fiction'
-            elif work.fiction == False:
-                sole_genre = 'Nonfiction'
-            if sole_genre:
-                simplified_genres.append(sole_genre)
 
-        categories = {}
         if simplified_genres:
             categories[Subject.SIMPLIFIED_GENRE] = [
                 dict(term=Subject.SIMPLIFIED_GENRE + urllib.quote(x),

--- a/opds.py
+++ b/opds.py
@@ -166,7 +166,7 @@ class Annotator(object):
         elif work.fiction == False:
             fiction_term = 'Nonfiction'
         if fiction_term:
-            fiction_scheme = simplified_ns + "fiction/"
+            fiction_scheme = Subject.SIMPLIFIED_FICTION_STATUS
             categories[fiction_scheme] = [
                 dict(term=fiction_scheme + fiction_term,
                      label=fiction_term)


### PR DESCRIPTION
I made up a new scheme for fiction/nonfiction status, and it's always included. Fiction/nonfiction no longer shows up as a genre if there are no other genres, so it will be up to the clients to check for genres and decide whether to display fiction/nonfiction.