### PR TITLE
Start using `argparse` to gather command-line arguments instead of per-script hacks

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -172,7 +172,7 @@ class IdentifierInputScript(Script):
         parser = argparse.ArgumentParser()
         parser.add_argument(
             '--identifier-type', 
-            help='Type of the identifiers to process'
+            help='Process identifiers of this type. If IDENTIFIER is not specified, all identifiers of this type will be processed. If IDENTIFIER is specified, this argument is required.'
         )
         parser.add_argument(
             'identifier_strings',

--- a/scripts.py
+++ b/scripts.py
@@ -63,6 +63,15 @@ class Script(object):
         return Configuration.data_directory()
 
     @classmethod
+    def parse_command_line(cls):
+        parser = cls.arg_parser()
+        return parser.parse_args()
+
+    @classmethod
+    def arg_parser(cls):
+        raise NotImplementedError()
+
+    @classmethod
     def parse_identifier_list(
             cls, _db, identifier_type, arguments, autocreate=False
     ):
@@ -212,11 +221,6 @@ class SubjectInputScript(Script):
         )
         return parser
 
-    @classmethod
-    def parse_command_line(cls):
-        parser = cls.arg_parser()
-        return parser.parse_args()
-
 
 class RunCoverageProviderScript(IdentifierInputScript):
     """Run a single coverage provider."""
@@ -231,8 +235,7 @@ class RunCoverageProviderScript(IdentifierInputScript):
         return parser
 
     def __init__(self, provider):
-        parser = self.arg_parser()
-        args = parser.parse_args()
+        args = self.parse_command_line()
         if callable(provider):
             cutoff_time = self.parse_time(args.cutoff_time)
             self.identifier_type = args.identifier_type or None
@@ -271,7 +274,7 @@ class BibliographicRefreshScript(IdentifierInputScript):
     def do_run(self):
         args = self.parse_command_line()
         identifiers = self.parse_identifier_list(
-            self._db, args.identifiers
+            self._db, args.identifier_type, args.identifiers
         )
         if not identifiers:
             raise Exception(
@@ -304,7 +307,7 @@ class WorkProcessingScript(IdentifierInputScript):
     name = "Work processing script"
 
     def __init__(self, force=False, batch_size=10):
-        args = self.arg_parser().parse_args()
+        args = self.parse_command_line()
         identifiers = self.parse_identifier_list(
             self._db, args.identifier_type, args.identifiers
         )
@@ -562,7 +565,7 @@ class RefreshMaterializedViewsScript(Script):
 class Explain(IdentifierInputScript):
     """Explain everything known about a given work."""
     def run(self):
-        args = self.arg_parser().parse_args()
+        args = self.parse_command_line()
         identifiers = self.parse_identifier_list(
             self._db, args.identifier_type, args.identifiers
         )

--- a/scripts.py
+++ b/scripts.py
@@ -277,7 +277,7 @@ class RunCoverageProviderScript(IdentifierInputScript):
                 self.identifier_types = []
             provider = provider(
                 self._db, input_identifier_types=self.identifier_types, 
-                cutoff_time=cutoff_time
+                cutoff_time=args.cutoff_time
             )
         self.provider = provider
         self.name = self.provider.service_name

--- a/scripts.py
+++ b/scripts.py
@@ -155,7 +155,7 @@ class IdentifierInputScript(Script):
     def parse_command_line(cls, _db=None, cmd_args=None, *args, **kwargs):
         parser = cls.arg_parser()
         parsed = parser.parse_args(cmd_args)
-        return cls.look_up_identifiers(_db, *args, **kwargs)
+        return cls.look_up_identifiers(_db, parsed, *args, **kwargs)
 
     @classmethod
     def look_up_identifiers(cls, _db, parsed, *args, **kwargs):

--- a/scripts.py
+++ b/scripts.py
@@ -254,9 +254,14 @@ class RunCoverageProviderScript(IdentifierInputScript):
         args = self.parse_command_line(self._db)
         if callable(provider):
             cutoff_time = self.parse_time(args.cutoff_time)
-            self.identifier_type = args.identifier_type or None
+            if args.identifier_type:
+                self.identifier_type = args.identifier_type
+                self.identifier_types = [self.identifier_type]
+            else:
+                self.identifier_type = None
+                self.identifier_types = []
             provider = provider(
-                self._db, input_identifier_types=[self.identifier_type], 
+                self._db, input_identifier_types=self.identifier_types, 
                 cutoff_time=cutoff_time
             )
         self.provider = provider

--- a/scripts.py
+++ b/scripts.py
@@ -229,19 +229,28 @@ class RunCoverageProviderScript(IdentifierInputScript):
     """Run a single coverage provider."""
 
     @classmethod
-    def parse_cutoff_time(cls):
+    def parse_command_line(cls):
         parser = argparse.ArgumentParser()
         parser.add_argument(
             '--cutoff-time', 
             help='Update existing coverage records if they were originally created after this time.'
         )
-        args = parser.parse_args()
-        return cls.parse_time(args.cutoff_time)
+        parser.add_argument(
+            '--identifier-type', 
+            help='Add coverage only for identifiers of the given type.',
+            action='append'
+        )
+        return parser.parse_args()
 
     def __init__(self, provider):
-        cutoff_time = self.parse_cutoff_time()
         if callable(provider):
-            provider = provider(self._db, cutoff_time=cutoff_time)
+            args = self.parse_command_line()
+            cutoff_time = self.parse_time(args.cutoff_time)
+            identifier_types = args.identifier_type or None
+            provider = provider(
+                self._db, input_identifier_types=identifier_types, 
+                cutoff_time=cutoff_time
+            )
         self.provider = provider
         self.name = self.provider.service_name
 

--- a/scripts.py
+++ b/scripts.py
@@ -180,11 +180,11 @@ class IdentifierInputScript(Script):
         parser = argparse.ArgumentParser()
         parser.add_argument(
             '--identifier-type', 
-            help='Process identifiers of this type'
+            help='Type of the identifiers to process'
         )
         parser.add_argument(
             'identifiers',
-            help='An identifier to process',
+            help='A specific identifier to process.',
             metavar='IDENTIFIER', nargs='*'
         )
         return parser

--- a/scripts.py
+++ b/scripts.py
@@ -66,7 +66,11 @@ class Script(object):
     def parse_identifier_list(
             cls, _db, identifier_type, arguments, autocreate=False
     ):
-        """Turn a list of arguments into a list of identifiers.
+        """Turn a list of identifiers into a list of Identifier objects.
+
+        The list of arguments is probably derived from a command-line
+        parser such as the one defined in
+        IdentifierInputScript.arg_parser().
 
         This makes it easy to identify specific identifiers on the
         command line. Examples:
@@ -74,8 +78,6 @@ class Script(object):
         1 2
         
         a b c
-
-        Basic but effective.
         """
         current_identifier_type = None
         if len(arguments) == 0:

--- a/scripts.py
+++ b/scripts.py
@@ -175,6 +175,7 @@ class RunCoverageProvidersScript(Script):
 class IdentifierInputScript(Script):
     """A script that takes identifiers as command line inputs."""
 
+    @classmethod
     def arg_parser(cls):
         parser = argparse.ArgumentParser()
         parser.add_argument(
@@ -219,21 +220,22 @@ class RunCoverageProviderScript(IdentifierInputScript):
     """Run a single coverage provider."""
 
     @classmethod
-    def parse_command_line(cls):
-        parser = argparse.ArgumentParser()
+    def arg_parser(cls):
+        parser = IdentifierInputScript.arg_parser()
         parser.add_argument(
             '--cutoff-time', 
             help='Update existing coverage records if they were originally created after this time.'
         )
-        return parser.parse_args()
+        return parser
 
     def __init__(self, provider):
-        args = self.parse_command_line()
+        parser = self.arg_parser()
+        args = parser.parse_args()
         if callable(provider):
             cutoff_time = self.parse_time(args.cutoff_time)
             self.identifier_type = args.identifier_type or None
             provider = provider(
-                self._db, input_identifier_types=[identifier_type], 
+                self._db, input_identifier_types=[self.identifier_type], 
                 cutoff_time=cutoff_time
             )
         self.provider = provider

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -25,7 +25,7 @@ from scripts import (
 class TestScript(DatabaseTest):
 
     def test_parse_time(self): 
-        reference_date = datetime.datetime(2016, 01, 01)
+        reference_date = datetime.datetime(2016, 1, 1)
 
         eq_(Script.parse_time("2016-01-01"), reference_date)
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -26,35 +26,20 @@ class TestScript(DatabaseTest):
 
         i1 = self._identifier()
         i2 = self._identifier()
-        args = [i1.type, i1.identifier, 'no-such-identifier', i2.identifier]
-        identifiers = Script.parse_identifier_list(self._db, args)
+        args = [i1.identifier, 'no-such-identifier', i2.identifier]
+        identifiers = Script.parse_identifier_list(self._db, i1.type, args)
         eq_([i1, i2], identifiers)
-        eq_([], Script.parse_identifier_list(self._db, []))
+        eq_([], Script.parse_identifier_list(self._db, i1.type, []))
 
     def test_parse_list_as_identifiers_with_autocreate(self):
 
-        args = [Identifier.OVERDRIVE_ID, 'brand-new-identifier']
-        [i] = Script.parse_identifier_list(self._db, args, autocreate=True)
-        eq_(Identifier.OVERDRIVE_ID, i.type)
-        eq_('brand-new-identifier', i.identifier)
-
-    def test_parse_list_as_identifiers_or_data_source(self):
-
-        i1 = self._identifier()
-        i2 = self._identifier()
-        args = [i1.type, i1.identifier, 'no-such-identifier', i2.identifier]
-        identifiers = Script.parse_identifier_list_or_data_source(
-            self._db, args
+        type = Identifier.OVERDRIVE_ID
+        args = ['brand-new-identifier']
+        [i] = Script.parse_identifier_list(
+            self._db, type, args, autocreate=True
         )
-        eq_([i1, i2], identifiers)
-
-        args = [DataSource.OVERDRIVE]
-        data_source = Script.parse_identifier_list_or_data_source(self._db, args)
-        overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
-        eq_(overdrive, data_source)
-
-        eq_([], Script.parse_identifier_list(self._db, []))
-
+        eq_(type, i.type)
+        eq_('brand-new-identifier', i.identifier)
 
     def test_parse_time(self): 
         reference_date = datetime.datetime(2016, 01, 01)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -18,28 +18,11 @@ from model import (
 from scripts import (
     Script,
     CustomListManagementScript,
+    IdentifierInputScript,
+    RunCoverageProviderScript,
 )
 
 class TestScript(DatabaseTest):
-
-    def test_parse_list_as_identifiers(self):
-
-        i1 = self._identifier()
-        i2 = self._identifier()
-        args = [i1.identifier, 'no-such-identifier', i2.identifier]
-        identifiers = Script.parse_identifier_list(self._db, i1.type, args)
-        eq_([i1, i2], identifiers)
-        eq_([], Script.parse_identifier_list(self._db, i1.type, []))
-
-    def test_parse_list_as_identifiers_with_autocreate(self):
-
-        type = Identifier.OVERDRIVE_ID
-        args = ['brand-new-identifier']
-        [i] = Script.parse_identifier_list(
-            self._db, type, args, autocreate=True
-        )
-        eq_(type, i.type)
-        eq_('brand-new-identifier', i.identifier)
 
     def test_parse_time(self): 
         reference_date = datetime.datetime(2016, 01, 01)
@@ -55,3 +38,63 @@ class TestScript(DatabaseTest):
         assert_raises(ValueError, Script.parse_time, "201601-01")
 
 
+class TestIdentifierInputScript(DatabaseTest):
+
+    def test_parse_list_as_identifiers(self):
+
+        i1 = self._identifier()
+        i2 = self._identifier()
+        args = [i1.identifier, 'no-such-identifier', i2.identifier]
+        identifiers = IdentifierInputScript.parse_identifier_list(
+            self._db, i1.type, args
+        )
+        eq_([i1, i2], identifiers)
+
+        eq_([], IdentifierInputScript.parse_identifier_list(
+            self._db, i1.type, [])
+        )
+
+    def test_parse_list_as_identifiers_with_autocreate(self):
+
+        type = Identifier.OVERDRIVE_ID
+        args = ['brand-new-identifier']
+        [i] = IdentifierInputScript.parse_identifier_list(
+            self._db, type, args, autocreate=True
+        )
+        eq_(type, i.type)
+        eq_('brand-new-identifier', i.identifier)
+
+    def test_parse_command_line(self):
+        i1 = self._identifier()
+        i2 = self._identifier()
+        cmd_args = ["--identifier-type",
+                    i1.type, i1.identifier, i2.identifier]
+        parsed = RunCoverageProviderScript.parse_command_line(
+            self._db, cmd_args
+        )
+        eq_([i1, i2], parsed.identifiers)
+        eq_(i1.type, parsed.identifier_type)
+
+    def test_parse_command_line_no_identifiers(self):
+        cmd_args = ["--identifier-type", Identifier.OVERDRIVE_ID]
+        parsed = RunCoverageProviderScript.parse_command_line(
+            self._db, cmd_args
+        )
+        eq_([], parsed.identifiers)
+        eq_(Identifier.OVERDRIVE_ID, parsed.identifier_type)
+
+
+class TestRunCoverageProviderScript(DatabaseTest):
+
+    def test_parse_command_line(self):
+        identifier = self._identifier()
+        cmd_args = ["--cutoff-time", "2016-05-01", "--identifier-type", 
+                    identifier.type, identifier.identifier]
+        parsed = RunCoverageProviderScript.parse_command_line(
+            self._db, cmd_args
+        )
+        eq_(datetime.datetime(2016, 5, 1), parsed.cutoff_time)
+        eq_([identifier], parsed.identifiers)
+        eq_(identifier.type, parsed.identifier_type)
+
+        

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -69,7 +69,7 @@ class TestIdentifierInputScript(DatabaseTest):
         i2 = self._identifier()
         cmd_args = ["--identifier-type",
                     i1.type, i1.identifier, i2.identifier]
-        parsed = RunCoverageProviderScript.parse_command_line(
+        parsed = IdentifierInputScript.parse_command_line(
             self._db, cmd_args
         )
         eq_([i1, i2], parsed.identifiers)
@@ -77,7 +77,7 @@ class TestIdentifierInputScript(DatabaseTest):
 
     def test_parse_command_line_no_identifiers(self):
         cmd_args = ["--identifier-type", Identifier.OVERDRIVE_ID]
-        parsed = RunCoverageProviderScript.parse_command_line(
+        parsed = IdentifierInputScript.parse_command_line(
             self._db, cmd_args
         )
         eq_([], parsed.identifiers)


### PR DESCRIPTION
This branch overhauls script.py to use the Python standard library's `argparse` module to parse command-line arguments. The alternative was an increasingly hacky arrangement which made it very difficult to add features to scripts.

There are basically three types of scripts:

* `IdentifierInputScript`s, which accept a named --identifier-type argument and an optional list of IDENTIFIER positional arguments. If you specify an identifier-type but no IDENTIFIERs, it's assumed that you want to operate on all identifiers of a given type. Once you parse the command line, the corresponding Identifier objects will be automatically loaded from the database and be made available as `parsed.identifiers`.

Previously we only took positional arguments and the first positional argument was equivalent to --identifier-type, unless it was the _only_ positional argument, in which case it identified the data source. I took out the data source code as not currently useful.

* `RunCoverageProviderScript`s, which are like `IdentifierInputScript`s except that they also take a --cutoff-date argument.

* `SubjectInputScript`s, which take arguments --subject-type (to restrict their operation to subjects of a specific type) and --subject-filter (to restrict their operation to subjects that match a substring filter).

We should also convert `CustomListManagementScript`, which currently doesn't really interact with the command line (it expects positional arguments in a very specific order), but that can wait til later.

I've added some front-to-back tests of the command-line parsing functionality to show how these things work.