### PR TITLE
Admin classifier fix

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -3827,7 +3827,7 @@ class SimplifiedGenreClassifier(Classifier):
 
     @classmethod
     def is_fiction(cls, identifier, name):
-        if not globals()["genres"][identifier.original]:
+        if not globals()["genres"].get(identifier.original):
             return None
         return globals()["genres"][identifier.original].is_fiction
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -27,7 +27,13 @@ from classifier import (
     InterestLevelClassifier,
     Axis360AudienceClassifier,
     WorkClassifier,
+    fiction_genres,
+    nonfiction_genres,
+    GenreData
     )
+
+genres = dict()
+GenreData.populate(globals(), genres, fiction_genres, nonfiction_genres)
 
 class TestClassifier(object):
 
@@ -716,6 +722,35 @@ class TestSimplifiedGenreClassifier(object):
         sf2 = SimplifiedGenreClassifier.scrub_identifier("Science Fiction")
         eq_(sf1, sf2)
         eq_("Science Fiction", sf1.original)
+
+    def test_genre(self):
+        genre_name = "Space Opera"
+        scrubbed = SimplifiedGenreClassifier.scrub_identifier(genre_name)
+
+        genre = SimplifiedGenreClassifier.genre(scrubbed, genre_name, fiction=True)
+        eq_(genre.name, globals()["genres"][genre_name].name)
+
+        genre = SimplifiedGenreClassifier.genre(scrubbed, genre_name)
+        eq_(genre.name, globals()["genres"][genre_name].name)
+
+        genre = SimplifiedGenreClassifier.genre(scrubbed, genre_name, fiction=False)
+        eq_(genre, None)
+
+    def test_is_fiction(self):
+        genre_name = "Space Opera"
+        scrubbed = SimplifiedGenreClassifier.scrub_identifier(genre_name)
+        is_fiction = SimplifiedGenreClassifier.is_fiction(scrubbed, genre_name)
+        eq_(is_fiction, True)
+
+        genre_name = "Cooking"
+        scrubbed = SimplifiedGenreClassifier.scrub_identifier(genre_name)
+        is_fiction = SimplifiedGenreClassifier.is_fiction(scrubbed, genre_name)
+        eq_(is_fiction, False)
+
+        genre_name = "Fake Genre"
+        scrubbed = SimplifiedGenreClassifier.scrub_identifier(genre_name)
+        is_fiction = SimplifiedGenreClassifier.is_fiction(scrubbed, genre_name)
+        eq_(is_fiction, None)
 
 
 class TestWorkClassifier(DatabaseTest):


### PR DESCRIPTION
This branch fixes a bug in SimplifiedGenreClassifier where is_fiction() throws an error when supplied a nonexistent genre name. It also adds tests for SimplifiedGenreClassifier's is_fiction() and genre() methods.