### PR TITLE
Removed Edition.is_primary_for_work. (Fixes #242)

### DIFF
--- a/external_list.py
+++ b/external_list.py
@@ -102,7 +102,7 @@ class CustomListFromCSV(CSVMetadataImporter):
             # couldn't find a useful Identifier.
             self.log.info("Could not create edition for %s", metadata.title)
         else:
-            q = _db.query(Work).join(Work.primary_edition).filter(
+            q = _db.query(Work).join(Work.presentation_edition).filter(
                 Edition.permanent_work_id==e.permanent_work_id)
             if q.count() > 0:
                 self.log.info("Found matching work in collection for %s", 

--- a/files/materialized_view_works.sql
+++ b/files/materialized_view_works.sql
@@ -30,7 +30,7 @@ as
     licensepools.availability_time
 
    FROM works
-     JOIN editions ON editions.work_id = works.id AND editions.is_primary_for_work = true
+     JOIN editions ON editions.id = works.presentation_edition_id
      JOIN licensepools ON editions.data_source_id = licensepools.data_source_id AND editions.primary_identifier_id = licensepools.identifier_id
      JOIN datasources ON editions.data_source_id = datasources.id
      JOIN identifiers on editions.primary_identifier_id = identifiers.id

--- a/files/materialized_view_works_workgenres.sql
+++ b/files/materialized_view_works_workgenres.sql
@@ -32,7 +32,7 @@ as
     licensepools.id AS license_pool_id,
     licensepools.availability_time
    FROM works
-     JOIN editions ON editions.work_id = works.id AND editions.is_primary_for_work = true
+     JOIN editions ON editions.id = works.presentation_edition_id
      JOIN licensepools ON editions.data_source_id = licensepools.data_source_id AND editions.primary_identifier_id = licensepools.identifier_id
      JOIN datasources ON editions.data_source_id = datasources.id
      JOIN identifiers on editions.primary_identifier_id = identifiers.id

--- a/lane.py
+++ b/lane.py
@@ -872,17 +872,17 @@ class Lane(object):
         * Have an unsuppressed license pool.
         """
 
-        q = self._db.query(Work).join(Work.primary_edition)
+        q = self._db.query(Work).join(Work.presentation_edition)
         q = q.join(Work.license_pools).join(LicensePool.data_source).join(
             LicensePool.identifier
         )
         q = q.options(
             contains_eager(Work.license_pools),
-            contains_eager(Work.primary_edition),
+            contains_eager(Work.presentation_edition),
             contains_eager(Work.license_pools, LicensePool.data_source),
             contains_eager(Work.license_pools, LicensePool.presentation_edition),
             contains_eager(Work.license_pools, LicensePool.identifier),
-            defer(Work.primary_edition, Edition.extra),
+            defer(Work.presentation_edition, Edition.extra),
             defer(Work.license_pools, LicensePool.presentation_edition, Edition.extra),
         )
         q = self._defer_unused_opds_entry(q)

--- a/migration/20160517-remove-edition-is-primary-for-work.sql
+++ b/migration/20160517-remove-edition-is-primary-for-work.sql
@@ -1,0 +1,223 @@
+ALTER TABLE works ADD COLUMN presentation_edition_id integer;
+UPDATE works as w SET presentation_edition_id = e.id from editions as e where e.work_id = w.id and e.is_primary_for_work = true;
+ALTER TABLE editions DROP COLUMN work_id CASCADE;
+ALTER TABLE editions DROP COLUMN is_primary_for_work CASCADE;
+
+
+create materialized view mv_works_editions_datasources_identifiers
+as
+ SELECT 
+    distinct works.id AS works_id,
+    editions.id AS editions_id,
+    editions.data_source_id,
+    editions.primary_identifier_id,
+    editions.sort_title,
+    editions.permanent_work_id,
+    editions.sort_author,
+    editions.medium,
+    editions.language,
+    editions.cover_full_url,
+    editions.cover_thumbnail_url,
+    editions.open_access_download_url,
+    datasources.name,
+    identifiers.type,
+    identifiers.identifier,
+    works.audience,
+    works.target_age,
+    works.fiction,
+    works.quality,
+    works.rating,
+    works.popularity,
+    works.random,
+    works.last_update_time,
+    works.simple_opds_entry,
+    works.verbose_opds_entry,
+    licensepools.id AS license_pool_id,
+    licensepools.availability_time
+
+   FROM works
+     JOIN editions ON editions.id = works.presentation_edition_id
+     JOIN licensepools ON editions.data_source_id = licensepools.data_source_id AND editions.primary_identifier_id = licensepools.identifier_id
+     JOIN datasources ON editions.data_source_id = datasources.id
+     JOIN identifiers on editions.primary_identifier_id = identifiers.id
+  WHERE works.presentation_ready = true
+    AND works.simple_opds_entry IS NOT NULL
+  
+  ORDER BY editions.sort_title, editions.sort_author, licensepools.availability_time;
+
+-- Create a unique index so that searches can look up books by work ID.
+
+create unique index mv_works_editions_work_id on mv_works_editions_datasources_identifiers (works_id);
+
+-- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
+
+create index mv_works_editions_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id);
+
+-- Similarly, an index on everything, sorted by descending update time.
+
+create index mv_works_editions_by_modification on mv_works_editions_datasources_identifiers (last_update_time DESC, sort_author, sort_title, works_id);
+
+-- We need three versions of each index:
+--- One that orders by sort_author, sort_title, and works_id
+--- One that orders by sort_title, sort_author, and works_id
+--- One that orders by availability_time (descending!), sort_title, sort_author, and works_id
+
+-- English adult fiction
+
+create index mv_works_editions_english_adult_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_editions_english_adult_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_editions_english_adult_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+-- English adult nonfiction
+
+create index mv_works_editions_english_adult_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_editions_english_adult_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_editions_english_adult_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+-- Nonenglish adult fiction
+--- These are also ordered by language
+
+create index mv_works_editions_nonenglish_adult_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+-- Nonenglish adult nonfiction
+--- These are also ordered by language
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+-- YA/Children's fiction, regardless of language
+
+create index mv_works_editions_ya_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_editions_ya_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_editions_ya_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+-- YA/Children's nonfiction, regardless of language
+
+create index mv_works_editions_ya_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_editions_ya_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_editions_ya_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+
+
+create materialized view mv_works_editions_workgenres_datasources_identifiers
+as
+ SELECT 
+    works.id AS works_id,
+    editions.id AS editions_id,
+    editions.data_source_id,
+    editions.primary_identifier_id,
+    editions.sort_title,
+    editions.permanent_work_id,
+    editions.sort_author,
+    editions.medium,
+    editions.language,
+    editions.cover_full_url,
+    editions.cover_thumbnail_url,
+    editions.open_access_download_url,
+    datasources.name,
+    identifiers.type,
+    identifiers.identifier,
+    workgenres.id AS workgenres_id,
+    workgenres.genre_id,
+    workgenres.affinity,
+    works.audience,
+    works.target_age,
+    works.fiction,
+    works.quality,
+    works.rating,
+    works.popularity,
+    works.random,
+    works.last_update_time,
+    works.simple_opds_entry,
+    works.verbose_opds_entry,
+    licensepools.id AS license_pool_id,
+    licensepools.availability_time
+   FROM works
+     JOIN editions ON editions.id = works.presentation_edition_id
+     JOIN licensepools ON editions.data_source_id = licensepools.data_source_id AND editions.primary_identifier_id = licensepools.identifier_id
+     JOIN datasources ON editions.data_source_id = datasources.id
+     JOIN identifiers on editions.primary_identifier_id = identifiers.id
+     JOIN workgenres ON works.id = workgenres.work_id
+  WHERE works.presentation_ready = true AND works.simple_opds_entry IS NOT NULL
+  ORDER BY (editions.sort_title, editions.sort_author, licensepools.availability_time);
+
+-- Create a work/genre lookup.
+create unique index mv_works_genres_work_id_genre_id on mv_works_editions_workgenres_datasources_identifiers (works_id, genre_id);
+
+-- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
+
+create index mv_works_genres_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id);
+
+-- Similarly, an index on everything, sorted by descending update time.
+
+create index mv_works_genres_by_modification on mv_works_editions_workgenres_datasources_identifiers (last_update_time DESC, sort_author, sort_title, works_id);
+
+-- We need three versions of each index:
+--- One that orders by sort_author, sort_title, and works_id
+--- One that orders by sort_title, sort_author, and works_id
+--- One that orders by availability_time (descending!), sort_title, sort_author, and works_id
+
+-- English adult fiction
+
+create index mv_works_genres_english_adult_fiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_genres_english_adult_fiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_genres_english_adult_fiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+-- English adult nonfiction
+
+create index mv_works_genres_english_adult_nonfiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_genres_english_adult_nonfiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_genres_english_adult_nonfiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+-- Nonenglish adult fiction
+--- These are also ordered by language
+
+create index mv_works_genres_nonenglish_adult_fiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_fiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_fiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+-- Nonenglish adult nonfiction
+--- These are also ordered by language
+
+create index mv_works_genres_nonenglish_adult_nonfiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_nonfiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_nonfiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+-- YA/Children's fiction, regardless of language
+
+create index mv_works_genres_ya_fiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_genres_ya_fiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_genres_ya_fiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+-- YA/Children's nonfiction, regardless of language
+
+create index mv_works_genres_ya_nonfiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_genres_ya_nonfiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_genres_ya_nonfiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;

--- a/migration/20160517-remove-edition-is-primary-for-work.sql
+++ b/migration/20160517-remove-edition-is-primary-for-work.sql
@@ -1,4 +1,5 @@
 ALTER TABLE works ADD COLUMN presentation_edition_id integer;
+CREATE INDEX ix_works_presentation_edition_id on works USING btree (presentation_edition_id);
 UPDATE works as w SET presentation_edition_id = e.id from editions as e where e.work_id = w.id and e.is_primary_for_work = true;
 ALTER TABLE editions DROP COLUMN work_id CASCADE;
 ALTER TABLE editions DROP COLUMN is_primary_for_work CASCADE;

--- a/model.py
+++ b/model.py
@@ -2239,13 +2239,9 @@ class Edition(Base):
     primary_identifier_id = Column(
         Integer, ForeignKey('identifiers.id'), index=True)
 
-    # A Edition may be associated with a single Work.
-    work_id = Column(Integer, ForeignKey('works.id'), index=True)
+    # An Edition may be the presentation edition for a single Work.
+    work = relationship("Work", uselist=False, backref="presentation_edition")
  
-    # An Edition may be the primary edition associated with its
-    # Work, or it may not be.
-    is_primary_for_work = Column(Boolean, index=True, default=False)
-
     # An Edition may show up in many CustomListEntries.
     custom_list_entries = relationship("CustomListEntry", backref="edition")
 
@@ -2761,17 +2757,6 @@ class Edition(Base):
         if policy is None:
             policy = PresentationCalculationPolicy()
 
-        """
-        TODO: 
-        # first presentation edition of a non-suppressed, non-superceded licensepool
-        # but edition already has a work_id?
-        parent_work_license_pools = self.license_pool.work.license_pools
-
-        for (work in parent_works)
-        see if license pool is active,
-        if yes, set its work to mine and continue
-        """
-
         # Gather information up front that will be used to determine
         # whether this method actually did anything.
         old_author = self.author
@@ -2883,7 +2868,6 @@ class Edition(Base):
 
 
 Index("ix_editions_data_source_id_identifier_id", Edition.data_source_id, Edition.primary_identifier_id, unique=True)
-Index("ix_editions_work_id_is_primary_for_work_id", Edition.work_id, Edition.is_primary_for_work)
 
 class WorkGenre(Base):
     """An assignment of a genre to a work."""
@@ -2993,15 +2977,9 @@ class Work(Base):
     # One Work may have copies scattered across many LicensePools.
     license_pools = relationship("LicensePool", backref="work", lazy='joined')
 
-    # A single Work may claim many Editions.
-    editions = relationship("Edition", backref="work")
-
-    # A Work takes its presentation metadata from a single Edition.  
+    # A Work takes its presentation metadata from a single Edition.
     # But this Edition is a composite of provider, metadata wrangler, admin interface, etc.-derived Editions.
-    clause = "and_(Edition.work_id==Work.id, Edition.is_primary_for_work==True)"
-    primary_edition = relationship(
-        "Edition", primaryjoin=clause, uselist=False, lazy='joined'
-    )
+    presentation_edition_id = Column(Integer, ForeignKey('editions.id'), index=True)
 
     # One Work may have many asosciated WorkCoverageRecords.
     coverage_records = relationship("WorkCoverageRecord", backref="work")
@@ -3076,81 +3054,81 @@ class Work(Base):
 
     @property
     def title(self):
-        if self.primary_edition:
-            return self.primary_edition.title
+        if self.presentation_edition:
+            return self.presentation_edition.title
         return None
 
     @property
     def sort_title(self):
-        if not self.primary_edition:
+        if not self.presentation_edition:
             return None
-        return self.primary_edition.sort_title or self.primary_edition.title
+        return self.presentation_edition.sort_title or self.presentation_edition.title
 
     @property
     def subtitle(self):
-        if not self.primary_edition:
+        if not self.presentation_edition:
             return None
-        return self.primary_edition.subtitle
+        return self.presentation_edition.subtitle
 
     @property
     def series(self):
-        if not self.primary_edition:
+        if not self.presentation_edition:
             return None
-        return self.primary_edition.series
+        return self.presentation_edition.series
 
     @property
     def series_position(self):
-        if not self.primary_edition:
+        if not self.presentation_edition:
             return None
-        return self.primary_edition.series_position
+        return self.presentation_edition.series_position
 
     @property
     def author(self):
-        if self.primary_edition:
-            return self.primary_edition.author
+        if self.presentation_edition:
+            return self.presentation_edition.author
         return None
 
     @property
     def sort_author(self):
-        if not self.primary_edition:
+        if not self.presentation_edition:
             return None
-        return self.primary_edition.sort_author or self.primary_edition.author
+        return self.presentation_edition.sort_author or self.presentation_edition.author
 
     @property
     def language(self):
-        if self.primary_edition:
-            return self.primary_edition.language
+        if self.presentation_edition:
+            return self.presentation_edition.language
         return None
 
     @property
     def language_code(self):
-        if not self.primary_edition:
+        if not self.presentation_edition:
             return None
-        return self.primary_edition.language_code
+        return self.presentation_edition.language_code
 
     @property
     def publisher(self):
-        if not self.primary_edition:
+        if not self.presentation_edition:
             return None
-        return self.primary_edition.publisher
+        return self.presentation_edition.publisher
 
     @property
     def imprint(self):
-        if not self.primary_edition:
+        if not self.presentation_edition:
             return None
-        return self.primary_edition.imprint
+        return self.presentation_edition.imprint
 
     @property
     def cover_full_url(self):
-        if not self.primary_edition:
+        if not self.presentation_edition:
             return None
-        return self.primary_edition.cover_full_url
+        return self.presentation_edition.cover_full_url
 
     @property
     def cover_thumbnail_url(self):
-        if not self.primary_edition:
+        if not self.presentation_edition:
             return None
-        return self.primary_edition.cover_thumbnail_url
+        return self.presentation_edition.cover_thumbnail_url
 
     @property
     def target_age_string(self):
@@ -3169,9 +3147,9 @@ class Work(Base):
         return any(x.open_access for x in self.license_pools)
 
     def __repr__(self):
-        return (u'%s "%s" (%s) %s %s (%s wr, %s lp)' % (
+        return (u'%s "%s" (%s) %s %s (%s lp)' % (
                 self.id, self.title, self.author, ", ".join([g.name for g in self.genres]), self.language,
-                len(self.editions), len(self.license_pools))).encode("utf8")
+                len(self.license_pools))).encode("utf8")
 
     def set_summary(self, resource):
         self.summary = resource
@@ -3187,16 +3165,16 @@ class Work(Base):
     @classmethod
     def feed_query(cls, _db, languages, availability=CURRENTLY_AVAILABLE):
         """Return a query against Work suitable for using in OPDS feeds."""
-        q = _db.query(Work).join(Work.primary_edition)
+        q = _db.query(Work).join(Work.presentation_edition)
         q = q.join(Work.license_pools).join(LicensePool.data_source).join(LicensePool.identifier)
         q = q.options(
             contains_eager(Work.license_pools),
-            contains_eager(Work.primary_edition),
+            contains_eager(Work.presentation_edition),
             contains_eager(Work.license_pools, LicensePool.data_source),
             contains_eager(Work.license_pools, LicensePool.edition),
             contains_eager(Work.license_pools, LicensePool.identifier),
             defer(Work.verbose_opds_entry),
-            defer(Work.primary_edition, Edition.extra),
+            defer(Work.presentation_edition, Edition.extra),
             defer(Work.license_pools, LicensePool.edition, Edition.extra),
         )
         if availability == cls.CURRENTLY_AVAILABLE:
@@ -3237,7 +3215,7 @@ class Work(Base):
 
     def all_editions(self, recursion_level=5):
         """All Editions identified by a Identifier equivalent to 
-        any of the primary identifiers of this Work's Editions.
+        the primary identifiers of this Work's presentation edition.
 
         `recursion_level` controls how far to go when looking for equivalent
         Identifiers.
@@ -3250,12 +3228,9 @@ class Work(Base):
 
     def all_identifier_ids(self, recursion_level=5):
         _db = Session.object_session(self)
-        primary_identifier_ids = [
-            x.primary_identifier.id for x in self.editions
-            if x.primary_identifier
-        ]
+        primary_identifier_id = self.presentation_edition.primary_identifier.id
         identifier_ids = Identifier.recursively_equivalent_identifier_ids_flat(
-            _db, primary_identifier_ids, recursion_level)
+            _db, [primary_identifier_id], recursion_level)
         return identifier_ids
 
     @property
@@ -3270,10 +3245,9 @@ class Work(Base):
 
     def all_cover_images(self):
         _db = Session.object_session(self)
-        primary_identifier_ids = [
-            x.primary_identifier.id for x in self.editions]
+        primary_identifier_id = self.presentation_edition.primary_identifier.id
         data = Identifier.recursively_equivalent_identifier_ids(
-            _db, primary_identifier_ids, 5, threshold=0.5)
+            _db, [primary_identifier_id], 5, threshold=0.5)
         flattened_data = Identifier.flatten_identifier_ids(data)
         return Identifier.resources_for_identifier_ids(
             _db, flattened_data, Hyperlink.IMAGE).join(
@@ -3284,10 +3258,9 @@ class Work(Base):
 
     def all_descriptions(self):
         _db = Session.object_session(self)
-        primary_identifier_ids = [
-            x.primary_identifier.id for x in self.editions]
+        primary_identifier_id = self.presentation_edition.primary_identifier.id
         data = Identifier.recursively_equivalent_identifier_ids(
-            _db, primary_identifier_ids, 5, threshold=0.5)
+            _db, [primary_identifier_id], 5, threshold=0.5)
         flattened_data = Identifier.flatten_identifier_ids(data)
         return Identifier.resources_for_identifier_ids(
             _db, flattened_data, Hyperlink.DESCRIPTION).filter(
@@ -3295,48 +3268,30 @@ class Work(Base):
                 Resource.quality.desc())
 
 
-    def set_primary_edition(self, new_primary_edition):
-        """ Sets primary edition and lets owned pools and editions know.
+    def set_presentation_edition(self, new_presentation_edition):
+        """ Sets presentation edition and lets owned pools and editions know.
             Raises exception if edition to set to is None.
         """
         # only bother if something changed, or if were explicitly told to 
         # set (useful for setting to None)
-        if not new_primary_edition:
-            error_message = "Trying to set primary_edition to None on Work [%s]" % self.id
+        if not new_presentation_edition:
+            error_message = "Trying to set presentation_edition to None on Work [%s]" % self.id
             raise ValueError(error_message)
 
-        self.primary_edition = new_primary_edition
+        self.presentation_edition = new_presentation_edition
 
-        # go through the loser pools, and tell them they lost
-        for pool in self.license_pools:
-            if pool.presentation_edition is self.primary_edition:
-                # make sure edition knows it's primary
-                pool.presentation_edition.is_primary_for_work = True
-            else:
-                pool.mark_edition_primarity(primary_for_work_edition=None)
+        # Let the edition's license pool know it has a work.
+        if self.presentation_edition.is_presentation_for:
+            self.presentation_edition.is_presentation_for.work = self
 
-
-        # Tell child editions if they match work's primary edition.
-        for edition in self.editions:
-            if edition != self.primary_edition:
-                edition.is_primary_for_work = False
-            else:
-                edition.is_primary_for_work = True
-                # let the edition know it's attached to this work now
-                edition.work = self
-                # let the edition's pool know they have a work
-                if edition.is_presentation_for:
-                    edition.is_presentation_for.work = self
-
-
-    def calculate_primary_edition(self, policy=None):
+    def calculate_presentation_edition(self, policy=None):
         """ Which of this Work's Editions should be used as the default?
 
         First, every LicensePool associated with this work must have
         its presentation edition set.
 
         Then, we go through the pools, see which has the best presentation edition, 
-        and make it our primary.
+        and make it our presentation edition.
         """
         changed = False
         policy = policy or PresentationCalculationPolicy()
@@ -3344,14 +3299,14 @@ class Work(Base):
             return changed
 
         # For each owned edition, see if its LicensePool was superceded or suppressed
-        # if yes, the edition is unlikely to be primary.  
+        # if yes, the edition is unlikely to be the best.
         # An open access pool may be "superceded", if there's a better-quality 
         # open-access pool available.
         self.mark_licensepools_as_superceded()
 
         edition_metadata_changed = False
-        old_primary_edition = self.primary_edition
-        new_primary_edition = None
+        old_presentation_edition = self.presentation_edition
+        new_presentation_edition = None
 
         for pool in self.license_pools:
             # a superceded pool's composite edition is not good enough
@@ -3367,37 +3322,35 @@ class Work(Base):
                 edition_metadata_changed or
                 pool_edition_changed   
             )
-            potential_primary_edition = pool.presentation_edition
+            potential_presentation_edition = pool.presentation_edition
 
             # We currently have no real way to choose between
-            # competing primary editions. But it doesn't matter much
+            # competing presentation editions. But it doesn't matter much
             # because in the current system there should never be more
             # than one non-superceded license pool per Work.
             #
             # So basically we pick the first available edition and
-            # make it the primary.
-            if (not new_primary_edition
-                or (potential_primary_edition is old_primary_edition and old_primary_edition)):
-                # We would prefer not to change the Work's primary
-                # edition unnecessarily, so if the current primary
+            # make it the presentation edition.
+            if (not new_presentation_edition
+                or (potential_presentation_edition is old_presentation_edition and old_presentation_edition)):
+                # We would prefer not to change the Work's presentation
+                # edition unnecessarily, so if the current presentation
                 # edition is still an option, choose it.
-                new_primary_edition = potential_primary_edition
+                new_presentation_edition = potential_presentation_edition
 
         # Note: policy.choose_edition is true in default PresentationCalculationPolicy.
-        # If we don't have a self.primary_edition by now, this will just set all the editions' 
-        # is_primary_for_work attributes to False.
-        if ((self.primary_edition != new_primary_edition) and new_primary_edition != None):
+        if ((self.presentation_edition != new_presentation_edition) and new_presentation_edition != None):
             # did we find a pool whose presentation edition was better than the work's?
-            self.set_primary_edition(new_primary_edition)
+            self.set_presentation_edition(new_presentation_edition)
 
-        # tell everyone else we tried to set work's primary edition
+        # tell everyone else we tried to set work's presentation edition
         WorkCoverageRecord.add_for(
             self, operation=WorkCoverageRecord.CHOOSE_EDITION_OPERATION
         )
 
         changed = (
             edition_metadata_changed or
-            old_primary_edition != self.primary_edition 
+            old_presentation_edition != self.presentation_edition
         )
         return changed
 
@@ -3406,7 +3359,7 @@ class Work(Base):
     def calculate_presentation(self, policy=None, search_index_client=None):
         """Make a Work ready to show to patrons.
 
-        Call set_primary_edition() to find the best-quality presentation edition 
+        Call calculate_presentation_edition() to find the best-quality presentation edition 
         that could represent this work.
 
         Then determine the following information, global to the work:
@@ -3417,7 +3370,6 @@ class Work(Base):
         * The best available summary for the work.
         * The overall popularity of the work.
         """
-
         # Gather information up front so we can see if anything
         # actually changed.
         changed = False
@@ -3426,7 +3378,7 @@ class Work(Base):
 
         policy = policy or PresentationCalculationPolicy()
 
-        edition_changed = self.calculate_primary_edition(policy)
+        edition_changed = self.calculate_presentation_edition(policy)
 
         summary = self.summary
         summary_text = self.summary_text
@@ -3448,12 +3400,9 @@ class Work(Base):
             # classifications, or measurements.
             _db = Session.object_session(self)
 
-            primary_identifier_ids = [
-                x.primary_identifier.id for x in self.editions
-                if x.primary_identifier
-            ]
+            primary_identifier_id = self.presentation_edition.primary_identifier.id
             data = Identifier.recursively_equivalent_identifier_ids(
-                _db, primary_identifier_ids, 5, threshold=0.5
+                _db, [primary_identifier_id], 5, threshold=0.5
             )
             flattened_data = Identifier.flatten_identifier_ids(data)
         else:
@@ -3541,8 +3490,8 @@ class Work(Base):
         l.append(" language=%s" % self.language)
         l.append(" quality=%s" % self.quality)
 
-        if self.primary_edition and self.primary_edition.primary_identifier:
-            primary_identifier = self.primary_edition.primary_identifier
+        if self.presentation_edition and self.presentation_edition.primary_identifier:
+            primary_identifier = self.presentation_edition.primary_identifier
         else:
             primary_identifier=None
         l.append(" primary id=%s" % primary_identifier)
@@ -3646,7 +3595,7 @@ class Work(Base):
         and a fiction/nonfiction status. We don't need a cover or an
         author -- we can fill in that info later if it exists.
         """
-        if (not self.primary_edition
+        if (not self.presentation_edition
             or not self.license_pools
             or not self.title
             or not self.language
@@ -3771,7 +3720,7 @@ class Work(Base):
         """Generate a search document for this Work."""
 
         _db = Session.object_session(self)
-        if not self.primary_edition:
+        if not self.presentation_edition:
             return None
         doc = dict(_id=self.id,
                    title=self.title,
@@ -3781,10 +3730,10 @@ class Work(Base):
                    sort_title=self.sort_title, 
                    author=self.author,
                    sort_author=self.sort_author,
-                   medium=self.primary_edition.medium,
+                   medium=self.presentation_edition.medium,
                    publisher=self.publisher,
                    imprint=self.imprint,
-                   permanent_work_id=self.primary_edition.permanent_work_id,
+                   permanent_work_id=self.presentation_edition.permanent_work_id,
                    fiction= "Fiction" if self.fiction else "Nonfiction",
                    audience=self.audience.replace(" ", ""),
                    summary = self.summary_text,
@@ -3795,7 +3744,7 @@ class Work(Base):
 
         contribution_desc = []
         doc['contributors'] = contribution_desc
-        for contribution in self.primary_edition.contributions:
+        for contribution in self.presentation_edition.contributions:
             contributor = contribution.contributor
             contribution_desc.append(
                 dict(name=contributor.name, family_name=contributor.family_name,
@@ -3910,7 +3859,7 @@ class Work(Base):
 
     def classifications_with_genre(self):
         _db = Session.object_session(self)
-        identifier = self.primary_edition.primary_identifier
+        identifier = self.presentation_edition.primary_identifier
         return _db.query(Classification) \
                     .join(Subject) \
                     .filter(Classification.identifier_id == identifier.id) \
@@ -5280,33 +5229,17 @@ class LicensePool(Base):
 
             self.presentation_edition, edition_core_changed = metadata.apply(edition)
 
-        self.presentation_edition.work = self.work
         changed = changed or self.presentation_edition.calculate_presentation()
 
         # if the license pool is associated with a work, and the work currently has no presentation edition, 
-        # then do a courtesy call to the presentation edition and the work, and tell them about each other. 
-        if self.work and not self.work.primary_edition:
-            self.presentation_edition.is_primary_for_work = True
-            # tell work it has a primary edition now
-            self.work.set_primary_edition(self.presentation_edition)
+        # then do a courtesy call to the work, and tell it about the presentation edition.
+        if self.work and not self.work.presentation_edition:
+            self.work.set_presentation_edition(self.presentation_edition)
 
         return (
             self.presentation_edition != old_presentation_edition 
             or changed
         )
-
-
-    def mark_edition_primarity(self, primary_for_work_edition=None):
-        """Go through this pool's editions, and explicitly tell them  
-        whether they're primary for the pool's work.
-        """
-        all_editions = list(self.editions_in_priority_order())
-        for edition in all_editions:
-            if (primary_for_work_edition != None and (edition is primary_for_work_edition)):
-                edition.is_primary_for_work = True
-            else:
-                edition.is_primary_for_work = False
-
 
     def add_link(self, rel, href, data_source, media_type=None,
                  content=None, content_path=None):
@@ -5449,7 +5382,7 @@ class LicensePool(Base):
         """Try to find an existing Work for this LicensePool.
 
         If there are no Works for the permanent work ID associated
-        with this LicensePool's primary edition, create a new Work.
+        with this LicensePool's presentation edition, create a new Work.
 
         Pools that are not open-access will always have a new Work
         created for them.
@@ -5462,75 +5395,68 @@ class LicensePool(Base):
         """
         self.set_presentation_edition(None)
 
-        primary_edition = known_edition or self.presentation_edition
+        presentation_edition = known_edition or self.presentation_edition
 
         if self.work:
-            if primary_edition:
-                primary_edition.work = self.work
-            
             # The work has already been done. Make sure the work's
             # display is up to date.
             self.work.calculate_presentation()
             return self.work, False
 
 
-        logging.info("Calculating work for %r", primary_edition)
-        if not primary_edition:
+        logging.info("Calculating work for %r", presentation_edition)
+        if not presentation_edition:
             # We don't have any information about the identifier
             # associated with this LicensePool, so we can't create a work.
             logging.warn("NO EDITION for %s, cowardly refusing to create work.",
                      self.identifier)
             
             return None, False
-        if primary_edition.is_presentation_for != self:
+        if presentation_edition.is_presentation_for != self:
             raise ValueError(
-                "Primary edition's license pool is not the license pool for which work is being calculated!")
+                "Presentation edition's license pool is not the license pool for which work is being calculated!")
 
-        if not primary_edition.title or not primary_edition.author:
-            primary_edition.calculate_presentation()
+        if not presentation_edition.title or not presentation_edition.author:
+            presentation_edition.calculate_presentation()
 
-        if not primary_edition.title:
-            if primary_edition.work:
+        if not presentation_edition.title:
+            if presentation_edition.work:
                 logging.warn(
-                    "Edition %r has no title but has a Work assigned. This is troubling.", primary_edition
+                    "Edition %r has no title but has a Work assigned. This is troubling.", presentation_edition
                 )
-                return primary_edition.work, False
+                return presentation_edition.work, False
             else:
-                logging.info("Edition %r has no title, will not assign it a Work.", primary_edition)
+                logging.info("Edition %r has no title, will not assign it a Work.", presentation_edition)
                 return None, False
 
-        if (not primary_edition.work 
-            and primary_edition.author in (None, Edition.UNKNOWN_AUTHOR)
+        if (not presentation_edition.work
+            and presentation_edition.author in (None, Edition.UNKNOWN_AUTHOR)
             and not even_if_no_author
         ):
             logging.warn(
                 "Edition %r has no author, not assigning Work to Edition.", 
-                primary_edition
+                presentation_edition
             )
-            # msg = u"WARN: NO TITLE/AUTHOR for %s/%s/%s/%s, cowardly refusing to create work." % (
-            #    self.identifier.type, self.identifier.identifier,
-            #    primary_edition.title, primary_edition.author)
-            #print msg.encode("utf8")
             return None, False
 
-        primary_edition.calculate_permanent_work_id()
+        presentation_edition.calculate_permanent_work_id()
 
-        if primary_edition.work:
-            # This pool's primary edition is already associated with
+        if presentation_edition.work:
+            # This pool's presentation edition is already associated with
             # a Work. Use that Work.
-            work = primary_edition.work
+            work = presentation_edition.work
 
         else:
             _db = Session.object_session(self)
             work = None
-            if self.open_access and primary_edition.permanent_work_id:
+            if self.open_access and presentation_edition.permanent_work_id:
                 # Is there already an open-access Work which includes editions
                 # with this edition's permanent work ID?
                 q = _db.query(Edition).filter(
                     Edition.permanent_work_id
-                    ==primary_edition.permanent_work_id).filter(
+                    ==presentation_edition.permanent_work_id).filter(
                         Edition.work != None).filter(
-                            Edition.id != primary_edition.id)
+                            Edition.id != presentation_edition.id)
                 for edition in q:
                     if edition.work.has_open_access_license:
                         work = edition.work
@@ -5541,7 +5467,7 @@ class LicensePool(Base):
         else:
             # There is no better choice than creating a brand new Work.
             created = True
-            logging.info("NEW WORK for %s" % primary_edition.title)
+            logging.info("NEW WORK for %s" % presentation_edition.title)
             work = Work()
             _db = Session.object_session(self)
             _db.add(work)
@@ -5550,7 +5476,6 @@ class LicensePool(Base):
         # Associate this LicensePool and its Edition with the work we
         # chose or created.
         work.license_pools.append(self)
-        primary_edition.work = work
 
         # Recalculate the display information for the Work, since the
         # associated Editions have changed.

--- a/model.py
+++ b/model.py
@@ -2172,7 +2172,8 @@ class Edition(Base):
     primary_identifier_id = Column(
         Integer, ForeignKey('identifiers.id'), index=True)
 
-    # An Edition may be the presentation edition for a single Work.
+    # An Edition may be the presentation edition for a single Work. If it's not
+    # a presentation edition for a work, work will be None.
     work = relationship("Work", uselist=False, backref="presentation_edition")
  
     # An Edition may show up in many CustomListEntries.

--- a/monitor.py
+++ b/monitor.py
@@ -499,7 +499,7 @@ class PresentationReadyMonitor(WorkSweepMonitor):
         return max_id
 
     def prepare(self, work):
-        edition = work.primary_edition
+        edition = work.presentation_edition
         if not edition:
             work = work.calculate_presentation()
         identifier = edition.primary_identifier

--- a/opds.py
+++ b/opds.py
@@ -240,7 +240,7 @@ class Annotator(object):
 
     @classmethod
     def work_id(cls, work):
-        return work.primary_edition.primary_identifier.urn
+        return work.presentation_edition.primary_identifier.urn
 
     @classmethod
     def permalink_for(cls, work, license_pool, identifier):
@@ -294,8 +294,8 @@ class Annotator(object):
             
         if work.has_open_access_license:
             # All licenses are issued from the license pool associated with
-            # the work's primary edition.
-            edition = work.primary_edition
+            # the work's presentation edition.
+            edition = work.presentation_edition
 
             if (edition and edition.license_pool and
                 edition.open_access_download_url and edition.title):
@@ -701,7 +701,7 @@ class AcquisitionFeed(OPDSFeed):
     def single_entry(cls, _db, work, annotator, force_create=False):
         """Create a single-entry feed for one specific work."""
         feed = cls(_db, '', '', [], annotator=annotator)
-        if not isinstance(work, Edition) and not work.primary_edition:
+        if not isinstance(work, Edition) and not work.presentation_edition:
             return None
         return feed.create_entry(work, None, even_if_no_license_pool=True,
                                  force_create=force_create)
@@ -786,8 +786,8 @@ class AcquisitionFeed(OPDSFeed):
             elif active_license_pool:        
                 identifier = active_license_pool.identifier
                 active_edition = active_license_pool.presentation_edition
-            else:
-                active_edition = work.primary_edition
+            elif work.presentation_edition:
+                active_edition = work.presentation_edition
                 identifier = active_edition.primary_identifier
 
         # There's no reason to present a book that has no active license pool.
@@ -1208,7 +1208,7 @@ class LookupAcquisitionFeed(AcquisitionFeed):
             self.feed.append(entry)
             return None
 
-        edition = work.primary_edition
+        edition = work.presentation_edition
         return self._create_entry(
             work, active_license_pool, edition, identifier, lane_link
         )

--- a/opds_import.py
+++ b/opds_import.py
@@ -206,7 +206,6 @@ class OPDSImporter(object):
                          cutoff_date=None, 
                          immediately_presentation_ready=False):
         metadata_objs, messages, next_links = self.extract_metadata(feed)
-
         imported = []
         for metadata in metadata_objs:
             try:

--- a/scripts.py
+++ b/scripts.py
@@ -450,7 +450,7 @@ class WorkConsolidationScript(WorkProcessingScript):
                 self.clear_existing_works()
             LicensePool.consolidate_works(self._db, batch_size=self.batch_size)
 
-            qu = self._db.query(Work).filter(Work.primary_edition==None)
+            qu = self._db.query(Work).filter(Work.presentation_edition==None)
             self.log.info("Deleting %d Works that lack Editions." % qu.count())
             for i in qu:
                 self._db.delete(i)            

--- a/testing.py
+++ b/testing.py
@@ -229,7 +229,7 @@ class DatabaseTest(object):
     def _work(self, title=None, authors=None, genre=None, language=None,
               audience=None, fiction=True, with_license_pool=False, 
               with_open_access_download=False, quality=0.5,
-              primary_edition=None):
+              presentation_edition=None):
         pool = None
         if with_open_access_download:
             with_license_pool = True
@@ -245,9 +245,9 @@ class DatabaseTest(object):
         if fiction is None:
             fiction = True
         new_edition = False
-        if not primary_edition:
+        if not presentation_edition:
             new_edition = True
-            primary_edition = self._edition(
+            presentation_edition = self._edition(
                 title=title, language=language,
                 authors=authors,
                 with_license_pool=with_license_pool,
@@ -255,14 +255,14 @@ class DatabaseTest(object):
                 data_source_name=data_source_name
             )
             if with_license_pool:
-                primary_edition, pool = primary_edition
+                presentation_edition, pool = presentation_edition
         else:
-            pool = primary_edition.license_pool
+            pool = presentation_edition.license_pool
         if with_open_access_download:
             pool.open_access = True
-            primary_edition.set_open_access_link()
+            presentation_edition.set_open_access_link()
         if new_edition:
-            primary_edition.calculate_presentation()
+            presentation_edition.calculate_presentation()
         work, ignore = get_one_or_create(
             self._db, Work, create_method_kwargs=dict(
                 audience=audience,
@@ -274,10 +274,8 @@ class DatabaseTest(object):
             work.genres = [genre]
         work.random = 0.5
 
-        work.editions = [primary_edition]
-        primary_edition.is_primary_for_work = True
-
-        work.calculate_primary_edition()
+        work.set_presentation_edition(presentation_edition)
+        work.calculate_presentation_edition()
 
         if pool != None:
             # make sure the pool's presentation_edition is set, 
@@ -405,7 +403,7 @@ class DatabaseTest(object):
         for i in range(num_entries):
             if entries_exist_as_works:
                 work = self._work(with_open_access_download=True)
-                edition = work.editions[0]
+                edition = work.presentation_edition
             else:
                 edition = self._edition(
                     data_source_name, title="Item %s" % i)
@@ -455,10 +453,8 @@ class DatabaseTest(object):
         edition_gut.subtitle = u"The GUtenberg Subtitle"
         edition_gut.add_contributor(bob, Contributor.AUTHOR_ROLE)
 
-        work = self._work(primary_edition=edition_git)
+        work = self._work(presentation_edition=edition_git)
 
-        for ed in edition_gut, edition_std_ebooks:
-            work.editions.append(ed)
         for p in pool_gut, pool_std_ebooks:
             work.license_pools.append(p)
 
@@ -531,17 +527,12 @@ class DatabaseTest(object):
             # pipe character at end of line helps see whitespace issues
             print "Work[%s]=%s|" % (wCount, work)
 
-            if (not work.editions):
-                print "    NO Work.Edition found"
-            for weCount, edition in enumerate(work.editions):
-                print "    Work.Edition[%s]=%s|" % (weCount, edition)
-
             if (not work.license_pools):
                 print "    NO Work.LicensePool found"
             for lpCount, license_pool in enumerate(work.license_pools):
                 print "    Work.LicensePool[%s]=%s|" % (lpCount, license_pool)
 
-            print "    Work.primary_edition=%s|" % work.primary_edition
+            print "    Work.presentation_edition=%s|" % work.presentation_edition
 
         if (not identifiers):
             print "NO Identifier found"
@@ -567,7 +558,6 @@ class DatabaseTest(object):
             print "Edition[%s]=%s|" % (index, edition)
             print "    Edition.work_id=%s|" % edition.work_id
             print "    Edition.primary_identifier_id=%s|" % edition.primary_identifier_id
-            print "    Edition.is_primary_for_work=%s|" % edition.is_primary_for_work
             print "    Edition.permanent_work_id=%s|" % edition.permanent_work_id
             print "    Edition.author=%s|" % edition.author
             print "    Edition.title=%s|" % edition.title

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -75,7 +75,7 @@ class TestURNLookupController(DatabaseTest):
         code, message = self.controller.process_urn(identifier.urn)
         eq_(None, code)
         eq_(None, message)
-        eq_([(work.primary_edition.primary_identifier, work)], self.controller.works)
+        eq_([(work.presentation_edition.primary_identifier, work)], self.controller.works)
 
     def test_process_urn_work_is_not_presentation_ready(self):
         work = self._work(with_license_pool=True)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -708,7 +708,7 @@ class TestWorkClassifier(DatabaseTest):
     def setup(self):
         super(TestWorkClassifier, self).setup()
         self.work = self._work(with_license_pool=True)
-        self.identifier = self.work.primary_edition.primary_identifier
+        self.identifier = self.work.presentation_edition.primary_identifier
         self.classifier = WorkClassifier(self.work, test_session=self._db)
 
     def _genre(self, genre_data):
@@ -716,22 +716,22 @@ class TestWorkClassifier(DatabaseTest):
         return expected_genre
 
     def test_weight_metadata_title(self):
-        self.work.primary_edition.title = u"Star Trek: The Book"
+        self.work.presentation_edition.title = u"Star Trek: The Book"
         expected_genre = self._genre(classifier.Media_Tie_in_SF)
         self.classifier.weigh_metadata()
         eq_(100, self.classifier.genre_weights[expected_genre])
 
     def test_weight_metadata_publisher(self):
         # Genre publisher and imprint
-        self.work.primary_edition.publisher = u"Harlequin"
+        self.work.presentation_edition.publisher = u"Harlequin"
         expected_genre = self._genre(classifier.Romance)
         self.classifier.weigh_metadata()
         eq_(100, self.classifier.genre_weights[expected_genre])
 
     def test_weight_metadata_imprint(self):
         # Imprint is more specific than publisher, so it takes precedence.
-        self.work.primary_edition.publisher = u"Harlequin"
-        self.work.primary_edition.imprint = u"Harlequin Intrigue"
+        self.work.presentation_edition.publisher = u"Harlequin"
+        self.work.presentation_edition.imprint = u"Harlequin Intrigue"
         expected_genre = self._genre(classifier.Romantic_Suspense)
         general_romance = self._genre(classifier.Romance)
 
@@ -741,8 +741,8 @@ class TestWorkClassifier(DatabaseTest):
 
     def test_metadata_implies_audience_and_genre(self):
         # Genre and audience publisher 
-        self.work.primary_edition.publisher = u"Harlequin"
-        self.work.primary_edition.imprint = u"Harlequin Teen"
+        self.work.presentation_edition.publisher = u"Harlequin"
+        self.work.presentation_edition.imprint = u"Harlequin Teen"
         expected_genre = self._genre(classifier.Romance)
 
         self.classifier.weigh_metadata()
@@ -750,8 +750,8 @@ class TestWorkClassifier(DatabaseTest):
         eq_(100, self.classifier.audience_weights[Classifier.AUDIENCE_YOUNG_ADULT])
 
     def test_metadata_implies_fiction_status(self):
-        self.work.primary_edition.publisher = u"Harlequin"
-        self.work.primary_edition.imprint = u"Harlequin Nonfiction"
+        self.work.presentation_edition.publisher = u"Harlequin"
+        self.work.presentation_edition.imprint = u"Harlequin Nonfiction"
         self.classifier.weigh_metadata()
 
         eq_(100, self.classifier.fiction_weights[False])
@@ -760,14 +760,14 @@ class TestWorkClassifier(DatabaseTest):
     def test_publisher_excludes_adult_audience(self):
         # We don't know if this is a children's book or a young adult
         # book, but we're confident it's not a book for adults.
-        self.work.primary_edition.publisher = u"Scholastic Inc."
+        self.work.presentation_edition.publisher = u"Scholastic Inc."
 
         self.classifier.weigh_metadata()
         eq_(-100, self.classifier.audience_weights[Classifier.AUDIENCE_ADULT])
         eq_(-100, self.classifier.audience_weights[Classifier.AUDIENCE_ADULTS_ONLY])
 
     def test_imprint_excludes_adult_audience(self):
-        self.work.primary_edition.imprint = u"Delacorte Books for Young Readers"
+        self.work.presentation_edition.imprint = u"Delacorte Books for Young Readers"
 
         self.classifier.weigh_metadata()
         eq_(-100, self.classifier.audience_weights[Classifier.AUDIENCE_ADULT])
@@ -1045,7 +1045,7 @@ class TestWorkClassifier(DatabaseTest):
             data_source_name=source.name, with_license_pool=True,
             identifier_id=i.identifier
         )
-        self.classifier.work = self._work(primary_edition=overdrive_edition)
+        self.classifier.work = self._work(presentation_edition=overdrive_edition)
         for classification in i.classifications:
             self.classifier.add(classification)
         genres, fiction, audience, target_age = self.classifier.classify
@@ -1170,7 +1170,7 @@ class TestWorkClassifier(DatabaseTest):
         # do an overall test to verify that classify() returns a 4-tuple
         # (genres, fiction, audience, target_age)
 
-        self.work.primary_edition.title = u"Science Fiction: A Comprehensive History"
+        self.work.presentation_edition.title = u"Science Fiction: A Comprehensive History"
         i = self.identifier
         source = DataSource.lookup(self._db, DataSource.OVERDRIVE)
         c1 = i.classify(source, Subject.OVERDRIVE, u"History", weight=10)

--- a/tests/test_external_list.py
+++ b/tests/test_external_list.py
@@ -139,7 +139,6 @@ class TestCustomListFromCSV(DatabaseTest):
         row = self.create_row(display_author="Octavia Butler")
         work = self._work(title=row[self.l.title_field],
                           authors=['Butler, Octavia'])
-        work.editions[0].contributors[0].display_name
         self._db.commit()
         metadata = self.l.row_to_metadata(row)
         list_entry = self.l.metadata_to_list_entry(

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -51,17 +51,17 @@ class TestExternalSearch(DatabaseTest):
 
         if self.search:
             self.moby_dick = self._work(title="Moby Dick", authors="Herman Melville", fiction=True)
-            self.moby_dick.primary_edition.subtitle = "Or, the Whale"
-            self.moby_dick.primary_edition.series = "Classics"
+            self.moby_dick.presentation_edition.subtitle = "Or, the Whale"
+            self.moby_dick.presentation_edition.series = "Classics"
             self.moby_dick.summary_text = "Ishmael"
-            self.moby_dick.primary_edition.publisher = "Project Gutenberg"
+            self.moby_dick.presentation_edition.publisher = "Project Gutenberg"
             self.moby_dick.set_presentation_ready()
             self.moby_dick.update_external_index(self.search)
 
             self.moby_duck = self._work(title="Moby Duck", authors="Donovan Hohn", fiction=False)
-            self.moby_duck.primary_edition.subtitle = "The True Story of 28,800 Bath Toys Lost at Sea"
+            self.moby_duck.presentation_edition.subtitle = "The True Story of 28,800 Bath Toys Lost at Sea"
             self.moby_duck.summary_text = "A compulsively readable narrative"
-            self.moby_duck.primary_edition.publisher = "Penguin"
+            self.moby_duck.presentation_edition.publisher = "Penguin"
             self.moby_duck.set_presentation_ready()
             self.moby_duck.update_external_index(self.search)
 
@@ -70,7 +70,7 @@ class TestExternalSearch(DatabaseTest):
             self.title_match.update_external_index(self.search)
 
             self.subtitle_match = self._work()
-            self.subtitle_match.primary_edition.subtitle = "Match"
+            self.subtitle_match.presentation_edition.subtitle = "Match"
             self.subtitle_match.set_presentation_ready()
             self.subtitle_match.update_external_index(self.search)
 
@@ -80,7 +80,7 @@ class TestExternalSearch(DatabaseTest):
             self.summary_match.update_external_index(self.search)
         
             self.publisher_match = self._work()
-            self.publisher_match.primary_edition.publisher = "Match"
+            self.publisher_match.presentation_edition.publisher = "Match"
             self.publisher_match.set_presentation_ready()
             self.publisher_match.update_external_index(self.search)
 
@@ -93,7 +93,7 @@ class TestExternalSearch(DatabaseTest):
             self.tiffany.update_external_index(self.search)
             
             self.les_mis = self._work()
-            self.les_mis.primary_edition.title = u"Les Mis\u00E9rables"
+            self.les_mis.presentation_edition.title = u"Les Mis\u00E9rables"
             self.les_mis.set_presentation_ready()
             self.les_mis.update_external_index(self.search)
 
@@ -165,22 +165,22 @@ class TestExternalSearch(DatabaseTest):
             self.age_2_10.update_external_index(self.search)
 
             self.pride = self._work(title="Pride and Prejudice")
-            self.pride.primary_edition_medium = Edition.BOOK_MEDIUM
+            self.pride.presentation_edition.medium = Edition.BOOK_MEDIUM
             self.pride.set_presentation_ready()
             self.pride.update_external_index(self.search)
 
             self.pride_audio = self._work(title="Pride and Prejudice")
-            self.pride_audio.primary_edition.medium = Edition.AUDIO_MEDIUM
+            self.pride_audio.presentation_edition.medium = Edition.AUDIO_MEDIUM
             self.pride_audio.set_presentation_ready()
             self.pride_audio.update_external_index(self.search)
 
             self.sherlock = self._work(title="The Adventures of Sherlock Holmes")
-            self.sherlock.primary_edition.language = "en"
+            self.sherlock.presentation_edition.language = "en"
             self.sherlock.set_presentation_ready()
             self.sherlock.update_external_index(self.search)
 
             self.sherlock_spanish = self._work(title="Las Aventuras de Sherlock Holmes")
-            self.sherlock_spanish.primary_edition.language = "es"
+            self.sherlock_spanish.presentation_edition.language = "es"
             self.sherlock_spanish.set_presentation_ready()
             self.sherlock_spanish.update_external_index(self.search)
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -193,7 +193,7 @@ class TestFacetsApply(DatabaseTest):
         (licensed_e1, licensed_p1) = self._edition(
             data_source_name=DataSource.OVERDRIVE,
             with_license_pool=True)
-        licensed_high = self._work(primary_edition=licensed_e1)
+        licensed_high = self._work(presentation_edition=licensed_e1)
         licensed_high.license_pools.append(licensed_p1)
         licensed_high.quality = 0.8
         licensed_p1.open_access = False
@@ -206,14 +206,14 @@ class TestFacetsApply(DatabaseTest):
             data_source_name=DataSource.OVERDRIVE,
             with_license_pool=True)
         licensed_p2.open_access = False
-        licensed_low = self._work(primary_edition=licensed_e2)
+        licensed_low = self._work(presentation_edition=licensed_e2)
         licensed_low.license_pools.append(licensed_p2)
         licensed_low.quality = 0.2
         licensed_p2.licenses_owned = 1
         licensed_p2.licenses_available = 1
         licensed_low.random = 0.1
 
-        qu = self._db.query(Work).join(Work.primary_edition).join(
+        qu = self._db.query(Work).join(Work.presentation_edition).join(
             Work.license_pools
         )
         def facetify(collection=Facets.COLLECTION_FULL, 
@@ -594,7 +594,7 @@ class TestLanesQuery(DatabaseTest):
                 audience=Lane.AUDIENCE_YOUNG_ADULT,
                 fiction=fiction,
                 with_license_pool=True,
-                primary_edition=ya_edition,
+                presentation_edition=ya_edition,
                 genre=genre,
             )
             self.ya_works[genre] = ya_work
@@ -608,7 +608,7 @@ class TestLanesQuery(DatabaseTest):
                 audience=Lane.AUDIENCE_CHILDREN,
                 fiction=fiction,
                 with_license_pool=True,
-                primary_edition=childrens_edition,
+                presentation_edition=childrens_edition,
                 genre=genre,
             )
             if genre == self.epic_fantasy:
@@ -639,7 +639,7 @@ class TestLanesQuery(DatabaseTest):
             audience=Lane.AUDIENCE_ADULT,
             with_license_pool=True,
         )
-        self.music.primary_edition.medium=Edition.MUSIC_MEDIUM
+        self.music.presentation_edition.medium=Edition.MUSIC_MEDIUM
         self.music.simple_opds_entry = '<entry>'
 
         # Create a Spanish book.
@@ -695,7 +695,7 @@ class TestLanesQuery(DatabaseTest):
         lane = Lane(self._db, "Music", media=Edition.MUSIC_MEDIUM)
         w, mw = _assert_expectations(
             lane, 1, 
-            lambda x: x.primary_edition.medium==Edition.MUSIC_MEDIUM,
+            lambda x: x.presentation_edition.medium==Edition.MUSIC_MEDIUM,
             lambda x: x.medium==Edition.MUSIC_MEDIUM
         )
         
@@ -710,7 +710,7 @@ class TestLanesQuery(DatabaseTest):
         lane = Lane(self._db, "Nonfiction", fiction=False)
         w, mw = _assert_expectations(
             lane, 7, 
-            lambda x: x.primary_edition.medium==Edition.BOOK_MEDIUM and not x.fiction,
+            lambda x: x.presentation_edition.medium==Edition.BOOK_MEDIUM and not x.fiction,
             lambda x: x.medium==Edition.BOOK_MEDIUM and not x.fiction
         )
 
@@ -828,7 +828,7 @@ class TestLanesQuery(DatabaseTest):
             num_entries=0
         )
         best_seller_list_1.add_entry(
-            self.fiction.primary_edition, first_appearance=one_day_ago
+            self.fiction.presentation_edition, first_appearance=one_day_ago
         )
         
         nonfic_name = "Best Sellers - Nonfiction"
@@ -836,7 +836,7 @@ class TestLanesQuery(DatabaseTest):
             foreign_identifier=nonfic_name, name=nonfic_name, num_entries=0
         )
         best_seller_list_2.add_entry(
-            self.nonfiction.primary_edition, first_appearance=one_year_ago
+            self.nonfiction.presentation_edition, first_appearance=one_year_ago
         )
 
         # Create a lane for one specific list

--- a/tests/test_measurement.py
+++ b/tests/test_measurement.py
@@ -186,10 +186,10 @@ class TestMeasurement(DatabaseTest):
         eq_(0, Measurement.overall_quality([irrelevant]))
 
     def test_calculate_quality(self):
-        w = self._work()
+        w = self._work(with_open_access_download=True)
 
         # This book used to be incredibly popular.
-        identifier = w.primary_edition.primary_identifier
+        identifier = w.presentation_edition.primary_identifier
         old_popularity = identifier.add_measurement(
             self.source, Measurement.POPULARITY, 6000)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -692,16 +692,16 @@ class TestEdition(DatabaseTest):
 
         # Here's a Work that incorporates one of the Gutenberg records.
         work = Work()
-        work.editions.extend([gutenberg2])
+        work.set_presentation_edition(gutenberg2)
 
         # Its set-of-all-editions contains only one record.
         eq_(1, work.all_editions().count())
 
-        # If we add the other Gutenberg record to it, then its
-        # set-of-all-editions is extended by that record, *plus*
-        # all the Editions equivalent to that record.
-        work.editions.extend([gutenberg])
-        eq_(4, work.all_editions().count())
+        # If we change to the other Gutenberg record, then its
+        # set-of-all-editions is that record, *plus* all the 
+        # Editions equivalent to that record.
+        work.set_presentation_edition(gutenberg)
+        eq_(3, work.all_editions().count())
 
     def test_calculate_presentation_title(self):
         wr = self._edition(title="The Foo")
@@ -740,7 +740,7 @@ class TestEdition(DatabaseTest):
 
     def test_set_summary(self):
         e, pool = self._edition(with_license_pool=True)
-        work = self._work(primary_edition=e)
+        work = self._work(presentation_edition=e)
         overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
 
         # Set the work's summmary.
@@ -1207,27 +1207,6 @@ class TestLicensePool(DatabaseTest):
         eq_(edition_composite.subtitle, u"MetadataWranglerSubTitle1")
         license_pool = edition_composite.is_presentation_for
         eq_(license_pool, pool)
-        
-        # is_primary_for_work can only happen if the pool has a work associated with it.
-        # add a work, and re-call set_presentation_edition, and test the primarity.
-        work = self._work()
-        # default testing work object creates and sets a primary edition, and we want an clean slate
-        work.primary_edition = None
-
-        # we haven't set a primary yet
-        eq_(edition_mw.is_primary_for_work, False)
-        eq_(edition_od.is_primary_for_work, False)
-        eq_(edition_admin.is_primary_for_work, False)
-        eq_(edition_composite.is_primary_for_work, False)
-
-        work.license_pools.append(pool)
-        pool.set_presentation_edition()
-
-        eq_(edition_mw.is_primary_for_work, False)
-        eq_(edition_od.is_primary_for_work, False)
-        eq_(edition_admin.is_primary_for_work, False)
-        eq_(edition_composite.is_primary_for_work, True)
-
 
 
 class TestWork(DatabaseTest):
@@ -1237,8 +1216,8 @@ class TestWork(DatabaseTest):
         - work coverage records are made on work creation and primary edition selection.
         - work's presentation information (author, title, etc. fields) does a proper job 
           of combining fields from underlying editions.
-        - work's presentation information keeps in sync with work's primary edition.
-        - there can be only one edition that thinks it's the primary edition for this work.
+        - work's presentation information keeps in sync with work's presentation edition.
+        - there can be only one edition that thinks it's the presentation edition for this work.
         - time stamps are stamped.
         """
         gutenberg_source = DataSource.GUTENBERG
@@ -1269,11 +1248,9 @@ class TestWork(DatabaseTest):
         edition3.add_contributor(bob, Contributor.AUTHOR_ROLE)
         edition3.add_contributor(alice, Contributor.AUTHOR_ROLE)
 
-        work = self._work(primary_edition=edition2)
-        # add in 3, 2, 1 order to make sure the selection of edition1 as primary
+        work = self._work(presentation_edition=edition2)
+        # add in 3, 2, 1 order to make sure the selection of edition1 as presentation
         # in the second half of the test is based on business logic, not list order.
-        for i in edition3, edition1:
-            work.editions.append(i)
         for p in pool3, pool1:
             work.license_pools.append(p)
 
@@ -1301,13 +1278,13 @@ class TestWork(DatabaseTest):
         eq_(pool3.superceded, True)
 
         # sanity check
-        eq_(work.primary_edition, pool2.presentation_edition)
-        eq_(work.primary_edition, edition2)
+        eq_(work.presentation_edition, pool2.presentation_edition)
+        eq_(work.presentation_edition, edition2)
 
-        # editions know who's primary
-        eq_(edition1.is_primary_for_work, False)
-        eq_(edition2.is_primary_for_work, True)
-        eq_(edition3.is_primary_for_work, False)
+        # editions that aren't the presentation edition have no work
+        eq_(edition1.work, None)
+        eq_(edition2.work, work)
+        eq_(edition3.work, None)
 
         # The title of the Work is the title of its primary work record.
         eq_("The 2nd Title", work.title)
@@ -1345,8 +1322,6 @@ class TestWork(DatabaseTest):
         # Make sure that work's presentation edition and work's author, etc. 
         # fields are updated accordingly, and that the superceded pool's edition 
         # knows it's no longer the champ.
-        #for pool in work.license_pools:
-        #    if pool.presentation_edition is work.primary_edition:
         pool2.suppressed = True
         
         work.calculate_presentation(search_index_client=index)
@@ -1360,13 +1335,13 @@ class TestWork(DatabaseTest):
         eq_("Bitshifter, Bob", work.sort_author)
 
         # sanity check
-        eq_(work.primary_edition, pool1.presentation_edition)
-        eq_(work.primary_edition, edition1)
+        eq_(work.presentation_edition, pool1.presentation_edition)
+        eq_(work.presentation_edition, edition1)
 
-        # editions know who's primary
-        eq_(edition1.is_primary_for_work, True)
-        eq_(edition2.is_primary_for_work, False)
-        eq_(edition3.is_primary_for_work, False)
+        # editions that aren't the presentation edition have no work
+        eq_(edition1.work, work)
+        eq_(edition2.work, None)
+        eq_(edition3.work, None)
 
         # The last update time has been set.
         # Updating availability also modified work.last_update_time.
@@ -1376,7 +1351,7 @@ class TestWork(DatabaseTest):
 
     def test_set_presentation_ready(self):
         work = self._work(with_license_pool=True)
-        primary = work.primary_edition
+        presentation = work.presentation_edition
         work.set_presentation_ready_based_on_content()
         eq_(True, work.presentation_ready)
         
@@ -1385,11 +1360,11 @@ class TestWork(DatabaseTest):
 
         # Remove the title, and the work stops being presentation
         # ready.
-        primary.title = None
+        presentation.title = None
         work.set_presentation_ready_based_on_content()
         eq_(False, work.presentation_ready)        
 
-        primary.title = u"foo"
+        presentation.title = u"foo"
         work.set_presentation_ready_based_on_content()
         eq_(True, work.presentation_ready)        
 
@@ -1419,8 +1394,8 @@ class TestWork(DatabaseTest):
         eq_([(u'Romance', 0.25), (u'Science Fiction', 0.75)], after)
 
     def test_classifications_with_genre(self):
-        work = self._work()
-        identifier = work.primary_edition.primary_identifier
+        work = self._work(with_open_access_download=True)
+        identifier = work.presentation_edition.primary_identifier
         genres = self._db.query(Genre).all()
         subject1 = self._subject(type="type1", identifier="subject1")
         subject1.genre = genres[0]
@@ -1490,7 +1465,7 @@ class TestWork(DatabaseTest):
             data_source_name=DataSource.GUTENBERG, with_open_access_download=True
         )
 
-        work_multipool = self._work(primary_edition=None)
+        work_multipool = self._work(presentation_edition=None)
         work_multipool.license_pools.append(gutenberg1)
         work_multipool.license_pools.append(gitenberg2)
         work_multipool.license_pools.append(gitenberg1)
@@ -1535,19 +1510,19 @@ class TestWork(DatabaseTest):
         eq_(pool_gut.suppressed, False)
 
         # sanity check - we like standard ebooks and it got determined to be the best
-        eq_(work.primary_edition, pool_std_ebooks.presentation_edition)
-        eq_(work.primary_edition, edition_std_ebooks)
+        eq_(work.presentation_edition, pool_std_ebooks.presentation_edition)
+        eq_(work.presentation_edition, edition_std_ebooks)
 
-        # editions know who's primary
-        eq_(edition_std_ebooks.is_primary_for_work, True)
-        eq_(edition_git.is_primary_for_work, False)
-        eq_(edition_gut.is_primary_for_work, False)
+        # editions know who's the presentation edition
+        eq_(edition_std_ebooks.work, work)
+        eq_(edition_git.work, None)
+        eq_(edition_gut.work, None)
 
-        # The title of the Work is the title of its primary edition.
+        # The title of the Work is the title of its presentation edition.
         eq_("The Standard Ebooks Title", work.title)
         eq_("The Standard Ebooks Subtitle", work.subtitle)
 
-        # The author of the Work is the author of its primary edition.
+        # The author of the Work is the author of its presentation edition.
         eq_("Alice Adder", work.author)
         eq_("Adder, Alice", work.sort_author)
 
@@ -1560,19 +1535,19 @@ class TestWork(DatabaseTest):
         work.calculate_presentation()
 
         # standard ebooks was last viable pool, and it stayed as work's choice
-        eq_(work.primary_edition, pool_std_ebooks.presentation_edition)
-        eq_(work.primary_edition, edition_std_ebooks)
+        eq_(work.presentation_edition, pool_std_ebooks.presentation_edition)
+        eq_(work.presentation_edition, edition_std_ebooks)
 
-        # editions know who's primary
-        eq_(edition_std_ebooks.is_primary_for_work, True)
-        eq_(edition_git.is_primary_for_work, False)
-        eq_(edition_gut.is_primary_for_work, False)
+        # editions know who's the presentation edition
+        eq_(edition_std_ebooks.work, work)
+        eq_(edition_git.work, None)
+        eq_(edition_gut.work, None)
 
-        # The title of the Work is still the title of its last viable primary edition.
+        # The title of the Work is still the title of its last viable presentation edition.
         eq_("The Standard Ebooks Title", work.title)
         eq_("The Standard Ebooks Subtitle", work.subtitle)
 
-        # The author of the Work is still the author of its last viable primary edition.
+        # The author of the Work is still the author of its last viable presentation edition.
         eq_("Alice Adder", work.author)
         eq_("Adder, Alice", work.sort_author)
 
@@ -1580,9 +1555,9 @@ class TestWork(DatabaseTest):
 
 
     def test_work_updates_info_on_pool_suppressed(self):
-        """ If the provider of the work's primary edition gets suppressed, 
+        """ If the provider of the work's presentation edition gets suppressed, 
         the work will choose another child license pool's presentation edition as 
-        its primary edition.
+        its presentation edition.
         """
         (work, pool_std_ebooks, pool_git, pool_gut, 
             edition_std_ebooks, edition_git, edition_gut, alice, bob) = self._sample_ecosystem()
@@ -1593,19 +1568,19 @@ class TestWork(DatabaseTest):
         eq_(pool_gut.suppressed, False)
 
         # sanity check - we like standard ebooks and it got determined to be the best
-        eq_(work.primary_edition, pool_std_ebooks.presentation_edition)
-        eq_(work.primary_edition, edition_std_ebooks)
+        eq_(work.presentation_edition, pool_std_ebooks.presentation_edition)
+        eq_(work.presentation_edition, edition_std_ebooks)
 
-        # editions know who's primary
-        eq_(edition_std_ebooks.is_primary_for_work, True)
-        eq_(edition_git.is_primary_for_work, False)
-        eq_(edition_gut.is_primary_for_work, False)
+        # editions know who's the presentation edition
+        eq_(edition_std_ebooks.work, work)
+        eq_(edition_git.work, None)
+        eq_(edition_gut.work, None)
 
-        # The title of the Work is the title of its primary edition.
+        # The title of the Work is the title of its presentation edition.
         eq_("The Standard Ebooks Title", work.title)
         eq_("The Standard Ebooks Subtitle", work.subtitle)
 
-        # The author of the Work is the author of its primary edition.
+        # The author of the Work is the author of its presentation edition.
         eq_("Alice Adder", work.author)
         eq_("Adder, Alice", work.sort_author)
 
@@ -1616,19 +1591,19 @@ class TestWork(DatabaseTest):
         work.calculate_presentation()
 
         # gitenberg is next best and it got determined to be the best
-        eq_(work.primary_edition, pool_git.presentation_edition)
-        eq_(work.primary_edition, edition_git)
+        eq_(work.presentation_edition, pool_git.presentation_edition)
+        eq_(work.presentation_edition, edition_git)
 
-        # editions know who's primary
-        eq_(edition_std_ebooks.is_primary_for_work, False)
-        eq_(edition_git.is_primary_for_work, True)
-        eq_(edition_gut.is_primary_for_work, False)
+        # editions know who's the presentation edition
+        eq_(edition_std_ebooks.work, None)
+        eq_(edition_git.work, work)
+        eq_(edition_gut.work, None)
 
-        # The title of the Work is still the title of its last viable primary edition.
+        # The title of the Work is still the title of its last viable presentation edition.
         eq_("The GItenberg Title", work.title)
         eq_("The GItenberg Subtitle", work.subtitle)
 
-        # The author of the Work is still the author of its last viable primary edition.
+        # The author of the Work is still the author of its last viable presentation edition.
         eq_("Alice Adder, Bob Bitshifter", work.author)
         eq_("Adder, Alice ; Bitshifter, Bob", work.sort_author)
 
@@ -1793,7 +1768,7 @@ class TestWorkConsolidation(DatabaseTest):
     def test_calculate_work_success(self):
         e, p = self._edition(with_license_pool=True)
         work, new = p.calculate_work(even_if_no_author=True)
-        eq_(p.presentation_edition, work.primary_edition)
+        eq_(p.presentation_edition, work.presentation_edition)
         eq_(True, new)
 
     def test_calculate_work_bails_out_if_no_title(self):
@@ -1812,7 +1787,7 @@ class TestWorkConsolidation(DatabaseTest):
         # If we know that there simply is no author for this work,
         # we can pass in even_if_no_author=True
         work, new = p.calculate_work(even_if_no_author=True)
-        eq_(p.presentation_edition, work.primary_edition)
+        eq_(p.presentation_edition, work.presentation_edition)
         eq_(True, new)
 
 
@@ -1829,16 +1804,13 @@ class TestWorkConsolidation(DatabaseTest):
         eq_(created, True)
 
         # Calling calculate_work() on the second edition associated
-        # the second edition with the first work.
+        # the second edition's pool with the first work.
         work2, created = edition2.license_pool.calculate_work()
         eq_(created, False)
 
         eq_(work1, work2)
 
-        eq_(set([edition1, edition2]), set(work1.editions))
-
-        # Note that this works even though the Edition somehow got a
-        # Work without having a title or author.
+        eq_(set([edition1.license_pool, edition2.license_pool]), set(work1.license_pools))
 
 
     def test_calculate_work_for_licensepool_creates_new_work(self):
@@ -1847,7 +1819,7 @@ class TestWorkConsolidation(DatabaseTest):
 
         # This edition is unique to the existing work.
         preexisting_work = Work()
-        preexisting_work.editions = [edition1]
+        preexisting_work.set_presentation_edition(edition1)
 
         # This edition is unique to the new LicensePool
         edition2, pool = self._edition(data_source_name=DataSource.GUTENBERG, identifier_type=Identifier.GUTENBERG_ID, 
@@ -1877,18 +1849,17 @@ class TestWorkConsolidation(DatabaseTest):
         work, created = pool.calculate_work()
         eq_(True, created)
 
-        # Even before the forthcoming commit, the edition is clearly
-        # associated with the work.
+        # Even before the forthcoming commit, the edition is the
+        # work's presentation edition.
         eq_(work, edition.work)
-        eq_(True, edition.is_primary_for_work)
-        eq_(edition, work.primary_edition)
+        eq_(edition, work.presentation_edition)
 
-        # But without this commit, the join for the .primary_edition
+        # But without this commit, the join for the .presentation_edition
         # won't succeed and work.title won't work.
         self._db.commit()
 
         # Ta-da!
-        eq_(edition, work.primary_edition)
+        eq_(edition, work.presentation_edition)
         eq_(u"foo", work.title)
         eq_(u"bar", work.author)
 
@@ -1904,7 +1875,7 @@ class TestWorkConsolidation(DatabaseTest):
         work, created = pool.calculate_work(even_if_no_author=True)
         eq_(True, created)
         self._db.commit()
-        eq_(edition, work.primary_edition)
+        eq_(edition, work.presentation_edition)
         eq_(u"foo", work.title)
         eq_(Edition.UNKNOWN_AUTHOR, work.author)
 
@@ -1936,8 +1907,7 @@ class TestWorkConsolidation(DatabaseTest):
         for make_equivalent in edition3, edition1:
             edition4.primary_identifier.equivalent_to(
                 data_source, make_equivalent.primary_identifier, 1)
-        preexisting_work = self._work(primary_edition=edition1)
-        preexisting_work.editions.append(edition2)
+        preexisting_work = self._work(presentation_edition=edition1)
 
         pool, ignore = LicensePool.for_foreign_id(
             self._db, DataSource.GUTENBERG, Identifier.GUTENBERG_ID, "4")
@@ -1955,10 +1925,10 @@ class TestWorkConsolidation(DatabaseTest):
         ed2, open2 = self._edition(title=title, authors=author, with_license_pool=True)
         ed3, restricted3 = self._edition(
             title=title, authors=author, data_source_name=DataSource.OVERDRIVE,
-        with_license_pool=True)
+            with_license_pool=True)
         ed4, restricted4 = self._edition(
             title=title, authors=author, data_source_name=DataSource.OVERDRIVE,
-        with_license_pool=True)
+            with_license_pool=True)
 
         restricted3.open_access = False
         restricted4.open_access = False

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1855,16 +1855,8 @@ class TestWorkConsolidation(DatabaseTest):
         work, created = pool.calculate_work()
         eq_(True, created)
 
-        # Even before the forthcoming commit, the edition is the
-        # work's presentation edition.
+        # The edition is the work's presentation edition.
         eq_(work, edition.work)
-        eq_(edition, work.presentation_edition)
-
-        # But without this commit, the join for the .presentation_edition
-        # won't succeed and work.title won't work.
-        self._db.commit()
-
-        # Ta-da!
         eq_(edition, work.presentation_edition)
         eq_(u"foo", work.title)
         eq_(u"bar", work.author)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -133,7 +133,7 @@ class TestPresentationReadyMonitor(DatabaseTest):
         eq_([], result)
 
         # The monitor that takes Gutenberg identifiers as input ran.
-        eq_([self.work.primary_edition.primary_identifier], gutenberg_monitor.attempts)
+        eq_([self.work.presentation_edition.primary_identifier], gutenberg_monitor.attempts)
 
         # The monitor that takes OCLC editions as input did not.
         # (If it had, it would have failed.)

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -139,8 +139,8 @@ class TestAnnotatorWithGroup(TestAnnotator):
 class TestAnnotators(DatabaseTest):
 
     def test_all_subjects(self):
-        work = self._work(genre="Fiction")
-        edition = work.primary_edition
+        work = self._work(genre="Fiction", with_open_access_download=True)
+        edition = work.presentation_edition
         identifier = edition.primary_identifier
         source1 = DataSource.lookup(self._db, DataSource.GUTENBERG)
         source2 = DataSource.lookup(self._db, DataSource.OCLC)
@@ -216,24 +216,24 @@ class TestAnnotators(DatabaseTest):
         assert "<schema:sameas>http://id.loc.gov/authorities/names/n100</"
 
         work = self._work(authors=[], with_license_pool=True)
-        work.primary_edition.add_contributor(c, Contributor.PRIMARY_AUTHOR_ROLE)
+        work.presentation_edition.add_contributor(c, Contributor.PRIMARY_AUTHOR_ROLE)
 
         [same_tag] = VerboseAnnotator.authors(
-            work, work.license_pools[0], work.primary_edition,
-            work.primary_edition.primary_identifier)
+            work, work.license_pools[0], work.presentation_edition,
+            work.presentation_edition.primary_identifier)
         eq_(tag_string, etree.tostring(same_tag))
 
     def test_verbose_annotator_mentions_every_author(self):
         work = self._work(authors=[], with_license_pool=True)
-        work.primary_edition.add_contributor(
+        work.presentation_edition.add_contributor(
             self._contributor()[0], Contributor.PRIMARY_AUTHOR_ROLE)
-        work.primary_edition.add_contributor(
+        work.presentation_edition.add_contributor(
             self._contributor()[0], Contributor.AUTHOR_ROLE)
-        work.primary_edition.add_contributor(
+        work.presentation_edition.add_contributor(
             self._contributor()[0], "Illustrator")
         eq_(2, len(VerboseAnnotator.authors(
-            work, work.license_pools[0], work.primary_edition,
-            work.primary_edition.primary_identifier)))
+            work, work.license_pools[0], work.presentation_edition,
+            work.presentation_edition.primary_identifier)))
 
     def test_ratings(self):
         work = self._work(
@@ -369,7 +369,7 @@ class TestOPDS(DatabaseTest):
         u = unicode(feed)
         parsed = feedparser.parse(u)
         entry = parsed['entries'][0]
-        eq_(work.primary_edition.permanent_work_id, 
+        eq_(work.presentation_edition.permanent_work_id, 
             entry['simplified_pwid'])
 
     def test_lane_feed_contains_facet_links(self):
@@ -435,14 +435,14 @@ class TestOPDS(DatabaseTest):
         # This work has both issued and published. issued will be used
         # for the dc:created tag.
         work1 = self._work(with_open_access_download=True)
-        work1.primary_edition.issued = today
-        work1.primary_edition.published = the_past
+        work1.presentation_edition.issued = today
+        work1.presentation_edition.published = the_past
         work1.license_pools[0].availability_time = the_distant_past
 
         # This work only has published. published will be used for the
         # dc:created tag.
         work2 = self._work(with_open_access_download=True)
-        work2.primary_edition.published = the_past
+        work2.presentation_edition.published = the_past
         work2.license_pools[0].availability_time = the_distant_past
 
         # This work has neither published nor issued. There will be no
@@ -453,8 +453,8 @@ class TestOPDS(DatabaseTest):
         # This work is issued in the future. Since this makes no
         # sense, there will be no dc:issued tag.
         work4 = self._work(with_open_access_download=True)
-        work4.primary_edition.issued = the_future
-        work4.primary_edition.published = the_future
+        work4.presentation_edition.issued = the_future
+        work4.presentation_edition.published = the_future
         work4.license_pools[0].availability_time = None
 
         for w in work1, work2, work3, work4:
@@ -483,9 +483,9 @@ class TestOPDS(DatabaseTest):
 
     def test_acquisition_feed_includes_language_tag(self):
         work = self._work(with_open_access_download=True)
-        work.primary_edition.publisher = "The Publisher"
+        work.presentation_edition.publisher = "The Publisher"
         work2 = self._work(with_open_access_download=True)
-        work2.primary_edition.publisher = None
+        work2.presentation_edition.publisher = None
 
         self._db.commit()
         for w in work, work2:
@@ -648,8 +648,8 @@ class TestOPDS(DatabaseTest):
         lane=self.lanes.by_languages['']['Fantasy']
         work = self._work(genre=Fantasy, language="eng",
                           with_open_access_download=True)
-        work.primary_edition.cover_thumbnail_url = "http://thumbnail/b"
-        work.primary_edition.cover_full_url = "http://full/a"
+        work.presentation_edition.cover_thumbnail_url = "http://thumbnail/b"
+        work.presentation_edition.cover_full_url = "http://full/a"
 
         with temp_config() as config:
             config['integrations'][Configuration.CDN_INTEGRATION] = {}
@@ -662,8 +662,8 @@ class TestOPDS(DatabaseTest):
     def test_acquisition_feed_image_links_respect_cdn(self):
         work = self._work(genre=Fantasy, language="eng",
                           with_open_access_download=True)
-        work.primary_edition.cover_thumbnail_url = "http://thumbnail/b"
-        work.primary_edition.cover_full_url = "http://full/a"
+        work.presentation_edition.cover_thumbnail_url = "http://thumbnail/b"
+        work.presentation_edition.cover_full_url = "http://full/a"
 
         with temp_config() as config:
             config['integrations'][Configuration.CDN_INTEGRATION] = {}

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -246,7 +246,7 @@ class TestOPDSImporter(OPDSImporterTest):
 
         # But the 'mouse' book is known to come from Project Gutenberg,
         # so a Work has been created for that book.
-        assert mouse.work is not None
+        assert mouse.license_pool.work is not None
         eq_(Edition.PERIODICAL_MEDIUM, mouse.medium)
 
         popularity, quality, rating = sorted(
@@ -286,7 +286,7 @@ class TestOPDSImporter(OPDSImporterTest):
         classifier = Classifier.classifiers.get(seven.subject.type, None)
         classifier.classify(seven.subject)
 
-        work = mouse.work
+        work = mouse.license_pool.work
         work.calculate_presentation()
         eq_(0.4142, round(work.quality, 4))
         eq_(Classifier.AUDIENCE_CHILDREN, work.audience)
@@ -350,7 +350,7 @@ class TestOPDSImporter(OPDSImporterTest):
             with_license_pool=True
         )
         edition.license_pool.calculate_work()
-        old_work = edition.work
+        work = edition.license_pool.work
 
         old_license_pool = edition.license_pool
         feed = feed.replace("{OVERDRIVE ID}", edition.primary_identifier.identifier)
@@ -360,9 +360,9 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(imported, edition)
         eq_("The Green Mouse", imported.title)
 
-        # But the work and license pools have not changed.
+        # But the license pools have not changed.
         eq_(edition.license_pool, old_license_pool)
-        eq_(edition.work.license_pools, [old_license_pool])
+        eq_(work.license_pools, [old_license_pool])
 
     def test_import_from_license_source(self):
         # Instead of importing this data as though it came from the
@@ -378,10 +378,10 @@ class TestOPDSImporter(OPDSImporterTest):
         [crow, mouse] = sorted(imported, key=lambda x: x.title)
 
         # Because the content server actually tells you how to get a
-        # copy of the 'mouse' book, a work and licensepool has been
+        # copy of the 'mouse' book, a work and licensepool have been
         # created for it.
-        assert mouse.work != None
         assert mouse.license_pool != None
+        assert mouse.license_pool.work != None
 
         # The OPDS importer knows that the content server aggregates
         # books from elsewhere, so the data source for the 'mouse'
@@ -398,7 +398,7 @@ class TestOPDSImporter(OPDSImporterTest):
         # The 'mouse' work has not been marked presentation-ready,
         # because the OPDS importer was not told to make works
         # presentation-ready as they're imported.
-        eq_(False, mouse.work.presentation_ready)
+        eq_(False, mouse.license_pool.work.presentation_ready)
 
         # The OPDS feed didn't actually say where the 'crow' book
         # comes from, so no Work or LicensePool have been created for
@@ -427,7 +427,7 @@ class TestOPDSImporter(OPDSImporterTest):
         
         # But the 'mouse' book has had a presentation-ready work
         # created for it.
-        eq_(True, mouse.work.presentation_ready)
+        eq_(True, mouse.license_pool.work.presentation_ready)
 
     def test_status_and_message(self):
         path = os.path.join(self.resource_path, "unrecognized_identifier.opds")

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -111,7 +111,7 @@ class TestWorkProcessingScript(DatabaseTest):
             identifier_type=Identifier.OVERDRIVE_ID,
             with_license_pool=True
         )
-        overdrive_work = self._work(primary_edition=overdrive_edition)
+        overdrive_work = self._work(presentation_edition=overdrive_edition)
 
         everything = WorkProcessingScript.make_query(self._db, None, None)
         eq_(set([g1, g2, overdrive_work]), set(everything.all()))


### PR DESCRIPTION
Instead of multiple Editions sharing a work id, Work now has a presentation edition id, and only one edition is directly associated with a work. This matches how license pools are linked to their presentation editions.