### PR TITLE
Don't store DataSource or CustomList objects in Lane objects

### DIFF
--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -322,11 +322,12 @@ class TestLanes(DatabaseTest):
         best, picks = lane.sublanes.lanes
         eq_("Best Sellers", best.display_name)
         eq_("Everything - Best Sellers", best.name)
-        eq_(DataSource.NYT, best.list_data_source.name)
+        nyt = DataSource.lookup(self._db, DataSource.NYT)
+        eq_(nyt.id, best.list_data_source_id)
 
         eq_("Staff Picks", picks.display_name)
         eq_("Everything - Staff Picks", picks.name)
-        eq_([staff_picks], picks.lists)
+        eq_([staff_picks.id], picks.list_ids)
 
     def test_gather_matching_genres(self):
         self.fantasy, ig = Genre.lookup(self._db, classifier.Fantasy)


### PR DESCRIPTION
This branch changes the Lane setup so that a lane based on a data source or a set of custom lists (such as a list of best-sellers) stores the ID of the data source or the IDs of the lists instead of the database objects themselves. If we store objects, they can't be used outside the database session that created them.

As with https://github.com/NYPL-Simplified/circulation/pull/168, the existing tests verify that we maintain functionality, but I don't have a solution for testing the specific case where database sessions go in and out of scope.