### PR TITLE
Improve work consolidation

### DIFF
--- a/model.py
+++ b/model.py
@@ -5532,7 +5532,8 @@ class LicensePool(Base):
         return hold, new
 
     @classmethod
-    def consolidate_works(cls, _db, calculate_work_even_if_no_author=False):
+    def consolidate_works(cls, _db, calculate_work_even_if_no_author=False,
+                          batch_size=10):
         """Assign a (possibly new) Work to every unassigned LicensePool."""
         a = 0
         lps = cls.with_no_work(_db)
@@ -5549,9 +5550,9 @@ class LicensePool(Base):
                 continue
             a += 1
             logging.info("When consolidating works, created %r", etext)
-            if a and not a % 10:
+            if a and not a % batch_size:
                 _db.commit()
-
+        _db.commit()
 
 
     def calculate_work(self, even_if_no_author=False, known_edition=None):

--- a/scripts.py
+++ b/scripts.py
@@ -426,6 +426,8 @@ class WorkConsolidationScript(WorkProcessingScript):
                         "No LicensePool for %r, cannot create work.", i
                     )
                     continue
+                if pool.work:
+                    self.clear_works(pool.work.id)
                 pool.calculate_work()
                 self._db.commit()
         else:
@@ -439,11 +441,14 @@ class WorkConsolidationScript(WorkProcessingScript):
             self._db.commit()
 
     def clear_existing_works(self):
-        # Locate works we want to consolidate.
-        unset_work_id = { Edition.work_id : None }
         work_ids_to_delete = set()
         for wr in self.query:
             work_ids_to_delete.add(wr.id)
+        self.clear_works(self, *work_ids_to_delete)
+
+    def clear_works(self, *work_ids_to_delete):
+        # Locate works we want to consolidate.
+        unset_work_id = { Edition.work_id : None }
         editions = self._db.query(Edition).filter(
             Edition.work_id.in_(work_ids_to_delete))
 

--- a/scripts.py
+++ b/scripts.py
@@ -422,7 +422,7 @@ class WorkConsolidationScript(WorkProcessingScript):
             for i in self.identifiers:
                 pool = i.licensed_through
                 if not pool:
-                    logging.warn(
+                    self.log.warn(
                         "No LicensePool for %r, cannot create work.", i
                     )
                     continue
@@ -442,11 +442,16 @@ class WorkConsolidationScript(WorkProcessingScript):
                     pool.calculate_work()
                 self._db.commit()
         else:
-            logging.info("Consolidating all works.")
+            self.log.info("Consolidating all works.")
+            if self.force:
+                self.log.warn(
+                    "Clearing all works! This will probably take a long time, so now is a good time to evaluate if you really want to do this."
+                )
+                self.clear_existing_works()
             LicensePool.consolidate_works(self._db, batch_size=self.batch_size)
 
             qu = self._db.query(Work).filter(Work.primary_edition==None)
-            logging.info("Deleting %d Works that lack Editions." % qu.count())
+            self.log.info("Deleting %d Works that lack Editions." % qu.count())
             for i in qu:
                 self._db.delete(i)            
             self._db.commit()

--- a/scripts.py
+++ b/scripts.py
@@ -426,9 +426,20 @@ class WorkConsolidationScript(WorkProcessingScript):
                         "No LicensePool for %r, cannot create work.", i
                     )
                     continue
+
                 if pool.work:
+                    # We're about to delete a preexisting work. If the
+                    # problem is that this LicensePool is incorrectly
+                    # grouped together with some other LicensePool,
+                    # then that LicensePool must also have
+                    # calculate_work() called on it, so that we can
+                    # create two Works where there used to be one.
+                    all_pools = pool.work.license_pools
                     self.clear_works(pool.work.id)
-                pool.calculate_work()
+                else:
+                    all_pools = [pool]
+                for pool in all_pools:
+                    pool.calculate_work()
                 self._db.commit()
         else:
             logging.info("Consolidating all works.")

--- a/tests/test_equivalency.py
+++ b/tests/test_equivalency.py
@@ -1,4 +1,4 @@
-nosefrom nose.tools import (
+from nose.tools import (
     assert_raises_regexp,
     eq_,
     set_trace,

--- a/tests/test_equivalency.py
+++ b/tests/test_equivalency.py
@@ -1,4 +1,4 @@
-from nose.tools import (
+nosefrom nose.tools import (
     assert_raises_regexp,
     eq_,
     set_trace,
@@ -42,7 +42,7 @@ class TestEquivalency(DatabaseTest):
 
         eq_([eq], record.primary_identifier.equivalencies)
 
-        eq_([record, record2], record.equivalent_editions().all())
+        eq_(set([record, record2]), set(record.equivalent_editions().all()))
 
     def test_recursively_equivalent_identifiers(self):
 


### PR DESCRIPTION
This branch fixes a number of problems with the work consolidation script and the workflow it triggers. It was driven by my attempt to fix bad works in a real database.

The biggest change is that when you invoke the work consolidation script on a specific identifier, it deletes any preexisting Work for that identifier, and it makes sure to call calculate_work() on _every_ `LicensePool` that used to be associated with that work. Basically, it deletes one `Work` and creates two new `Work`s in its place. Without the delete code, `LicensePool`s that are in bad `Work`s never leave those `Work`s. Without the loop over `LicensePool`s, deleting a bad `Work` creates orphan `LicensePool`s.

I think the code that deletes a work is becoming too important to sit untested in a script class, but this is good enough for now.
