### PR TITLE
Use client details for wrangler

### DIFF
--- a/config.py
+++ b/config.py
@@ -116,6 +116,8 @@ class Configuration(object):
     ELASTICSEARCH_INDEX_KEY = "works_index"
 
     METADATA_WRANGLER_INTEGRATION = "Metadata Wrangler"
+    METADATA_WRANGLER_CLIENT_ID = "client_id"
+    METADATA_WRANGLER_CLIENT_SECRET = "client_secret"
     CONTENT_SERVER_INTEGRATION = "Content Server"
     CIRCULATION_MANAGER_INTEGRATION = "Circulation Manager"
 
@@ -139,9 +141,6 @@ class Configuration(object):
     CDN_BOOK_COVERS = "book_covers"
     CDN_OPDS_FEEDS = "opds"
     CDN_OPEN_ACCESS_CONTENT = "open_access_books"
-
-    METADATA_WRANGLER_INTEGRATION = "Metadata Wrangler"
-    CONTENT_SERVER_INTEGRATION = "Content Server"
 
     BASE_OPDS_AUTHENTICATION_DOCUMENT = "base_opds_authentication_document"
     SHOW_STAFF_PICKS_ON_TOP_LEVEL = "show_staff_picks_on_top_level"

--- a/model.py
+++ b/model.py
@@ -604,6 +604,7 @@ class DataSource(Base):
     GUTENBERG_COVER_GENERATOR = "Gutenberg Illustrated"
     GUTENBERG_EPUB_GENERATOR = "Project Gutenberg EPUB Generator"
     METADATA_WRANGLER = "Library Simplified metadata wrangler"
+    METADATA_WRANGLER_COLLECTION = "Library Simplified Metadata Wrangler Collection"
     MANUAL = "Manual intervention"
     NYT = "New York Times"
     NYPL_SHADOWCAT = "NYPL Shadowcat"
@@ -779,6 +780,7 @@ class DataSource(Base):
                 (cls.NYT, False, False, Identifier.ISBN, None),
                 (cls.LIBRARY_STAFF, False, False, Identifier.ISBN, None),
                 (cls.METADATA_WRANGLER, False, False, Identifier.URI, None),
+                (cls.METADATA_WRANGLER_COLLECTION, False, False, None, None),
                 (cls.PROJECT_GITENBERG, True, False, Identifier.GUTENBERG_ID, None),
                 (cls.STANDARD_EBOOKS, True, False, Identifier.URI, None),
                 (cls.UNGLUE_IT, True, False, Identifier.URI, None),

--- a/model.py
+++ b/model.py
@@ -600,7 +600,6 @@ class DataSource(Base):
     GUTENBERG_COVER_GENERATOR = "Gutenberg Illustrated"
     GUTENBERG_EPUB_GENERATOR = "Project Gutenberg EPUB Generator"
     METADATA_WRANGLER = "Library Simplified metadata wrangler"
-    METADATA_WRANGLER_COLLECTION = "Library Simplified Metadata Wrangler Collection"
     MANUAL = "Manual intervention"
     NYT = "New York Times"
     NYPL_SHADOWCAT = "NYPL Shadowcat"
@@ -771,7 +770,6 @@ class DataSource(Base):
                 (cls.NYT, False, False, Identifier.ISBN, None),
                 (cls.LIBRARY_STAFF, False, False, Identifier.ISBN, None),
                 (cls.METADATA_WRANGLER, False, False, Identifier.URI, None),
-                (cls.METADATA_WRANGLER_COLLECTION, False, False, None, None),
                 (cls.PROJECT_GITENBERG, True, False, Identifier.GUTENBERG_ID, None),
                 (cls.STANDARD_EBOOKS, True, False, Identifier.URI, None),
                 (cls.UNGLUE_IT, True, False, Identifier.URI, None),
@@ -807,6 +805,8 @@ class CoverageRecord(Base):
 
     SET_EDITION_METADATA_OPERATION = 'set-edition-metadata'
     CHOOSE_COVER_OPERATION = 'choose-cover'
+    SYNC_OPERATION = 'sync'
+    REAP_OPERATION = 'reap'
 
     id = Column(Integer, primary_key=True)
     identifier_id = Column(

--- a/opds_import.py
+++ b/opds_import.py
@@ -60,6 +60,8 @@ class SimplifiedOPDSLookup(object):
 
     LOOKUP_ENDPOINT = "lookup"
     CANONICALIZE_ENDPOINT = "canonical-author-name"
+    UPDATES_ENDPOINT = "updates"
+    REMOVAL_ENDPOINT = "remove"
 
     @classmethod
     def from_config(cls, integration='Metadata Wrangler'):
@@ -126,6 +128,16 @@ class SimplifiedOPDSLookup(object):
             args += "&urn=%s" % urllib.quote(identifier.urn)
         url = self.base_url + self.CANONICALIZE_ENDPOINT + "?" + args
         logging.info("GET %s", url)
+        return self._get(url)
+
+    def remove(self, identifiers):
+        """Remove items from an authenticated Metadata Wrangler collection"""
+
+        if not self.authenticated:
+            raise AccessNotAuthenticated("Metadata Wrangler Collection not authenticated.")
+        args = "&".join(set(["urn=%s" % i.urn for i in identifiers]))
+        url = self.base_url + self.REMOVAL_ENDPOINT + "?" + args
+        logging.info("Metadata Wrangler Removal URL: %s", url)
         return self._get(url)
 
 

--- a/opds_import.py
+++ b/opds_import.py
@@ -18,7 +18,10 @@ from lxml import builder, etree
 from monitor import Monitor
 from util import LanguageCodes
 from util.xmlparser import XMLParser
-from config import Configuration
+from config import (
+    Configuration,
+    CannotLoadConfiguration,
+)
 from metadata_layer import (
     CirculationData,
     Metadata,
@@ -48,6 +51,10 @@ from model import (
 from opds import OPDSFeed
 from s3 import S3Uploader
 
+class AccessNotAuthenticated(Exception):
+    """No authentication is configured for this service"""
+    pass
+
 class SimplifiedOPDSLookup(object):
     """Tiny integration class for the Simplified 'lookup' protocol."""
 
@@ -65,13 +72,42 @@ class SimplifiedOPDSLookup(object):
         if not base_url.endswith('/'):
             base_url += "/"
         self.base_url = base_url
+        self._set_auth()
+
+    def _set_auth(self):
+        """Sets client authentication details for the Metadata Wrangler"""
+
+        metadata_wrangler_url = Configuration.integration_url(
+            Configuration.METADATA_WRANGLER_INTEGRATION
+        )
+        if (self.base_url==metadata_wrangler_url or
+            self.base_url==metadata_wrangler_url+'/'):
+            values = Configuration.integration(Configuration.METADATA_WRANGLER_INTEGRATION)
+            self.client_id = values.get(Configuration.METADATA_WRANGLER_CLIENT_ID)
+            self.client_secret = values.get(Configuration.METADATA_WRANGLER_CLIENT_SECRET)
+
+            details = [self.client_id, self.client_secret]
+            if len([d for d in details if not d]) == 1:
+                # Raise an error if one is set, but not the other.
+                raise CannotLoadConfiguration("Metadata Wrangler improperly configured.")
+
+    @property
+    def authenticated(self):
+        return bool(self.client_id and self.client_secret)
+
+    def _get(self, url):
+        """Runs requests with the appropriate authentication"""
+
+        if self.client_id and self.client_secret:
+            return requests.get(url, auth=(self.client_id, self.client_secret))
+        return requests.get(url)
 
     def lookup(self, identifiers):
         """Retrieve an OPDS feed with metadata for the given identifiers."""
         args = "&".join(set(["urn=%s" % i.urn for i in identifiers]))
         url = self.base_url + self.LOOKUP_ENDPOINT + "?" + args
         logging.info("Lookup URL: %s", url)
-        return requests.get(url)
+        return self._get(url)
 
     def canonicalize_author_name(self, identifier, working_display_name):
         """Attempt to find the canonical name for the author of a book.
@@ -90,7 +126,8 @@ class SimplifiedOPDSLookup(object):
             args += "&urn=%s" % urllib.quote(identifier.urn)
         url = self.base_url + self.CANONICALIZE_ENDPOINT + "?" + args
         logging.info("GET %s", url)
-        return requests.get(url)
+        return self._get(url)
+
 
 class OPDSXMLParser(XMLParser):
 
@@ -102,6 +139,7 @@ class OPDSXMLParser(XMLParser):
                    "schema" : "http://schema.org/",
                    "atom" : "http://www.w3.org/2005/Atom",
     }
+
 
 class StatusMessage(object):
 
@@ -123,6 +161,7 @@ class StatusMessage(object):
         return '<StatusMessage: code=%s message="%s">' % (
             self.status_code, self.message
         )
+
 
 class OPDSImporter(object):
 
@@ -172,7 +211,6 @@ class OPDSImporter(object):
                 messages[identifier.urn] = message
 
         return imported, messages, next_links
-
 
     def import_from_metadata(
             self, metadata, even_if_no_author, cutoff_date, immediately_presentation_ready
@@ -230,7 +268,6 @@ class OPDSImporter(object):
                     work.set_presentation_ready_based_on_content()
         return edition
 
-
     def extract_metadata(self, feed):
         """Turn an OPDS feed into a list of Metadata objects and a list of
         messages.
@@ -269,7 +306,6 @@ class OPDSImporter(object):
             elif k not in new_dict or v != None:
                 new_dict[k] = v
         return new_dict
-
 
     @classmethod
     def extract_metadata_from_feedparser(cls, feed):
@@ -399,7 +435,7 @@ class OPDSImporter(object):
                 media_type=media_type,
                 content=content
             )
-            
+
         summary_detail = entry.get('summary_detail', None)
         link = summary_to_linkdata(summary_detail)
         if link:
@@ -531,7 +567,6 @@ class OPDSImporter(object):
 
         logging.info("Refusing to create ContributorData for contributor with no sort name, display name, or VIAF.")
         return None
-
 
     @classmethod
     def extract_subject(cls, parser, category_tag):
@@ -693,8 +728,6 @@ class OPDSImportMonitor(Monitor):
         else:
             return next_links
 
-        
-
     def run_once(self, start, cutoff):
         queue = [self.feed_url]
         seen_links = set([])
@@ -710,6 +743,7 @@ class OPDSImportMonitor(Monitor):
                 self._db.commit()
 
             queue = new_queue
+
 
 class OPDSImporterWithS3Mirror(OPDSImporter):
     """OPDS Importer that mirrors content to S3."""

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -281,6 +281,28 @@ class TestCoverageProvider(DatabaseTest):
         # triggered.
         eq_(True, presentation_calculation_policy.tripped)
 
+    def test_operation_included_in_records(self):
+        provider = AlwaysSuccessfulCoverageProvider(
+            "Always successful", self.input_identifier_types,
+            self.output_source, operation=CoverageRecord.SYNC_OPERATION
+        )
+        result = provider.ensure_coverage(self.edition)
+
+        # The provider's operation is added to the record on success
+        [record] = self._db.query(CoverageRecord).all()
+        eq_(record.operation, CoverageRecord.SYNC_OPERATION)
+        self._db.delete(record)
+
+        provider = NeverSuccessfulCoverageProvider(
+            "Never successful", self.input_identifier_types,
+            self.output_source, operation=CoverageRecord.REAP_OPERATION
+        )
+        result = provider.ensure_coverage(self.edition)
+
+        # The provider's operation is added to the record on failure
+        [record] = self._db.query(CoverageRecord).all()
+        eq_(record.operation, CoverageRecord.REAP_OPERATION)
+
 
 class TestBibliographicCoverageProvider(DatabaseTest):
 


### PR DESCRIPTION
Once you get past all the whitespace changes, this branch allows circulation to make authenticated requests of the Metadata Wrangler, if it's been configured with a `client_id` and a `client_secret`. Unauthenticated requests still work as well, and the endpoint and functionality to remove identifiers from a Metadata Wrangler collection has been added.

Pairs with NYPL-Simplified/circulation#167. Fixes NYPL-Simplified/circulation#156.