### PR TITLE
Lookups without licensepools

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -372,12 +372,13 @@ class URNLookupController(object):
         # We made it!
         return entry
 
-    def work_lookup(self, annotator, controller_name='lookup', collection=None):
+    def work_lookup(self, annotator, route_name='lookup',
+                    require_active_licensepool=True, collection=None):
         """Generate an OPDS feed describing works identified by identifier."""
         urns = flask.request.args.getlist('urn')
 
         messages_by_urn = dict()
-        this_url = cdn_url_for(controller_name, _external=True, urn=urns)
+        this_url = cdn_url_for(route_name, _external=True, urn=urns)
         for urn in urns:
             code, message = self.process_urn(urn, collection=collection)
             if code:
@@ -396,8 +397,9 @@ class URNLookupController(object):
         opds_feed = LookupAcquisitionFeed(
             self._db, "Lookup results", this_url, self.works, annotator,
             messages_by_urn=messages_by_urn, 
-            precomposed_entries=self.precomposed_entries)
-
+            precomposed_entries=self.precomposed_entries,
+            require_active_licensepool=require_active_licensepool
+        )
         return feed_response(opds_feed)
 
     def permalink(self, urn, annotator):

--- a/app_server.py
+++ b/app_server.py
@@ -383,6 +383,12 @@ class URNLookupController(object):
             if code:
                 messages_by_urn[urn] = (code, message)
 
+        missing_urns = set(urns).difference(set(messages_by_urn.keys()))
+        if missing_urns:
+            # One or more urns have disappeared in the process.
+            for urn in missing_urns:
+                messages_by_urn[urn] = (400, self.UNRESOLVABLE_URN)
+
         # The commit is necessary because we may have registered new
         # Identifier or UnresolvedIdentifier objects.
         self._db.commit()

--- a/app_server.py
+++ b/app_server.py
@@ -388,7 +388,10 @@ class URNLookupController(object):
         if missing_urns:
             # One or more urns have disappeared in the process.
             for urn in missing_urns:
-                messages_by_urn[urn] = (400, self.UNRESOLVABLE_URN)
+                messages_by_urn[urn] = (
+                    INTERNAL_SERVER_ERROR.status_code,
+                    INTERNAL_SERVER_ERROR.detail
+                )
 
         # The commit is necessary because we may have registered new
         # Identifier or UnresolvedIdentifier objects.

--- a/opds.py
+++ b/opds.py
@@ -1190,8 +1190,9 @@ class LookupAcquisitionFeed(AcquisitionFeed):
     def create_entry(self, work, lane_link):
         """Turn a work into an entry for an acquisition feed."""
         identifier, work = work
-
         active_license_pool = self.annotator.active_licensepool_for(work)
+
+        edition = None
         if active_license_pool:
             edition = active_license_pool.presentation_edition
         if not edition:

--- a/opds.py
+++ b/opds.py
@@ -297,7 +297,8 @@ class Annotator(object):
             # the work's primary edition.
             edition = work.primary_edition
 
-            if edition and edition.license_pool and edition.open_access_download_url and edition.title:
+            if (edition and edition.license_pool and
+                edition.open_access_download_url and edition.title):
                 # Looks good.
                 open_access_license_pool = edition.license_pool
 
@@ -312,9 +313,7 @@ class Annotator(object):
                     # audio-only or something.
                     if edition and edition.open_access_download_url:
                         open_access_license_pool = p
-                elif edition and edition.title:
-                    # TODO: It's OK to have a non-open-access license pool,
-                    # but the pool needs to have copies available.
+                elif edition and edition.title and p.licenses_owned > 0:
                     active_license_pool = p
                     break
         if not active_license_pool:
@@ -1191,12 +1190,13 @@ class LookupAcquisitionFeed(AcquisitionFeed):
     def create_entry(self, work, lane_link):
         """Turn a work into an entry for an acquisition feed."""
         identifier, work = work
-        active_license_pool = self.annotator.active_licensepool_for(work)
-        # There's no reason to present a book that has no active license pool.
-        if not active_license_pool:
-            return None
 
-        active_edition = active_license_pool.presentation_edition
+        active_license_pool = self.annotator.active_licensepool_for(work)
+        if active_license_pool:
+            edition = active_license_pool.presentation_edition
+        if not edition:
+            edition = work.primary_edition
+
         return self._create_entry(
-            work, active_license_pool, work.primary_edition, 
-            identifier, lane_link)
+            work, active_license_pool, edition, identifier, lane_link
+        )

--- a/problem_details.py
+++ b/problem_details.py
@@ -27,3 +27,10 @@ INVALID_URN = pd(
       "Invalid URN",
       "Could not parse identifier.",
 )
+
+INTERNAL_SERVER_ERROR = pd(
+      "http://librarysimplified.org/terms/problem/internal-server-error",
+      500,
+      "Internal server error.",
+      "Internal server error"
+)

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -39,9 +39,10 @@ from lane import (
 
 from opds import (    
      AtomFeed,
-     OPDSFeed,
      AcquisitionFeed,
      Annotator,
+     LookupAcquisitionFeed,
+     OPDSFeed,
      VerboseAnnotator,
      simplified_ns,
 )
@@ -957,3 +958,20 @@ class TestOPDS(DatabaseTest):
             assert work2.title in cached3.content
 
 
+class TestLookupAcquisitionFeed(DatabaseTest):
+
+    def test_lookup_feed_ignores_licensepool_activeness(self):
+        """It doesn't matter whether a work has a licensepool or not in lookup
+        feeds.
+        """
+        work = self._work(title=u"Hello, World!", with_license_pool=True)
+        identifier = work.license_pools[0].identifier
+        feed = LookupAcquisitionFeed(
+            self._db, u"Feed Title", u"http://whatever.io", [(identifier, work)],
+            annotator=VerboseAnnotator
+        )
+        feed = feedparser.parse(unicode(feed))
+        eq_(1, len(feed.entries))
+        [entry] = feed.entries
+        eq_("Hello, World!", entry.title)
+        eq_(identifier.urn, entry.id)


### PR DESCRIPTION
This branch adjusts the LookupAcquisitionFeed so that it doesn't lose entries for works without license pools, for all the reasons detailed in #217. 

I have a little confusion around whether a work's primary_edition is still a viable way to get edition information in a post-presentation_edition world. I'm also not sure `UNRESOLVABLE_URN` is the right error message here -- would something new, like `ANOMALOUS_IDENTIFIER` be more useful? Particularly given this is something we _shouldn't_ see happening?

Fixes #217.