### PR TITLE
Make problem detail documents out of network errors and timeouts

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -199,8 +199,11 @@ class ErrorHandler(object):
             document = exception.as_problem_detail_document(self.debug)
             if not self.debug:
                 document.debug_message = None
-            elif not document.debug_message:
-                document.debug_message = tb
+            else:
+                if document.debug_message:
+                    document.debug_message += "\n\n" + tb
+                else:
+                    document.debug_message = tb
             return make_response(document.response)
 
         if self.debug:

--- a/app_server.py
+++ b/app_server.py
@@ -196,8 +196,10 @@ class ErrorHandler(object):
         if hasattr(exception, 'as_problem_detail_document'):
             # This exception can be turned directly into a problem
             # detail document.
-            document = exception.as_problem_detail_document
-            if self.debug:
+            document = exception.as_problem_detail_document(self.debug)
+            if not self.debug:
+                document.debug_message = None
+            elif not document.debug_message:
                 document.debug_message = tb
             return make_response(document.response)
 

--- a/axis.py
+++ b/axis.py
@@ -2,7 +2,6 @@ from nose.tools import set_trace
 from collections import defaultdict
 import datetime
 import base64
-import requests
 import os
 import json
 import logging
@@ -10,6 +9,7 @@ import re
 
 from util import LanguageCodes
 from util.xmlparser import XMLParser
+from util.http import HTTP
 from coverage import CoverageFailure
 from model import (
     Contributor,
@@ -172,9 +172,11 @@ class Axis360API(object):
 
     def _make_request(self, url, method, headers, data=None, params=None):
         """Actually make an HTTP request."""
-        return requests.request(
-            url=url, method=method, headers=headers, data=data,
-            params=params)
+        return HTTP.request_with_timeout(
+            method, url, headers=headers, data=data,
+            params=params
+        )
+
 
 class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
     """Fill in bibliographic metadata for Axis 360 records.

--- a/model.py
+++ b/model.py
@@ -135,7 +135,7 @@ def production_session():
     return SessionManager.session(url)
 
 class PolicyException(Exception):
-    pass    
+    pass
 
 class BaseMaterializedWork(object):
     """A mixin class for materialized views that incorporate Work and Edition."""

--- a/overdrive.py
+++ b/overdrive.py
@@ -158,7 +158,9 @@ class OverdriveAPI(object):
         if status_code == 401:
             if exception_on_401:
                 # This is our second try. Give up.
-                raise Exception("Something's wrong with the OAuth Bearer Token!")
+                raise Exception(
+                    "Something's wrong with the Overdrive OAuth Bearer Token!"
+                )
             else:
                 # Refresh the token and try again.
                 self.check_creds(True)
@@ -197,13 +199,10 @@ class OverdriveAPI(object):
             self.ALL_PRODUCTS_ENDPOINT % params)
 
         while next_link:
-            try:
-                page_inventory, next_link = self._get_book_list_page(
-                    next_link, 'next')
-            except Exception, e:
-                self.log.error("OVERDRIVE ERROR: %r %r %r",
-                               status_code, headers, content)
-                return
+            page_inventory, next_link = self._get_book_list_page(
+                next_link, 'next'
+            )
+
             for i in page_inventory:
                 yield i
 
@@ -215,15 +214,7 @@ class OverdriveAPI(object):
         """
         # We don't cache this because it changes constantly.
         status_code, headers, content = self.get(link, {})
-        try:
-            data = json.loads(content)
-        except Exception, e:
-            self.log.error(
-                "Error getting book list page: %r %r %r", 
-                status_code, headers, content,
-                exc_info=e
-            )
-            return [], None
+        data = json.loads(content)
 
         # Find the link to the next page of results, if any.
         next_link = OverdriveRepresentationExtractor.link(data, rel_to_follow)

--- a/overdrive.py
+++ b/overdrive.py
@@ -5,7 +5,6 @@ import isbnlib
 import os
 import json
 import logging
-import requests
 import urlparse
 import urllib
 import sys
@@ -154,7 +153,8 @@ class OverdriveAPI(object):
         headers = dict(Authorization="Bearer %s" % self.token)
         headers.update(extra_headers)
         status_code, headers, content = Representation.simple_http_get(
-            url, headers)
+            url, headers
+        )
         if status_code == 401:
             if exception_on_401:
                 # This is our second try. Give up.
@@ -174,7 +174,7 @@ class OverdriveAPI(object):
         auth = base64.encodestring(s).strip()
         headers = dict(headers)
         headers['Authorization'] = "Basic %s" % auth
-        return requests.post(url, payload, headers=headers)
+        return HTTP.post_with_timeout(url, payload, headers=headers)
 
     def _update_credential(self, credential, overdrive_data):
         """Copy Overdrive OAuth data into a Credential object."""

--- a/problem_details.py
+++ b/problem_details.py
@@ -1,4 +1,5 @@
 from util.problem_detail import ProblemDetail as pd
+from util.http import INTEGRATION_ERROR
 
 INVALID_INPUT = pd(
       "http://librarysimplified.org/terms/problem/invalid-input",
@@ -33,11 +34,4 @@ INTERNAL_SERVER_ERROR = pd(
       500,
       "Internal server error.",
       "Internal server error"
-)
-
-INTEGRATION_ERROR = pd(
-      "http://librarysimplified.org/terms/problem/integration-error",
-      502,
-      "Integration error.",
-      "Integration error"
 )

--- a/tests/test_util_http.py
+++ b/tests/test_util_http.py
@@ -1,5 +1,9 @@
 import requests
-from util.http import HTTP, RequestTimedOut
+from util.http import (
+    HTTP, 
+    RequestNetworkException,
+    RequestTimedOut,
+)
 from nose.tools import (
     assert_raises_regexp,
     eq_, 
@@ -28,6 +32,18 @@ class TestHTTP(object):
             "a", "b"
         )
 
+    def test_request_with_network_failure(self):
+
+        def immediately_fail(*args, **kwargs):
+            raise requests.exceptions.ConnectionError("a disaster")
+
+        assert_raises_regexp(
+            RequestNetworkException,
+            "Network error accessing http://url/: a disaster",
+            HTTP._request_with_timeout, "http://url/", immediately_fail,
+            "a", "b"
+        )
+
 
 class TestRequestTimedOut(object):
 
@@ -42,6 +58,25 @@ class TestRequestTimedOut(object):
         # show the hostname.
         standard_detail = exception.as_problem_detail_document(debug=False)
         eq_("Request timed out while accessing url", standard_detail.detail)
+
+        # The status code corresponding to an upstream timeout is 502.
+        document, status_code, headers = standard_detail.response
+        eq_(502, status_code)
+
+
+class TestRequestNetworkException(object):
+
+    def test_as_problem_detail_document(self):
+        exception = RequestNetworkException("http://url/", "Colossal failure")
+
+        debug_detail = exception.as_problem_detail_document(debug=True)
+        eq_("Network failure contacting external service", debug_detail.title)
+        eq_('The server experienced a network error while accessing http://url/', debug_detail.detail)
+
+        # If we're not in debug mode, we hide the URL we accessed and just
+        # show the hostname.
+        standard_detail = exception.as_problem_detail_document(debug=False)
+        eq_("The server experienced a network error while accessing url", standard_detail.detail)
 
         # The status code corresponding to an upstream timeout is 502.
         document, status_code, headers = standard_detail.response

--- a/tests/test_util_http.py
+++ b/tests/test_util_http.py
@@ -52,12 +52,12 @@ class TestRequestTimedOut(object):
 
         debug_detail = exception.as_problem_detail_document(debug=True)
         eq_("Timeout", debug_detail.title)
-        eq_('Request timed out while accessing http://url/', debug_detail.detail)
+        eq_('The server made a request to http://url/, and that request timed out.', debug_detail.detail)
 
         # If we're not in debug mode, we hide the URL we accessed and just
         # show the hostname.
         standard_detail = exception.as_problem_detail_document(debug=False)
-        eq_("Request timed out while accessing url", standard_detail.detail)
+        eq_("The server made a request to url, and that request timed out.", standard_detail.detail)
 
         # The status code corresponding to an upstream timeout is 502.
         document, status_code, headers = standard_detail.response
@@ -71,12 +71,12 @@ class TestRequestNetworkException(object):
 
         debug_detail = exception.as_problem_detail_document(debug=True)
         eq_("Network failure contacting external service", debug_detail.title)
-        eq_('The server experienced a network error while accessing http://url/', debug_detail.detail)
+        eq_('The server experienced a network error while accessing http://url/.', debug_detail.detail)
 
         # If we're not in debug mode, we hide the URL we accessed and just
         # show the hostname.
         standard_detail = exception.as_problem_detail_document(debug=False)
-        eq_("The server experienced a network error while accessing url", standard_detail.detail)
+        eq_("The server experienced a network error while accessing url.", standard_detail.detail)
 
         # The status code corresponding to an upstream timeout is 502.
         document, status_code, headers = standard_detail.response

--- a/tests/test_util_http.py
+++ b/tests/test_util_http.py
@@ -1,0 +1,48 @@
+import requests
+from util.http import HTTP, RequestTimedOut
+from nose.tools import (
+    assert_raises_regexp,
+    eq_, 
+    set_trace
+)
+
+
+class TestHTTP(object):
+
+    def test_request_with_timeout_success(self):
+
+        def succeed(*args, **kwargs):
+            return True
+
+        eq_(True, HTTP._request_with_timeout("the url", succeed, "a", "b"))
+
+    def test_request_with_timeout_failure(self):
+
+        def immediately_timeout(*args, **kwargs):
+            raise requests.exceptions.Timeout("I give up")
+
+        assert_raises_regexp(
+            RequestTimedOut,
+            "Timeout accessing http://url/: I give up",
+            HTTP._request_with_timeout, "http://url/", immediately_timeout,
+            "a", "b"
+        )
+
+
+class TestRequestTimedOut(object):
+
+    def test_as_problem_detail_document(self):
+        exception = RequestTimedOut("http://url/", "I give up")
+
+        debug_detail = exception.as_problem_detail_document(debug=True)
+        eq_("Timeout", debug_detail.title)
+        eq_('Request timed out while accessing http://url/', debug_detail.detail)
+
+        # If we're not in debug mode, we hide the URL we accessed and just
+        # show the hostname.
+        standard_detail = exception.as_problem_detail_document(debug=False)
+        eq_("Request timed out while accessing url", standard_detail.detail)
+
+        # The status code corresponding to an upstream timeout is 502.
+        document, status_code, headers = standard_detail.response
+        eq_(502, status_code)

--- a/threem.py
+++ b/threem.py
@@ -153,11 +153,10 @@ class ThreeMAPI(object):
             content = representation.content
             return content
         else:
-            HTTP.request_with_timeout(
+            return HTTP.request_with_timeout(
                 method, url, data=body, headers=headers, 
                 allow_redirects=False
             )
-            return response
         
     def get_bibliographic_info_for(self, editions, max_age=None):
         results = dict()

--- a/threem.py
+++ b/threem.py
@@ -6,7 +6,6 @@ import hmac
 import hashlib
 import os
 import re
-import requests
 import logging
 from datetime import datetime, timedelta
 
@@ -40,6 +39,7 @@ from metadata_layer import (
     SubjectData,
 )
 
+from util.http import HTTP
 from util.xmlparser import XMLParser
 
 class ThreeMAPI(object):
@@ -148,12 +148,15 @@ class ThreeMAPI(object):
         if max_age and method=='GET':
             representation, cached = Representation.get(
                 self._db, url, extra_request_headers=headers,
-                do_get=Representation.http_get_no_timeout, max_age=max_age)
+                do_get=Representation.http_get_no_timeout, max_age=max_age
+            )
             content = representation.content
             return content
         else:
-            response = requests.request(
-                method, url, data=body, headers=headers, allow_redirects=False)
+            HTTP.request_with_timeout(
+                method, url, data=body, headers=headers, 
+                allow_redirects=False
+            )
             return response
         
     def get_bibliographic_info_for(self, editions, max_age=None):

--- a/util/http.py
+++ b/util/http.py
@@ -1,28 +1,48 @@
 import requests
 import urlparse
 
-from problem_details import INTEGRATION_ERROR
+from problem_detail import ProblemDetail as pd
+INTEGRATION_ERROR = pd(
+      "http://librarysimplified.org/terms/problem/integration-error",
+      502,
+      "Integration error.",
+      "Integration error"
+)
 
-class RequestTimedOut(requests.exceptions.Timeout):
+class RequestNetworkException(requests.exceptions.RequestException):
+    """An exception from the requests module that can be represented as
+    a problem detail document.
+    """
+
+    title = "Network failure contacting external service"
+    detail = "The server experienced a network error while accessing %s."
+    internal_message = "Network error accessing %s: %s"
+
+    def __init__(self, url, message):
+        self.url = url
+        self.hostname = urlparse.urlparse(url).netloc
+        super(RequestNetworkException, self).__init__(message)
+
+    def __str__(self):
+        return self.internal_message % (self.url, self.message)
+
+    def as_problem_detail_document(self, debug):
+        if debug:
+            message = self.detail % self.url
+        else:
+            message = self.detail % self.hostname
+        return INTEGRATION_ERROR.detailed(
+            detail=message, title=title
+        )
+
+class RequestTimedOut(RequestNetworkException, requests.exceptions.Timeout):
     """A timeout exception that can be represented as a problem
     detail document.
     """
 
-    def __init__(self, url, response):
-        self.url = url
-        self.hostname = urlparse.urlparse(url).netloc
-        super(RequestTimedOut, self).__init__(response)
-
-    def __str__(self):
-        return "Timeout accessing %s: %s" % (self.url, self.message)
-
-    def as_problem_detail_document(self, debug):
-        template = "Request timed out while accessing %s"
-        if debug:
-            message = template % self.url
-        else:
-            message = template % self.hostname
-        return INTEGRATION_ERROR.detailed(detail=message, title="Timeout")
+    title = "Timeout"
+    detail = "The server made a request to %s, and that request timed out."
+    internal_message = "Timeout accessing %s: %s"
 
 
 class HTTP(object):
@@ -62,5 +82,9 @@ class HTTP(object):
             # Wrap the requests-specific Timeout exception 
             # in a generic RequestTimedOut exception.
             raise RequestTimedOut(url, e.message)
+        except requests.exceptions.RequestException, e:
+            # Wrap all other requests-specific exceptions in
+            # a generic RequestNetworkException.
+            raise RequestNetworkException(url, e.message)
         return response
 

--- a/util/http.py
+++ b/util/http.py
@@ -43,7 +43,6 @@ class HTTP(object):
         """Call requests.request and turn a timeout into a RequestTimedOut
         exception.
         """
-        m = requests.request
         return cls._request_with_timeout(
             url, requests.request, http_method, url, *args, **kwargs
         )

--- a/util/http.py
+++ b/util/http.py
@@ -1,12 +1,13 @@
+from nose.tools import set_trace
 import requests
 import urlparse
-
 from problem_detail import ProblemDetail as pd
+
 INTEGRATION_ERROR = pd(
-      "http://librarysimplified.org/terms/problem/integration-error",
+      "http://librarysimplified.org/terms/problem/remote-integration-failed",
       502,
-      "Integration error.",
-      "Integration error"
+      "Third-party service failed.",
+      "A third-party service has failed.",
 )
 
 class RequestNetworkException(requests.exceptions.RequestException):
@@ -32,7 +33,7 @@ class RequestNetworkException(requests.exceptions.RequestException):
         else:
             message = self.detail % self.hostname
         return INTEGRATION_ERROR.detailed(
-            detail=message, title=title
+            detail=message, title=self.title
         )
 
 class RequestTimedOut(RequestNetworkException, requests.exceptions.Timeout):

--- a/util/http.py
+++ b/util/http.py
@@ -1,0 +1,50 @@
+import requests
+from ..problem_details import INTEGRATION_ERROR
+
+class RequestTimedOut(Exception):
+    """A timeout exception that can be represented as a problem
+    detail document.
+    """
+
+    def __init__(self, url, response):
+        self.url = url
+        self.hostname = urlparse.urlparse(url).netloc
+
+    def as_problem_detail_document(self, debug):
+        template = "Connection timed out while accessing %s"
+        if debug:
+            message = template % self.url
+        else:
+            message = template % self.hostname
+        if debug:
+            instance = self.url
+        else:
+            instance = None
+        return INTEGRATION_ERROR.detail(
+            detail=message, title="Timeout", instance=instance
+        )
+
+
+class HTTP(object):
+    """A helper for the `requests` module."""
+
+    def request_with_timeout(cls, http_method, url, *args, **kwargs):
+        """Call requests.request and turn a timeout into a RequestTimedOut
+        exception.
+        """
+        if not 'timeout' in kwargs:
+            kwargs['timeout'] = 20
+        kwargs['timeout'] = 0.001
+        try:
+            response = requests.request(http_method, url, *args, **kwargs)
+        except requests.exceptions.Timeout, e:
+            # Wrap the requests-specific Timeout exception 
+            # in a generic RequestTimedOut exception.
+            raise RequestTimedOut(url, e.message)
+        return response
+
+    def get_with_timeout(cls, url, *args, **kwargs):
+        return request_with_timeout("POST", url, *args, **kwargs)
+
+    def post_with_timeout(cls, url, *args, **kwargs):
+        return request_with_timeout("POST", url, *args, **kwargs)

--- a/util/http.py
+++ b/util/http.py
@@ -3,7 +3,7 @@ import urlparse
 
 from problem_details import INTEGRATION_ERROR
 
-class RequestTimedOut(Exception):
+class RequestTimedOut(requests.exceptions.Timeout):
     """A timeout exception that can be represented as a problem
     detail document.
     """

--- a/util/http.py
+++ b/util/http.py
@@ -1,7 +1,7 @@
 import requests
 import urlparse
 
-from ..problem_details import INTEGRATION_ERROR
+from problem_details import INTEGRATION_ERROR
 
 class RequestTimedOut(Exception):
     """A timeout exception that can be represented as a problem
@@ -11,6 +11,10 @@ class RequestTimedOut(Exception):
     def __init__(self, url, response):
         self.url = url
         self.hostname = urlparse.urlparse(url).netloc
+        super(RequestTimedOut, self).__init__(response)
+
+    def __str__(self):
+        return "Timeout accessing %s: %s" % (self.url, self.message)
 
     def as_problem_detail_document(self, debug):
         template = "Request timed out while accessing %s"
@@ -18,38 +22,46 @@ class RequestTimedOut(Exception):
             message = template % self.url
         else:
             message = template % self.hostname
-        if debug:
-            instance = self.url
-        else:
-            instance = None
-        return INTEGRATION_ERROR.detailed(
-            detail=message, title="Timeout", instance=instance
-        )
+        return INTEGRATION_ERROR.detailed(detail=message, title="Timeout")
 
 
 class HTTP(object):
     """A helper for the `requests` module."""
 
     @classmethod
+    def get_with_timeout(cls, url, *args, **kwargs):
+        """Make a GET request with timeout handling."""
+        return cls.request_with_timeout("GET", url, *args, **kwargs)
+
+    @classmethod
+    def post_with_timeout(cls, url, *args, **kwargs):
+        """Make a POST request with timeout handling."""
+        return cls.request_with_timeout("POST", url, *args, **kwargs)
+
+    @classmethod
     def request_with_timeout(cls, http_method, url, *args, **kwargs):
         """Call requests.request and turn a timeout into a RequestTimedOut
         exception.
         """
+        m = requests.request
+        return cls._request_with_timeout(
+            url, requests.request, http_method, url, *args, **kwargs
+        )
+
+    @classmethod
+    def _request_with_timeout(cls, url, m, *args, **kwargs):
+        """Call some kind of method and turn a timeout into a RequestTimedOut
+        exception.
+
+        The core of `request_with_timeout` made easy to test.
+        """
         if not 'timeout' in kwargs:
             kwargs['timeout'] = 20
-        kwargs['timeout'] = 0.001
         try:
-            response = requests.request(http_method, url, *args, **kwargs)
+            response = m(*args, **kwargs)
         except requests.exceptions.Timeout, e:
             # Wrap the requests-specific Timeout exception 
             # in a generic RequestTimedOut exception.
             raise RequestTimedOut(url, e.message)
         return response
 
-    @classmethod
-    def get_with_timeout(cls, url, *args, **kwargs):
-        return cls.request_with_timeout("POST", url, *args, **kwargs)
-
-    @classmethod
-    def post_with_timeout(cls, url, *args, **kwargs):
-        return cls.request_with_timeout("POST", url, *args, **kwargs)

--- a/util/http.py
+++ b/util/http.py
@@ -1,4 +1,6 @@
 import requests
+import urlparse
+
 from ..problem_details import INTEGRATION_ERROR
 
 class RequestTimedOut(Exception):
@@ -11,7 +13,7 @@ class RequestTimedOut(Exception):
         self.hostname = urlparse.urlparse(url).netloc
 
     def as_problem_detail_document(self, debug):
-        template = "Connection timed out while accessing %s"
+        template = "Request timed out while accessing %s"
         if debug:
             message = template % self.url
         else:
@@ -20,7 +22,7 @@ class RequestTimedOut(Exception):
             instance = self.url
         else:
             instance = None
-        return INTEGRATION_ERROR.detail(
+        return INTEGRATION_ERROR.detailed(
             detail=message, title="Timeout", instance=instance
         )
 
@@ -28,6 +30,7 @@ class RequestTimedOut(Exception):
 class HTTP(object):
     """A helper for the `requests` module."""
 
+    @classmethod
     def request_with_timeout(cls, http_method, url, *args, **kwargs):
         """Call requests.request and turn a timeout into a RequestTimedOut
         exception.
@@ -43,8 +46,10 @@ class HTTP(object):
             raise RequestTimedOut(url, e.message)
         return response
 
+    @classmethod
     def get_with_timeout(cls, url, *args, **kwargs):
-        return request_with_timeout("POST", url, *args, **kwargs)
+        return cls.request_with_timeout("POST", url, *args, **kwargs)
 
+    @classmethod
     def post_with_timeout(cls, url, *args, **kwargs):
-        return request_with_timeout("POST", url, *args, **kwargs)
+        return cls.request_with_timeout("POST", url, *args, **kwargs)


### PR DESCRIPTION
This branch makes it clear to the patron when their request failed because of the failure of an external service accessible via HTTP.

Every HTTP interaction that might involve a patron is routed through the new helper method `HTTP.request_with_timeout`. All `requests` exceptions are caught and rethrown as new exception subclasses that support `to_problem_detail`.
