### PR TITLE
Find the main library simplified directory dynamically

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -19,10 +19,11 @@ pidfile=$piddir/$SCRIPT
 logdir=/var/log/libsimple
 logfile=$logdir/$SCRIPT
 
-# Assume the path to the Library Simplified directory is
-# /var/www/circulation unless it's been set as an environment variable
+# Assume this run file is the Library Simplified directory/core/bin
+# unless the Library Simplified directory has been set as an environment
+# variable $LIBSIMPLE_DIR
 if [ -z "$LIBSIMPLE_DIR" ]; then
-  LIBSIMPLE_DIR=/var/www/circulation
+  LIBSIMPLE_DIR=$(dirname $(dirname $(dirname $0)))
 fi
 
 create_dir () {


### PR DESCRIPTION
Because this script came from our circulation-docker, this directory in the code was hardcoded up until now as /var/www/circulation. Now that `run` is in core/bin, we know we can find the main directory if we shed the filename and go up two levels.

I've tested this on the BPL server, and it's working great. Just trust me. It's fine. 😉👌 