### PR TITLE
Use NoveList API

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -169,7 +169,6 @@ class Axis360API(object):
 
     def _make_request(self, url, method, headers, data=None, params=None):
         """Actually make an HTTP request."""
-        # self.log.debug("Making Axis 360 request to %s params=%r", url, params)
         return requests.request(
             url=url, method=method, headers=headers, data=data,
             params=params)

--- a/config.py
+++ b/config.py
@@ -124,6 +124,10 @@ class Configuration(object):
     NYT_INTEGRATION = "New York Times"
     NYT_BEST_SELLERS_API_KEY = "best_sellers_api_key"
 
+    NOVELIST_INTEGRATION = "NoveList Select"
+    NOVELIST_PROFILE = "profile"
+    NOVELIST_PASSWORD = "password"
+
     OVERDRIVE_INTEGRATION = "Overdrive"
     THREEM_INTEGRATION = "3M"
     AXIS_INTEGRATION = "Axis 360"

--- a/model.py
+++ b/model.py
@@ -5971,8 +5971,8 @@ class Representation(Base):
 
     @classmethod
     def get(cls, _db, url, do_get=None, extra_request_headers=None,
-            params=None, accept=None, max_age=None, pause_before=0,
-            allow_redirects=True, presumed_media_type=None, debug=True):
+            accept=None, max_age=None, pause_before=0, allow_redirects=True,
+            presumed_media_type=None, debug=True):
         """Retrieve a representation from the cache if possible.
         
         If not possible, retrieve it from the web and store it in the
@@ -5990,10 +5990,6 @@ class Representation(Base):
 
         """
         representation = None
-        request_kwargs = {}
-        if params:
-            do_get = do_get or cls.simple_http_post
-            request_kwargs.update({'data' : params})
         do_get = do_get or cls.simple_http_get
 
         # TODO: We allow representations of the same URL in different
@@ -6067,7 +6063,7 @@ class Representation(Base):
             time.sleep(pause_before)
         media_type = None
         try:
-            status_code, headers, content = do_get(url, headers, **request_kwargs)
+            status_code, headers, content = do_get(url, headers)
             exception = None
             if 'content-type' in headers:
                 media_type = headers['content-type'].lower()
@@ -6151,9 +6147,15 @@ class Representation(Base):
         return representation, False
 
     @classmethod
-    def post(cls, _db, url, params, max_age=None):
+    def cacheable_post(cls, _db, url, params, max_age=None):
+        """Transforms cacheable POST request into a Representation"""
+
+        def do_post(url, headers, **kwargs):
+            kwargs.update({'data' : params})
+            return cls.simple_http_post(url, headers, **kwargs)
+
         return cls.get(
-            _db, url, do_get=cls.simple_http_post, params=params, max_age=max_age
+            _db, url, do_get=do_post, max_age=max_age
         )
 
     def update_image_size(self):

--- a/model.py
+++ b/model.py
@@ -4022,6 +4022,7 @@ class Measurement(Base):
         DataSource.OVERDRIVE : [1, 5],
         DataSource.AMAZON : [1, 5],
         DataSource.UNGLUE_IT: [1, 5],
+        DataSource.NOVELIST: [0, 5]
     }
 
     id = Column(Integer, primary_key=True)

--- a/model.py
+++ b/model.py
@@ -601,6 +601,7 @@ class DataSource(Base):
     GUTENBERG_EPUB_GENERATOR = "Project Gutenberg EPUB Generator"
     METADATA_WRANGLER = "Library Simplified metadata wrangler"
     MANUAL = "Manual intervention"
+    NOVELIST = "NoveList Select"
     NYT = "New York Times"
     NYPL_SHADOWCAT = "NYPL Shadowcat"
     LIBRARY_STAFF = "Library staff"
@@ -776,6 +777,7 @@ class DataSource(Base):
                 (cls.ADOBE, False, False, None, None),
                 (cls.PLYMPTON, True, False, Identifier.ISBN, None),
                 (cls.OA_CONTENT_SERVER, True, False, Identifier.URI, None),
+                (cls.NOVELIST, False, True, Identifier.ISBN, None),
         ):
 
             extra = dict()
@@ -1185,7 +1187,6 @@ class Identifier(Base):
                 "Could not turn %s into a recognized identifier." %
                 identifier_string)
         return (type, identifier_string)
-
 
     @classmethod
     def parse_urn(cls, _db, identifier_string, must_support_license_pools=False):

--- a/overdrive.py
+++ b/overdrive.py
@@ -70,7 +70,6 @@ class OverdriveAPI(object):
     EVENT_SOURCE = "Overdrive"
 
     EVENT_DELAY = datetime.timedelta(minutes=120)
-    #EVENT_DELAY = datetime.timedelta(minutes=0)
 
     # The ebook formats we care about.
     FORMATS = "ebook-epub-open,ebook-epub-adobe,ebook-pdf-adobe,ebook-pdf-open"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1905,7 +1905,6 @@ class TestRepresentation(DatabaseTest):
         eq_(byte_content, representation.content)
         eq_(None, representation.unicode_content)
 
-
     def test_404_creates_cachable_representation(self):
         h = DummyHTTPClient()
         h.queue_response(404)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -115,10 +115,15 @@ class TestDataSource(DatabaseTest):
             self._db, "No such data source " + self._str))
 
     def test_metadata_sources_for(self):
-        [content_cafe] = DataSource.metadata_sources_for(
+        content_cafe = DataSource.lookup(self._db, DataSource.CONTENT_CAFE)
+        novelist = DataSource.lookup(self._db, DataSource.NOVELIST)
+        isbn_metadata_sources = DataSource.metadata_sources_for(
             self._db, Identifier.ISBN
         )
-        eq_(DataSource.CONTENT_CAFE, content_cafe.name)
+
+        eq_(2, len(isbn_metadata_sources))
+        assert content_cafe in isbn_metadata_sources
+        assert novelist in isbn_metadata_sources
 
     def test_license_source_for(self):
         identifier = self._identifier(Identifier.OVERDRIVE_ID)


### PR DESCRIPTION
Sets up configuration and a DataSource for the NoveList Select service. Allows Representations to be created (or caches to be recalled) with POST requests.

Fixes #197. Supports NYPL-Simplified/metadata_wrangler#59.