### PR TITLE
Don't give books the same Work just because we have equally little information about any of them

### DIFF
--- a/model.py
+++ b/model.py
@@ -5592,13 +5592,18 @@ class LicensePool(Base):
             primary_edition.calculate_presentation()
 
         if not primary_edition.title:
-            logging.warn("Edition %r has no title, will not assign it a Work.")
-            return None, False
+            if primary_edition.work:
+                logging.warn(
+                    "Edition %r has no title but has a Work assigned. This is troubling.", primary_edition
+                )
+                return primary_Edition.work, False
+            else:
+                logging.info("Edition %r has no title, will not assign it a Work.", primary_edition)
+                return None, False
 
-        if not primary_edition.work and (
-                not primary_edition.title or (
-                    (primary_edition.author in (None, Edition.UNKNOWN_AUTHOR)
-                     and not even_if_no_author))
+        if (not primary_edition.work 
+            and primary_edition.author in (None, Edition.UNKNOWN_AUTHOR)
+            and not even_if_no_author
         ):
             logging.warn(
                 "Edition %r has no author or title, not assigning Work to Edition.", 

--- a/model.py
+++ b/model.py
@@ -2711,6 +2711,11 @@ class Edition(Base):
 
     def calculate_permanent_work_id(self, debug=False):
         title = self.title_for_permanent_work_id
+        if not title:
+            # If a book has no title, it has no permanent work ID.
+            self.permanent_work_id = None
+            return
+
         author = self.author_for_permanent_work_id
 
         if self.medium == Edition.BOOK_MEDIUM:
@@ -5586,6 +5591,10 @@ class LicensePool(Base):
         if not primary_edition.title or not primary_edition.author:
             primary_edition.calculate_presentation()
 
+        if not primary_edition.title:
+            logging.warn("Edition %r has no title, will not assign it a Work.")
+            return None, False
+
         if not primary_edition.work and (
                 not primary_edition.title or (
                     (primary_edition.author in (None, Edition.UNKNOWN_AUTHOR)
@@ -5612,7 +5621,7 @@ class LicensePool(Base):
         else:
             _db = Session.object_session(self)
             work = None
-            if self.open_access:
+            if self.open_access and primary_edition.permanent_work_id:
                 # Is there already an open-access Work which includes editions
                 # with this edition's permanent work ID?
                 q = _db.query(Edition).filter(

--- a/model.py
+++ b/model.py
@@ -5615,8 +5615,7 @@ class LicensePool(Base):
             #print msg.encode("utf8")
             return None, False
 
-        if not primary_edition.permanent_work_id:
-            primary_edition.calculate_permanent_work_id()
+        primary_edition.calculate_permanent_work_id()
 
         if primary_edition.work:
             # This pool's primary edition is already associated with

--- a/model.py
+++ b/model.py
@@ -5596,7 +5596,7 @@ class LicensePool(Base):
                 logging.warn(
                     "Edition %r has no title but has a Work assigned. This is troubling.", primary_edition
                 )
-                return primary_Edition.work, False
+                return primary_edition.work, False
             else:
                 logging.info("Edition %r has no title, will not assign it a Work.", primary_edition)
                 return None, False

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -890,6 +890,17 @@ class TestEdition(DatabaseTest):
             [x.data_source for x in records]
         )
 
+    def test_no_permanent_work_id_for_edition_with_no_title(self):
+        """An edition with no title is not assigned a permanent work ID."""
+        edition = self._edition()
+        edition.title = ''
+        eq_(None, edition.permanent_work_id)
+        edition.calculate_permanent_work_id()
+        eq_(None, edition.permanent_work_id)
+        edition.title = u'something'
+        edition.calculate_permanent_work_id()
+        assert_not_equal(None, edition.permanent_work_id)
+
 class TestLicensePool(DatabaseTest):
 
     def test_for_foreign_id(self):
@@ -1844,6 +1855,32 @@ class TestWorkConsolidation(DatabaseTest):
         Work.similarity_to = self.old_w
         Edition.similarity_to = self.old_wr
         super(TestWorkConsolidation, self).teardown()
+
+    def test_calculate_work_success(self):
+        e, p = self._edition(with_license_pool=True)
+        work, new = p.calculate_work(even_if_no_author=True)
+        eq_(p.presentation_edition, work.primary_edition)
+        eq_(True, new)
+
+    def test_calculate_work_bails_out_if_no_title(self):
+        e, p = self._edition(with_license_pool=True)
+        e.title=None
+        work, new = p.calculate_work(even_if_no_author=True)
+        eq_(None, work)
+        eq_(False, new)
+
+    def test_calculate_work_bails_out_if_no_author(self):
+        e, p = self._edition(with_license_pool=True, authors=[])
+        work, new = p.calculate_work(even_if_no_author=False)
+        eq_(None, work)
+        eq_(False, new)
+
+        # If we know that there simply is no author for this work,
+        # we can pass in even_if_no_author=True
+        work, new = p.calculate_work(even_if_no_author=True)
+        eq_(p.presentation_edition, work.primary_edition)
+        eq_(True, new)
+
 
     def test_calculate_work_matches_based_on_permanent_work_id(self):
         # Here are two Editions with the same permanent work ID, 


### PR DESCRIPTION
If we have no information about two Editions, they end up with the same permanent work ID and they can end up grouped together. This branch puts a stop to that in as many ways as I can think of:

* It stops a permanent work ID from being generated for an Edition that has no title.
* It stops a Work from being generated for an Edition that has no title. (This should have been happening before, but I made it more explicit.)