### PR TITLE
Possible fix for calculate_work loop

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1046,14 +1046,9 @@ class Metadata(object):
             )
 
         # Make sure the work we just did shows up.
-        if edition.work:
-            edition.work.calculate_presentation(
-                policy=replace.presentation_calculation_policy
-            )
-        else:
-            edition.calculate_presentation(
-                policy=replace.presentation_calculation_policy
-            )
+        edition.calculate_presentation(
+            policy=replace.presentation_calculation_policy
+        )
 
         if not edition.sort_author:
             # This may be a situation like the NYT best-seller list where

--- a/model.py
+++ b/model.py
@@ -5565,7 +5565,9 @@ class LicensePool(Base):
             if primary_edition:
                 primary_edition.work = self.work
             
-            # The work has already been done.
+            # The work has already been done. Make sure the work's
+            # display is up to date.
+            self.work.calculate_presentation()
             return self.work, False
 
 
@@ -5577,7 +5579,7 @@ class LicensePool(Base):
                      self.identifier)
             
             return None, False
-        if primary_edition.license_pool != self:
+        if primary_edition.is_presentation_for != self:
             raise ValueError(
                 "Primary edition's license pool is not the license pool for which work is being calculated!")
 

--- a/opds_import.py
+++ b/opds_import.py
@@ -273,7 +273,6 @@ class OPDSImporter(object):
                 even_if_no_author=even_if_no_author,
             )
             if work:
-                work.calculate_presentation()
                 if immediately_presentation_ready:
                     # We want this book to be presentation-ready
                     # immediately upon import. As long as no crucial

--- a/scripts.py
+++ b/scripts.py
@@ -404,7 +404,7 @@ class WorkConsolidationScript(WorkProcessingScript):
         LicensePool.consolidate_works(self._db)
 
         logging.info("Deleting works with no editions.")
-        for i in self.db.query(Work).filter(Work.primary_edition==None):
+        for i in self._db.query(Work).filter(Work.primary_edition==None):
             self._db.delete(i)            
         self._db.commit()
 


### PR DESCRIPTION
This is one way we could fix the loop in LicensePool.calculate_work.

There are two changes:
- metadata.apply(edition) no longer updates the work, it only calls edition.calculate_presentation (which already no longer calls work.calculate_presentation).
- license_pool.calculate_work always calls work.calculate_presentation, even if it returns a work that already existed.

I looked at all the calls to metadata.apply in core, and there's only one where we don't also call either work.calculate_presentation or license_pool.calculate_work, in TitleFromExternalList.to_edition. I"m not sure, but I don't think we're using metadata from the external lists in the works' presentation. If we are, we could also call work.calculate_presentation there.

