### PR TITLE
Stop storing session-specific information in global spaces

### DIFF
--- a/model.py
+++ b/model.py
@@ -4509,27 +4509,17 @@ class Genre(Base):
 
     @classmethod
     def lookup(cls, _db, name, autocreate=False):
-        if not hasattr(_db, '_genre_cache'):
-            _db._genre_cache = dict()
-        if isinstance(name, Genre):
-            return name, False
         if isinstance(name, GenreData):
             name = name.name
-        if name in _db._genre_cache:
-            return _db._genre_cache[name], False
+        args = (_db, Genre)
         if autocreate:
-            m = get_one_or_create
+            result, new = get_one_or_create(*args, name=name)
         else:
-            m = get_one
-        result = m(_db, Genre, name=name)
+            result = get_one(*args, name=name)
+            new = False
         if result is None:
             logging.getLogger().error('"%s" is not a recognized genre.', name)
-        if isinstance(result, tuple):
-            _db._genre_cache[name] = result[0]
-            return result
-        else:
-            _db._genre_cache[name] = result
-            return result, False
+        return result, new
 
     @property
     def genredata(self):

--- a/model.py
+++ b/model.py
@@ -743,7 +743,7 @@ class DataSource(Base):
             list(DataSource.well_known_sources(_db))
 
         names = cls.metadata_lookups_by_identifier_type[type] 
-        return _db.query(DataSource).filter(DataSource.name.in_(names))
+        return _db.query(DataSource).filter(DataSource.name.in_(names)).all()
 
     @classmethod
     def well_known_sources(cls, _db):

--- a/model.py
+++ b/model.py
@@ -805,6 +805,10 @@ class DataSource(Base):
             if offers_metadata_lookup:
                 l = _db.metadata_lookups_by_identifier_type[primary_identifier_type]
                 l.append(obj)
+
+                # Expunge the object from the current database session
+                # so that it can be used in other sessions.
+                _db.expunge(obj)
             yield obj
 
 
@@ -4499,6 +4503,10 @@ class Genre(Base):
         for g in _db.query(Genre):
             _db._genre_cache[g.name] = g
 
+            # Expunge the Genre object from this database session so
+            # that it can be used with other sessions.
+            _db.expunge(g)
+
     @classmethod
     def lookup(cls, _db, name, autocreate=False):
         if not hasattr(_db, '_genre_cache'):
@@ -6543,6 +6551,7 @@ class DeliveryMechanism(Base):
             _db._deliverymechanism_cache = dict()
         for m in _db.query(DeliveryMechanism):
             _db._deliverymechanism_cache[(m.content_type, m.drm_scheme)] = m
+            _db.expunge(m)
 
     @classmethod
     def lookup(cls, _db, content_type, drm_scheme):

--- a/testing.py
+++ b/testing.py
@@ -2,6 +2,7 @@ from datetime import (
     datetime,
     timedelta,
 )
+import logging
 import os
 import shutil
 import tempfile
@@ -25,11 +26,13 @@ from model import (
     Representation,
     Resource,
     Identifier,
+    SessionManager,
     Edition,
     Work,
     WorkCoverageRecord,
     UnresolvedIdentifier,
-    get_one_or_create
+    get_one_or_create,
+    production_session
 )
 from classifier import Classifier
 from coverage import (
@@ -40,17 +43,68 @@ from external_search import DummyExternalSearchIndex
 import mock
 import model
 
+def package_setup():
+    # Make sure the database schema is initialized and initial
+    # data is in place.
+    engine, connection, _db = DatabaseTest.get_database_connection()
+
+    # Create the schema and begin a transaction.
+    Base.metadata.create_all(connection)
+
+    # Initialize basic database data needed by the application.
+    SessionManager.initialize_data(_db)
+
+    # Initialize test data.
+    
+    # Create the patron used by the dummy authentication mechanism.
+    get_one_or_create(
+        _db, Patron, authorization_identifier="200",
+        create_method_kwargs=dict(external_identifier="200200200")
+    )
+    _db.commit()
+
 class DatabaseTest(object):
 
-    DBInfo = None
+    engine = None
+    connection = None
+
+    @classmethod
+    def get_database_connection(cls):
+        url = Configuration.database_url(test=True)
+        engine, connection = SessionManager.initialize(url)
+        session = Session(connection)
+        return engine, connection, session
+
+    @classmethod
+    def setup_class(cls):
+        cls.engine, cls.connection, ignore = cls.get_database_connection()
+
+        # Initialize a temporary data directory.
+        cls.old_data_dir = Configuration.data_directory
+        cls.tmp_data_dir = tempfile.mkdtemp(dir="/tmp")
+        Configuration.instance[Configuration.DATA_DIRECTORY] = cls.tmp_data_dir
+
+        os.environ['TESTING'] = 'true'
+
+    @classmethod
+    def teardown_class(cls):
+        # Roll back the top level transaction and disconnect from the database
+        cls.connection.close()
+        cls.engine.dispose()
+
+        if cls.tmp_data_dir.startswith("/tmp"):
+            logging.debug("Removing temporary directory %s" % cls.tmp_data_dir)
+            shutil.rmtree(cls.tmp_data_dir)
+        else:
+            logging.warn("Cowardly refusing to remove 'temporary' directory %s" % cls.tmp_data_dir)
+
+        Configuration.instance[Configuration.DATA_DIRECTORY] = cls.old_data_dir
+        if 'TESTING' in os.environ:
+            del os.environ['TESTING']
 
     def setup(self):
-        if not self.DBInfo.connection:
-            raise Exception("%r/%r connection was not initialized." % (
-                self, self.DBInfo)
-            )
-        self.__transaction = self.DBInfo.connection.begin_nested()
-        self._db = Session(self.DBInfo.connection)
+        self._db = Session(self.connection)
+        self.__transaction = self.connection.begin_nested()
 
         # Start with a high number so it won't interfere with tests that search for an age or grade
         self.counter = 1000
@@ -61,7 +115,6 @@ class DatabaseTest(object):
         self.search_mock.start()
 
     def teardown(self):
-        self._db.close()
         self.__transaction.rollback()
         self.search_mock.stop()
 
@@ -407,56 +460,3 @@ class DummyHTTPClient(object):
         self.requests.append(url)
         return self.responses.pop()
 
-import os
-from sqlalchemy.orm.session import Session
-
-from model import (
-    Patron,
-    SessionManager,
-    get_one_or_create,
-)
-
-def _setup(dbinfo):
-    # Connect to the database and create the schema within a transaction
-    url = Configuration.database_url(test=True)
-    engine, connection = SessionManager.initialize(url)
-    try:
-        Base.metadata.drop_all(connection)
-    except Exception, e:
-        print "Could not drop database:", e
-    Base.metadata.create_all(connection)
-    dbinfo.engine = engine
-    dbinfo.connection = connection
-    dbinfo.transaction = connection.begin_nested()
-
-    db = Session(dbinfo.connection)
-    SessionManager.initialize_data(db)
-    # Test data: Create the patron used by the dummy authentication
-    # mechanism.
-    get_one_or_create(db, Patron, authorization_identifier="200",
-                      create_method_kwargs=dict(external_identifier="200200200"))
-    db.commit()
-
-    print "Connection is now %r" % dbinfo.connection
-    print "Transaction is now %r" % dbinfo.transaction
-
-    dbinfo.old_data_dir = Configuration.data_directory
-    dbinfo.tmp_data_dir = tempfile.mkdtemp(dir="/tmp")
-    Configuration.instance[Configuration.DATA_DIRECTORY] =dbinfo.tmp_data_dir
-    os.environ['TESTING'] = 'true'
-
-def _teardown(dbinfo):
-    # Roll back the top level transaction and disconnect from the database
-    dbinfo.transaction.rollback()
-    dbinfo.connection.close()
-    dbinfo.engine.dispose()
-
-    if dbinfo.tmp_data_dir.startswith("/tmp"):
-        print "Removing temporary directory %s" % dbinfo.tmp_data_dir
-        shutil.rmtree(dbinfo.tmp_data_dir)
-    else:
-        print "Cowardly refusing to remove 'temporary' directory %s" % dbinfo.tmp_data_dir
-
-    Configuration.instance[Configuration.DATA_DIRECTORY] = dbinfo.old_data_dir
-    if 'TESTING' in os.environ:
-        del os.environ['TESTING']

--- a/testing.py
+++ b/testing.py
@@ -95,6 +95,7 @@ class DatabaseTest(object):
 
     @classmethod
     def teardown_class(cls):
+        # Destroy the database connection and engine.
         cls.connection.close()
         cls.engine.dispose()
 
@@ -111,7 +112,7 @@ class DatabaseTest(object):
     def setup(self):
         # Create a new connection to the database.
         self._db = Session(self.connection)
-        self.transaction = self._db.begin_nested()
+        self.transaction = self.connection.begin_nested()
 
         # Start with a high number so it won't interfere with tests that search for an age or grade
         self.counter = 1000
@@ -122,9 +123,13 @@ class DatabaseTest(object):
         self.search_mock.start()
 
     def teardown(self):
-        # Roll back all database changes that happened during this test.
-        self.transaction.rollback()
+        # Close the session.
         self._db.close()
+
+        # Roll back all database changes that happened during this
+        # test, whether in the session that was just closed or some
+        # other session.
+        self.transaction.rollback()
         self.search_mock.stop()
 
     @property

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,19 +17,7 @@ from testing import (
     DatabaseTest,
     DummyMetadataClient,
     DummyHTTPClient,
-    _setup,
-    _teardown,
+    package_setup
 )
 
-class CoreDBInfo(object):
-    connection = None
-    engine = None
-    transaction = None
-
-DatabaseTest.DBInfo = CoreDBInfo
-
-def setup():
-    _setup(CoreDBInfo)
-
-def teardown():
-    _teardown(CoreDBInfo)
+package_setup()

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -165,7 +165,6 @@ class TestComplaintController(DatabaseTest):
                 "detail": "bar",
             }
         )
-        set_trace()
         with self.app.test_request_context("/"):
             response = self.controller.register(self.pool, data)
         assert response.status.startswith('201')

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -165,6 +165,7 @@ class TestComplaintController(DatabaseTest):
                 "detail": "bar",
             }
         )
+        set_trace()
         with self.app.test_request_context("/"):
             response = self.controller.register(self.pool, data)
         assert response.status.startswith('201')

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -601,7 +601,7 @@ class TestLanesQuery(DatabaseTest):
         # I'm putting all these tests into one method because the
         # setup function is so very expensive.
 
-        def test_expectations(lane, expected_count, predicate,
+        def _assert_expectations(lane, expected_count, predicate,
                               mw_predicate=None):
             """Ensure that a database query and a query of the
             materialized view give the same results.
@@ -618,24 +618,24 @@ class TestLanesQuery(DatabaseTest):
         # The 'everything' lane contains 18 works -- everything except
         # the music.
         lane = Lane(self._db, "Everything")
-        w, mw = test_expectations(lane, 18, lambda x: True)
+        w, mw = _assert_expectations(lane, 18, lambda x: True)
 
         # The 'Spanish' lane contains 1 book.
         lane = Lane(self._db, "Spanish", languages='spa')
         eq_(['spa'], lane.languages)
-        w, mw = test_expectations(lane, 1, lambda x: True)
+        w, mw = _assert_expectations(lane, 1, lambda x: True)
         eq_([self.spanish], w)
 
         # The 'everything except English' lane contains that same book.
         lane = Lane(self._db, "Not English", exclude_languages='eng')
         eq_(None, lane.languages)
         eq_(['eng'], lane.exclude_languages)
-        w, mw = test_expectations(lane, 1, lambda x: True)
+        w, mw = _assert_expectations(lane, 1, lambda x: True)
         eq_([self.spanish], w)
 
         # The 'music' lane contains 1 work of music
         lane = Lane(self._db, "Music", media=Edition.MUSIC_MEDIUM)
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             lane, 1, 
             lambda x: x.primary_edition.medium==Edition.MUSIC_MEDIUM,
             lambda x: x.medium==Edition.MUSIC_MEDIUM
@@ -643,14 +643,14 @@ class TestLanesQuery(DatabaseTest):
         
         # The 'English fiction' lane contains ten fiction books.
         lane = Lane(self._db, "English Fiction", fiction=True, languages='eng')
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             lane, 10, lambda x: x.fiction
         )
 
         # The 'nonfiction' lane contains seven nonfiction books.
         # It does not contain the music.
         lane = Lane(self._db, "Nonfiction", fiction=False)
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             lane, 7, 
             lambda x: x.primary_edition.medium==Edition.BOOK_MEDIUM and not x.fiction,
             lambda x: x.medium==Edition.BOOK_MEDIUM and not x.fiction
@@ -659,7 +659,7 @@ class TestLanesQuery(DatabaseTest):
         # The 'adults' lane contains five books for adults.
         lane = Lane(self._db, "Adult English",
                     audiences=Lane.AUDIENCE_ADULT, languages='eng')
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             lane, 5, lambda x: x.audience==Lane.AUDIENCE_ADULT
         )
 
@@ -669,7 +669,7 @@ class TestLanesQuery(DatabaseTest):
         lane = Lane(self._db, "Adult + Adult Only",
                     audiences=audiences, languages='eng'
         )
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             lane, 7, lambda x: x.audience in audiences
         )
         eq_(2, len([x for x in w if x.audience==Lane.AUDIENCE_ADULTS_ONLY]))
@@ -678,7 +678,7 @@ class TestLanesQuery(DatabaseTest):
         # The 'Young Adults' lane contains five books.
         lane = Lane(self._db, "Young Adults", 
                     audiences=Lane.AUDIENCE_YOUNG_ADULT)
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             lane, 5, lambda x: x.audience==Lane.AUDIENCE_YOUNG_ADULT
         )
 
@@ -687,7 +687,7 @@ class TestLanesQuery(DatabaseTest):
             self._db, "If You're Seven", audiences=Lane.AUDIENCE_CHILDREN,
             age_range=7
         )
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             lane, 1, lambda x: x.audience==Lane.AUDIENCE_CHILDREN
         )
 
@@ -696,7 +696,7 @@ class TestLanesQuery(DatabaseTest):
             self._db, "10-12", audiences=Lane.AUDIENCE_CHILDREN,
             age_range=(10,12)
         )
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             lane, 4, lambda x: x.audience==Lane.AUDIENCE_CHILDREN
         )
        
@@ -714,7 +714,7 @@ class TestLanesQuery(DatabaseTest):
             audiences=Lane.AUDIENCE_ADULT,
         )
         # We get three books: Fantasy, Urban Fantasy, and Epic Fantasy.
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             lane, 3, lambda x: True
         )
         expect = [u'Epic Fantasy Adult', u'Fantasy Adult', u'Urban Fantasy Adult']
@@ -737,7 +737,7 @@ class TestLanesQuery(DatabaseTest):
             sorted([x.name for x in lane.genres]))
 
         # We get two books: Fantasy and Epic Fantasy.
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             lane, 2, lambda x: True
         )
         expect = [u'Epic Fantasy YA', u'Fantasy YA']
@@ -748,7 +748,7 @@ class TestLanesQuery(DatabaseTest):
         overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
         lane = Lane(self._db, full_name="Overdrive Books",
                     license_source=overdrive)
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             lane, 10, lambda x: True
         )
         for i in mw:
@@ -784,7 +784,7 @@ class TestLanesQuery(DatabaseTest):
             self._db, full_name="Fiction Best Sellers",
             list_identifier=fic_name
         )
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             fiction_best_sellers, 1, 
             lambda x: x.sort_title == self.fiction.sort_title
         )
@@ -794,7 +794,7 @@ class TestLanesQuery(DatabaseTest):
             self._db, full_name="All Best Sellers",
             list_data_source=best_seller_list_1.data_source.name
         )
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             all_best_sellers, 2, 
             lambda x: x.sort_title in (
                 self.fiction.sort_title, self.nonfiction.sort_title
@@ -807,7 +807,7 @@ class TestLanesQuery(DatabaseTest):
             fiction=False,
             list_data_source=best_seller_list_1.data_source.name
         )
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             all_nonfiction_best_sellers, 1, 
             lambda x: x.sort_title==self.nonfiction.sort_title
         )
@@ -819,7 +819,7 @@ class TestLanesQuery(DatabaseTest):
             list_data_source=best_seller_list_1.data_source.name,
             list_seen_in_previous_days=7
         )
-        w, mw = test_expectations(
+        w, mw = _assert_expectations(
             best_sellers_past_week, 1, 
             lambda x: x.sort_title==self.fiction.sort_title
         )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1866,7 +1866,7 @@ class TestRepresentation(DatabaseTest):
 
     def test_set_fetched_content_file_on_disk(self):
         filename = "set_fetched_content_file_on_disk.txt"
-        path = os.path.join(self.DBInfo.tmp_data_dir, filename)
+        path = os.path.join(self.tmp_data_dir, filename)
         open(path, "w").write("some text")
 
         representation, ignore = self._representation(self._url, "text/plain")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -114,6 +114,12 @@ class TestDataSource(DatabaseTest):
         eq_(None, DataSource.lookup(
             self._db, "No such data source " + self._str))
 
+    def test_metadata_sources_for(self):
+        [content_cafe] = DataSource.metadata_sources_for(
+            self._db, Identifier.ISBN
+        )
+        eq_(DataSource.CONTENT_CAFE, content_cafe.name)
+
     def test_license_source_for(self):
         identifier = self._identifier(Identifier.OVERDRIVE_ID)
         source = DataSource.license_source_for(self._db, identifier)


### PR DESCRIPTION
This branch makes two changes in preparation for giving each incoming request to an app server its own database session (allowing multithreaded use).

First, it stops pre-caching DataSource, Genre, and LicensepoolDeliveryMechanism objects globally. These objects are associated with a specific database session, which works as long as the entire app is running against the same session, but falls apart as soon as session #2 tries to use an object created by session #1.

I don't know what the performance implications of this will be, but I really don't see any way around this, and we've seen that sharing a single database session has terrible implications for scalability.

Second, it refactors the process of setting up database sessions and rolling them back to use the standard `unittest` setup/teardown mechanisms, rather than the old (very hacky) mechanism that I made because I didn't know what I was doing.

I think this second bit is not strictly necessary for the scoped-session code. It turns out it's nearly impossible to test app servers with scoped sessions, so we're mostly going to be using the same old technique where we use a single database connection for the whole test. But either way this is an improvement over the old system.