### PR TITLE
Remove license data source

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -259,7 +259,11 @@ class Axis360Parser(XMLParser):
             pass
         return datetime.datetime.strptime(value, self.FULL_DATE_FORMAT)
 
+
 class BibliographicParser(Axis360Parser):
+    """
+
+    """
 
     DELIVERY_DATA_FOR_AXIS_FORMAT = {
         "Blio" : None,
@@ -309,6 +313,7 @@ class BibliographicParser(Axis360Parser):
                     availability_updated, self.FULL_DATE_FORMAT)
 
         return CirculationData(
+            data_source=DataSource.AXIS_360, 
             licenses_owned=total_copies,
             licenses_available=available_copies,
             licenses_reserved=0,
@@ -417,7 +422,7 @@ class BibliographicParser(Axis360Parser):
         if isbn:
             identifiers.append(IdentifierData(Identifier.ISBN, isbn))
 
-        formats = []
+        #formats = []
         acceptable = False
         seen_formats = []
         for format_tag in self._xpath(
@@ -430,6 +435,7 @@ class BibliographicParser(Axis360Parser):
                 self.log("Unrecognized Axis format name for %s: %s" % (
                     identifier, informal_name
                 ))
+            '''
             elif self.DELIVERY_DATA_FOR_AXIS_FORMAT.get(informal_name):
                 content_type, drm_scheme = self.DELIVERY_DATA_FOR_AXIS_FORMAT[
                     informal_name
@@ -437,11 +443,16 @@ class BibliographicParser(Axis360Parser):
                 formats.append(
                     FormatData(content_type=content_type, drm_scheme=drm_scheme)
                 )
+        
+        TODO:  Do we need to also make a CirculationData so we can write the formats, 
+        or can we omit?
+
         if not formats:
             self.log.error(
                 "No supported format for %s (%s)! Saw: %s", identifier,
                 title, ", ".join(seen_formats)
             )
+        '''
 
         data = Metadata(
             data_source=DataSource.AXIS_360,
@@ -456,7 +467,7 @@ class BibliographicParser(Axis360Parser):
             identifiers=identifiers,
             subjects=subjects,
             contributors=contributors,
-            formats=formats,
+            # formats=formats,
         )
         return data
 

--- a/coverage.py
+++ b/coverage.py
@@ -342,7 +342,7 @@ class CoverageProvider(object):
         return work
 
 
-    def set_meta_circ_data(self, identifier, metadata, circulationdata, 
+    def set_metadata_and_circulation_data(self, identifier, metadata, circulationdata, 
         metadata_replacement_policy=None, 
         circulationdata_replacement_policy=None, 
     ):
@@ -353,6 +353,7 @@ class CoverageProvider(object):
 
         TODO:  Makes assumption of one license pool per identifier.  In a 
         later branch, this will change.
+        TODO:  Update doc string removing reference to past function.
 
         :return: The Identifier (if successful) or an appropriate
         CoverageFailure (if not).

--- a/coverage.py
+++ b/coverage.py
@@ -487,7 +487,8 @@ class BibliographicCoverageProvider(CoverageProvider):
     CAN_CREATE_LICENSE_POOLS = True
 
     def __init__(self, _db, api, datasource, workset_size=10,
-                 metadata_replacement_policy=None, cutoff_time=None
+                 metadata_replacement_policy=None, circulationdata_replacement_policy=None, 
+                 cutoff_time=None
     ):
         self._db = _db
         self.api = api
@@ -497,7 +498,11 @@ class BibliographicCoverageProvider(CoverageProvider):
         metadata_replacement_policy = (
             metadata_replacement_policy or ReplacementPolicy.from_metadata_source()
         )
+        circulationdata_replacement_policy = (
+            circulationdata_replacement_policy or ReplacementPolicy.from_license_source()
+        )
         self.metadata_replacement_policy = metadata_replacement_policy
+        self.circulationdata_replacement_policy = circulationdata_replacement_policy
         super(BibliographicCoverageProvider, self).__init__(
             service_name,
             input_identifier_types, output_source,

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -446,6 +446,7 @@ class CirculationData(object):
                 # If a link has a rights_uri, make that the overall rights_uri. 
                 # TODO: If there are multiple links with a rights_uri, make them go into individual delivery mechanisms 
                 # (first need to move rights_uri onto delivery mechanisms). 
+                # TODO: make sure am not writing anything to DB here, only on apply.
                 if link.rights_uri and not self.default_rights_uri:
                     self.set_default_rights_uri(data_source_name=self.data_source_name, default_rights_uri=link.rights_uri)
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -442,7 +442,22 @@ class CirculationData(object):
             )
 
 
+    def __repr__(self):
+        description_string = '<CirculationData primary_identifier="%s" licenses_owned="%s" licenses_available="%s" licenses_reserved=%d' % (
+            self.primary_identifier, self.licenses_owned, self.licenses_available, self.licenses_reserved
+        )
+        description_string += 'patrons_in_hold_queue="%s" default_rights_uri="%s" first_appearance="%s" last_checked="%s" >' % (
+            patrons_in_hold_queue, default_rights_uri, first_appearance, last_checked
+        )
+        description_string += 'links="%r" formats="%r" data_source_obj="%r">' % (
+            links, formats, data_source_obj
+        )
+
+        return description_string
+
+
     def data_source(self, _db):
+        set_trace()
         if not self.data_source_obj:
             if self._data_source:
                 obj = DataSource.lookup(_db, self._data_source)

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -462,6 +462,7 @@ class CirculationData(object):
     def data_source(self, _db):
         if not self.data_source_obj:
             if self._data_source:
+                print "CirculationData.data_source(): self._data_source=%s" % self._data_source
                 obj = DataSource.lookup(_db, self._data_source)
                 if not obj:
                     raise ValueError("Data source %s not found!" % self._data_source)

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1357,10 +1357,11 @@ class Metadata(MetaToModelUtility):
                 edition.display_author = primary_author.display_name
 
         # we updated the links.  but does the associated pool know?
+        pool = None
         if self.circulation:
-            pool, is_new = circulation.license_pool
+            pool, is_new = self.circulation.license_pool(_db)
             if (pool and not is_new):
-                circulation.apply(pool)
+                self.circulation.apply(pool)
 
             # we updated the pool.  but do the associated links know?
             for link in self.links:
@@ -1382,7 +1383,7 @@ class Metadata(MetaToModelUtility):
                 # We don't need to mirror this image, but we do need
                 # to make sure that its thumbnail exists locally and
                 # is associated with the original image.
-                self.make_thumbnail(data_source, link, link_obj)
+                self.make_thumbnail(data_source, link, link_obj, pool)
 
 
         # Finally, update the coverage record for this edition
@@ -1393,7 +1394,7 @@ class Metadata(MetaToModelUtility):
         return edition, made_core_changes
 
         
-    def make_thumbnail(self, data_source, link, link_obj):
+    def make_thumbnail(self, data_source, link, link_obj, pool=None):
         """Make sure a Hyperlink representing an image is connected
         to its thumbnail.
         """
@@ -1410,10 +1411,6 @@ class Metadata(MetaToModelUtility):
 
         # The thumbnail and image are different. Make sure there's a
         # separate link to the thumbnail.
-        pool = None
-        if self.circulation:
-            pool = self.circulation.license_pool
-
         thumbnail_obj, ignore = link_obj.identifier.add_link(
             rel=thumbnail.rel, href=thumbnail.href, 
             data_source=data_source, 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -838,7 +838,7 @@ class Metadata(object):
             measurements=None,
             links=None,
             opds_entry_updated=None,
-            #circulation=None,
+            #circulation=None,  # Note: OK to bring back if need.
     ):
         # data_source is where the data comes from (e.g. overdrive, metadata wrangler, admin interface), 
         # and not necessarily where the associated Identifier's LicencePool's lending licenses are coming from.

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -869,7 +869,7 @@ class Metadata(MetaToModelUtility):
             contributors=None,
             measurements=None,
             links=None,
-            opds_entry_updated=None,
+            provider_entry_updated=None,
             # Note: brought back to keep callers of bibliographic extraction process_one() methods simple.
             circulation=None,  
     ):
@@ -909,8 +909,8 @@ class Metadata(MetaToModelUtility):
         # circulation-metadata connection has been removed, but might come back
         #self.circulation = circulation
 
-        # renamed last_update_time to opds_entry_updated
-        self.opds_entry_updated = opds_entry_updated
+        # renamed last_update_time to provider_entry_updated
+        self.provider_entry_updated = provider_entry_updated
 
         self.__links = None
         self.links = links
@@ -1241,11 +1241,11 @@ class Metadata(MetaToModelUtility):
         # Check whether we should do any work at all.
         data_source = self.data_source(_db)
 
-        if self.opds_entry_updated and not replace.even_if_not_apparently_updated:
+        if self.provider_entry_updated and not replace.even_if_not_apparently_updated:
             coverage_record = CoverageRecord.lookup(edition, data_source)
             if coverage_record:
                 check_time = coverage_record.timestamp
-                last_time = self.opds_entry_updated
+                last_time = self.provider_entry_updated
                 if check_time >= last_time:
                     # The metadata has not changed since last time. Do nothing.
                     return edition, False
@@ -1407,7 +1407,7 @@ class Metadata(MetaToModelUtility):
         # Finally, update the coverage record for this edition
         # and data source.
         CoverageRecord.add_for(
-            edition, data_source, timestamp=self.opds_entry_updated
+            edition, data_source, timestamp=self.provider_entry_updated
         )
         return edition, made_core_changes
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -381,7 +381,7 @@ class CirculationData(object):
     def __init__(
             self, 
             data_source,
-            primary_identifier=None,
+            primary_identifier,
             licenses_owned=None,
             licenses_available=None,
             licenses_reserved=None,

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -351,6 +351,7 @@ class MeasurementData(object):
             self.quantity_measured, self.value, self.weight, self.taken_at
         )
 
+
 class FormatData(object):
     def __init__(self, content_type, drm_scheme, link=None, rights_uri=None):
         self.content_type = content_type
@@ -361,15 +362,16 @@ class FormatData(object):
             )
         self.link = link
         self.rights_uri = rights_uri
+        if ((not self.rights_uri) and self.link and self.link.rights_uri):
+            self.rights_uri = self.link.rights_uri
 
 
 
 class MetaToModelUtility(object):
     """
-    TODO
+    Contains functionality common to both CirculationData and Metadata.
     """
 
-    #def mirror_link(self, pool, data_source, link, link_obj, policy):
     def mirror_link(self, model_object, data_source, link, link_obj, policy):
         """Retrieve a copy of the given link and make sure it gets
         mirrored. If it's a full-size image, create a thumbnail and
@@ -379,7 +381,7 @@ class MetaToModelUtility(object):
         """
 
         if link_obj.rel not in (
-                Hyperlink.IMAGE, Hyperlink.OPEN_ACCESS_DOWNLOAD
+            Hyperlink.IMAGE, Hyperlink.OPEN_ACCESS_DOWNLOAD
         ):
             # we only host locally open-source epubs and cover images
             return
@@ -389,7 +391,6 @@ class MetaToModelUtility(object):
 
         _db = Session.object_session(link_obj)
         original_url = link.href
-        identifier = link_obj.identifier
 
         self.log.debug("About to mirror %s" % original_url)
 
@@ -412,6 +413,11 @@ class MetaToModelUtility(object):
             title = edition.title
         else:
             title = self.title or None
+
+        if ((not identifier) or (link_obj.identifier and identifier != link_obj.identifier)):
+            # insanity found
+            self.log.warn("Tried to mirror a link with an invalid identifier %r" % identifier)
+            return
 
         max_age = None
         if policy.link_content:
@@ -468,9 +474,10 @@ class MetaToModelUtility(object):
 
         # If we couldn't mirror an open access link representation, suppress
         # the license pool until someone fixes it manually.
-        if representation.mirror_exception and pool and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
-            pool.suppressed = True
-            pool.license_exception = "Mirror exception: %s" % representation.mirror_exception
+        if representation.mirror_exception: 
+            if pool and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
+                pool.suppressed = True
+                pool.license_exception = "Mirror exception: %s" % representation.mirror_exception
 
         # The metadata may have some idea about the media type for this
         # LinkObject, but the media type we actually just saw takes 
@@ -536,6 +543,7 @@ class CirculationData(MetaToModelUtility):
             formats=None,
             default_rights_uri=None,
             links=None,
+            last_checked=None,
     ):
         # data_source is where the lending licenses (our ability to actually access the book) are coming from.
         self._data_source = data_source
@@ -552,6 +560,7 @@ class CirculationData(MetaToModelUtility):
         self.licenses_available = licenses_available
         self.licenses_reserved = licenses_reserved
         self.patrons_in_hold_queue = patrons_in_hold_queue
+        self.last_checked = last_checked
 
         # format contains pdf/epub, drm, link
         self.formats = formats or []
@@ -582,6 +591,7 @@ class CirculationData(MetaToModelUtility):
 
         for link in arg_links:
             if link.rel in [Hyperlink.OPEN_ACCESS_DOWNLOAD, Hyperlink.DRM_ENCRYPTED_DOWNLOAD]:
+                # TODO:  what about Hyperlink.SAMPLE?
                 # only accept the types of links relevant to pools
                 self.__links.append(link)
 
@@ -632,7 +642,7 @@ class CirculationData(MetaToModelUtility):
                 if not obj:
                     raise ValueError("Data source %s not found!" % self._data_source)
                 if not obj.offers_licenses:
-                    raise ValueError("Data source %s does not offer licenses and cannot be used as a LicenseData data source." % self._data_source)
+                    raise ValueError("Data source %s does not offer licenses and cannot be used as a CirculationData data source." % self._data_source)
             else:
                 obj = None
             self.data_source_obj = obj
@@ -672,7 +682,7 @@ class CirculationData(MetaToModelUtility):
             if is_new:
                 license_pool.availability_time = datetime.datetime.utcnow()
                 # This is our first time seeing this LicensePool. Log its
-                # occurance as a separate event.
+                # occurence as a separate event.
                 event = get_one_or_create(
                     _db, CirculationEvent,
                     type=CirculationEvent.TITLE_ADD,
@@ -683,8 +693,8 @@ class CirculationData(MetaToModelUtility):
                         end=last_checked,
                     )
                 )
-
-            license_pool.last_checked = last_checked
+                # only set license_pool's last_checked time on creation and update
+                license_pool.last_checked = last_checked
 
             if self.has_open_access_link:
                 license_pool.open_access = True
@@ -704,8 +714,6 @@ class CirculationData(MetaToModelUtility):
 
 
     def set_default_rights_uri(self, data_source_name, default_rights_uri=None):
-        """ TODO: should there be a way to delete default_rights_uri?
-        """
         if default_rights_uri == None and data_source_name:
             # We didn't get rights passed in, so use the default rights for the data source if any.
             default = RightsStatus.DATA_SOURCE_DEFAULT_RIGHTS_STATUS.get(data_source_name, None)
@@ -726,7 +734,7 @@ class CirculationData(MetaToModelUtility):
 
 
     def apply(self, pool, replace=None):
-        """  TODO: apply name provisional, doc string follows.
+        """  Update the passed-in license pool with this CirculationData's information.
         """
         made_changes = False
 
@@ -790,10 +798,32 @@ class CirculationData(MetaToModelUtility):
 
         changed_licenses = False
         if pool:
-            changed_licenses = (pool.licenses_owned != self.licenses_owned or
-               pool.licenses_available != self.licenses_available or
-               pool.patrons_in_hold_queue != self.patrons_in_hold_queue or
-               pool.licenses_reserved != self.licenses_reserved)
+            # if we were not passed a last_checked value, then update pool as of now
+            if not self.last_checked: 
+                # Update availabily information. This may result in the issuance
+                # of additional events.
+                changed_licenses = pool.update_availability(
+                    new_licenses_owned=self.licenses_owned,
+                    new_licenses_available=self.licenses_available,
+                    new_licenses_reserved=self.licenses_reserved,
+                    new_patrons_in_hold_queue=self.patrons_in_hold_queue,
+                    as_of=datetime.datetime.utcnow(),
+                )
+            else:
+                # if we were passed a last_checked value, such as when creating the 
+                # CirculationData object in the bibliographic parser for a 3m log, then 
+                # check if that log update value is after the license pool's current knowledge, 
+                # and only update license infos if new information is really new.
+                if (pool.last_checked and (self.last_checked > pool.last_checked)):
+                    # Update availabily information. This may result in the issuance
+                    # of additional events.
+                    changed_licenses = pool.update_availability(
+                        new_licenses_owned=self.licenses_owned,
+                        new_licenses_available=self.licenses_available,
+                        new_licenses_reserved=self.licenses_reserved,
+                        new_patrons_in_hold_queue=self.patrons_in_hold_queue,
+                        as_of=self.last_checked
+                    )
 
         if changed_licenses:
             edition = pool.presentation_edition
@@ -817,17 +847,6 @@ class CirculationData(MetaToModelUtility):
                     pool.patrons_in_hold_queue, self.patrons_in_hold_queue
                 )
 
-        # Update availabily information. This may result in the issuance
-        # of additional events.
-        if pool:
-            last_checked = datetime.datetime.utcnow()
-            pool.update_availability(
-                self.licenses_owned,
-                self.licenses_available,
-                self.licenses_reserved,
-                self.patrons_in_hold_queue,
-                last_checked
-            )
 
         made_changes = made_changes or changed_licenses
 
@@ -906,8 +925,7 @@ class Metadata(MetaToModelUtility):
         self.contributors = contributors or []
         self.measurements = measurements or []
 
-        # circulation-metadata connection has been removed, but might come back
-        #self.circulation = circulation
+        self.circulation = circulation
 
         # renamed last_update_time to provider_entry_updated
         self.provider_entry_updated = provider_entry_updated
@@ -935,13 +953,6 @@ class Metadata(MetaToModelUtility):
                 # only accept the types of links relevant to editions
                 self.__links.append(link)
                 
-    # TODO: perhaps should move to CirculationData, as Metadata will no longer ever have open-access links.
-    def has_open_access_link(self):
-        """Does this Metadata object have an associated open-access link?"""
-        return any(
-            [x for x in self.links
-             if x.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD and x.href]
-        )
 
     @classmethod
     def from_edition(cls, edition):
@@ -1088,7 +1099,6 @@ class Metadata(MetaToModelUtility):
                 "Cannot find edition: metadata has no primary identifier."
             )
 
-        #data_source = self.license_data_source(_db) or self.data_source(_db)
         data_source = self.data_source(_db)
 
         return Edition.for_foreign_id(
@@ -1096,27 +1106,6 @@ class Metadata(MetaToModelUtility):
             self.primary_identifier.identifier,
             create_if_not_exists=create_if_not_exists
         )
-
-    # TODO: move method to CirculationData (compare first, see if something changed in master version)
-    def set_default_rights_uri(self, data_source):
-        if self.rights_uri == None and data_source:
-            # We haven't been able to determine rights from the metadata, so use the default rights
-            # for the data source if any.
-            default = RightsStatus.DATA_SOURCE_DEFAULT_RIGHTS_STATUS.get(data_source.name, None)
-            if default:
-                self.rights_uri = default
-
-        for format in self.formats:
-            if format.link:
-                link = format.link
-                if self.rights_uri in (None, RightsStatus.UNKNOWN) and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
-                    # We haven't determined rights from the metadata or the data source, but there's an
-                    # open access download link, so we'll consider it generic open access.
-                    self.rights_uri = RightsStatus.GENERIC_OPEN_ACCESS
-
-        if self.rights_uri == None:
-            # We still haven't determined rights, so it's unknown.
-            self.rights_uri = RightsStatus.UNKNOWN
 
 
     def consolidate_identifiers(self):
@@ -1183,16 +1172,6 @@ class Metadata(MetaToModelUtility):
     # TODO: We need to change all calls to apply() to use a ReplacementPolicy
     # instead of passing in individual `replace` arguments. Once that's done,
     # we can get rid of the `replace` arguments.
-    '''
-    def apply(self, edition, metadata_client=None, replace=None,
-              replace_identifiers=False,
-              replace_subjects=False,
-              replace_contributions=False,
-              replace_links=False,
-              replace_formats=False,
-              replace_rights=False,
-              force=False,
-    '''
     def apply(self, edition, metadata_client=None, replace=None,
               replace_identifiers=False,
               replace_subjects=False,
@@ -1388,7 +1367,6 @@ class Metadata(MetaToModelUtility):
 
         # obtains a presentation_edition for the title, which will later be used to get a mirror link.
         for link in self.links:
-            #if link.rel not in [Hyperlink.OPEN_ACCESS_DOWNLOAD, Hyperlink.DRM_ENCRYPTED_DOWNLOAD]:
             link_obj = link_objects[link]
             # TODO: We do not properly handle the (unlikely) case
             # where there is an IMAGE_THUMBNAIL link but no IMAGE

--- a/model.py
+++ b/model.py
@@ -2281,11 +2281,11 @@ class Edition(Base):
     publisher = Column(Unicode, index=True)
     imprint = Column(Unicode, index=True)
 
-    # `published is the original publication date of the
-    # text. `issued` is when made available in this ebook edition. A
-    # Project Gutenberg text was likely `published` long before being
-    # `issued`.
+    # `issued` is the date the ebook edition was sent to the distributor by the publisher, 
+    # i.e. the date it became available for librarians to buy for their libraries
     issued = Column(Date)
+    # `published is the original publication date of the text.
+    # A Project Gutenberg text was likely `published` long before being `issued`.
     published = Column(Date)
 
     BOOK_MEDIUM = u"Book"
@@ -5117,7 +5117,8 @@ class LicensePool(Base):
     # One LicensePool can be associated with many Complaints.
     complaints = relationship('Complaint', backref='license_pool')
 
-    # The date this LicensePool first became available.
+    # The date this LicensePool was first created in our db
+    # (the date we first discovered that ​we had that book in ​our collection).
     availability_time = Column(DateTime, index=True)
 
     # One LicensePool may have multiple DeliveryMechanisms, and vice
@@ -7248,3 +7249,10 @@ def numericrange_to_tuple(r):
     if upper and not r.upper_inc:
         upper -= 1
     return lower, upper
+
+
+
+
+
+
+

--- a/model.py
+++ b/model.py
@@ -1097,7 +1097,7 @@ class Identifier(Base):
     def __repr__(self):
         records = self.primarily_identifies
         if records and records[0].title:
-            title = u' wr=%d ("%s")' % (records[0].id, records[0].title)
+            title = u' prim_ed=%d ("%s")' % (records[0].id, records[0].title)
         else:
             title = ""
         return (u"%s/%s ID=%s%s" % (self.type, self.identifier, self.id,
@@ -1433,6 +1433,8 @@ class Identifier(Base):
         fetching, mirroring and scaling Representations as links are
         created. It might be good to move that code into here.
         """
+        #if href == 'http://www.gutenberg.org/ebooks/10441.epub.images':
+            #set_trace()
         _db = Session.object_session(self)
 
         if license_pool and license_pool.identifier != self:
@@ -4188,6 +4190,7 @@ class Resource(Base):
         if not self.representation:
             self.representation, is_new = get_one_or_create(
                 _db, Representation, url=self.url, media_type=media_type)
+        #set_trace()
         self.representation.mirror_url = self.url
         self.representation.set_as_mirrored()
 
@@ -4999,7 +5002,6 @@ class LicensePool(Base):
         # type for the data source.
         if (data_source.primary_identifier_type and 
             foreign_id_type != data_source.primary_identifier_type):
-            set_trace()
             raise ValueError(
                 "License pools for data source '%s' are keyed to "
                 "identifier type '%s' (not '%s', which was provided)" % (

--- a/model.py
+++ b/model.py
@@ -792,9 +792,9 @@ class DataSource(Base):
                 (cls.OVERDRIVE, True, False, Identifier.OVERDRIVE_ID, 0),
                 (cls.THREEM, True, False, Identifier.THREEM_ID, 60*60*6),
                 (cls.AXIS_360, True, False, Identifier.AXIS_360_ID, 0),
-                (cls.OCLC, False, False, Identifier.OCLC_NUMBER, None),
-                (cls.OCLC_LINKED_DATA, False, False, Identifier.OCLC_NUMBER, None),
-                (cls.AMAZON, False, False, Identifier.ASIN, None),
+                (cls.OCLC, False, False, None, None),
+                (cls.OCLC_LINKED_DATA, False, False, None, None),
+                (cls.AMAZON, False, False, None, None),
                 (cls.OPEN_LIBRARY, False, False, Identifier.OPEN_LIBRARY_ID, None),
                 (cls.GUTENBERG_COVER_GENERATOR, False, False, Identifier.GUTENBERG_ID, None),
                 (cls.GUTENBERG_EPUB_GENERATOR, False, False, Identifier.GUTENBERG_ID, None),
@@ -803,14 +803,14 @@ class DataSource(Base):
                 (cls.CONTENT_CAFE, True, True, Identifier.ISBN, None),
                 (cls.MANUAL, False, False, None, None),
                 (cls.NYT, False, False, Identifier.ISBN, None),
-                (cls.LIBRARY_STAFF, False, False, Identifier.ISBN, None),
-                (cls.METADATA_WRANGLER, False, False, Identifier.URI, None),
+                (cls.LIBRARY_STAFF, False, False, None, None),
+                (cls.METADATA_WRANGLER, False, False, None, None),
                 (cls.PROJECT_GITENBERG, True, False, Identifier.GUTENBERG_ID, None),
                 (cls.STANDARD_EBOOKS, True, False, Identifier.URI, None),
                 (cls.UNGLUE_IT, True, False, Identifier.URI, None),
                 (cls.ADOBE, False, False, None, None),
                 (cls.PLYMPTON, True, False, Identifier.ISBN, None),
-                (cls.OA_CONTENT_SERVER, True, False, Identifier.URI, None),
+                (cls.OA_CONTENT_SERVER, True, False, None, None),
                 (cls.NOVELIST, False, True, Identifier.NOVELIST_ID, None),
                 (cls.PRESENTATION_EDITION, False, False, None, None),
         ):
@@ -4997,7 +4997,9 @@ class LicensePool(Base):
 
         # The type of the foreign ID must be the primary identifier
         # type for the data source.
-        if foreign_id_type != data_source.primary_identifier_type:
+        if (data_source.primary_identifier_type and 
+            foreign_id_type != data_source.primary_identifier_type):
+            set_trace()
             raise ValueError(
                 "License pools for data source '%s' are keyed to "
                 "identifier type '%s' (not '%s', which was provided)" % (
@@ -6133,6 +6135,7 @@ class Representation(Base):
             # request, not that the HTTP request returned an error
             # condition.
             logging.error("Error making HTTP request to %s", url, exc_info=e)
+            # TODO: exception doesn't seem to be used
             exception = traceback.format_exc()
             status_code = None
             headers = None

--- a/model.py
+++ b/model.py
@@ -5265,7 +5265,7 @@ class LicensePool(Base):
         """Update the LicensePool with new availability information.
         Log the implied changes as CirculationEvents.
         """
-
+        changes_made = False
         _db = Session.object_session(self)
         if not as_of:
             as_of = datetime.datetime.utcnow()
@@ -5284,6 +5284,7 @@ class LicensePool(Base):
                 continue
             if old_value == new_value:
                 continue
+            changes_made = True
 
             if old_value < new_value:
                 event_name = more_event
@@ -5306,6 +5307,9 @@ class LicensePool(Base):
         # Update the last update time of the Work.
         if self.work:
             self.work.last_update_time = as_of
+
+        return changes_made
+
 
     def set_rights_status(self, uri, name=None):
         _db = Session.object_session(self)
@@ -5465,18 +5469,21 @@ class LicensePool(Base):
             _db.add(work)
             _db.flush()
 
-        # Associate this LicensePool and its Edition with the work we
-        # chose or created.
-        work.license_pools.append(self)
+        if work:
+            # Associate this LicensePool and its Edition with the work we
+            # chose or created.
+            work.license_pools.append(self)
 
-        # Recalculate the display information for the Work, since the
-        # associated Editions have changed.
-        work.calculate_presentation()
+            # Recalculate the display information for the Work, since the
+            # associated Editions have changed.
+            work.calculate_presentation()
 
         if created:
             logging.info("Created a new work: %r", work)
+            
         # All done!
         return work, created
+
 
     @property
     def open_access_links(self):

--- a/model.py
+++ b/model.py
@@ -2257,7 +2257,6 @@ class Edition(Base):
 
     # An Edition may be the presentation edition for many LicensePools.
     is_presentation_for = relationship(
-        # TODO: fix foreign key  presentation_edition_id
         "LicensePool", uselist=False, backref="presentation_edition"
     )
 

--- a/model.py
+++ b/model.py
@@ -4047,6 +4047,11 @@ class Hyperlink(Base):
     # TODO: Is this the appropriate relation?
     DRM_ENCRYPTED_DOWNLOAD = u"http://opds-spec.org/acquisition/"
 
+    CIRCULATION_ALLOWED = [OPEN_ACCESS_DOWNLOAD, DRM_ENCRYPTED_DOWNLOAD]
+    METADATA_ALLOWED = [CANONICAL, IMAGE, THUMBNAIL_IMAGE, ILLUSTRATION, REVIEW, 
+        DESCRIPTION, SHORT_DESCRIPTION, AUTHOR, SAMPLE]
+    MIRRORED = [OPEN_ACCESS_DOWNLOAD, IMAGE]
+
     id = Column(Integer, primary_key=True)
 
     # A Hyperlink is always associated with some Identifier.

--- a/model.py
+++ b/model.py
@@ -4098,8 +4098,11 @@ class Hyperlink(Base):
     def default_filename(self):
         return self._default_filename(self.rel)
 
+
 class Resource(Base):
-    """An external resource that may be mirrored locally."""
+    """An external resource that may be mirrored locally.
+    E.g: a cover image, an epub, a description.
+    """
 
     __tablename__ = 'resources'
 
@@ -5539,8 +5542,17 @@ class LicensePool(Base):
                 return pool, link
         return self, None
 
+
     def set_delivery_mechanism(
             self, content_type, drm_scheme, resource):
+        """
+        Additive, unless have more than one version of a book, in the same format, 
+        on the same license (ex.:  book with images and book without images in Gutenberg, 
+        Unglue.it has same open license book in same format from both Gutenberg and Gitenberg.
+
+        TODO:  Support having 2 or more delivery mechanisms with same drm and media type, 
+        so long as they have different resources.
+        """
         _db = Session.object_session(self)
         delivery_mechanism, ignore = DeliveryMechanism.lookup(
             _db, content_type, drm_scheme)

--- a/model.py
+++ b/model.py
@@ -4043,13 +4043,14 @@ class Hyperlink(Base):
     DESCRIPTION = u"http://schema.org/description"
     SHORT_DESCRIPTION = u"http://librarysimplified.org/terms/rel/short-description"
     AUTHOR = u"http://schema.org/author"
+    ALTERNATE = u"alternate"
 
     # TODO: Is this the appropriate relation?
     DRM_ENCRYPTED_DOWNLOAD = u"http://opds-spec.org/acquisition/"
 
     CIRCULATION_ALLOWED = [OPEN_ACCESS_DOWNLOAD, DRM_ENCRYPTED_DOWNLOAD]
     METADATA_ALLOWED = [CANONICAL, IMAGE, THUMBNAIL_IMAGE, ILLUSTRATION, REVIEW, 
-        DESCRIPTION, SHORT_DESCRIPTION, AUTHOR, SAMPLE]
+        DESCRIPTION, SHORT_DESCRIPTION, AUTHOR, ALTERNATE, SAMPLE]
     MIRRORED = [OPEN_ACCESS_DOWNLOAD, IMAGE]
 
     id = Column(Integer, primary_key=True)

--- a/model.py
+++ b/model.py
@@ -5550,20 +5550,11 @@ class LicensePool(Base):
         that's really the case, pass in even_if_no_author=True and the
         Work will be created.
         """
-        set_trace()
-        if (known_edition and known_edition.license_pool != self):
-            raise ValueError(
-                "Primary edition's license pool is not the license pool for which work is being calculated!")
-
-        self.set_presentation_edition(None)
-
-        presentation_edition = known_edition or self.presentation_edition
-
-        if self.work:
-            # The work has already been done. Make sure the work's
-            # display is up to date.
-            self.work.calculate_presentation()
-            return self.work, False
+        if known_edition:
+            presentation_edition = known_edition
+        else:
+            self.set_presentation_edition(None)
+            presentation_edition = self.presentation_edition
 
         logging.info("Calculating work for %r", presentation_edition)
         if not presentation_edition:
@@ -5606,7 +5597,6 @@ class LicensePool(Base):
         work = None
         is_new = False
         licensepools_changed = False
-        set_trace()
         if self.open_access and presentation_edition.permanent_work_id:
             # This is an open-access book. Use the Work for all
             # open-access books associated with this book's permanent

--- a/model.py
+++ b/model.py
@@ -1433,8 +1433,6 @@ class Identifier(Base):
         fetching, mirroring and scaling Representations as links are
         created. It might be good to move that code into here.
         """
-        #if href == 'http://www.gutenberg.org/ebooks/10441.epub.images':
-            #set_trace()
         _db = Session.object_session(self)
 
         if license_pool and license_pool.identifier != self:
@@ -1527,8 +1525,6 @@ class Identifier(Base):
         classifications = []
         subject, is_new = Subject.lookup(
             _db, subject_type, subject_identifier, subject_name)
-        #if is_new:
-        #    print repr(subject)
 
         logging.debug(
             "CLASSIFICATION: %s on %s/%s: %s %s/%s (wt=%d)",
@@ -3323,7 +3319,6 @@ class Work(Base):
             # Descriptions from Gutenberg are useless, so we
             # specifically exclude it from being a privileged data
             # source.
-            print "calculate_presentation: pool.data_source.name=%s" % pool.data_source.name
             if pool.data_source.name != DataSource.GUTENBERG:
                 licensed_data_sources.add(pool.data_source)
 
@@ -4190,7 +4185,6 @@ class Resource(Base):
         if not self.representation:
             self.representation, is_new = get_one_or_create(
                 _db, Representation, url=self.url, media_type=media_type)
-        #set_trace()
         self.representation.mirror_url = self.url
         self.representation.set_as_mirrored()
 
@@ -5194,9 +5188,6 @@ class LicensePool(Base):
             # LicensePool. Use it as the presentation edition rather
             # than creating an identical composite.
             self.presentation_edition = all_editions[0]
-            #self.presentation_edition.license_pool = self
-            print "set_presentation_edition: edition.data_source=%r" % self.presentation_edition.data_source
-            print "set_presentation_edition: edition.identifier=%r" % self.presentation_edition.primary_identifier
         else:
             edition_identifier = IdentifierData(self.identifier.type, self.identifier.identifier)
             metadata = Metadata(data_source=DataSource.PRESENTATION_EDITION, primary_identifier=edition_identifier)
@@ -5625,6 +5616,8 @@ class RightsStatus(Base):
     DATA_SOURCE_DEFAULT_RIGHTS_STATUS = {
         DataSource.GUTENBERG: PUBLIC_DOMAIN_USA,
         DataSource.PLYMPTON: CC_BY_NC,
+        # workaround for opds-imported license pools with 'content server' as data source
+        DataSource.OA_CONTENT_SERVER : GENERIC_OPEN_ACCESS,
     }
     
     __tablename__ = 'rightsstatus'

--- a/opds_import.py
+++ b/opds_import.py
@@ -217,6 +217,7 @@ class OPDSImporter(object):
 
         metadata_objs, circulation_objs, status_messages, next_links = self.extract_feed_data(feed)
 
+        #set_trace()
         imported_editions = {}
         imported_pools = {}
         imported_works = {}
@@ -430,10 +431,19 @@ class OPDSImporter(object):
             else:
                 internal_identifier = external_identifier
 
+            #set_trace()
             identifier_obj = IdentifierData(
                 type=internal_identifier.type,
                 identifier=internal_identifier.identifier
             )
+            '''
+            (Pdb) xml_data_meta['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10557']['links']
+            [<LinkData: rel="http://opds-spec.org/acquisition/open-access" href="http://www.gutenberg.org/ebooks/10557.epub.images" media_type='application/epub+zip'>]
+
+            (Pdb) xml_data_meta['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441']['links']
+            [<LinkData: rel="http://opds-spec.org/image" href="https://s3.amazonaws.com/book-covers.nypl.org/Gutenberg-Illustrated/10441/cover_10441_9.png" media_type=None, has thumbnail>, 
+             <LinkData: rel="http://opds-spec.org/acquisition/open-access" href="http://www.gutenberg.org/ebooks/10441.epub.images" media_type='application/epub+zip'>]            
+            '''
 
             # form the Metadata object
             xml_data_dict = xml_data_meta.get(id, {})

--- a/opds_import.py
+++ b/opds_import.py
@@ -218,11 +218,8 @@ class OPDSImporter(object):
         try:
             metadata_objs, circulation_objs, status_messages, next_links = self.extract_feed_data(feed)
         except Exception, e:
-            set_trace()
             message = StatusMessage(500, "Local exception during import:\n%s" % traceback.format_exc())
-            print "1.  %s" % message
 
-        #set_trace()
         imported_editions = {}
         imported_pools = {}
         imported_works = {}
@@ -241,7 +238,6 @@ class OPDSImporter(object):
                 if edition:
                     imported_editions[key] = edition
             except Exception, e:
-                #set_trace()
                 # Rather than scratch the whole import, treat this as a failure that only applies
                 # to this item.
                 message = StatusMessage(500, "Local exception during import:\n%s" % traceback.format_exc())
@@ -284,7 +280,6 @@ class OPDSImporter(object):
                         if work:
                             imported_works[key] = work
                 except Exception, e:
-                    #set_trace()
                     message = StatusMessage(500, "Local exception during import:\n%s" % traceback.format_exc())
                     status_messages[key] = message
                     # If problem importing a Work, then rather than scratch the whole import, 
@@ -366,6 +361,7 @@ class OPDSImporter(object):
             links=True,
             contributions=True,
             rights=True,
+            link_content=True,
             even_if_not_apparently_updated=True,
             mirror=self.mirror,
             http_get=self.http_get,
@@ -438,19 +434,10 @@ class OPDSImporter(object):
             else:
                 internal_identifier = external_identifier
 
-            #set_trace()
             identifier_obj = IdentifierData(
                 type=internal_identifier.type,
                 identifier=internal_identifier.identifier
             )
-            '''
-            (Pdb) xml_data_meta['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10557']['links']
-            [<LinkData: rel="http://opds-spec.org/acquisition/open-access" href="http://www.gutenberg.org/ebooks/10557.epub.images" media_type='application/epub+zip'>]
-
-            (Pdb) xml_data_meta['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441']['links']
-            [<LinkData: rel="http://opds-spec.org/image" href="https://s3.amazonaws.com/book-covers.nypl.org/Gutenberg-Illustrated/10441/cover_10441_9.png" media_type=None, has thumbnail>, 
-             <LinkData: rel="http://opds-spec.org/acquisition/open-access" href="http://www.gutenberg.org/ebooks/10441.epub.images" media_type='application/epub+zip'>]            
-            '''
 
             # form the Metadata object
             xml_data_dict = xml_data_meta.get(id, {})

--- a/opds_import.py
+++ b/opds_import.py
@@ -215,18 +215,17 @@ class OPDSImporter(object):
                          cutoff_date=None, 
                          immediately_presentation_ready=False):
 
+        imported_editions = {}
+        imported_pools = {}
+        imported_works = {}
+        # status_messages notes business logic errors and non-success download statuses
+        status_messages = {}
+        next_links = []
         try:
             metadata_objs, circulation_objs, status_messages, next_links = self.extract_feed_data(feed)
         except Exception, e:
             message = StatusMessage(500, "Local exception during import:\n%s" % traceback.format_exc())
-
-        imported_editions = {}
-        imported_pools = {}
-        imported_works = {}
-
-        # status_messages notes business logic errors and non-success download statuses
-        if not status_messages:
-            status_messages = {}
+            return imported_editions.values(), imported_pools.values(), imported_works.values(), status_messages, next_links
 
         # make editions.  if have problem, make sure associated pool and work aren't created.
         for key, metadata in metadata_objs.iteritems():
@@ -648,9 +647,9 @@ class OPDSImporter(object):
             # Metadata.rights_uri, but we're treating it same for now.
             default_rights_uri=rights_uri,
             # gets assigned to pool.last_checked on CirculationData.apply()
-            last_checked=datetime.datetime.utcnow(), 
+            #last_checked=datetime.datetime.utcnow(), 
             # first appearance in our databases, gets assigned to pool, if have to make new pool. 
-            first_appearance = datetime.datetime.utcnow()
+            #first_appearance = datetime.datetime.utcnow()
         )
 
         return identifier, kwargs_meta, kwargs_circ, status_message

--- a/opds_import.py
+++ b/opds_import.py
@@ -339,7 +339,7 @@ class OPDSImporter(object):
 
         if (cutoff_date 
             and not is_new_edition
-            and metadata.provider_entry_updated < cutoff_date
+            and metadata.data_source_last_updated < cutoff_date
         ):
             # We've already imported this book, we've been told
             # not to bother with books that haven't changed since a
@@ -379,7 +379,7 @@ class OPDSImporter(object):
         if (cutoff_date 
             and not is_new_license_pool 
             and associated_metadata 
-            and associated_metadata.provider_entry_updated < cutoff_date):
+            and associated_metadata.data_source_last_updated < cutoff_date):
             # We've already imported this book, we've been told
             # not to bother with books that appeared before a
             # certain date, and this book did in fact appear
@@ -666,7 +666,7 @@ class OPDSImporter(object):
             publisher=publisher,
             links=links,
             # refers to when was updated in opds feed, not our db
-            provider_entry_updated=last_opds_update,
+            data_source_last_updated=last_opds_update,
         )
 
         kwargs_circ = dict(

--- a/opds_import.py
+++ b/opds_import.py
@@ -275,9 +275,6 @@ class OPDSImporter(object):
                 # clean up any edition might have created
                 if key in imported_editions:
                     del imported_editions[key]
-                # stop the import, something went terribly wrong
-                return imported_editions.values(), imported_pools.values(), imported_works.values(), status_messages, next_links
-
 
 
         for key, circulationdata in circulation_objs.iteritems():
@@ -312,11 +309,6 @@ class OPDSImporter(object):
                 except Exception, e:
                     message = StatusMessage(500, "Local exception during import:\n%s" % traceback.format_exc())
                     status_messages[key] = message
-                    # If problem importing a Work, then rather than scratch the whole import, 
-                    # treat this as a failure that only applies to this item.
-                    # But if problem importing a pool, something is very wrong, and should stop the import.
-                    if not pool:
-                        return imported_editions.values(), imported_pools.values(), imported_works.values(), status_messages, next_links
             else:
                 self.log.debug(
                     "DataSource does not offer licenses.  No LicensePool created for CirculationData %r, not attempting to create Work.", 

--- a/opds_import.py
+++ b/opds_import.py
@@ -215,7 +215,12 @@ class OPDSImporter(object):
                          cutoff_date=None, 
                          immediately_presentation_ready=False):
 
-        metadata_objs, circulation_objs, status_messages, next_links = self.extract_feed_data(feed)
+        try:
+            metadata_objs, circulation_objs, status_messages, next_links = self.extract_feed_data(feed)
+        except Exception, e:
+            set_trace()
+            message = StatusMessage(500, "Local exception during import:\n%s" % traceback.format_exc())
+            print "1.  %s" % message
 
         #set_trace()
         imported_editions = {}
@@ -236,6 +241,7 @@ class OPDSImporter(object):
                 if edition:
                     imported_editions[key] = edition
             except Exception, e:
+                #set_trace()
                 # Rather than scratch the whole import, treat this as a failure that only applies
                 # to this item.
                 message = StatusMessage(500, "Local exception during import:\n%s" % traceback.format_exc())
@@ -278,6 +284,7 @@ class OPDSImporter(object):
                         if work:
                             imported_works[key] = work
                 except Exception, e:
+                    #set_trace()
                     message = StatusMessage(500, "Local exception during import:\n%s" % traceback.format_exc())
                     status_messages[key] = message
                     # If problem importing a Work, then rather than scratch the whole import, 

--- a/opds_import.py
+++ b/opds_import.py
@@ -475,7 +475,8 @@ class OPDSImporter(object):
 
             circ_links_dict = {}
             # extract just the links to pass to CirculationData constructor
-            circ_links_dict['links'] = xml_data_dict['links']
+            if 'links' in xml_data_dict:
+                circ_links_dict['links'] = xml_data_dict['links']
             combined_circ = self.combine(c_data_dict, circ_links_dict)
             if combined_circ.get('data_source') is None:
                 combined_circ['data_source'] = self.data_source_name

--- a/opds_import.py
+++ b/opds_import.py
@@ -338,7 +338,7 @@ class OPDSImporter(object):
 
         if (cutoff_date 
             and not is_new_edition
-            and metadata.opds_entry_updated < cutoff_date
+            and metadata.provider_entry_updated < cutoff_date
         ):
             # We've already imported this book, we've been told
             # not to bother with books that haven't changed since a
@@ -378,7 +378,7 @@ class OPDSImporter(object):
         if (cutoff_date 
             and not is_new_license_pool 
             and associated_metadata 
-            and associated_metadata.opds_entry_updated < cutoff_date):
+            and associated_metadata.provider_entry_updated < cutoff_date):
             # We've already imported this book, we've been told
             # not to bother with books that appeared before a
             # certain date, and this book did in fact appear
@@ -666,7 +666,7 @@ class OPDSImporter(object):
             publisher=publisher,
             links=links,
             # refers to when was updated in opds feed, not our db
-            opds_entry_updated=last_opds_update,
+            provider_entry_updated=last_opds_update,
         )
 
         kwargs_circ = dict(

--- a/overdrive.py
+++ b/overdrive.py
@@ -888,10 +888,12 @@ class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
             e = "Could not extract metadata from Overdrive data: %r" % info
             return CoverageFailure(self, identifier, e, transient=True)
 
-        result = self.set_metadata(
-            identifier, metadata, 
-            metadata_replacement_policy=self.metadata_replacement_policy
+        result = self.set_metadata_and_circulation_data(
+            identifier, metadata, metadata.circulation, 
+            metadata_replacement_policy=self.metadata_replacement_policy, 
+            circulationdata_replacement_policy=self.circulationdata_replacement_policy
         )
+
         if not isinstance(result, CoverageFailure):
             # Success!
             result = self.set_presentation_ready(result)

--- a/overdrive.py
+++ b/overdrive.py
@@ -528,10 +528,11 @@ class OverdriveRepresentationExtractor(object):
                 processed.append(cls.overdrive_role_to_simplified_role[x])
         return processed
 
+
     @classmethod
     def book_info_to_circulation(cls, book):
-        """ Note:  The json data passed into this method is from a different file 
-        from the json data that goes into the book_info_to_circulation() method.
+        """ Note:  The json data passed into this method is from a different file/stream 
+        from the json data that goes into the book_info_to_metadata() method.
         """
         # In Overdrive, 'reserved' books show up as books on
         # hold. There is no separate notion of reserved books.
@@ -580,12 +581,13 @@ class OverdriveRepresentationExtractor(object):
         media_type = link.get('type', None)
         return LinkData(rel=rel, href=href, media_type=media_type)
 
+
     @classmethod
     def book_info_to_metadata(cls, book):
         """Turn Overdrive's JSON representation of a book into a Metadata
         object.
 
-        Note:  The json data passed into this method is from a different file 
+        Note:  The json data passed into this method is from a different file/stream 
         from the json data that goes into the book_info_to_circulation() method.
         """
         if not 'id' in book:

--- a/overdrive.py
+++ b/overdrive.py
@@ -745,7 +745,6 @@ class OverdriveRepresentationExtractor(object):
             identifiers=identifiers,
             subjects=subjects,
             contributors=contributors,
-            formats=formats,
             measurements=measurements,
             links=links,
         )

--- a/testing.py
+++ b/testing.py
@@ -520,6 +520,7 @@ class DatabaseTest(object):
         identifiers = db_connection.query(Identifier).all()
         license_pools = db_connection.query(LicensePool).all()
         editions = db_connection.query(Edition).all()
+        data_sources = db_connection.query(DataSource).all()
 
         if (not works):
             print "NO Work found"
@@ -556,7 +557,6 @@ class DatabaseTest(object):
         for index, edition in enumerate(editions):
             # pipe character at end of line helps see whitespace issues
             print "Edition[%s]=%s|" % (index, edition)
-            print "    Edition.work_id=%s|" % edition.work_id
             print "    Edition.primary_identifier_id=%s|" % edition.primary_identifier_id
             print "    Edition.permanent_work_id=%s|" % edition.permanent_work_id
             if (edition.data_source):
@@ -575,6 +575,17 @@ class DatabaseTest(object):
                 print "    NO Edition.author_contributor found"
             for acCount, author_contributor in enumerate(edition.author_contributors):
                 print "    Edition.author_contributor[%s]=%s|" % (acCount, author_contributor)
+
+        if (not data_sources):
+            print "NO DataSource found"
+        for index, data_source in enumerate(data_sources):
+            print "DataSource[%s]=%s|" % (index, data_source)
+            print "    DataSource.id=%s|" % data_source.id
+            print "    DataSource.name=%s|" % data_source.name
+            print "    DataSource.offers_licenses=%s|" % data_source.offers_licenses
+            print "    DataSource.editions=%s|" % data_source.editions            
+            print "    DataSource.license_pools=%s|" % data_source.license_pools
+            print "    DataSource.links=%s|" % data_source.links
 
         return
 

--- a/testing.py
+++ b/testing.py
@@ -521,6 +521,7 @@ class DatabaseTest(object):
         license_pools = db_connection.query(LicensePool).all()
         editions = db_connection.query(Edition).all()
         data_sources = db_connection.query(DataSource).all()
+        representations = db_connection.query(Representation).all()
 
         if (not works):
             print "NO Work found"
@@ -535,12 +536,14 @@ class DatabaseTest(object):
 
             print "    Work.presentation_edition=%s|" % work.presentation_edition
 
+        print "__________________________________________________________________\n"
         if (not identifiers):
             print "NO Identifier found"
         for iCount, identifier in enumerate(identifiers):
             print "Identifier[%s]=%s|" % (iCount, identifier)
             print "    Identifier.licensed_through=%s|" % identifier.licensed_through           
 
+        print "__________________________________________________________________\n"
         if (not license_pools):
             print "NO LicensePool found"
         for index, license_pool in enumerate(license_pools):
@@ -552,6 +555,7 @@ class DatabaseTest(object):
             print "    LicensePool.superceded=%s|" % license_pool.superceded
             print "    LicensePool.suppressed=%s|" % license_pool.suppressed
 
+        print "__________________________________________________________________\n"
         if (not editions):
             print "NO Edition found"
         for index, edition in enumerate(editions):
@@ -576,6 +580,7 @@ class DatabaseTest(object):
             for acCount, author_contributor in enumerate(edition.author_contributors):
                 print "    Edition.author_contributor[%s]=%s|" % (acCount, author_contributor)
 
+        print "__________________________________________________________________\n"
         if (not data_sources):
             print "NO DataSource found"
         for index, data_source in enumerate(data_sources):
@@ -586,6 +591,17 @@ class DatabaseTest(object):
             print "    DataSource.editions=%s|" % data_source.editions            
             print "    DataSource.license_pools=%s|" % data_source.license_pools
             print "    DataSource.links=%s|" % data_source.links
+
+        print "__________________________________________________________________\n"
+        if (not representations):
+            print "NO Representation found"
+        for index, representation in enumerate(representations):
+            print "Representation[%s]=%s|" % (index, representation)
+            print "    Representation.id=%s|" % representation.id
+            print "    Representation.url=%s|" % representation.url
+            print "    Representation.mirror_url=%s|" % representation.mirror_url
+            print "    Representation.fetch_exception=%s|" % representation.fetch_exception   
+            print "    Representation.mirror_exception=%s|" % representation.mirror_exception
 
         return
 
@@ -691,3 +707,5 @@ class DummyHTTPClient(object):
     def do_get(self, url, headers, **kwargs):
         self.requests.append(url)
         return self.responses.pop()
+
+

--- a/testing.py
+++ b/testing.py
@@ -567,9 +567,18 @@ class DatabaseTest(object):
             print "    Edition.primary_identifier_id=%s|" % edition.primary_identifier_id
             print "    Edition.is_primary_for_work=%s|" % edition.is_primary_for_work
             print "    Edition.permanent_work_id=%s|" % edition.permanent_work_id
-            print "    Edition.author=%s|" % edition.author
-            print "    Edition.title=%s|" % edition.title
+            if (edition.data_source):
+                print "    Edition.data_source.id=%s|" % edition.data_source.id
+                print "    Edition.data_source.name=%s|" % edition.data_source.name
+            else:
+                print "    No Edition.data_source."
+            if (edition.license_pool):
+                print "    Edition.license_pool.id=%s|" % edition.license_pool.id
+            else:
+                print "    No Edition.license_pool."
 
+            print "    Edition.title=%s|" % edition.title
+            print "    Edition.author=%s|" % edition.author
             if (not edition.author_contributors):
                 print "    NO Edition.author_contributor found"
             for acCount, author_contributor in enumerate(edition.author_contributors):

--- a/tests/files/opds/content_server_mini.opds
+++ b/tests/files/opds/content_server_mini.opds
@@ -33,6 +33,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10441.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
+  
   <entry schema:additionalType="http://schema.org/Book">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10557</id>
     <title>Johnny Crow's Party</title>

--- a/tests/files/overdrive/overdrive_availability_information.json
+++ b/tests/files/overdrive/overdrive_availability_information.json
@@ -1,0 +1,22 @@
+{
+    "available": true,
+    "collections": [
+        {
+            "copiesAvailable": 5,
+            "copiesOwned": 5,
+            "id": "New York Public Library (NY)",
+            "numberOfHolds": 0
+        }
+    ],
+    "copiesAvailable": 5,
+    "copiesOwned": 5,
+    "id": "2a005d55-a417-4053-b90d-7a38ca6d2065",
+    "title": "Blah blah blah",
+    "links": {
+        "self": {
+            "href": "http://api.overdrive.com/v1/collections/collection-id/products/2a005d55-a417-4053-b90d-7a38ca6d2065/availability",
+            "type": "application/vnd.overdrive.api+json"
+        }
+    },
+    "numberOfHolds": 0
+}

--- a/tests/test_3m.py
+++ b/tests/test_3m.py
@@ -51,6 +51,7 @@ class TestItemListParser(object):
              "Renaissance"], 
             f("Action &amp;amp; Adventure,Science Fiction, Fantasy, Magic,Renaissance,"))
 
+
     def test_item_list(cls):
         data = cls.get_data("item_metadata_list_mini.xml")        
         data = list(ItemListParser().parse(data))

--- a/tests/test_3m.py
+++ b/tests/test_3m.py
@@ -180,7 +180,6 @@ class TestItemListParser(BaseThreeMTest):
         eq_(Measurement.PAGE_COUNT, pages.quantity_measured)
         eq_(304, pages.value)
 
-        set_trace()
         [alternate, image, description] = sorted(
             cooked.links, key = lambda x: x.rel)
         eq_("alternate", alternate.rel)

--- a/tests/test_3m.py
+++ b/tests/test_3m.py
@@ -180,6 +180,7 @@ class TestItemListParser(BaseThreeMTest):
         eq_(Measurement.PAGE_COUNT, pages.quantity_measured)
         eq_(304, pages.value)
 
+        set_trace()
         [alternate, image, description] = sorted(
             cooked.links, key = lambda x: x.rel)
         eq_("alternate", alternate.rel)

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -185,6 +185,7 @@ class TestParsers(object):
         eq_("Eve, Mallory", c.sort_name)
         eq_([Contributor.UNKNOWN_ROLE], c.roles)
 
+
     def test_availability_parser(self):
         """Make sure the availability information gets properly
         collated in preparation for updating a LicensePool.
@@ -199,7 +200,9 @@ class TestParsers(object):
         eq_(None, bib1)
         eq_(None, bib2)
 
-        eq_("0003642860", av1.primary_identifier)
+        eq_("0003642860", av1.primary_identifier.identifier)
         eq_(9, av1.licenses_owned)
         eq_(9, av1.licenses_available)
         eq_(0, av1.patrons_in_hold_queue)
+
+

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -87,6 +87,8 @@ class TestParsers(object):
         eq_(u'FICTION / Romance / Suspense', romantic_suspense)
         eq_(u'General Adult', adult)
 
+        '''
+        TODO:  Perhaps want to test formats separately.
         [format] = bib1.formats
         eq_(Representation.EPUB_MEDIA_TYPE, format.content_type)
         eq_(DeliveryMechanism.ADOBE_DRM, format.drm_scheme)
@@ -94,6 +96,8 @@ class TestParsers(object):
         # The second book is only available in 'Blio' format, which
         # we can't use.
         eq_([], bib2.formats)
+        '''
+
 
     def test_parse_author_role(self):
         """Suffixes on author names are turned into roles."""

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -137,8 +137,7 @@ class TestParsers(object):
         eq_(None, bib1)
         eq_(None, bib2)
 
-        eq_(datetime.datetime(2015, 5, 20, 14, 9, 8),
-            av1.last_checked)
+        eq_("0003642860", av1.primary_identifier)
         eq_(9, av1.licenses_owned)
         eq_(9, av1.licenses_available)
         eq_(0, av1.patrons_in_hold_queue)

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -1,0 +1,333 @@
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+
+from copy import deepcopy
+import datetime
+
+from metadata_layer import (
+    CirculationData,
+    ContributorData,
+    FormatData,
+    IdentifierData,
+    LinkData,
+    SubjectData,
+)
+
+from model import (
+    DataSource,
+    DeliveryMechanism,
+    Hyperlink, 
+    Identifier,
+    Representation,
+    RightsStatus,
+    Subject,
+)
+
+from . import (
+    DatabaseTest,
+)
+
+
+class TestCirculationData(DatabaseTest):
+
+    def test_metadata_can_be_deepcopied(self):
+        # Check that we didn't put something in the CirculationData that
+        # will prevent it from being copied. (e.g., self.log)
+
+        subject = SubjectData(Subject.TAG, "subject")
+        contributor = ContributorData()
+        identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
+        link = LinkData(Hyperlink.OPEN_ACCESS_DOWNLOAD, "example.epub")
+        format = FormatData(Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.NO_DRM)
+        rights_uri = RightsStatus.GENERIC_OPEN_ACCESS
+
+        circulation_data = CirculationData(
+            DataSource.GUTENBERG,
+            primary_identifier=identifier,
+            links=[link],
+            licenses_owned=5,
+            licenses_available=5,
+            licenses_reserved=None,
+            patrons_in_hold_queue=None,
+            formats=[format],
+            default_rights_uri=rights_uri,
+        )
+
+        circulation_data_copy = deepcopy(circulation_data)
+
+        # If deepcopy didn't throw an exception we're ok.
+        assert circulation_data_copy is not None
+
+
+    def test_book_info_with_circulation_data(self):
+        # Tests that can convert an overdrive json block into a CirculationData object.
+        # Originally from TestOverdriveRepresentationExtractor.
+
+        """
+        raw, info = self.sample_json("overdrive_metadata.json")
+        metadata = OverdriveRepresentationExtractor.book_info_to_circulation_data(info)
+
+        [...]
+
+        # Available formats.
+        [kindle, pdf] = sorted(metadata.formats, key=lambda x: x.content_type)
+        eq_(DeliveryMechanism.KINDLE_CONTENT_TYPE, kindle.content_type)
+        eq_(DeliveryMechanism.KINDLE_DRM, kindle.drm_scheme)
+
+        eq_(Representation.PDF_MEDIA_TYPE, pdf.content_type)
+        eq_(DeliveryMechanism.ADOBE_DRM, pdf.drm_scheme)
+
+
+
+    from: OPDSImporter
+    def detail_for_feedparser_entry(cls, entry):
+    	[...]
+        '''
+        # metadata no longer knows about circulation
+        if added_to_collection_time:
+            circulation = CirculationData(
+                licenses_owned=None, licenses_available=None,
+                licenses_reserved=None, patrons_in_hold_queue=None,
+                first_appearance=added_to_collection_time,
+                data_source=...
+            )
+        else:
+            circulation = None
+        '''
+        [...]
+        kwargs = dict(
+            license_data_source=license_data_source,
+            title=title,
+            subtitle=subtitle,
+            language=language,
+            publisher=publisher,
+            links=links,
+            rights_uri=rights_uri,
+            last_update_time=last_update_time,
+            #circulation=circulation,
+        )
+        return identifier, kwargs, status_message
+
+
+write test for opds_import.    @classmethod
+    def extract_circulationdata_from_feedparser(cls, feed):
+
+
+
+
+
+
+class TestCirculationData(DatabaseTest):
+
+    def test_links_filtered(self):
+        # TODO: Tests that passed-in links filter down to only the relevant ones.
+        links = []
+        def summary_to_linkdata(detail):
+            if not detail:
+                return None
+            if not 'value' in detail or not detail['value']:
+                return None
+
+            content = detail['value']
+            media_type = detail.get('type', 'text/plain')
+            return LinkData(
+                rel=Hyperlink.DESCRIPTION,
+                media_type=media_type,
+                content=content
+            )
+
+        summary_detail = entry.get('summary_detail', None)
+        link = summary_to_linkdata(summary_detail)
+        if link:
+            links.append(link)
+
+        for content_detail in entry.get('content', []):
+            link = summary_to_linkdata(content_detail)
+            if link:
+                links.append(link)
+
+        kwargs_circ = dict(
+            # Note: later on, we'll check to make sure data_source is lendable, and if not, abort creating a pool and a work.
+            data_source=data_source,
+            links=links,
+            # Note: CirculationData.default_rights_uri is not same as the old 
+            # Metadata.rights_uri, but we're treating it same for now.
+            default_rights_uri=rights_uri,
+            last_checked=last_update_time, 
+            # first appearance in our databases, 
+            # gets assigned to pool, if have to make new pool. 
+            first_appearance = datetime.datetime.utcnow()
+        )
+        circulation_data = CirculationData(**kwargs_circ)
+        pass
+
+
+
+
+    def test_open_access_content_mirrored(self):
+        # TODO: mirroring links is now also CirculationData's job.  So the unit tests 
+        # that test for that have been changed to call to mirror cover images.
+        # However, updated tests passing does not guarantee that all code now 
+        # correctly calls on CirculationData, too.  This is a risk.
+
+        # Make sure that open access material links are translated to our S3 buckets, and that 
+        # commercial material links are left as is.
+
+        mirror = DummyS3Uploader()
+        # Here's a book.
+        edition, pool = self._edition(with_license_pool=True)
+
+        # Here's a link to the content of the book, which will be mirrored.
+        link_mirrored = LinkData(
+            rel=Hyperlink.OPEN_ACCESS_DOWNLOAD, href="http://example.com/",
+            media_type=Representation.EPUB_MEDIA_TYPE,
+            content="i am a tiny book"
+        )
+
+        # This link will not be mirrored.
+        link_unmirrored = LinkData(
+            rel=Hyperlink.SAMPLE, href="http://example.com/2",
+            media_type=Representation.TEXT_PLAIN,
+            content="i am a tiny (This is a sample. To read the rest of this book, please visit your local library.)"
+        )
+
+        # Apply the metadata.
+        policy = ReplacementPolicy(mirror=mirror)
+        metadata = Metadata(links=[link_mirrored, link_unmirrored], data_source=edition.data_source)
+        metadata.apply(edition, replace=policy)
+        
+
+        # Only the open-access link has been 'mirrored'.
+        # TODO: make sure the refactor is done right, and metadata does not upload
+        #eq_(0, len(mirror.uploaded))
+        [book] = mirror.uploaded
+
+        # TODO: make sure the refactor is done right, and circulation does upload 
+        #circulation = CirculationData(links=[link_mirrored, link_unmirrored], data_source=edition.data_source)
+        #circulation.apply(pool, replace=policy)
+        #[book] = mirror.uploaded
+
+        # It's remained an open-access link.
+        eq_(
+            [Hyperlink.OPEN_ACCESS_DOWNLOAD], 
+            [x.rel for x in book.resource.links]
+        )
+
+
+        # It's been 'mirrored' to the appropriate S3 bucket.
+        assert book.mirror_url.startswith('http://s3.amazonaws.com/test.content.bucket/')
+        expect = '/%s/%s.epub' % (
+            edition.primary_identifier.identifier,
+            edition.title
+        )
+        assert book.mirror_url.endswith(expect)
+
+        # make sure the mirrored link is safely on edition
+        sorted_edition_links = sorted(edition.license_pool.identifier.links, key=lambda x: x.rel)
+        mirrored_representation, unmirrored_representation = [edlink.resource.representation for edlink in sorted_edition_links]
+        assert mirrored_representation.mirror_url.startswith('http://s3.amazonaws.com/test.content.bucket/')
+
+        # make sure the unmirrored link is safely on edition
+        eq_('http://example.com/2', unmirrored_representation.url)
+        # make sure the unmirrored link has not been translated to an S3 URL
+        eq_(None, unmirrored_representation.mirror_url)
+
+
+    def test_mirror_open_access_link_fetch_failure(self):
+        edition, pool = self._edition(with_license_pool=True)
+
+        data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)
+        m = Metadata(data_source=data_source)
+
+        mirror = DummyS3Uploader()
+        h = DummyHTTPClient()
+
+        policy = ReplacementPolicy(mirror=mirror, http_get=h.do_get)
+
+        link = LinkData(
+            rel=Hyperlink.OPEN_ACCESS_DOWNLOAD,
+            media_type=Representation.EPUB_MEDIA_TYPE,
+            href=self._url,
+        )
+
+        link_obj, ignore = edition.primary_identifier.add_link(
+            rel=link.rel, href=link.href, data_source=data_source,
+            license_pool=pool, media_type=link.media_type,
+            content=link.content,
+        )
+        h.queue_response(403)
+        
+        m.mirror_link(pool, data_source, link, link_obj, policy)
+
+        representation = link_obj.resource.representation
+
+        # Fetch failed, so we should have a fetch exception but no mirror url.
+        assert representation.fetch_exception != None
+        eq_(None, representation.mirror_exception)
+        eq_(None, representation.mirror_url)
+        eq_(link.href, representation.url)
+        assert representation.fetched_at != None
+        eq_(None, representation.mirrored_at)
+
+        # The license pool is suppressed when fetch fails.
+        eq_(True, pool.suppressed)
+        assert representation.fetch_exception in pool.license_exception
+
+    def test_mirror_open_access_link_mirror_failure(self):
+        edition, pool = self._edition(with_license_pool=True)
+
+        data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)
+        m = Metadata(data_source=data_source)
+
+        mirror = DummyS3Uploader(fail=True)
+        h = DummyHTTPClient()
+
+        policy = ReplacementPolicy(mirror=mirror, http_get=h.do_get)
+
+        link = LinkData(
+            rel=Hyperlink.OPEN_ACCESS_DOWNLOAD,
+            media_type=Representation.EPUB_MEDIA_TYPE,
+            href=self._url,
+        )
+
+        link_obj, ignore = edition.primary_identifier.add_link(
+            rel=link.rel, href=link.href, data_source=data_source,
+            license_pool=pool, media_type=link.media_type,
+            content=link.content,
+        )
+
+        h.queue_response(200, media_type=Representation.EPUB_MEDIA_TYPE)
+        
+        m.mirror_link(pool, data_source, link, link_obj, policy)
+
+        representation = link_obj.resource.representation
+
+        # The representation was fetched successfully.
+        eq_(None, representation.fetch_exception)
+        assert representation.fetched_at != None
+
+        # But mirroing failed.
+        assert representation.mirror_exception != None
+        eq_(None, representation.mirrored_at)
+        eq_(link.media_type, representation.media_type)
+        eq_(link.href, representation.url)
+
+        # The mirror url should still be set.
+        assert "Gutenberg" in representation.mirror_url
+        assert representation.mirror_url.endswith("%s.epub" % edition.title)
+
+        # Book content is still there since it wasn't mirrored.
+        assert representation.content != None
+
+        # The license pool is suppressed when mirroring fails.
+        eq_(True, pool.suppressed)
+        assert representation.mirror_exception in pool.license_exception
+
+
+
+
+
+"""
+

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -409,7 +409,7 @@ class TestCoverageProvider(DatabaseTest):
             primary_identifier=metadata.primary_identifier, 
             links=[link])
 
-        provider.set_meta_circ_data(
+        provider.set_metadata_and_circulation_data(
             identifier, metadata, circulationdata, 
             metadata_replacement_policy=metadata_replacement_policy, 
             circulationdata_replacement_policy=circulationdata_replacement_policy, 
@@ -632,7 +632,7 @@ class TestBibliographicCoverageProvider(DatabaseTest):
             with_license_pool=True)
 
         # If no metadata is passed in, a CoverageRecord results.
-        result = provider.set_meta_circ_data(edition.primary_identifier, None, None)
+        result = provider.set_metadata_and_circulation_data(edition.primary_identifier, None, None)
 
         assert isinstance(result, CoverageFailure)
         eq_("Did not receive metadata from input source", result.exception)
@@ -642,13 +642,13 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         edition.title = None
         old_title = test_metadata.title
         test_metadata.title = None
-        result = provider.set_meta_circ_data(edition.primary_identifier, test_metadata, test_circulationdata)
+        result = provider.set_metadata_and_circulation_data(edition.primary_identifier, test_metadata, test_circulationdata)
         assert isinstance(result, CoverageFailure)
         eq_("Work could not be calculated", result.exception)
         test_metadata.title = old_title        
 
         # Test success
-        result = provider.set_meta_circ_data(edition.primary_identifier, test_metadata, test_circulationdata)
+        result = provider.set_metadata_and_circulation_data(edition.primary_identifier, test_metadata, test_circulationdata)
         eq_(result, edition.primary_identifier)
 
         # If there's an exception setting the metadata, a
@@ -658,7 +658,7 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         test_metadata.primary_identifier = self._identifier(
             identifier_type=Identifier.OVERDRIVE_ID
         )
-        result = provider.set_meta_circ_data(lp.identifier, test_metadata, test_circulationdata)
+        result = provider.set_metadata_and_circulation_data(lp.identifier, test_metadata, test_circulationdata)
         assert isinstance(result, CoverageFailure)
         assert "ValueError" in result.exception
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -27,6 +27,7 @@ from model import (
 )
 from metadata_layer import (
     Metadata,
+    CirculationData,
     IdentifierData,
     ContributorData,
     LinkData,
@@ -391,18 +392,25 @@ class TestCoverageProvider(DatabaseTest):
             presentation_calculation_policy=presentation_calculation_policy
         )
 
+        circulationdata_replacement_policy = ReplacementPolicy(
+            mirror=mirror,
+            http_get=http.do_get,
+        )
+
         output_source = DataSource.lookup(self._db, DataSource.GUTENBERG)
         provider = CoverageProvider(
             "service", [identifier.type], output_source
         )
 
-        # We've got a Metadata object that includes an open-access download.
+        metadata = Metadata(output_source)
+        # We've got a CirculationData object that includes an open-access download.
         link = LinkData(rel=Hyperlink.OPEN_ACCESS_DOWNLOAD, href="http://foo.com/")
-        metadata = Metadata(output_source, links=[link])
+        circulationdata = CirculationData(output_source, links=[link])
 
-        provider.set_metadata(
-            identifier, metadata, 
-            metadata_replacement_policy=metadata_replacement_policy
+        provider.set_meta_circ_data(
+            identifier, metadata, circulationdata, 
+            metadata_replacement_policy=metadata_replacement_policy, 
+            circulationdata_replacement_policy=circulationdata_replacement_policy, 
         )
 
         # The open-access download was 'downloaded' and 'mirrored'.
@@ -421,6 +429,7 @@ class TestCoverageProvider(DatabaseTest):
         # presentation. We know this because the tripwire was
         # triggered.
         eq_(True, presentation_calculation_policy.tripped)
+
 
     def test_operation_included_in_records(self):
         provider = AlwaysSuccessfulCoverageProvider(
@@ -541,6 +550,10 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         ],
     )
 
+    CIRCULATION_DATA = CirculationData(
+        DataSource.OVERDRIVE,
+    )
+
     def test_edition(self):
         provider = BibliographicCoverageProvider(self._db, None,
                 DataSource.OVERDRIVE)
@@ -597,6 +610,7 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         provider.CAN_CREATE_LICENSE_POOLS = False
         identifier = self._identifier(identifier_type=Identifier.OVERDRIVE_ID)
         test_metadata = self.BIBLIOGRAPHIC_DATA
+        test_circulationdata = self.CIRCULATION_DATA
 
         # If there is no LicensePool and it can't be autocreated, a
         # CoverageRecord results.
@@ -607,7 +621,8 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         edition, lp = self._edition(with_license_pool=True)
 
         # If no metadata is passed in, a CoverageRecord results.
-        result = provider.set_metadata(edition.primary_identifier, None)
+        result = provider.set_meta_circ_data(edition.primary_identifier, None, None)
+
         assert isinstance(result, CoverageFailure)
         eq_("Did not receive metadata from input source", result.exception)
 
@@ -616,13 +631,13 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         edition.title = None
         old_title = test_metadata.title
         test_metadata.title = None
-        result = provider.set_metadata(edition.primary_identifier, test_metadata)
+        result = provider.set_meta_circ_data(edition.primary_identifier, test_metadata, test_circulationdata)
         assert isinstance(result, CoverageFailure)
         eq_("Work could not be calculated", result.exception)
         test_metadata.title = old_title        
 
         # Test success
-        result = provider.set_metadata(edition.primary_identifier, test_metadata)
+        result = provider.set_meta_circ_data(edition.primary_identifier, test_metadata, test_circulationdata)
         eq_(result, edition.primary_identifier)
 
         # If there's an exception setting the metadata, a
@@ -632,9 +647,10 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         test_metadata.primary_identifier = self._identifier(
             identifier_type=Identifier.OVERDRIVE_ID
         )
-        result = provider.set_metadata(lp.identifier, test_metadata)
+        result = provider.set_meta_circ_data(lp.identifier, test_metadata, test_circulationdata)
         assert isinstance(result, CoverageFailure)
         assert "ValueError" in result.exception
+
 
     def test_autocreate_licensepool(self):
         provider = BibliographicCoverageProvider(self._db, None,

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -405,7 +405,9 @@ class TestCoverageProvider(DatabaseTest):
         metadata = Metadata(output_source)
         # We've got a CirculationData object that includes an open-access download.
         link = LinkData(rel=Hyperlink.OPEN_ACCESS_DOWNLOAD, href="http://foo.com/")
-        circulationdata = CirculationData(output_source, links=[link])
+        circulationdata = CirculationData(output_source, 
+            primary_identifier=metadata.primary_identifier, 
+            links=[link])
 
         provider.set_meta_circ_data(
             identifier, metadata, circulationdata, 
@@ -530,6 +532,10 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         language='eng',
         title=u'A Girl Named Disaster',
         published=datetime.datetime(1998, 3, 1, 0, 0),
+        primary_identifier=IdentifierData(
+            type=Identifier.OVERDRIVE_ID,
+            identifier=u'ba9b3419-b0bd-4ca7-a24f-26c4246b6b44'
+        ),
         identifiers = [
             IdentifierData(
                     type=Identifier.OVERDRIVE_ID,
@@ -552,7 +558,9 @@ class TestBibliographicCoverageProvider(DatabaseTest):
 
     CIRCULATION_DATA = CirculationData(
         DataSource.OVERDRIVE,
+        primary_identifier=BIBLIOGRAPHIC_DATA.primary_identifier,
     )
+
 
     def test_edition(self):
         provider = BibliographicCoverageProvider(self._db, None,
@@ -618,7 +626,10 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         assert isinstance(result, CoverageFailure)
         eq_("No license pool available", result.exception)
 
-        edition, lp = self._edition(with_license_pool=True)
+        edition, lp = self._edition(data_source_name=DataSource.OVERDRIVE, 
+            identifier_type=Identifier.OVERDRIVE_ID, 
+            identifier_id=self.BIBLIOGRAPHIC_DATA.primary_identifier.identifier, 
+            with_license_pool=True)
 
         # If no metadata is passed in, a CoverageRecord results.
         result = provider.set_meta_circ_data(edition.primary_identifier, None, None)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -604,6 +604,11 @@ class TestMetadata(DatabaseTest):
         identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
         link = LinkData(Hyperlink.OPEN_ACCESS_DOWNLOAD, "example.epub")
         measurement = MeasurementData(Measurement.RATING, 5)
+        circulation = CirculationData(0, 0, 0, 0)
+        primary_as_data = IdentifierData(
+            type=identifier.type, identifier=identifier.identifier
+        )
+        other_data = IdentifierData(type=u"abc", identifier=u"def")
 
         m = Metadata(
             DataSource.GUTENBERG,
@@ -612,6 +617,21 @@ class TestMetadata(DatabaseTest):
             primary_identifier=identifier,
             links=[link],
             measurements=[measurement],
+            circulation=circulation,
+
+            title="Hello Title",
+            subtitle="Subtle Hello",
+            sort_title="Sorting Howdy",
+            language="US English",
+            medium=Edition.BOOK_MEDIUM,
+            series="1",
+            series_position=1,
+            publisher="Hello World Publishing House",
+            imprint=u"Follywood",
+            issued=datetime.datetime.utcnow(),
+            published=datetime.datetime.utcnow(),
+            identifiers=[primary_as_data, other_data],
+            opds_entry_updated=datetime.datetime.utcnow(),
         )
 
         m_copy = deepcopy(m)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -270,10 +270,13 @@ class TestMetadataImporter(DatabaseTest):
         assert representation.fetched_at != None
         eq_(None, representation.mirrored_at)
 
-        # TODO:  should the edition's identifier-associated license pool be 
-        # suppressed when fetch fails on getting image?
-        #eq_(True, pool.suppressed)
-        #assert representation.fetch_exception in pool.license_exception
+        # the edition's identifier-associated license pool should not be 
+        # suppressed just because fetch failed on getting image.
+        eq_(False, pool.suppressed)
+
+        # the license pool only gets its license_exception column filled in
+        # if fetch failed on getting an Hyperlink.OPEN_ACCESS_DOWNLOAD-type epub.
+        eq_(None, pool.license_exception)
 
 
     def test_mirror_open_access_link_mirror_failure(self):
@@ -319,18 +322,18 @@ class TestMetadataImporter(DatabaseTest):
 
         # The mirror url should still be set.
         assert "Gutenberg" in representation.mirror_url
-        # TODO:  changed from edition.title to edition.primary_identifier.identifier.  make sure 
-        # the change is warranted.
         assert representation.mirror_url.endswith("%s/cover.jpg" % edition.primary_identifier.identifier)
 
         # Book content is still there since it wasn't mirrored.
         assert representation.content != None
 
-        # The license pool is suppressed when mirroring fails.
-        # TODO:  should the edition's identifier-associated license pool be 
-        # suppressed when link fails on getting image?
-        #eq_(True, pool.suppressed)
-        #assert representation.mirror_exception in pool.license_exception
+        # the edition's identifier-associated license pool should not be 
+        # suppressed just because fetch failed on getting image.
+        eq_(False, pool.suppressed)
+
+        # the license pool only gets its license_exception column filled in
+        # if fetch failed on getting an Hyperlink.OPEN_ACCESS_DOWNLOAD-type epub.
+        eq_(None, pool.license_exception)
 
 
     def test_measurements(self):
@@ -344,89 +347,6 @@ class TestMetadataImporter(DatabaseTest):
         eq_(Measurement.POPULARITY, m.quantity_measured)
         eq_(100, m.value)
 
-
-    def test_explicit_formatdata(self):
-        # Creating an edition with an open-access download will
-        # automatically create a delivery mechanism.
-        edition, pool = self._edition(with_open_access_download=True)
-
-        # Let's also add a DRM format.
-        drm_format = FormatData(
-            content_type=Representation.PDF_MEDIA_TYPE,
-            drm_scheme=DeliveryMechanism.ADOBE_DRM,
-        )
-
-        circulation_data = CirculationData(formats=[drm_format],
-                            data_source=edition.data_source, 
-                            primary_identifier=edition.primary_identifier)
-        circulation_data.apply(pool)
-
-        [epub, pdf] = sorted(pool.delivery_mechanisms, 
-                             key=lambda x: x.delivery_mechanism.content_type)
-        eq_(epub.resource, edition.license_pool.best_open_access_link)
-
-        eq_(Representation.PDF_MEDIA_TYPE, pdf.delivery_mechanism.content_type)
-        eq_(DeliveryMechanism.ADOBE_DRM, pdf.delivery_mechanism.drm_scheme)
-
-        # If we tell Metadata to replace the list of formats, we only
-        # have the one format we manually created.
-        replace = ReplacementPolicy(
-                formats=True,
-            )
-        circulation_data.apply(pool, replace=replace)
-        [pdf] = pool.delivery_mechanisms
-        eq_(Representation.PDF_MEDIA_TYPE, pdf.delivery_mechanism.content_type)
-
-
-    def test_implicit_format_for_open_access_link(self):
-        # A format is a delivery mechanism.  We handle delivery on open access 
-        # pools from our mirrored content in S3.  
-        # Tests that when a link is open access, a pool can be delivered.
-        
-        edition, pool = self._edition(with_license_pool=True)
-
-        # This is the delivery mechanism created by default when you
-        # create a book with _edition().
-        [epub] = pool.delivery_mechanisms
-        eq_(Representation.EPUB_MEDIA_TYPE, epub.delivery_mechanism.content_type)
-        eq_(DeliveryMechanism.ADOBE_DRM, epub.delivery_mechanism.drm_scheme)
-
-
-        link = LinkData(
-            rel=Hyperlink.OPEN_ACCESS_DOWNLOAD,
-            media_type=Representation.PDF_MEDIA_TYPE,
-            href=self._url
-        )
-        circulation_data = CirculationData(
-            data_source=DataSource.GUTENBERG, 
-            primary_identifier=edition.primary_identifier, 
-            links=[link], 
-        )
-
-        replace = ReplacementPolicy(
-                formats=True,
-            )
-        circulation_data.apply(pool, replace)
-
-        # We destroyed the default delivery format and added a new,
-        # open access delivery format.
-        [pdf] = pool.delivery_mechanisms
-        eq_(Representation.PDF_MEDIA_TYPE, pdf.delivery_mechanism.content_type)
-        eq_(DeliveryMechanism.NO_DRM, pdf.delivery_mechanism.drm_scheme)
-
-        circulation_data = CirculationData(
-            data_source=DataSource.GUTENBERG, 
-            primary_identifier=edition.primary_identifier, 
-            links=[]
-        )
-        replace = ReplacementPolicy(
-                formats=True,
-                links=True,
-            )
-        circulation_data.apply(pool, replace)
-
-        # Now we have no formats at all.
-        eq_([], pool.delivery_mechanisms)
 
     def test_coverage_record(self):
         edition, pool = self._edition(with_license_pool=True)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -619,3 +619,60 @@ class TestMetadata(DatabaseTest):
         # If deepcopy didn't throw an exception we're ok.
         assert m_copy is not None
 
+    def test_links_filtered(self):
+        # TODO:
+        # TODO: might want to filter links to only metadata-relevant ones
+        pass
+
+
+class TestCirculationData(DatabaseTest):
+
+    def test_links_filtered(self):
+        # TODO: might want to filter links to only circulation-relevant ones
+
+        # TODO:
+        links = []
+        def summary_to_linkdata(detail):
+            if not detail:
+                return None
+            if not 'value' in detail or not detail['value']:
+                return None
+
+            content = detail['value']
+            media_type = detail.get('type', 'text/plain')
+            return LinkData(
+                rel=Hyperlink.DESCRIPTION,
+                media_type=media_type,
+                content=content
+            )
+
+        summary_detail = entry.get('summary_detail', None)
+        link = summary_to_linkdata(summary_detail)
+        if link:
+            links.append(link)
+
+        for content_detail in entry.get('content', []):
+            link = summary_to_linkdata(content_detail)
+            if link:
+                links.append(link)
+
+        kwargs_circ = dict(
+            # Note: later on, we'll check to make sure data_source is lendable, and if not, abort creating a pool and a work.
+            data_source=data_source,
+            links=links,
+            # Note: CirculationData.default_rights_uri is not same as the old 
+            # Metadata.rights_uri, but we're treating it same for now.
+            default_rights_uri=rights_uri,
+            last_checked=last_update_time, 
+            # first appearance in our databases, 
+            # gets assigned to pool, if have to make new pool. 
+            first_appearance = datetime.datetime.utcnow()
+        )
+        circulation_data = CirculationData(**kwargs_circ)
+        pass
+
+
+
+
+
+

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -354,7 +354,8 @@ class TestMetadataImporter(DatabaseTest):
         )
 
         circulation_data = CirculationData(formats=[drm_format],
-                            data_source=edition.data_source)
+                            data_source=edition.data_source, 
+                            primary_identifier=edition.primary_identifier)
         circulation_data.apply(pool)
 
         [epub, pdf] = sorted(pool.delivery_mechanisms, 
@@ -395,7 +396,8 @@ class TestMetadataImporter(DatabaseTest):
         )
         circulation_data = CirculationData(
             data_source=DataSource.GUTENBERG, 
-            links=[link]
+            primary_identifier=edition.primary_identifier, 
+            links=[link], 
         )
 
         replace = ReplacementPolicy(
@@ -411,6 +413,7 @@ class TestMetadataImporter(DatabaseTest):
 
         circulation_data = CirculationData(
             data_source=DataSource.GUTENBERG, 
+            primary_identifier=edition.primary_identifier, 
             links=[]
         )
         replace = ReplacementPolicy(
@@ -595,6 +598,7 @@ class TestMetadata(DatabaseTest):
         eq_(equivalency.output.type, u"abc")
         eq_(equivalency.output.identifier, u"def")
 
+
     def test_metadata_can_be_deepcopied(self):
         # Check that we didn't put something in the metadata that
         # will prevent it from being copied. (e.g., self.log)
@@ -604,7 +608,12 @@ class TestMetadata(DatabaseTest):
         identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
         link = LinkData(Hyperlink.OPEN_ACCESS_DOWNLOAD, "example.epub")
         measurement = MeasurementData(Measurement.RATING, 5)
-        circulation = CirculationData(0, 0, 0, 0)
+        circulation = CirculationData(data_source=DataSource.GUTENBERG,
+            primary_identifier=identifier, 
+            licenses_owned=0, 
+            licenses_available=0, 
+            licenses_reserved=0, 
+            patrons_in_hold_queue=0)
         primary_as_data = IdentifierData(
             type=identifier.type, identifier=identifier.identifier
         )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -614,7 +614,7 @@ class TestMetadata(DatabaseTest):
 
         identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
         metadata = Metadata(
-            DataSource.GUTENBERG,
+            data_source=DataSource.GUTENBERG,
             primary_identifier=identifier,
             links=links,
         )
@@ -625,24 +625,31 @@ class TestMetadata(DatabaseTest):
 
 
     def test_make_thumbnail_assigns_pool(self):
-        edition = self._edition()
+        identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
+        #identifier = self._identifier()
+        #identifier = IdentifierData(type=Identifier.GUTENBERG_ID, identifier=edition.primary_identifier)
+        edition = self._edition(identifier_id=identifier.identifier)
+
         link = LinkData(
             rel=Hyperlink.THUMBNAIL_IMAGE, href="http://thumbnail.com/",
             media_type=Representation.JPEG_MEDIA_TYPE,
         )
 
-        metadata = Metadata(links=[link], 
-                            data_source=edition.data_source)
+        metadata = Metadata(data_source=edition.data_source, 
+            primary_identifier=identifier,
+            links=[link], 
+        )
 
         circulation = CirculationData(data_source=edition.data_source, 
-            primary_identifier=edition.primary_identifier)
+            primary_identifier=identifier)
 
         metadata.circulation = circulation
 
         metadata.apply(edition)
         thumbnail_link = edition.primary_identifier.links[0]
 
-        eq_(thumbnail_link.license_pool, circulation.license_pool)
+        circulation_pool, is_new = circulation.license_pool(self._db)
+        eq_(thumbnail_link.license_pool, circulation_pool)
 
 
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -359,7 +359,7 @@ class TestMetadataImporter(DatabaseTest):
         last_update = datetime.datetime(2015, 1, 1)
 
         m = Metadata(data_source=data_source,
-                     title=u"New title", provider_entry_updated=last_update)
+                     title=u"New title", data_source_last_updated=last_update)
         m.apply(edition)
         
         coverage = CoverageRecord.lookup(edition, data_source)
@@ -369,7 +369,7 @@ class TestMetadataImporter(DatabaseTest):
         older_last_update = datetime.datetime(2014, 1, 1)
         m = Metadata(data_source=data_source,
                      title=u"Another new title", 
-                     provider_entry_updated=older_last_update
+                     data_source_last_updated=older_last_update
         )
         m.apply(edition)
         eq_(u"New title", edition.title)
@@ -588,7 +588,7 @@ class TestMetadata(DatabaseTest):
             issued=datetime.datetime.utcnow(),
             published=datetime.datetime.utcnow(),
             identifiers=[primary_as_data, other_data],
-            provider_entry_updated=datetime.datetime.utcnow(),
+            data_source_last_updated=datetime.datetime.utcnow(),
         )
 
         m_copy = deepcopy(m)
@@ -622,6 +622,28 @@ class TestMetadata(DatabaseTest):
         filtered_links = sorted(metadata.links, key=lambda x:x.rel)
 
         eq_([link2, link5, link4, link3], filtered_links)
+
+
+    def test_make_thumbnail_assigns_pool(self):
+        edition = self._edition()
+        link = LinkData(
+            rel=Hyperlink.THUMBNAIL_IMAGE, href="http://thumbnail.com/",
+            media_type=Representation.JPEG_MEDIA_TYPE,
+        )
+
+        metadata = Metadata(links=[link], 
+                            data_source=edition.data_source)
+
+        circulation = CirculationData(data_source=edition.data_source, 
+            primary_identifier=edition.primary_identifier)
+
+        metadata.circulation = circulation
+
+        metadata.apply(edition)
+        thumbnail_link = edition.primary_identifier.links[0]
+
+        eq_(thumbnail_link.license_pool, circulation.license_pool)
+
 
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2051,7 +2051,6 @@ class TestWorkConsolidation(DatabaseTest):
         # The LicensePool we called calculate_work() on gets to stay
         # in the Work, but the other two have been kicked out and
         # given their own works.
-        set_trace()
         assert abcd_commercial_2.work != work
         assert abcd_open_access.work != work
 

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -307,36 +307,46 @@ class TestOPDSImporter(OPDSImporterTest):
         imported2, messages, next_links = OPDSImporter(self._db).import_from_feed(feed)
         eq_(imported2, imported)
 
+
     def test_import_with_cutoff(self):
         cutoff = datetime.datetime(2016, 1, 2, 16, 56, 40)
         path = os.path.join(self.resource_path, "content_server_mini.opds")
         feed = open(path).read()
-        importer = OPDSImporter(self._db)
-        imported, messages, next_links = (
+        importer = OPDSImporter(self._db, data_source_name=DataSource.OVERDRIVE)
+        imported_editions, imported_pools, imported_works, messages, next_links = (
             importer.import_from_feed(feed, cutoff_date=cutoff)
         )
 
         # Despite the cutoff, both books were imported, because they
         # were new.
-        eq_(2, len(imported))
+        eq_(2, len(imported_editions))
+        eq_(2, len(imported_pools))
+        eq_(2, len(imported_works))
 
         # But if we try it again...
-        imported, messages, next_links = (
+        imported_editions, imported_pools, imported_works, messages, next_links = (
             importer.import_from_feed(feed, cutoff_date=cutoff)
         )
 
         # None of the books were imported because they all appeared in
         # the feed after the cutoff.
-        eq_(0, len(imported))
+        eq_(0, len(imported_editions))
+        eq_(0, len(imported_pools))
+        eq_(0, len(imported_works))
 
         # And if we change the cutoff...
-        cutoff = datetime.datetime(2013, 1, 2, 16, 56, 40)
-        imported, messages, next_links = (
-            importer.import_from_feed(feed, cutoff_date=cutoff)
-        )
+        # TODO:  we've messed with the cutoff date in import_editions_from_metadata, 
+        # and need to fix it before re-activating the assert.
+        #cutoff = datetime.datetime(2013, 1, 2, 16, 56, 40)
+        #imported_editions, imported_pools, imported_works, messages, next_links = (
+        #    importer.import_from_feed(feed, cutoff_date=cutoff)
+        #)
 
         # Both books were imported again.
-        eq_(2, len(imported))
+        #eq_(2, len(imported_editions))
+        #eq_(2, len(imported_pools))
+        #eq_(2, len(imported_works))
+
 
     def test_import_updates_metadata(self):
 

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -158,7 +158,6 @@ class TestOPDSImporter(OPDSImporterTest):
 
         circulation = values_circ['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441']
         eq_(DataSource.OA_CONTENT_SERVER, circulation['data_source'])
-        assert (datetime.datetime.utcnow() - circulation['first_appearance']) < datetime.timedelta(seconds=10)
 
         message = status_messages['http://www.gutenberg.org/ebooks/1984']
         eq_(202, message.status_code)

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -551,7 +551,7 @@ class TestOPDSImporter(OPDSImporterTest):
             DoomedOPDSImporter(self._db).import_from_feed(feed)
         )
 
-        # No books were imported.
+        # Only one book was imported, the other failed.
         eq_(1, len(imported_editions))
 
         # The other failed to import, and became a StatusMessage

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -543,6 +543,7 @@ class TestOPDSImporter(OPDSImporterTest):
                 else:
                     # Any other import fails.
                     raise Exception("Utter failure!")
+
         path = os.path.join(self.resource_path, "content_server_mini.opds")
         feed = open(path).read()
 
@@ -551,7 +552,7 @@ class TestOPDSImporter(OPDSImporterTest):
         )
 
         # No books were imported.
-        eq_(0, len(imported_editions))
+        eq_(1, len(imported_editions))
 
         # The other failed to import, and became a StatusMessage
         message = error_messages['http://www.gutenberg.org/ebooks/10441']

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -308,32 +308,56 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(imported2, imported)
 
 
-    # TODO
+
     def test_import_with_wrangler_data_source(self):
         # will create editions, but not license pools or works, because the 
         # metadata wrangler data source is not lendable
+        cutoff = datetime.datetime(2016, 1, 2, 16, 56, 40)
+        path = os.path.join(self.resource_path, "content_server_mini.opds")
+        feed = open(path).read()
 
+        set_trace()
+        print "DOING MW"
         importer_mw = OPDSImporter(self._db, data_source_name=DataSource.METADATA_WRANGLER)
         imported_editions_mw, imported_pools_mw, imported_works_mw, messages_meta_mw, messages_circ_mw, next_links_mw = (
             importer_mw.import_from_feed(feed, cutoff_date=cutoff)
         )
+
+        # TODO: if the test feed sites Gutenberg as data source, should 
+        # use MW or Gutenberg?  Ex: 
+        # <bibframe:distribution bibframe:ProviderName="Gutenberg"/>
+        # <title>The Green Mouse</title>
+
         # Despite the cutoff, both books were imported, because they were new.
         eq_(2, len(imported_editions_mw))
 
         # but pools and works weren't, because we passed the wrong data source
-        eq_(0, len(imported_pools_mw))
-        eq_(0, len(imported_works_mw))
+        # and we have no error messages, because correctly didn't even get to trying to create pools.
+        #eq_(0, len(messages_meta_mw))
+        #eq_(0, len(imported_pools_mw))
+        #eq_(0, len(imported_works_mw))
+        # TODO: when do have error, have 3 error messages, when should have 2.
 
+        set_trace()
+        print "DOING G"
         # try again, with a license pool-acceptable data source
         importer_g = OPDSImporter(self._db, data_source_name=DataSource.GUTENBERG)
         imported_editions_g, imported_pools_g, imported_works_g, messages_meta_g, messages_circ_g, next_links_g = (
             importer_g.import_from_feed(feed, cutoff_date=cutoff)
         )
-        # now pools and works are in
+
+        set_trace()
+        # we made new editions -- one for each data source
+        eq_(2, len(imported_editions_g))
+        # TODO: and we also created presentation editions, with author and title set
+
+        # now pools and works are in, too
+        #eq_(0, len(messages_meta_g))
         eq_(2, len(imported_pools_g))
         eq_(2, len(imported_works_g))        
-        # but not editions, because they were already there
+        # editions are also in, because we're now creating edition per data source, not overwriting
         eq_(2, len(imported_editions_g))
+
 
 
     def test_import_with_cutoff(self):

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -321,7 +321,7 @@ class TestOPDSImporter(OPDSImporterTest):
         set_trace()
         print "DOING MW"
         importer_mw = OPDSImporter(self._db, data_source_name=DataSource.METADATA_WRANGLER)
-        imported_editions_mw, imported_pools_mw, imported_works_mw, messages_meta_mw, messages_circ_mw, next_links_mw = (
+        imported_editions_mw, imported_pools_mw, imported_works_mw, error_messages_mw, next_links_mw = (
             importer_mw.import_from_feed(feed, cutoff_date=cutoff)
         )
 
@@ -336,20 +336,30 @@ class TestOPDSImporter(OPDSImporterTest):
         # but pools and works weren't, because we passed the wrong data source
         # and we have no error messages, because correctly didn't even get to trying to create pools.
         #eq_(0, len(messages_meta_mw))
-        #eq_(0, len(imported_pools_mw))
-        #eq_(0, len(imported_works_mw))
+        eq_(0, len(imported_pools_mw))
+        eq_(0, len(imported_works_mw))
         # TODO: when do have error, have 3 error messages, when should have 2.
+
+        '''
+        import testing
+        testing.DatabaseTest.print_database_class(Session.object_session(self))
+        or
+        testing.DatabaseTest.print_database_class(Session.object_session(self))
+        '''
+        # TODO: assert that bibframe datasource from feed was correctly overwritten
+        # with data source I passed into the importer.
+
 
         set_trace()
         print "DOING G"
         # try again, with a license pool-acceptable data source
         importer_g = OPDSImporter(self._db, data_source_name=DataSource.GUTENBERG)
-        imported_editions_g, imported_pools_g, imported_works_g, messages_meta_g, messages_circ_g, next_links_g = (
+        imported_editions_g, imported_pools_g, imported_works_g, error_messages_g, next_links_g = (
             importer_g.import_from_feed(feed, cutoff_date=cutoff)
         )
 
-        set_trace()
         # we made new editions -- one for each data source
+        set_trace()
         eq_(2, len(imported_editions_g))
         # TODO: and we also created presentation editions, with author and title set
 
@@ -367,7 +377,7 @@ class TestOPDSImporter(OPDSImporterTest):
         path = os.path.join(self.resource_path, "content_server_mini.opds")
         feed = open(path).read()
         importer = OPDSImporter(self._db, data_source_name=DataSource.GUTENBERG)
-        imported_editions, imported_pools, imported_works, messages_meta, messages_circ, next_links = (
+        imported_editions, imported_pools, imported_works, error_messages, next_links = (
             importer.import_from_feed(feed, cutoff_date=cutoff)
         )
 
@@ -376,8 +386,9 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(2, len(imported_pools))
         eq_(2, len(imported_works))        
 
+        set_trace()
         # But if we try it again...
-        imported_editions, imported_pools, imported_works, messages_meta, messages_circ, next_links = (
+        imported_editions, imported_pools, imported_works, error_messages, next_links = (
             importer.import_from_feed(feed, cutoff_date=cutoff)
         )
 
@@ -391,7 +402,7 @@ class TestOPDSImporter(OPDSImporterTest):
         # TODO:  we've messed with the cutoff date in import_editions_from_metadata, 
         # and need to fix it before re-activating the assert.
         cutoff = datetime.datetime(2013, 1, 2, 16, 56, 40)
-        imported_editions, imported_pools, imported_works, messages_meta, messages_circ, next_links = (
+        imported_editions, imported_pools, imported_works, error_messages, next_links = (
             importer.import_from_feed(feed, cutoff_date=cutoff)
         )
 

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -237,6 +237,7 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(0.25, r3.value)
         eq_(1, r3.weight)
 
+
     def test_import(self):
         path = os.path.join(self.resource_path, "content_server_mini.opds")
         feed = open(path).read()
@@ -254,8 +255,7 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(None, crow.license_pool)
         eq_(Edition.BOOK_MEDIUM, crow.medium)
 
-        # But the 'mouse' book is known to come from Project Gutenberg,
-        # so a Work has been created for that book.
+        # not even the 'mouse'
         eq_(None, mouse.work)
         eq_(Edition.PERIODICAL_MEDIUM, mouse.medium)
 
@@ -313,8 +313,6 @@ class TestOPDSImporter(OPDSImporterTest):
         assert crow.license_pool.work is not None
         eq_(Edition.BOOK_MEDIUM, crow.medium)
 
-        # But the 'mouse' book is known to come from Project Gutenberg,
-        # so a Work has been created for that book.
         assert mouse.license_pool.work is not None
         eq_(Edition.PERIODICAL_MEDIUM, mouse.medium)
 
@@ -333,7 +331,7 @@ class TestOPDSImporter(OPDSImporterTest):
 
 
 
-    def test_import_with_wrangler_data_source(self):
+    def test_import_with_lendability(self):
         # Tests that will create Edition, LicensePool, and Work objects, when appropriate.
         # For example, on a Metadata_Wrangler data source, it is only appropriate to create 
         # editions, but not pools or works.  On a lendable data source, should create 
@@ -422,8 +420,7 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(2, len(imported_pools))
         eq_(2, len(imported_works))
 
-        # TODO: last_checked isn't getting set.  correct behavior or should fix?
-        #assert (datetime.datetime.utcnow() - imported_pools[0].last_checked) < datetime.timedelta(seconds=10)
+        assert (datetime.datetime.utcnow() - imported_pools[0].last_checked) < datetime.timedelta(seconds=10)
 
 
     def test_import_updates_metadata(self):
@@ -548,7 +545,7 @@ class TestOPDSImporter(OPDSImporterTest):
                     raise Exception("Utter failure!")
         path = os.path.join(self.resource_path, "content_server_mini.opds")
         feed = open(path).read()
-        #imported, messages, next_links = DoomedOPDSImporter(self._db).import_from_feed(feed)
+
         imported_editions, imported_pools, imported_works, error_messages, next_links = (
             DoomedOPDSImporter(self._db).import_from_feed(feed)
         )
@@ -666,7 +663,6 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
         eq_(4, len(s3.uploaded))
 
         # Each resource was 'mirrored' to an Amazon S3 bucket.
-        # The first resource has no bibframe provider in OPDS so it uses the importer's data source.
         url0 = u'http://s3.amazonaws.com/test.cover.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441/cover_10441_9.png'
         url1 = u'http://s3.amazonaws.com/test.cover.bucket/scaled/300/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441/cover_10441_9.png'
         url2 = 'http://s3.amazonaws.com/test.content.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441/The%20Green%20Mouse.epub.images'

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -589,6 +589,8 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(t1, i1.thumbnail)
         eq_(None, i2.thumbnail)
 
+
+
 class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
 
     def test_resources_are_mirrored_on_import(self):
@@ -624,17 +626,17 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
         imported_editions, imported_pools, imported_works, error_messages, next_links = (
             importer.import_from_feed(self.content_server_mini_feed)
         )
-        e1 = imported_editions[0]
-        e2 = imported_editions[1]
+        e1 = imported_editions[1]
+        e2 = imported_editions[0]
 
         # The import process requested each remote resource in the
         # order they appeared in the OPDS feed. The thumbnail
         # image was not requested, since we were going to make our own
         # thumbnail anyway.
         eq_(http.requests, [
-            'http://www.gutenberg.org/ebooks/10557.epub.images',
             'https://s3.amazonaws.com/book-covers.nypl.org/Gutenberg-Illustrated/10441/cover_10441_9.png', 
             'http://www.gutenberg.org/ebooks/10441.epub.images',
+            'http://www.gutenberg.org/ebooks/10557.epub.images',
         ])
 
         [e1_oa_link] = e1.primary_identifier.links
@@ -644,6 +646,7 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
 
         # The two open-access links were mirrored to S3, as was the
         # original SVG image and its PNG thumbnail.
+        set_trace()
         eq_(
             [e1_oa_link.resource.representation,
              e2_image_link.resource.representation,

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -54,9 +54,20 @@ class TestOverdriveRepresentationExtractor(object):
         eq_(expect, OverdriveRepresentationExtractor.link(raw, "first"))
 
 
+    def test_book_info_with_circulationdata(self):
+        # Tests that can convert an overdrive json block into a CirculationData object.
+
+        raw, info = self.sample_json("overdrive_availability_information.json")
+        circulationdata = OverdriveRepresentationExtractor.book_info_to_circulation(info)
+
+        # Related IDs.
+        eq_((Identifier.OVERDRIVE_ID, '2a005d55-a417-4053-b90d-7a38ca6d2065'),
+            (circulationdata.primary_identifier.type, circulationdata.primary_identifier.identifier))
+
+
+
     def test_book_info_with_metadata(self):
         # Tests that can convert an overdrive json block into a Metadata object.
-        # 
 
         raw, info = self.sample_json("overdrive_metadata.json")
         metadata = OverdriveRepresentationExtractor.book_info_to_metadata(info)
@@ -134,6 +145,7 @@ class TestOverdriveRepresentationExtractor(object):
         rating = [x for x in measurements
                   if x.quantity_measured==Measurement.RATING][0]
         eq_(1, rating.value)
+
 
     def test_book_info_with_sample(self):
         raw, info = self.sample_json("has_sample.json")

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -179,7 +179,6 @@ class TestOverdriveRepresentationExtractor(object):
             (circulationdata.primary_identifier.type, circulationdata.primary_identifier.identifier))
 
 
-
     def test_book_info_with_metadata(self):
         # Tests that can convert an overdrive json block into a Metadata object.
 
@@ -228,6 +227,14 @@ class TestOverdriveRepresentationExtractor(object):
             ],
             sorted(ids)
         )
+
+        # Available formats.      
+        [kindle, pdf] = sorted(metadata.circulation.formats, key=lambda x: x.content_type)        
+        eq_(DeliveryMechanism.KINDLE_CONTENT_TYPE, kindle.content_type)       
+        eq_(DeliveryMechanism.KINDLE_DRM, kindle.drm_scheme)      
+
+        eq_(Representation.PDF_MEDIA_TYPE, pdf.content_type)      
+        eq_(DeliveryMechanism.ADOBE_DRM, pdf.drm_scheme)
 
         # Links to various resources.
         shortd, image, longd = sorted(

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -53,7 +53,10 @@ class TestOverdriveRepresentationExtractor(object):
         expect = OverdriveAPI.make_link_safe("http://api.overdrive.com/v1/collections/collection-id/products?limit=300&offset=0&lastupdatetime=2014-04-28%2009:25:09&sort=popularity:desc&formats=ebook-epub-open,ebook-epub-adobe,ebook-pdf-adobe,ebook-pdf-open")
         eq_(expect, OverdriveRepresentationExtractor.link(raw, "first"))
 
+
     def test_book_info_with_metadata(self):
+        # Tests that can convert an overdrive json block into a Metadata object.
+        # 
 
         raw, info = self.sample_json("overdrive_metadata.json")
         metadata = OverdriveRepresentationExtractor.book_info_to_metadata(info)
@@ -100,14 +103,6 @@ class TestOverdriveRepresentationExtractor(object):
             ],
             sorted(ids)
         )
-
-        # Available formats.
-        [kindle, pdf] = sorted(metadata.formats, key=lambda x: x.content_type)
-        eq_(DeliveryMechanism.KINDLE_CONTENT_TYPE, kindle.content_type)
-        eq_(DeliveryMechanism.KINDLE_DRM, kindle.drm_scheme)
-
-        eq_(Representation.PDF_MEDIA_TYPE, pdf.content_type)
-        eq_(DeliveryMechanism.ADOBE_DRM, pdf.drm_scheme)
 
         # Links to various resources.
         shortd, image, longd = sorted(

--- a/threem.py
+++ b/threem.py
@@ -285,6 +285,10 @@ class ItemListParser(XMLParser):
             )
 
         medium = Edition.BOOK_MEDIUM
+        '''
+        TODO:  Do we need to also make a CirculationData so we can write the formats, 
+        or can we omit?
+        
         book_format = value("BookFormat")
         format = None
         if book_format == 'EPUB':
@@ -305,6 +309,7 @@ class ItemListParser(XMLParser):
             medium = Edition.AUDIO_MEDIUM
 
         formats = [format]
+        '''
 
         return Metadata(
             data_source=DataSource.THREEM,
@@ -318,7 +323,7 @@ class ItemListParser(XMLParser):
             identifiers=identifiers,
             subjects=subjects,
             contributors=contributors,
-            formats=formats,
+            #formats=formats,
             measurements=measurements,
             links=links,
         )

--- a/threem.py
+++ b/threem.py
@@ -32,6 +32,7 @@ from model import (
 
 from metadata_layer import (
     ContributorData,
+    CirculationData, 
     Metadata,
     LinkData,
     IdentifierData,
@@ -218,11 +219,14 @@ class ItemListParser(XMLParser):
             genres.append(SubjectData(Subject.THREEM, i, weight=15))
         return genres
 
+
     def process_one(self, tag, namespaces):
-        """Turn an <item> tag into a Metadata object."""
+        """Turn an <item> tag into a Metadata and a CirculationData objects, 
+        and return them as a tuple."""
 
         def value(threem_key):
             return self.text_of_optional_subtag(tag, threem_key)
+
         links = dict()
         identifiers = dict()
         subjects = []
@@ -285,10 +289,7 @@ class ItemListParser(XMLParser):
             )
 
         medium = Edition.BOOK_MEDIUM
-        '''
-        TODO:  Do we need to also make a CirculationData so we can write the formats, 
-        or can we omit?
-        
+
         book_format = value("BookFormat")
         format = None
         if book_format == 'EPUB':
@@ -309,9 +310,8 @@ class ItemListParser(XMLParser):
             medium = Edition.AUDIO_MEDIUM
 
         formats = [format]
-        '''
 
-        return Metadata(
+        metadata = Metadata(
             data_source=DataSource.THREEM,
             title=title,
             subtitle=subtitle,
@@ -323,11 +323,20 @@ class ItemListParser(XMLParser):
             identifiers=identifiers,
             subjects=subjects,
             contributors=contributors,
-            #formats=formats,
             measurements=measurements,
             links=links,
         )
 
+        # Also make a CirculationData so we can write the formats, 
+        circulationdata = CirculationData(
+            data_source=DataSource.THREEM,
+            primary_identifier=primary_identifier,
+            formats=formats,
+            links=links,
+        )
+
+        metadata.circulation = circulationdata
+        return metadata
 
 
 class ThreeMBibliographicCoverageProvider(BibliographicCoverageProvider):

--- a/threem.py
+++ b/threem.py
@@ -289,8 +289,8 @@ class ItemListParser(XMLParser):
 
 
     def process_one(self, tag, namespaces):
-        """Turn an <item> tag into a Metadata and a CirculationData objects, 
-        and return them as a tuple."""
+        """Turn an <item> tag into a Metadata and an encompassed CirculationData 
+        objects, and return the Metadata."""
 
         def value(threem_key):
             return self.text_of_optional_subtag(tag, threem_key)


### PR DESCRIPTION
This is Darya's branch to change the way we do OPDS imports. An OPDS import no longer edits the 'real' `Edition` obtained from the license source--it creates a new `Edition` representing the provider of the OPDS feed's view of certain `Identifier`s and `LicenseSource`s. As such, there is no need for `license_data_source`, which  keeps track of which one is the 'real' `Edition`.
