### PR TITLE
If an Exception tells you how to turn it into a problem detail document, use that document when handling the error

### DIFF
--- a/problem_details.py
+++ b/problem_details.py
@@ -34,3 +34,10 @@ INTERNAL_SERVER_ERROR = pd(
       "Internal server error.",
       "Internal server error"
 )
+
+INTEGRATION_ERROR = pd(
+      "http://librarysimplified.org/terms/problem/integration-error",
+      502,
+      "Integration error.",
+      "Integration error"
+)

--- a/util/problem_detail.py
+++ b/util/problem_detail.py
@@ -21,6 +21,8 @@ class ProblemDetail(object):
 
     """A common type of problem."""
 
+    JSON_MEDIA_TYPE = JSON_MEDIA_TYPE
+
     def __init__(self, uri, status_code=None, title=None, detail=None,
                  instance=None, debug_message=None):
         self.uri = uri


### PR DESCRIPTION
This branch makes it so that an Exception subclass can have an associated ProblemDetail associated with it. If that exception is raised in the operation of the app server, and not caught, the ErrorHandler will use the ProblemDetail to generate the response instead of returning a generic plain-text response.