### PR TITLE
Remove ids from collections

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -192,15 +192,12 @@ class HeartbeatController(object):
 
 class URNLookupController(object):
 
-    INVALID_URN = "Could not parse identifier."
     UNRECOGNIZED_IDENTIFIER = "I've never heard of this work."
     UNRESOLVABLE_URN = "I don't know how to get metadata for this kind of identifier."
     WORK_NOT_PRESENTATION_READY = "Work created but not yet presentation-ready."
     WORK_NOT_CREATED = "Identifier resolved but work not yet created."
     IDENTIFIER_REGISTERED = "You're the first one to ask about this identifier. I'll try to find out about it."
     WORKING_TO_RESOLVE_IDENTIFIER = "I'm working to locate a source for this identifier."
-
-    COULD_NOT_PARSE_URN_TYPE = "http://librarysimplified.org/terms/problem/could-not-parse-urn"
 
     def __init__(self, _db, can_resolve_identifiers=False):
         self._db = _db
@@ -217,7 +214,7 @@ class URNLookupController(object):
             identifier, is_new = Identifier.parse_urn(
                 _db, urn)
         except ValueError, e:
-            return (400, self.INVALID_URN)
+            return (INVALID_URN.status_code, INVALID_URN.detail)
 
         if not must_support_metadata:
             return identifier

--- a/app_server.py
+++ b/app_server.py
@@ -7,6 +7,7 @@ import os
 import sys
 import subprocess
 from lxml import etree
+from functools import wraps
 from flask import url_for, make_response
 from util.flask_util import problem
 import traceback
@@ -156,6 +157,14 @@ def load_pagination(size, offset):
             return INVALID_INPUT.detailed("Invalid offset: %s" % offset)
     return Pagination(offset, size)
 
+def returns_problem_detail(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        v = f(*args, **kwargs)
+        if isinstance(v, ProblemDetail):
+            return v.response
+        return v
+    return decorated
 
 class ErrorHandler(object):
     def __init__(self, app, debug):

--- a/problem_details.py
+++ b/problem_details.py
@@ -20,3 +20,10 @@ INVALID_CREDENTIALS = pd(
       "Invalid credentials",
       "Valid credentials are required.",
 )
+
+INVALID_URN = pd(
+      "http://librarysimplified.org/terms/problem/could-not-parse-urn",
+      400,
+      "Invalid URN",
+      "Could not parse identifier.",
+)

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -28,7 +28,10 @@ from app_server import (
     load_pagination_from_request,
 )
 
-from problem_details import INVALID_INPUT
+from problem_details import (
+    INVALID_INPUT,
+    INVALID_URN,
+)
 
 class TestURNLookupController(DatabaseTest):
 
@@ -39,7 +42,7 @@ class TestURNLookupController(DatabaseTest):
     def test_process_urn_invalid_urn(self):
         code, message = self.controller.process_urn("not even a URN")
         eq_(400, code)
-        eq_(URNLookupController.INVALID_URN, message)
+        eq_(INVALID_URN.detail, message)
 
     def test_process_urn_initial_registration(self):
         identifier = self._identifier(Identifier.GUTENBERG_ID)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2475,6 +2475,10 @@ class TestComplaint(DatabaseTest):
 
 class TestCollection(DatabaseTest):
 
+    def setup(self):
+        super(TestCollection, self).setup()
+        self.collection = self._collection()
+
     def test_encrypts_client_secret(self):
         collection, new = get_one_or_create(
             self._db, Collection, name=u"Test Collection", client_id=u"test",
@@ -2496,10 +2500,9 @@ class TestCollection(DatabaseTest):
         assert_raises(ValueError, Collection.register, self._db, u"A Library")
 
     def test_authenticate(self):
-        collection = self._collection()
 
         result = Collection.authenticate(self._db, u"abc", u"def")
-        eq_(collection, result)
+        eq_(self.collection, result)
 
         result = Collection.authenticate(self._db, u"abc", u"bad_secret")
         eq_(None, result)
@@ -2511,27 +2514,23 @@ class TestCollection(DatabaseTest):
         """#catalog_identifier associates an identifier with the collection"""
 
         identifier = self._identifier()
-        collection = self._collection()
-
-        collection.catalog_identifier(self._db, identifier)
-        eq_(1, len(collection.catalog))
-        eq_(identifier, collection.catalog[0])
+        self.collection.catalog_identifier(self._db, identifier)
+        eq_(1, len(self.collection.catalog))
+        eq_(identifier, self.collection.catalog[0])
 
     def test_works_updated_since(self):
 
-        collection = self._collection()
         w1 = self._work(with_license_pool=True)
         w2 = self._work(with_license_pool=True)
         w3 = self._work(with_license_pool=True)
-
         timestamp = datetime.datetime.utcnow()
         # A collection with no catalog returns nothing.
-        eq_([], collection.works_updated_since(self._db, timestamp).all())
+        eq_([], self.collection.works_updated_since(self._db, timestamp).all())
 
         # When no timestamp is passed, all works in the catalog are returned.
-        collection.catalog_identifier(self._db, w1.license_pools[0].identifier)
-        collection.catalog_identifier(self._db, w2.license_pools[0].identifier)
-        updated_works = collection.works_updated_since(self._db, None).all()
+        self.collection.catalog_identifier(self._db, w1.license_pools[0].identifier)
+        self.collection.catalog_identifier(self._db, w2.license_pools[0].identifier)
+        updated_works = self.collection.works_updated_since(self._db, None).all()
 
         eq_(2, len(updated_works))
         assert w1 in updated_works and w2 in updated_works
@@ -2540,4 +2539,4 @@ class TestCollection(DatabaseTest):
         # When a timestamp is passed, only works that have been updated
         # since then will be returned
         w1.coverage_records[0].timestamp = datetime.datetime.utcnow()
-        eq_([w1], collection.works_updated_since(self._db, timestamp).all())
+        eq_([w1], self.collection.works_updated_since(self._db, timestamp).all())


### PR DESCRIPTION
Supports NYPL-Simplified/metadata_wrangler#55 by:
- Pulling the `returns_problem_detail` wrapper from the Circulation Manager (to be updated accordingly in a soon-to-come submodule update), and
- factoring the `INVALID_URN` response into a problem detail.

Also a teensy refactoring in the `TestCollection` class. It's a grab bag, people! 👜

Fixes NYPL-Simplified/metadata_wrangler#54.