### PR TITLE
Immediate bibliographic coverage upon discovery of book

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -3804,6 +3804,16 @@ class SimplifiedGenreClassifier(Classifier):
     NONE = "NONE"
 
     @classmethod
+    def scrub_identifier(cls, identifier):
+        # If the identifier is a URI identifying a Simplified genre,
+        # strip off the first part of the URI to get the genre name.
+        if not identifier:
+            return identifier
+        if identifier.startswith(cls.SIMPLIFIED_GENRE):
+            identifier = identifier[len(cls.SIMPLIFIED_GENRE):]
+        return Lowercased(identifier)
+
+    @classmethod
     def genre(cls, identifier, name, fiction=None, audience=None):
         if fiction == True:
             all_genres = fiction_genres

--- a/classifier.py
+++ b/classifier.py
@@ -17,6 +17,7 @@ import json
 import os
 import pkgutil
 import re
+import urllib
 from collections import (
     Counter,
     defaultdict,
@@ -3811,6 +3812,7 @@ class SimplifiedGenreClassifier(Classifier):
             return identifier
         if identifier.startswith(cls.SIMPLIFIED_GENRE):
             identifier = identifier[len(cls.SIMPLIFIED_GENRE):]
+            identifier = urllib.unquote(identifier)
         return Lowercased(identifier)
 
     @classmethod

--- a/model.py
+++ b/model.py
@@ -4168,7 +4168,7 @@ class Resource(Base):
 
     # The point at which a generic geometric image is better
     # than a lousy cover we got from the Internet.
-    MINIMUM_IMAGE_QUALITY = 1.0/8
+    MINIMUM_IMAGE_QUALITY = 0.25
 
     id = Column(Integer, primary_key=True)
 

--- a/model.py
+++ b/model.py
@@ -1616,7 +1616,7 @@ class Identifier(Base):
 
             # If the size of the image is known, that might affect
             # the quality.
-            quality = quality * Representation.image_size_quality_penalty(
+            quality = quality * Representation.cover_size_quality_penalty(
                 rep.image_width, rep.image_height
             )
 

--- a/model.py
+++ b/model.py
@@ -4295,24 +4295,21 @@ class Resource(Base):
     @classmethod
     def best_covers_among(cls, resources):
         """Choose the best covers from a list of Resources."""
-        champion = None
         champions = []
         champion_score = None
 
         for r in resources:
-            rep = self.representation
+            rep = r.representation
             if not rep:
                 # A Resource with no Representation is not usable, period
                 continue
 
-            if not champion:
-                champion = r
-                continue
-
             quality = r.quality_as_thumbnail_image
             if not quality >= cls.MINIMUM_IMAGE_QUALITY:
+                # A Resource below the minimum quality threshold is not
+                # usable, period.
                 continue
-            if quality > champion_score:
+            if not champions or quality > champion_score:
                 champions = [r]
                 champion_score = r.quality
             elif quality == champion_score:

--- a/model.py
+++ b/model.py
@@ -1589,6 +1589,57 @@ class Identifier(Base):
     MINIMUM_IMAGE_QUALITY = 0.25
 
     @classmethod
+    def aspect_ratio_quality_quotient(cls, width, height):
+        """Measure an image's deviation from the ideal aspect ratio, and by
+        its deviation (in the "too small" direction only) from the
+        ideal thumbnail resolution.
+        """
+
+        quotient = 1
+
+        if not width or not height:
+            # In the absence of any information, assume the cover is
+            # just dandy.
+            #
+            # This is obviously less than ideal, but this code is used
+            # pretty rarely now that we no longer have hundreds of
+            # covers competing for the privilege of representing a
+            # public domain book, so I'm not too concerned about it.
+            #
+            # Look at it this way: this escape hatch only causes a
+            # problem if we compare an image whose size we know
+            # against an image whose size we don't know.
+            #
+            # In the circulation manager, we never know what size an
+            # image is, and we must always trust that the cover
+            # (e.g. Overdrive and the metadata wrangler) give us
+            # "thumbnail" images that are approximately the right
+            # size. So we always use this escape hatch.
+            #
+            # In the metadata wrangler and content server, we always
+            # have access to the covers themselves, so we always have
+            # size information and we never use this escape hatch.
+            return quotient
+
+        # Penalize an image for deviation from the ideal aspect ratio.
+        aspect_ratio = rep.image_width / float(rep.image_height)
+        aspect_difference = abs(aspect_ratio-cls.IDEAL_COVER_ASPECT_RATIO)
+        quotient -= aspect_difference
+
+        # Penalize an image for not being wide enough.
+        width_shortfall = (
+            float(rep.image_width - cls.IDEAL_IMAGE_WIDTH) / cls.IDEAL_IMAGE_WIDTH)
+        if width_shortfall < 0:
+            quotient -= (1+width_shortfall)
+
+        # Penalize an image for not being tall enough.
+        height_shortfall = (
+            float(rep.image_height - cls.IDEAL_IMAGE_HEIGHT) / cls.IDEAL_IMAGE_HEIGHT)
+        if height_shortfall < 0:
+            quotient -= (1+height_shortfall)
+        return quotient
+
+    @classmethod
     def best_cover_for(cls, _db, identifier_ids):
         # Find all image resources associated with any of
         # these identifiers.
@@ -1602,22 +1653,8 @@ class Identifier(Base):
         champion = None
         champions = []
         champion_score = None
-        # Judge the image resource by its deviation from the ideal
-        # aspect ratio, and by its deviation (in the "too small"
-        # direction only) from the ideal resolution.
+
         for r in images:
-            for link in r.links:
-                if link.license_pool and not link.license_pool.open_access:
-                    # For licensed works, always present the cover
-                    # provided by the licensing authority.
-                    r.quality = 1
-                    champion = r
-                    break
-
-            if champion and champion.quality == 1:
-                # No need to look further
-                break
-
             rep = r.representation
             if not rep:
                 continue
@@ -1626,21 +1663,13 @@ class Identifier(Base):
                 champion = r
                 continue
 
-            if not rep.image_width or not rep.image_height:
-                continue
-            aspect_ratio = rep.image_width / float(rep.image_height)
-            aspect_difference = abs(aspect_ratio-cls.IDEAL_COVER_ASPECT_RATIO)
-            quality = 1 - aspect_difference
-            width_difference = (
-                float(rep.image_width - cls.IDEAL_IMAGE_WIDTH) / cls.IDEAL_IMAGE_WIDTH)
-            if width_difference < 0:
-                # Image is not wide enough.
-                quality = quality * (1+width_difference)
-            height_difference = (
-                float(rep.image_height - cls.IDEAL_IMAGE_HEIGHT) / cls.IDEAL_IMAGE_HEIGHT)
-            if height_difference < 0:
-                # Image is not tall enough.
-                quality = quality * (1+height_difference)
+            quality = 1
+
+            # If the size of the image is known, that might affect
+            # the quality.
+            quality = quality * cls.aspect_ratio_quality_quotient(
+                rep.image_width, rep.image_height
+            )
 
             # Scale the estimated quality by the source of the image.
             source_name = r.data_source.name
@@ -1650,7 +1679,14 @@ class Identifier(Base):
                 quality = quality * 0.50
             elif source_name==DataSource.OPEN_LIBRARY:
                 quality = quality * 0.25
-
+            elif source_name in DataSource.PRESENTATION_EDITION_PRIORITY:
+                # Covers from the data sources listed in
+                # PRESENTATION_EDITION_PRIORITY (e.g. the metadata wrangler 
+                # and the administrative interface) are given priority
+                # over all others, relative to their position in 
+                # PRESENTATION_EDITION_PRIORITY.
+                i = DataSource.PRESENTATION_EDITION_PRIORITY.index(source_name)
+                quality = quality * (i+2)
             r.set_estimated_quality(quality)
 
             # TODO: that says how good the image is as an image. But
@@ -1667,6 +1703,7 @@ class Identifier(Base):
                 champion_score = r.quality
             elif r.quality == champion_score:
                 champions.append(r)
+
         if champions and not champion:
             champion = random.choice(champions)
             

--- a/model.py
+++ b/model.py
@@ -1616,7 +1616,7 @@ class Identifier(Base):
 
             # If the size of the image is known, that might affect
             # the quality.
-            quality = quality * cls.image_size_quality_penalty(
+            quality = quality * Representation.image_size_quality_penalty(
                 rep.image_width, rep.image_height
             )
 

--- a/overdrive.py
+++ b/overdrive.py
@@ -790,4 +790,4 @@ class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
         if not isinstance(result, CoverageFailure):
             # Success!
             result = self.set_presentation_ready(result)
-
+        return result

--- a/overdrive.py
+++ b/overdrive.py
@@ -783,8 +783,11 @@ class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
             e = "Could not extract metadata from Overdrive data: %r" % info
             return CoverageFailure(self, identifier, e, transient=True)
 
-        return self.set_metadata(
+        result = self.set_metadata(
             identifier, metadata, 
             metadata_replacement_policy=self.metadata_replacement_policy
         )
+        if not isinstance(result, CoverageFailure):
+            # Success!
+            result = self.set_presentation_ready(result)
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -711,7 +711,7 @@ class TestSimplifiedGenreClassifier(object):
         the genre itself.
         """
         sf1 = SimplifiedGenreClassifier.scrub_identifier(
-            SimplifiedGenreClassifier.SIMPLIFIED_GENRE + "Science Fiction"
+            SimplifiedGenreClassifier.SIMPLIFIED_GENRE + "Science%20Fiction"
         )
         sf2 = SimplifiedGenreClassifier.scrub_identifier("Science Fiction")
         eq_(sf1, sf2)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -20,6 +20,7 @@ from classifier import (
     OverdriveClassifier as Overdrive,
     FASTClassifier as FAST,
     KeywordBasedClassifier as Keyword,
+    SimplifiedGenreClassifier,
     GradeLevelClassifier,
     AgeClassifier,
     AgeOrGradeClassifier,
@@ -702,6 +703,20 @@ class TestOverdriveClassifier(object):
         eq_(Classifier.AUDIENCE_CHILDREN, a("Juvenile Nonfiction"))
         eq_(Classifier.AUDIENCE_YOUNG_ADULT, a("Young Adult Nonfiction"))
         eq_(Classifier.AUDIENCE_ADULTS_ONLY, a("Erotic Literature"))
+
+class TestSimplifiedGenreClassifier(object):
+
+    def test_scrub_identifier(self):
+        """The URI for a Library Simplified genre is treated the same as
+        the genre itself.
+        """
+        sf1 = SimplifiedGenreClassifier.scrub_identifier(
+            SimplifiedGenreClassifier.SIMPLIFIED_GENRE + "Science Fiction"
+        )
+        sf2 = SimplifiedGenreClassifier.scrub_identifier("Science Fiction")
+        eq_(sf1, sf2)
+        eq_("Science Fiction", sf1.original)
+
 
 class TestWorkClassifier(DatabaseTest):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2391,7 +2391,7 @@ class TestRepresentation(DatabaseTest):
         ideal_width = IDEAL_IMAGE_WIDTH = 160
 
         def f(width, height):
-            return Identifier.cover_size_quality_penalty(width, height)
+            return Representation.cover_size_quality_penalty(width, height)
 
         # In the absence of any size information we assume
         # everything's fine.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2525,11 +2525,6 @@ class TestCoverResource(DatabaseTest):
         # Here's a book with a thumbnail image.
         edition, pool = self._edition(with_license_pool=True)
 
-        hyperlink, ignore = pool.add_link(
-            Hyperlink.THUMBNAIL_IMAGE, self._url, pool.data_source
-        )
-        resource_with_no_representation = hyperlink.resource
-
         link1, ignore = pool.add_link(
             Hyperlink.THUMBNAIL_IMAGE, self._url, pool.data_source
         )

--- a/threem.py
+++ b/threem.py
@@ -323,7 +323,10 @@ class ItemListParser(XMLParser):
 
 
 class ThreeMBibliographicCoverageProvider(BibliographicCoverageProvider):
-    """Fill in bibliographic metadata for 3M records."""
+    """Fill in bibliographic metadata for 3M records.
+
+    Then mark the works as presentation-ready.
+    """
 
     def __init__(self, _db, input_identifier_types=None,
                  metadata_replacement_policy=None, **kwargs):
@@ -340,6 +343,9 @@ class ThreeMBibliographicCoverageProvider(BibliographicCoverageProvider):
         for identifier in identifiers:
             metadata = self.api.bibliographic_lookup(identifier)
             result = self.set_metadata(identifier, metadata)
+            if not isinstance(result, CoverageFailure):
+                # Success!
+                result = self.set_presentation_ready(result)
             batch_results.append(result)
         return batch_results
 


### PR DESCRIPTION
This wide-ranging branch fixes a number of problems that stand between me and Sensible Behavior.

This is Sensible Behavior:

* When the Overdrive or 3M circulation monitor hears about a book it hasn't encountered before, it immediately provides that book with bibliographic coverage, creates a Work, and sets the Work to presentation ready. 

* A 3M book will have no cover image until we hear from the Metadata wrangler, because 3M doesn't provide thumbnail images. An Overdrive book will start using the Overdrive thumbnail image immediately, but once we hear from the metadata wrangler, we'll switch to using the MW thumbnail image.

Here are the problems:

* The code that sets newly created Overdrive and 3M works to presentation-ready was located in custom subclasses located in `circulation`. But the script that provides bibliographic coverage was located in `core` and was using the parent classes located in `core`, which doesn't run this code. I moved the code into `core` and will be removing it from `circulation`.

* The metadata wrangler serves OPDS categories that classify a book under Simplified genres:

`<category term="http://librarysimplified.org/terms/genres/Simplified/Urban%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Urban Fiction"/>`

The OPDS import process runs these classifications through the `SimplifiedGenreClassifier`, but the `SimplifiedGenreClassifier` can't handle an identifier like "http://librarysimplified.org/terms/genres/Simplified/Urban%20Fiction". It's expecting "Urban Fiction". I added a `scrub_identifier` implementation to make `SimplifiedGenreClassifier` handle both Simplified genre URIs and normal genre names.

* There's no way to say "All else being equal, a book cover from the metadata wrangler is better than one that comes from Overdrive." `Identifier.best_cover_for()` is the natural place to put this code, but that method is a mess of code that has no unit tests and currently sits mostly unused. It was designed for a no-longer-used system where we would give a Gutenberg book a decent book cover by gathering covers from commercially published editions of those works, and picking the 'best' one. It's still potentially useful for resolving conflicts, but most of the time, if there are two covers for the same book, it's the case I'm trying to fix--one cover comes from the license source and one comes from the metadata wrangler, and the data source, not the aspect ratios, are the deciding factor in which one we display to patrons.

Anyway, I had to refactor all that code and then, to make sure I didn't break anything, write tests for as much of it as I could. (I think I fixed several preexisting bugs in the code as I did this.) My current implementation gives a cover image a big quality bump if it comes from one of the data sources in `DataSource.PRESENTATION_EDITION_PRIORITY` -- basically the metadata wrangler or the admin interface.

* Here's the problem I can't fix yet. Because opds_import still uses `license_data_source`, when we import a cover image for an Overdrive book from the metadata wrangler, it's inserted into the database as though it came from Overdrive. This used to be desirable behavior, but now that we have presentation edition code it's not necessary, and now that we _also_ get a cover image direct from Overdrive it's downright harmful. It means that there's no way to _stop_ using the Overdrive cover image. Even with my code in place, we're talking about comparing two images that are approximately the same aspect ratio and both (supposedly) come from Overdrive. 

Once we stop using `license_data_source` and start being honest about where the metadata wrangler data comes from, this problem should be fixed automatically.