### PR TITLE
Made it possible to deepcopy a metadata object with circulation data.

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -340,6 +340,11 @@ class FormatData(object):
         self.link = link
 
 class CirculationData(object):
+    
+    log = logging.getLogger(
+        "Abstract metadata layer - Circulation data"
+    )
+
     def __init__(
             self, licenses_owned, 
             licenses_available, 
@@ -354,10 +359,6 @@ class CirculationData(object):
         self.patrons_in_hold_queue = patrons_in_hold_queue
         self.first_appearance = first_appearance
         self.last_checked = last_checked or datetime.datetime.utcnow()
-        self.log = logging.getLogger(
-            "Abstract metadata layer - Circulation data"
-        )
-
 
     def update(self, license_pool, license_pool_is_new):
         _db = Session.object_session(license_pool)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -6,10 +6,13 @@ from nose.tools import (
 import datetime
 import pkgutil
 import csv
+from copy import deepcopy
 
 from metadata_layer import (
     CSVFormatError,
     CSVMetadataImporter,
+    CirculationData,
+    ContributorData,
     MeasurementData,
     FormatData,
     LinkData,
@@ -392,3 +395,32 @@ class TestMetadataImporter(DatabaseTest):
         eq_(1, len(links))
         eq_(gutenberg, links[0].data_source)
         eq_(gutenberg, links[0].resource.data_source)
+
+    def test_metadata_can_be_deepcopied(self):
+
+        # Check that we didn't put something in the metadata that
+        # will prevent it from being copied. (e.g., self.log)
+
+        subject = SubjectData(Subject.TAG, "subject")
+        contributor = ContributorData()
+        identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
+        link = LinkData(Hyperlink.OPEN_ACCESS_DOWNLOAD, "example.epub")
+        measurement = MeasurementData(Measurement.RATING, 5)
+        format = FormatData(Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.NO_DRM)
+        circulation = CirculationData(0, 0, 0, 0)
+
+        m = Metadata(
+            DataSource.GUTENBERG,
+            subjects=[subject],
+            contributors=[contributor],
+            primary_identifier=identifier,
+            links=[link],
+            measurements=[measurement],
+            formats=[format],
+            circulation=circulation,
+        )
+
+        m_copy = deepcopy(m)
+
+        # If deepcopy didn't throw an exception we're ok.
+        assert m_copy is not None


### PR DESCRIPTION
I use deepcopy in the unglue.it importer to make separate metadata objects for each book link, in case they have different rights. 

deepcopy uses pickle internally and the logger contains a thread.lock object which can't be pickled, so I moved it to the class instead of the object's state.