### PR TITLE
Don't add breadcrumbs to a feed with no visible parent.

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -655,7 +655,7 @@ class AcquisitionFeed(OPDSFeed):
         if visible_parent:
             up_uri = annotator.lane_url(visible_parent)
             feed.add_link(href=up_uri, rel="up", title=title)
-        feed.add_breadcrumbs(lane, annotator)
+            feed.add_breadcrumbs(lane, annotator)
 
         feed.add_link(rel='start', href=annotator.default_lane_url(), title=top_level_title)
         


### PR DESCRIPTION
This fixes the content server, which has page feeds with no parent or ancestors, and doesn't have an implementation of lane_url in its annotator.

I don't think we'd ever have a lane with ancestors but no visible parent.