### PR TITLE
Stop opds import on error

### DIFF
--- a/opds_import.py
+++ b/opds_import.py
@@ -727,6 +727,11 @@ class OPDSImportMonitor(Monitor):
     def follow_one_link(self, link, start):
         self.log.info("Following next link: %s, cutoff=%s", link, start)
         response = requests.get(link)
+
+        if response.status_code / 100 not in [2, 3]:
+            self.log.error("Fetching next link failed with status %i" % response.status_code)
+            return []
+
         imported, messages, next_links = self.importer.import_from_feed(
             response.content, even_if_no_author=True, cutoff_date=start,
             immediately_presentation_ready = self.immediately_presentation_ready

--- a/opds_import.py
+++ b/opds_import.py
@@ -729,7 +729,7 @@ class OPDSImportMonitor(Monitor):
         response = requests.get(link)
 
         if response.status_code / 100 not in [2, 3]:
-            self.log.error("Fetching next link failed with status %i" % response.status_code)
+            self.log.error("Fetching next link %s failed with status %i" % (link, response.status_code))
             return []
 
         imported, messages, next_links = self.importer.import_from_feed(


### PR DESCRIPTION
This is a tiny change that stops the OPDS import monitor when it gets an error code from the link it's trying to follow, instead of trying to import the error page and failing to parse it.

Unfortunately I haven't been able to think of a reliable way to automatically resume the import later, since the books' positions in the feed may have changed. This will log the error so someone can investigate and fix problems or manually restart from an appropriate page.