### PR TITLE
Pass around identifier object instead of string during OPDS creation.

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -788,7 +788,7 @@ class AcquisitionFeed(OPDSFeed):
                 return None
 
             if isinstance(work, BaseMaterializedWork):
-                identifier = work.identifier
+                identifier = work.license_pool.identifier
                 active_edition = None
             elif active_license_pool:
                 identifier = active_license_pool.identifier


### PR DESCRIPTION
This tiny change to core is to support https://github.com/NYPL-Simplified/circulation/issues/187, since we need the identifier type as well the identifier when creating URLs now.