### PR TITLE
SimplifiedGenreClassifier returns correct fiction status

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -3814,6 +3814,12 @@ class SimplifiedGenreClassifier(Classifier):
         return cls._genre_by_name(identifier.original, all_genres)
 
     @classmethod
+    def is_fiction(cls, identifier, name):
+        if not globals()["genres"][identifier.original]:
+            return None
+        return globals()["genres"][identifier.original].is_fiction
+
+    @classmethod
     def _genre_by_name(cls, name, genres):
         for genre in genres:
             if genre == name:


### PR DESCRIPTION
This branch has SimplifiedGenreClassifier look up a genre name in the canonical genre data to determine whether it's fiction or nonfiction, instead of the default method of looking for "fiction" or "nonfiction" in the genre name.