### PR TITLE
Don't roll back database session if database session hasn't been created yet

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -175,7 +175,9 @@ class ErrorHandler(object):
     def handle(self, exception):
         logging.error(
             "Exception in web app: %s", exception, exc_info=exception)
-        self.app.manager._db.rollback()
+        if hasattr(self.app, 'manager') and hasattr(self.app.manager, '_db'):
+            # There is an active database session. Roll it back.
+            self.app.manager._db.rollback()
         tb = traceback.format_exc()
         if self.debug:
             body = tb

--- a/app_server.py
+++ b/app_server.py
@@ -173,9 +173,9 @@ class ErrorHandler(object):
         self.debug = debug
 
     def handle(self, exception):
-        self.app.manager._db.rollback()
         logging.error(
             "Exception in web app: %s", exception, exc_info=exception)
+        self.app.manager._db.rollback()
         tb = traceback.format_exc()
         if self.debug:
             body = tb

--- a/external_search.py
+++ b/external_search.py
@@ -36,7 +36,9 @@ class ExternalSearchIndex(object):
             url = integration[Configuration.URL]
             use_ssl = url and url.startswith('https://')
             self.log.info("Connecting to Elasticsearch cluster at %s", url)
-            ExternalSearchIndex.__client = Elasticsearch(url, use_ssl=use_ssl)
+            ExternalSearchIndex.__client = Elasticsearch(
+                url, use_ssl=use_ssl, timeout=20
+            )
             ExternalSearchIndex.__client.works_index = works_index
             if not url:
                 raise Exception("Cannot connect to Elasticsearch cluster.")

--- a/external_search.py
+++ b/external_search.py
@@ -37,7 +37,7 @@ class ExternalSearchIndex(object):
             use_ssl = url and url.startswith('https://')
             self.log.info("Connecting to Elasticsearch cluster at %s", url)
             ExternalSearchIndex.__client = Elasticsearch(
-                url, use_ssl=use_ssl, timeout=20
+                url, use_ssl=use_ssl, timeout=20, maxsize=25
             )
             ExternalSearchIndex.__client.works_index = works_index
             if not url:


### PR DESCRIPTION
This branch fixes the display of errors that happen early on in the startup process, by removing code that can mask that error with another, more stupid error--the attempt to roll back a database session that hasn't been initialized yet.

This branch also changes the ElasticSearch client configuration to increase the default timeout and number of simultaneous connections.
