### PR TITLE
Dont store datasource in coverageprovider

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -63,10 +63,22 @@ class CoverageProvider(object):
         if not isinstance(input_identifier_types, list):
             input_identifier_types = [input_identifier_types]
         self.input_identifier_types = input_identifier_types
-        self.output_source = output_source
+        self.output_source_name = output_source.name
         self.workset_size = workset_size
         self.cutoff_time = cutoff_time
         self.operation = operation
+
+    @property
+    def output_source(self):
+        """Look up the DataSource object corresponding to the
+        service we're running this data through.
+
+        Out of an excess of caution, we look up the DataSource every
+        time, rather than storing it, in case a CoverageProvider is
+        ever used in an environment where the database session is
+        scoped (e.g. the circulation manager).
+        """
+        return DataSource.lookup(self._db, self.output_source_name)
 
     @property
     def log(self):

--- a/overdrive.py
+++ b/overdrive.py
@@ -81,6 +81,7 @@ class OverdriveAPI(object):
         self._db = _db
 
         # Set some stuff from environment variables
+        self.testing = testing
         if not testing:
             values = self.environment_values()
             if len([x for x in values if not x]):
@@ -758,12 +759,15 @@ class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
     """Fill in bibliographic metadata for Overdrive records."""
 
     def __init__(self, _db, input_identifier_types=None,
-                 metadata_replacement_policy=None, **kwargs):
+                 metadata_replacement_policy=None, overdrive_api=None,
+                 **kwargs
+    ):
+        overdrive_api = overdrive_api or OverdriveAPI(_db)
         # We ignore the value of input_identifier_types, but it's
         # passed in by RunCoverageProviderScript, so we accept it as
         # part of the signature.
         super(OverdriveBibliographicCoverageProvider, self).__init__(
-            _db, OverdriveAPI(_db), DataSource.OVERDRIVE,
+            _db, overdrive_api, DataSource.OVERDRIVE,
             workset_size=10, metadata_replacement_policy=metadata_replacement_policy, **kwargs
         )
 

--- a/threem.py
+++ b/threem.py
@@ -329,12 +329,15 @@ class ThreeMBibliographicCoverageProvider(BibliographicCoverageProvider):
     """
 
     def __init__(self, _db, input_identifier_types=None,
-                 metadata_replacement_policy=None, **kwargs):
+                 metadata_replacement_policy=None, threem_api=None,
+                 **kwargs
+    ):
         # We ignore the value of input_identifier_types, but it's
         # passed in by RunCoverageProviderScript, so we accept it as
         # part of the signature.
+        threem_api = threem_api or ThreeMAPI(_db)
         super(ThreeMBibliographicCoverageProvider, self).__init__(
-            _db, ThreeMAPI(_db), DataSource.THREEM,
+            _db, threem_api, DataSource.THREEM,
             workset_size=25, metadata_replacement_policy=metadata_replacement_policy, **kwargs
         )
 


### PR DESCRIPTION
This branch stops `CoverageProvider` from storing the `DataSource` object it's provided with. Instead, it stores `DataSource.name` and then looks up the `DataSource` object whenever necessary. This avoids problems where we're in a multithreaded environment with a scoped session and the `DataSource` is accessed outside of the session that created it. This is mainly a hypothetical worry at this point but I believe it does actually happen in the admin interface for the circulation manager.

This branch also allows you to pass in a custom OverdriveAPI (e.g. a DummyOverdriveAPI for use in testing) into the OverdriveBibliographicCoverageProvider constructor. Similarly for the ThreeMBibliographicCoverageProvider.

Both of these changes are used by https://github.com/NYPL-Simplified/circulation/pull/192
