### PR TITLE
Dont store data source objects

### DIFF
--- a/nyt.py
+++ b/nyt.py
@@ -63,12 +63,15 @@ class NYTBestSellerAPI(NYTAPI):
             Configuration.NYT_BEST_SELLERS_API_KEY
         ]
         self.do_get = do_get or Representation.simple_http_get
-        self.source = DataSource.lookup(_db, DataSource.NYT)
         if not metadata_client:
             metadata_url = Configuration.integration_url(
                 Configuration.METADATA_WRANGLER_INTEGRATION)
             metadata_client = SimplifiedOPDSLookup(metadata_url)
         self.metadata_client = metadata_client
+
+    @property
+    def source(self):
+        return DataSource.lookup(_db, DataSource.NYT)
 
     def request(self, path, identifier=None, max_age=LIST_MAX_AGE):
         if not path.startswith(self.BASE_URL):


### PR DESCRIPTION
This branch stops the practice of caching DataSource objects in the API interface objects for Overdrive, 3M, Axis 360, and the NYT API. This stopped being okay when we introduced request-scoped database sessions so that we could start using multiple threads on the circ manager.

This only seems to be a real problem for Overdrive (where it affects some situations where a book is put on hold), but it's good to change everywhere in case it becomes a problem in the future.