### PR TITLE
Turn 5xx response codes into RemoteIntegrationExceptions.

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -9,7 +9,10 @@ import re
 
 from util import LanguageCodes
 from util.xmlparser import XMLParser
-from util.http import HTTP
+from util.http import (
+    HTTP,
+    RemoteIntegrationException,
+)
 from coverage import CoverageFailure
 from model import (
     Contributor,
@@ -107,9 +110,13 @@ class Axis360API(object):
         headers = self.authorization_headers
         response = self._make_request(url, 'post', headers)
         if response.status_code != 200:
-            raise Exception(
-                "Could not acquire bearer token: %s, %s" % (
-                    response.status_code, response.content))
+            raise RemoteIntegrationException(
+                url,
+                "Status code %s while acquiring bearer token." % (
+                    response.status_code
+                ),
+                debug_message=response.content
+            )
         return self.parse_token(response.content)
 
     def request(self, url, method='get', extra_headers={}, data=None,

--- a/testing.py
+++ b/testing.py
@@ -671,3 +671,13 @@ class DummyHTTPClient(object):
     def do_get(self, url, headers, **kwargs):
         self.requests.append(url)
         return self.responses.pop()
+
+
+class MockRequestsResponse(object):
+    """A mock object that simulates an HTTP response from the
+    `requests` library.
+    """
+    def __init__(self, status_code, headers={}, content=None):
+        self.status_code = status_code
+        self.headers = headers
+        self.content = content

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -3,6 +3,10 @@ from nose.tools import (
     eq_, 
     set_trace,
 )
+from config import (
+    Configuration, 
+    temp_config,
+)
 
 import datetime
 import os
@@ -30,7 +34,14 @@ from testing import MockRequestsResponse
 class MockAxis360API(Axis360API):
 
     def __init__(self, _db, *args, **kwargs):        
-        super(MockAxis360API, self).__init__(_db, *args, **kwargs)
+        with temp_config() as config:
+            config[Configuration.INTEGRATIONS]['Axis 360'] = {
+                'library_id' : 'a',
+                'username' : 'b',
+                'password' : 'c',
+                'server' : 'http://axis.test/',
+            }
+            super(MockAxis360API, self).__init__(_db, *args, **kwargs)
         self.responses = []
 
     def queue_response(self, status_code, headers={}, content=None):
@@ -53,7 +64,7 @@ class TestAxis360API(DatabaseTest):
         api = MockAxis360API(self._db)
         api.queue_response(412)
         assert_raises_regexp(
-            RemoteIntegrationException, "Network error accessing https://.*: Status code 412 while acquiring bearer token.", 
+            RemoteIntegrationException, "Network error accessing http://axis.test/accesstoken: Status code 412 while acquiring bearer token.", 
             api.refresh_bearer_token
         )
 


### PR DESCRIPTION
This branch adds a new type of exception, RemoteIntegrationException, for errors that are caused by the failure of a remote integration rather than something on our side. RequestNetworkException is now a `requests`-specific subclass of this exception, but it is also raised if the HTTP request completes normally but with a 5xx response code. I also changed the one place in core where `RemoteIntegrationException` should be raised even on a non-5xx response code: the code that acquires the Axis 360 access token, where anything other than a 200 response is treated as an error.