### PR TITLE
Coverage providers should add coverage

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -217,8 +217,10 @@ class CoverageProvider(object):
     def ensure_coverage(self, item, force=False):
         """Ensure coverage for one specific item.
 
-        :return: If coverage was already present, None. Otherwise,
-            either a CoverageRecord or a CoverageFailure.
+        :param force: Run the coverage code even if a CoverageRecord already
+        exists for this item.
+
+        :return: Either a CoverageRecord or a CoverageFailure.
         """
         if isinstance(item, Identifier):
             identifier = item
@@ -240,7 +242,7 @@ class CoverageProvider(object):
             else:
                 record = None
             return record
-        return None
+        return coverage_record
 
     def license_pool(self, identifier):
         """Finds or creates the LicensePool for a given Identifier."""

--- a/coverage.py
+++ b/coverage.py
@@ -192,7 +192,7 @@ class CoverageProvider(object):
         """Do what it takes to give CoverageRecords to a batch of
         items.
 
-        :return: A mixed list of Identifiers, Editions, and CoverageFailures.
+        :return: A mixed list of CoverageRecords and CoverageFailures.
         """
         results = []
         for item in batch:
@@ -204,7 +204,11 @@ class CoverageProvider(object):
     def ensure_coverage(self, item, force=False):
         """Ensure coverage for one specific item.
 
-        :return: A CoverageRecord if one was created, a CoverageFailure if not.
+        :return: The same (counts, records) 2-tuple as
+            process_batch_and_handle_results. `records` will either be
+            empty (indicating that coverage was already present) or it
+            will contain a single item (either a CoverageRecord or a
+            CoverageFailure).
         """
         if isinstance(item, Identifier):
             identifier = item

--- a/coverage.py
+++ b/coverage.py
@@ -205,6 +205,7 @@ class CoverageProvider(object):
         )
         if force or coverage_record is None:
             return self.process_batch_and_handle_results([identifier])
+        return (0, 0, 0)
 
     def license_pool(self, identifier):
         """Finds or creates the LicensePool for a given Identifier."""

--- a/coverage.py
+++ b/coverage.py
@@ -217,11 +217,8 @@ class CoverageProvider(object):
     def ensure_coverage(self, item, force=False):
         """Ensure coverage for one specific item.
 
-        :return: The same (counts, records) 2-tuple as
-            process_batch_and_handle_results. `records` will either be
-            empty (indicating that coverage was already present) or it
-            will contain a single item (either a CoverageRecord or a
-            CoverageFailure).
+        :return: If coverage was already present, None. Otherwise,
+            either a CoverageRecord or a CoverageFailure.
         """
         if isinstance(item, Identifier):
             identifier = item
@@ -235,8 +232,15 @@ class CoverageProvider(object):
             on_multiple='interchangeable',
         )
         if force or coverage_record is None:
-            return self.process_batch_and_handle_results([identifier])
-        return ((0, 0, 0), [])
+            counts, records = self.process_batch_and_handle_results(
+                [identifier]
+            )
+            if records:
+                record = records[0]
+            else:
+                record = None
+            return record
+        return None
 
     def license_pool(self, identifier):
         """Finds or creates the LicensePool for a given Identifier."""

--- a/coverage.py
+++ b/coverage.py
@@ -32,7 +32,7 @@ class CoverageFailure(object):
 
     def to_coverage_record(self, operation=None):
         if not self.transient:
-            # This is a permanent error. Turn it into a CoverageRecord
+            # This is a persistent error. Turn it into a CoverageRecord
             # so we don't keep trying to provide coverage that isn't
             # gonna happen.
             record, ignore = CoverageRecord.add_for(
@@ -135,7 +135,7 @@ class CoverageProvider(object):
         if not batch.count():
             # The batch is empty. We're done.
             return None
-        (successes, transient_failures, permanent_failures), results = (
+        (successes, transient_failures, persistent_failures), results = (
             self.process_batch_and_handle_results(batch)
         )
 
@@ -157,7 +157,7 @@ class CoverageProvider(object):
         results = self.process_batch(batch)
         successes = 0
         transient_failures = 0
-        permanent_failures = 0
+        persistent_failures = 0
         records = []
         for item in results:
             if isinstance(item, CoverageFailure):
@@ -170,7 +170,7 @@ class CoverageProvider(object):
                     # Create a CoverageRecord memorializing this
                     # failure. It won't show up anymore, on this 
                     # run or subsequent runs.
-                    permanent_failures += 1
+                    persistent_failures += 1
                     record = item.to_coverage_record(operation=self.operation)
             else:
                 # Count this as a success and add a CoverageRecord for
@@ -189,8 +189,8 @@ class CoverageProvider(object):
         num_ignored = max(0, batch_size - len(results))
 
         self.log.info(
-            "Batch processed with %d successes, %d transient failures, %d ignored, %d permanent failures.",
-            successes, transient_failures, permanent_failures, num_ignored
+            "Batch processed with %d successes, %d transient failures, %d ignored, %d persistent failures.",
+            successes, transient_failures, persistent_failures, num_ignored
         )
 
         # Finalize this batch before moving on to the next one.
@@ -199,7 +199,7 @@ class CoverageProvider(object):
         # For all purposes outside this method, treat an ignored identifier
         # as a transient failure.
         transient_failures += num_ignored
-        return (successes, transient_failures, permanent_failures), records
+        return (successes, transient_failures, persistent_failures), records
 
     def process_batch(self, batch):
         """Do what it takes to give CoverageRecords to a batch of

--- a/monitor.py
+++ b/monitor.py
@@ -155,9 +155,9 @@ class IdentifierResolutionMonitor(Monitor):
         for provider in self.required_coverage_providers:
             if not identifier.type in provider.input_identifier_types:
                 continue
-            counts, records = provider.ensure_coverage(identifier, force=True)
-            if records and records[0].exception:
-                raise ResolutionFailed(500, records[0].exception)
+            record = provider.ensure_coverage(identifier, force=True)
+            if record.exception:
+                raise ResolutionFailed(500, record.exception)
 
         # Now go through the optional providers. It's the same deal,
         # but a CoverageFailure doesn't cause the entire identifier
@@ -165,7 +165,7 @@ class IdentifierResolutionMonitor(Monitor):
         for provider in self.optional_coverage_providers:
             if not identifier.type in provider.input_identifier_types:
                 continue
-            counts, records = provider.ensure_coverage(identifier, force=True)
+            record = provider.ensure_coverage(identifier, force=True)
 
         # We're not out of the woods yet. If finalize() raises an
         # exception the process could still fail and need to be
@@ -507,12 +507,10 @@ class PresentationReadyMonitor(WorkSweepMonitor):
         failures = []
         for provider in self.coverage_providers:
             if identifier.type in provider.input_identifier_types:
-                counts, records = provider.ensure_coverage(identifier)
-                if records:
-                    coverage_record = records[0]
-                    if (not isinstance(coverage_record, CoverageRecord) 
-                        or coverage_record.exception is not None):
-                        failures.append(provider)
+                coverage_record = provider.ensure_coverage(identifier)
+                if (not isinstance(coverage_record, CoverageRecord) 
+                    or coverage_record.exception is not None):
+                    failures.append(provider)
         return failures
 
     def finalize_batch(self):

--- a/monitor.py
+++ b/monitor.py
@@ -155,9 +155,9 @@ class IdentifierResolutionMonitor(Monitor):
         for provider in self.required_coverage_providers:
             if not identifier.type in provider.input_identifier_types:
                 continue
-            record = provider.ensure_coverage(identifier, force=True)
-            if record.exception:
-                raise ResolutionFailed(500, record.exception)                
+            counts, records = provider.ensure_coverage(identifier, force=True)
+            if records and records[0].exception:
+                raise ResolutionFailed(500, records[0].exception)
 
         # Now go through the optional providers. It's the same deal,
         # but a CoverageFailure doesn't cause the entire identifier
@@ -165,7 +165,7 @@ class IdentifierResolutionMonitor(Monitor):
         for provider in self.optional_coverage_providers:
             if not identifier.type in provider.input_identifier_types:
                 continue
-            record = provider.ensure_coverage(identifier, force=True)
+            counts, records = provider.ensure_coverage(identifier, force=True)
 
         # We're not out of the woods yet. If finalize() raises an
         # exception the process could still fail and need to be
@@ -507,10 +507,12 @@ class PresentationReadyMonitor(WorkSweepMonitor):
         failures = []
         for provider in self.coverage_providers:
             if identifier.type in provider.input_identifier_types:
-                coverage_record = provider.ensure_coverage(identifier)
-                if (not isinstance(coverage_record, CoverageRecord) 
-                    or coverage_record.exception is not None):
-                    failures.append(provider)
+                counts, records = provider.ensure_coverage(identifier)
+                if records:
+                    coverage_record = records[0]
+                    if (not isinstance(coverage_record, CoverageRecord) 
+                        or coverage_record.exception is not None):
+                        failures.append(provider)
         return failures
 
     def finalize_batch(self):

--- a/testing.py
+++ b/testing.py
@@ -617,7 +617,6 @@ class InstrumentedCoverageProvider(CoverageProvider):
 class AlwaysSuccessfulCoverageProvider(InstrumentedCoverageProvider):
     """A CoverageProvider that does nothing and always succeeds."""
 
-
 class NeverSuccessfulCoverageProvider(InstrumentedCoverageProvider):
     def process_item(self, item):
         self.attempts.append(item)
@@ -631,6 +630,11 @@ class TransientFailureCoverageProvider(InstrumentedCoverageProvider):
     def process_item(self, item):
         self.attempts.append(item)
         return CoverageFailure(self, item, "Oops!", True)
+
+class TaskIgnoringCoverageProvider(InstrumentedCoverageProvider):
+    """A coverage provider that ignores all work given to it."""
+    def process_batch(self, batch):
+        return []
 
 class DummyCanonicalizeLookupResponse(object):
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -95,8 +95,7 @@ class TestCoverageProvider(DatabaseTest):
         result = provider.ensure_coverage(self.edition)
         eq_((0, 0, 1), result)
 
-        [record] = _db.query(CoverageRecord).all()
-        assert isinstance(record, CoverageRecord)
+        [record] = self._db.query(CoverageRecord).all()
         eq_(self.edition.primary_identifier, record.identifier)
         eq_("What did you expect?", record.exception)
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -83,10 +83,16 @@ class TestCoverageProvider(DatabaseTest):
         # Ensure coverage of both providers.
         result1 = provider1.ensure_coverage(self.edition)
         result2 = provider2.ensure_coverage(self.edition)
+        eq_((1,0,0), result1)
+        eq_((1,0,0), result2)
 
         # There are now two CoverageRecords, one for each operation.
         eq_(["foo", "bar"],
             [x.operation for x in self._db.query(CoverageRecord)])
+
+        # If we try to ensure coverage again, nothing happens.
+        result3 = provider1.ensure_coverage(self.edition)
+        eq_((0,0,0), result3)
 
     def test_ensure_coverage_persistent_coverage_failure(self):
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -95,7 +95,7 @@ class TestCoverageProvider(DatabaseTest):
         # If we try to ensure coverage again, no work is done and we
         # get the old coverage record back.
         new_coverage = provider1.ensure_coverage(self.edition)
-        eq_(new_coverage, coverage)
+        eq_(new_coverage, coverage1)
         new_coverage.timestamp = old_timestamp
 
     def test_ensure_coverage_persistent_coverage_failure(self):

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -9,6 +9,7 @@ from . import (
 from testing import (
     AlwaysSuccessfulCoverageProvider,
     DummyHTTPClient,
+    TaskIgnoringCoverageProvider,
     NeverSuccessfulCoverageProvider,
     TransientFailureCoverageProvider,
 )
@@ -361,6 +362,19 @@ class TestCoverageProvider(DatabaseTest):
 
         # Because the failures were transient, no new coverage records
         # were added.
+        eq_(['success', 'success'], operations())
+
+        task_ignoring_provider = TaskIgnoringCoverageProvider(
+            "Ignores all tasks", self.input_identifier_types,
+            self.output_source, operation="ignore"
+        )
+        results = task_ignoring_provider.process_batch_and_handle_results(batch)
+
+        # When a provider ignores a task given to it, it's treated as
+        # a transient error.
+        eq_((0, 2, 0), results)
+
+        # Again, no new coverage records
         eq_(['success', 'success'], operations())
 
         persistent_failure_provider = NeverSuccessfulCoverageProvider(

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -166,11 +166,18 @@ class TestCoverageProvider(DatabaseTest):
         provider = AlwaysSuccessfulCoverageProvider(
             "Always successful", self.input_identifier_types, self.output_source
         )
-        provider.workset_size = 6
-        
+        provider.workset_size = 3
         to_be_tested = [self._identifier() for i in range(6)]
         not_to_be_tested = [self._identifier() for i in range(6)]
-        provider.run_on_identifiers(to_be_tested)
+        counts, records = provider.run_on_identifiers(to_be_tested)
+
+        # Six identifiers were covered in two batches.
+        eq_((6,0,0), counts)
+        eq_(6, len(records))
+
+        # Only the identifiers in to_be_tested were covered.
+        assert all(isinstance(x, CoverageRecord) for x in records)
+        eq_(set(to_be_tested), set([x.identifier for x in records]))
         for i in to_be_tested:
             assert i in provider.attempts
         for i in not_to_be_tested:

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -84,6 +84,7 @@ class TestCoverageProvider(DatabaseTest):
         # Ensure coverage of both providers.
         coverage1 = provider1.ensure_coverage(self.edition)
         eq_("foo", coverage1.operation)
+        old_timestamp = coverage1.timestamp
 
         coverage2  = provider2.ensure_coverage(self.edition)
         eq_("bar", coverage2.operation)
@@ -91,9 +92,11 @@ class TestCoverageProvider(DatabaseTest):
         # There are now two CoverageRecords, one for each operation.
         eq_(set([coverage1, coverage2]), set(self._db.query(CoverageRecord)))
 
-        # If we try to ensure coverage again, nothing happens.
-        coverage = provider1.ensure_coverage(self.edition)
-        eq_(None, coverage)
+        # If we try to ensure coverage again, no work is done and we
+        # get the old coverage record back.
+        new_coverage = provider1.ensure_coverage(self.edition)
+        eq_(new_coverage, coverage)
+        new_coverage.timestamp = old_timestamp
 
     def test_ensure_coverage_persistent_coverage_failure(self):
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -55,8 +55,7 @@ class TestCoverageProvider(DatabaseTest):
         provider = AlwaysSuccessfulCoverageProvider(
             "Always successful", self.input_identifier_types, self.output_source
         )
-        counts, [record] = provider.ensure_coverage(self.edition)
-        eq_((1, 0, 0), counts)
+        record = provider.ensure_coverage(self.edition)
         assert isinstance(record, CoverageRecord)
         eq_(self.edition.primary_identifier, record.identifier)
         eq_(self.output_source, record.data_source)
@@ -83,29 +82,25 @@ class TestCoverageProvider(DatabaseTest):
         )
 
         # Ensure coverage of both providers.
-        counts, [coverage1] = provider1.ensure_coverage(self.edition)
-        eq_((1,0,0), counts)
+        coverage1 = provider1.ensure_coverage(self.edition)
         eq_("foo", coverage1.operation)
 
-        counts, [coverage2]  = provider2.ensure_coverage(self.edition)
-        eq_((1,0,0), counts)
+        coverage2  = provider2.ensure_coverage(self.edition)
         eq_("bar", coverage2.operation)
 
         # There are now two CoverageRecords, one for each operation.
         eq_(set([coverage1, coverage2]), set(self._db.query(CoverageRecord)))
 
         # If we try to ensure coverage again, nothing happens.
-        counts, records = provider1.ensure_coverage(self.edition)
-        eq_((0,0,0), counts)
-        eq_([], records)
+        coverage = provider1.ensure_coverage(self.edition)
+        eq_(None, coverage)
 
     def test_ensure_coverage_persistent_coverage_failure(self):
 
         provider = NeverSuccessfulCoverageProvider(
             "Never successful", self.input_identifier_types, self.output_source
         )
-        counts, [failure] = provider.ensure_coverage(self.edition)
-        eq_((0, 0, 1), counts)
+        failure = provider.ensure_coverage(self.edition)
 
         # A CoverageRecord has been created to memorialize the
         # persistent failure.
@@ -151,8 +146,7 @@ class TestCoverageProvider(DatabaseTest):
         provider = TransientFailureCoverageProvider(
             "Transient failure", self.input_identifier_types, self.output_source
         )
-        counts, [failure] = provider.ensure_coverage(self.edition)
-        eq_((0, 1, 0), counts)
+        failure = provider.ensure_coverage(self.edition)
         eq_(True, failure.transient)
         eq_("Oops!", failure.exception)
 


### PR DESCRIPTION
This branch fixes two problems with coverage records not being added:

* When ensure_coverage() checked for an existing coverage record, it didn't take the operation into account. So if your coverage provider ran operation 'foo' and there was an existing record for operation 'bar', it would seem as though the 'foo' operation had completed. No work would be done and no new coverage record would be created.

* The run_on_identifiers() method was doing the work, but not creating coverage records reflecting the work done. This is because it called process_batch(), which does the work, but not running the coverage record code, which was duplicated across run_once() and ensure_coverage(). I refactored this code into a new method, process_batch_and_handle_results(). I also added tests for the code in process_batch_and_handle_results, which was previously untested.

I normalized the return value of all of these methods so they return a 2-tuple (counts, records), where `counts` is a 3-tuple (# of successes, # of transient failures, # of persistent failures) and `records` is a mixed list of `CoverageRecord` and `CoverageFailure` objects.

I tested a previously untested code path using a CoverageProvider that simply ignores all the work given to it. (This is treated as a transient failure.)