### PR TITLE
Update changed books on OPDS import.

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1082,7 +1082,7 @@ class Metadata(object):
 
         if policy.link_content:
             # We want to fetch the representation again, even if we 
-            # already have a recent usable copy. If we fetch it ahd it 
+            # already have a recent usable copy. If we fetch it and it 
             # hasn't changed, we'll keep using the one we have.
             max_age = 0
         else:

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -51,6 +51,7 @@ class ReplacementPolicy(object):
             links=False,
             formats=False,
             rights=False,
+            link_content=False,
             mirror=None,
             http_get=None,
             even_if_not_apparently_updated=False,
@@ -62,6 +63,7 @@ class ReplacementPolicy(object):
         self.links = links
         self.rights = rights
         self.formats = formats
+        self.link_content = link_content
         self.even_if_not_apparently_updated = even_if_not_apparently_updated
         self.mirror = mirror
         self.http_get = http_get
@@ -1078,11 +1080,20 @@ class Metadata(object):
 
         self.log.debug("About to mirror %s" % original_url)
 
+        if policy.link_content:
+            # We want to fetch the representation again, even if we 
+            # already have a recent usable copy. If we fetch it ahd it 
+            # hasn't changed, we'll keep using the one we have.
+            max_age = 0
+        else:
+            max_age = None
+
         # This will fetch a representation of the original and 
         # store it in the database.
         representation, is_new = Representation.get(
             _db, link.href, do_get=http_get,
             presumed_media_type=link.media_type,
+            max_age=max_age,
         )
 
         # Make sure the (potentially newly-fetched) representation is
@@ -1096,6 +1107,12 @@ class Metadata(object):
             if pool and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
                 pool.suppressed = True
                 pool.license_exception = "Fetch exception: %s" % representation.fetch_exception
+            return
+
+        # If we fetched the representation and it hasn't changed,
+        # the previously mirrored version is fine. Don't mirror it
+        # again.
+        if representation.status_code == 304:
             return
 
         # Determine the best URL to use when mirroring this

--- a/model.py
+++ b/model.py
@@ -6101,6 +6101,7 @@ class Representation(Base):
             # Set its fetched_at property and return the cached
             # version as though it were new.
             representation.fetched_at = fetched_at
+            representation.status_code = status_code
             return representation, False
 
         if status_code:

--- a/opds_import.py
+++ b/opds_import.py
@@ -234,16 +234,16 @@ class OPDSImporter(object):
         # Locate or create an Edition for this book.
         edition, is_new_edition = metadata.edition(self._db)
 
-        if (cutoff_date 
-            and not is_new_license_pool 
+        if (cutoff_date
+            and not is_new_license_pool
             and not is_new_edition
-            and metadata.circulation 
-            and metadata.circulation.first_appearance < cutoff_date
+            and metadata.last_update_time
+            and metadata.last_update_time < cutoff_date
         ):
             # We've already imported this book, we've been told
-            # not to bother with books that appeared before a
-            # certain date, and this book did in fact appear
-            # before that date. There's no reason to do anything.
+            # not to bother with books that haven't changed since a
+            # certain date, and this book hasn't changed since that
+            # that date. There's no reason to do anything.
             return
 
         policy = ReplacementPolicy(
@@ -251,6 +251,7 @@ class OPDSImporter(object):
             links=True,
             contributions=True,
             rights=True,
+            link_content=True,
             even_if_not_apparently_updated=True,
             mirror=self.mirror,
             http_get=self.http_get,
@@ -279,6 +280,7 @@ class OPDSImporter(object):
                     # information is missing (like language or title),
                     # this will do it.
                     work.set_presentation_ready_based_on_content()
+
         return edition
 
     def extract_metadata(self, feed):
@@ -735,7 +737,7 @@ class OPDSImportMonitor(Monitor):
             # We did not end up importing a single book on this page.
             # There's no need to keep going.
             self.log.info(
-                "Saw a full page with no new books. Stopping."
+                "Saw a full page with no new or updated books. Stopping."
             )
             return []
         else:

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -325,8 +325,8 @@ class TestOPDSImporter(OPDSImporterTest):
             importer.import_from_feed(feed, cutoff_date=cutoff)
         )
 
-        # None of the books were imported because they all appeared in
-        # the feed after the cutoff.
+        # None of the books were imported because they weren't updated
+        # after the cutoff.
         eq_(0, len(imported))
 
         # And if we change the cutoff...
@@ -567,3 +567,47 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
          ],
             [x.mirror_url for x in s3.uploaded]
         )
+
+        # If we fetch the feed again, and the entries have been updated since the
+        # cutoff, but the content of the open access links hasn't changed, we won't mirror
+        # them again.
+        cutoff = datetime.datetime(2013, 1, 2, 16, 56, 40)
+
+        http.queue_response(
+            304, media_type=Representation.EPUB_MEDIA_TYPE
+        )
+
+        http.queue_response(
+            304, media_type=Representation.SVG_MEDIA_TYPE
+        )
+
+        http.queue_response(
+            304, media_type=Representation.EPUB_MEDIA_TYPE
+        )
+
+        imported, messages, next_link = importer.import_from_feed(self.content_server_mini_feed, cutoff_date=cutoff)
+
+        eq_([e1, e2], imported)
+        # Nothing new has been uploaded
+        eq_(4, len(s3.uploaded))
+
+        # If the content has changed, it will be mirrored again.
+        http.queue_response(
+            200, content="I am a new version of 10557.epub.images",
+            media_type=Representation.EPUB_MEDIA_TYPE
+        )
+
+        http.queue_response(
+            200, content=svg,
+            media_type=Representation.SVG_MEDIA_TYPE
+        )
+
+        http.queue_response(
+            200, content="I am a new version of 10441.epub.images",
+            media_type=Representation.EPUB_MEDIA_TYPE
+        )
+
+        imported, messages, next_link = importer.import_from_feed(self.content_server_mini_feed, cutoff_date=cutoff)
+
+        eq_([e1, e2], imported)
+        eq_(8, len(s3.uploaded))


### PR DESCRIPTION
This branch changes the way the cutoff date is used in OPDS import - now it's compared with the time the book was updated instead of the time it was first added to the collection. 

Since the content of an open access link may have been updated as well as the metadata, I also had to make Representation.get always fetch again to see if it changed and we need to update our mirror. I made a policy for this, but maybe policy.mirror + policy.links should imply that we fetch the links again. If we fetch the content and get a 304, we don't mirror it again.