### PR TITLE
staff genres override all other genres

### DIFF
--- a/model.py
+++ b/model.py
@@ -3612,6 +3612,10 @@ class Work(Base):
         for wg in by_genre.values():
             _db.delete(wg)
             changed = True
+
+        # ensure that work_genres is up to date without having to read from database again
+        self.work_genres = workgenres
+
         return workgenres, changed
 
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -1154,8 +1154,8 @@ class TestWorkClassifier(DatabaseTest):
         # eq_((historical_romance.genredata, 105), genre)
 
     def test_staff_genre_overrides_others(self):
-        genre1 = self._db.query(Genre).filter(Genre.name == "Poetry").first()
-        genre2 = self._db.query(Genre).filter(Genre.name == "Cooking").first()
+        genre1 = Genre.lookup(self._db, "Poetry")
+        genre2 = Genre.lookup(self._db, "Cooking")
         subject1 = self._subject(type="type1", identifier="subject1")
         subject1.genre = genre1
         subject2 = self._subject(type="type2", identifier="subject2")
@@ -1174,7 +1174,7 @@ class TestWorkClassifier(DatabaseTest):
         eq_([genre2.name], [genre.name for genre in genre_weights.keys()])
 
     def test_staff_none_genre_overrides_others(self):
-        genre1 = self._db.query(Genre).filter(Genre.name == "Poetry").first()
+        genre1 = Genre.lookup(self._db, "Poetry")
         subject1 = self._subject(type="type1", identifier="subject1")
         subject1.genre = genre1
         subject2 = self._subject(


### PR DESCRIPTION
This branch modifies WorkClassifier to ensure that genres entered by staff (including the "none" genre) override all other genres.
