### PR TITLE
Make bibliographic coverage providers runnable from scripts

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -184,7 +184,7 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
     bibliographic and availability data.
     """
     def __init__(self, _db, input_identifier_types=None, 
-                 metadata_replacement_policy=None, cutoff_time=None):
+                 metadata_replacement_policy=None, **kwargs):
         # We ignore the value of input_identifier_types, but it's
         # passed in by RunCoverageProviderScript, so we accept it as
         # part of the signature.
@@ -193,7 +193,7 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
             _db, Axis360API(_db), DataSource.AXIS_360,
             workset_size=25, 
             metadata_replacement_policy=metadata_replacement_policy,
-            cutoff_time=cutoff_time
+            **kwargs
         )
 
     def process_batch(self, identifiers):

--- a/axis.py
+++ b/axis.py
@@ -183,12 +183,17 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
     not normally necessary because the Axis 360 API combines
     bibliographic and availability data.
     """
-    def __init__(self, _db, metadata_replacement_policy=None):
+    def __init__(self, _db, input_identifier_types=None, 
+                 metadata_replacement_policy=None, cutoff_time=None):
+        # We ignore the value of input_identifier_types, but it's
+        # passed in by RunCoverageProviderScript, so we accept it as
+        # part of the signature.
         self.parser = BibliographicParser()
         super(Axis360BibliographicCoverageProvider, self).__init__(
             _db, Axis360API(_db), DataSource.AXIS_360,
             workset_size=25, 
-            metadata_replacement_policy=metadata_replacement_policy
+            metadata_replacement_policy=metadata_replacement_policy,
+            cutoff_time=cutoff_time
         )
 
     def process_batch(self, identifiers):

--- a/coverage.py
+++ b/coverage.py
@@ -405,7 +405,7 @@ class BibliographicCoverageProvider(CoverageProvider):
     CAN_CREATE_LICENSE_POOLS = True
 
     def __init__(self, _db, api, datasource, workset_size=10,
-                 metadata_replacement_policy=None
+                 metadata_replacement_policy=None, cutoff_time=None
     ):
         self._db = _db
         self.api = api
@@ -420,6 +420,7 @@ class BibliographicCoverageProvider(CoverageProvider):
             service_name,
             input_identifier_types, output_source,
             workset_size=workset_size,
+            cutoff_time=cutoff_time
         )
 
     def process_batch(self):

--- a/overdrive.py
+++ b/overdrive.py
@@ -757,10 +757,14 @@ class OverdriveRepresentationExtractor(object):
 class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
     """Fill in bibliographic metadata for Overdrive records."""
 
-    def __init__(self, _db, metadata_replacement_policy=None):
+    def __init__(self, _db, input_identifier_types=None,
+                 metadata_replacement_policy=None, **kwargs):
+        # We ignore the value of input_identifier_types, but it's
+        # passed in by RunCoverageProviderScript, so we accept it as
+        # part of the signature.
         super(OverdriveBibliographicCoverageProvider, self).__init__(
             _db, OverdriveAPI(_db), DataSource.OVERDRIVE,
-            workset_size=10, metadata_replacement_policy=metadata_replacement_policy
+            workset_size=10, metadata_replacement_policy=metadata_replacement_policy, **kwargs
         )
 
     def process_batch(self, identifiers):

--- a/threem.py
+++ b/threem.py
@@ -325,10 +325,14 @@ class ItemListParser(XMLParser):
 class ThreeMBibliographicCoverageProvider(BibliographicCoverageProvider):
     """Fill in bibliographic metadata for 3M records."""
 
-    def __init__(self, _db, metadata_replacement_policy=None):
+    def __init__(self, _db, input_identifier_types=None,
+                 metadata_replacement_policy=None, **kwargs):
+        # We ignore the value of input_identifier_types, but it's
+        # passed in by RunCoverageProviderScript, so we accept it as
+        # part of the signature.
         super(ThreeMBibliographicCoverageProvider, self).__init__(
             _db, ThreeMAPI(_db), DataSource.THREEM,
-            workset_size=25, metadata_replacement_policy=metadata_replacement_policy
+            workset_size=25, metadata_replacement_policy=metadata_replacement_policy, **kwargs
         )
 
     def process_batch(self, identifiers):


### PR DESCRIPTION
This branch upgrades the various BibliographicCoverageProvider classes so they can be run with the RunCoverageProviderScript. This means accepting (and ignoring) the standard `input_identifier_types` argument, and also accepting (and passing on) general `**kwargs` such as the `cutoff_time` now gathered from the command line and passed into the `CoverageProvder` constructor.