### PR TITLE
Dont store database objects in lanes

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -387,7 +387,13 @@ class ExternalSearchIndex(object):
         if exclude_languages:
             clauses.append({'not': dict(terms=dict(language=list(exclude_languages)))})
         if genres:
-            genre_ids = [genre.id for genre in genres]
+            if isinstance(genre[0], int):
+                # We were given genre IDs.
+                genre_ids = genres
+            else:
+                # We were given genre objects. This should
+                # no longer happen but we'll handle it.
+                genre_ids = [genre.id for genre in genres]
             clauses.append(dict(terms={"genres.term": genre_ids}))
         if media:
             media = [_f(medium) for medium in media]

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -576,17 +576,17 @@ class TestExternalSearch(DatabaseTest):
         fantasy_lane = Lane(self._db, "Fantasy", genres=["Fantasy"])
         both_lane = Lane(self._db, "Both", genres=["Biography & Memoir", "Fantasy"], fiction=Lane.BOTH_FICTION_AND_NONFICTION)
 
-        results = self.search.query_works("lincoln", None, None, None, None, None, None, biography_lane.genres)
+        results = self.search.query_works("lincoln", None, None, None, None, None, None, biography_lane.genre_ids)
         hits = results["hits"]["hits"]
         eq_(1, len(hits))
         eq_(unicode(self.lincoln.id), hits[0]["_id"])
 
-        results = self.search.query_works("lincoln", None, None, None, None, None, None, fantasy_lane.genres)
+        results = self.search.query_works("lincoln", None, None, None, None, None, None, fantasy_lane.genre_ids)
         hits = results["hits"]["hits"]
         eq_(1, len(hits))
         eq_(unicode(self.lincoln_vampire.id), hits[0]["_id"])
 
-        results = self.search.query_works("lincoln", None, None, None, None, None, None, both_lane.genres)
+        results = self.search.query_works("lincoln", None, None, None, None, None, None, both_lane.genre_ids)
         hits = results["hits"]["hits"]
         eq_(2, len(hits))
 
@@ -757,7 +757,7 @@ class TestSearchFilterFromLane(DatabaseTest):
         filter = search.make_filter(
             lane.media, lane.languages, lane.exclude_languages,
             lane.fiction, list(lane.audiences), lane.age_range,
-            lane.genres,
+            lane.genre_ids,
         )
 
         medium_filter, audience_filter, target_age_filter = filter['and']
@@ -777,7 +777,7 @@ class TestSearchFilterFromLane(DatabaseTest):
         filter = search.make_filter(
             lane.media, lane.languages, lane.exclude_languages,
             lane.fiction, list(lane.audiences), lane.age_range,
-            lane.genres,
+            lane.genre_ids,
         )
         
         languages_filter, medium_filter = filter['and']
@@ -796,7 +796,7 @@ class TestSearchFilterFromLane(DatabaseTest):
         filter = search.make_filter(
             lane.media, lane.languages, lane.exclude_languages,
             lane.fiction, list(lane.audiences), lane.age_range,
-            lane.genres,
+            lane.genre_ids,
         )
         
         exclude_languages_filter, medium_filter = filter['and']

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -437,7 +437,7 @@ class TestLanes(DatabaseTest):
             subgenre_behavior=Lane.IN_SAME_LANE,
             sublanes="Urban Fantasy"
         )
-        eq_([[urban_fantasy]], [x.genres for x in fantasy_lane.sublanes.lanes])
+        eq_([["Urban Fantasy"]], [x.genre_names for x in fantasy_lane.sublanes.lanes])
 
     def test_custom_lanes_conflict_with_subgenre_sublanes(self):
 
@@ -771,8 +771,10 @@ class TestLanesQuery(DatabaseTest):
         )
 
         # Urban Fantasy does not show up in this lane's genres.
-        eq_(["Epic Fantasy", "Fantasy", "Historical Fantasy"], 
-            sorted([x.name for x in lane.genres]))
+        eq_(
+            ["Epic Fantasy", "Fantasy", "Historical Fantasy"], 
+            sorted(lane.genre_names)
+        )
 
         # We get two books: Fantasy and Epic Fantasy.
         w, mw = _assert_expectations(
@@ -893,22 +895,23 @@ class TestLanesQuery(DatabaseTest):
 
         eq_("Fiction", fiction.name)
         eq_(set([Classifier.AUDIENCE_ADULT]), fiction.audiences)
-        eq_([], fiction.genres)
+        eq_([], fiction.genre_ids)
         eq_(True, fiction.fiction)
 
         eq_("Fantasy", fantasy.name)
         eq_(set(), fantasy.audiences)
-        eq_(set(fantasy_genre.self_and_subgenres), set(fantasy.genres))
+        expect = set(x.name for x in fantasy_genre.self_and_subgenres)
+        eq_(expect, set(fantasy.genre_names))
         eq_(True, fantasy.fiction)
 
         eq_("Urban Fantasy", urban_fantasy.name)
         eq_(set(), urban_fantasy.audiences)
-        eq_([urban_fantasy_genre], urban_fantasy.genres)
+        eq_([urban_fantasy_genre.id], urban_fantasy.genre_ids)
         eq_(True, urban_fantasy.fiction)
 
         eq_("Young Adult", young_adult.name)
         eq_(set([Classifier.AUDIENCE_YOUNG_ADULT]), young_adult.audiences)
-        eq_([], young_adult.genres)
+        eq_([], young_adult.genre_ids)
         eq_(Lane.BOTH_FICTION_AND_NONFICTION, young_adult.fiction)
 
 class TestFilters(DatabaseTest):


### PR DESCRIPTION
Same problem as before but with Genre objects. Same solution as before: store the IDs (and in this case the human-readable names), not the objects.