### PR TITLE
Raise a subclass of RemoteIntegrationException when the request completes but gives a bad result

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -63,7 +63,6 @@ class Axis360API(object):
             self.base_url = self.QA_BASE_URL
         elif self.base_url == 'production':
             self.base_url = self.PRODUCTION_BASE_URL
-        print self.base_url
         self.token = None
 
     @classmethod
@@ -124,6 +123,7 @@ class Axis360API(object):
         """Make an HTTP request, acquiring/refreshing a bearer token
         if necessary.
         """
+        set_trace()
         if not self.token:
             self.token = self.refresh_bearer_token()
 

--- a/axis.py
+++ b/axis.py
@@ -107,15 +107,7 @@ class Axis360API(object):
     def refresh_bearer_token(self):
         url = self.base_url + self.access_token_endpoint
         headers = self.authorization_headers
-        response = self._make_request(url, 'post', headers)
-        if response.status_code != 200:
-            raise RemoteIntegrationException(
-                url,
-                "Status code %s while acquiring bearer token." % (
-                    response.status_code
-                ),
-                debug_message=response.content
-            )
+        response = self._make_request(url, 'post', headers, require_200=True)
         return self.parse_token(response.content)
 
     def request(self, url, method='get', extra_headers={}, data=None,
@@ -177,11 +169,12 @@ class Axis360API(object):
         data = json.loads(token)
         return data['access_token']
 
-    def _make_request(self, url, method, headers, data=None, params=None):
+    def _make_request(self, url, method, headers, data=None, params=None, 
+                      **kwargs):
         """Actually make an HTTP request."""
         return HTTP.request_with_timeout(
             method, url, headers=headers, data=data,
-            params=params
+            params=params, **kwargs
         )
 
 

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -26,7 +26,10 @@ from axis import (
     BibliographicParser,
 )
 
-from util.http import RemoteIntegrationException
+from util.http import (
+    RemoteIntegrationException,
+    HTTP,
+)
 
 from . import DatabaseTest
 from testing import MockRequestsResponse
@@ -51,10 +54,10 @@ class MockAxis360API(Axis360API):
             0, MockRequestsResponse(status_code, headers, content)
         )
 
-    def _make_request(self, *args, **kwargs):
+    def _make_request(self, url, *args, **kwargs):
         response = self.responses.pop()
         return HTTP._process_response(
-            response, kwargs.get('allowed_response_codes'),
+            url, response, kwargs.get('allowed_response_codes'),
             kwargs.get('disallowed_response_codes')
         )
 
@@ -70,7 +73,7 @@ class TestAxis360API(DatabaseTest):
         api = MockAxis360API(self._db, with_token=False)
         api.queue_response(412)
         assert_raises_regexp(
-            RemoteIntegrationException, "Network error accessing http://axis.test/accesstoken: Status code 412 while acquiring bearer token.", 
+            RemoteIntegrationException, "Network error accessing http://axis.test/accesstoken: Got status code 412 from external server, but can only continue on: 200.", 
             api.refresh_bearer_token
         )
 
@@ -78,7 +81,7 @@ class TestAxis360API(DatabaseTest):
         api = MockAxis360API(self._db)
         api.queue_response(500)
         assert_raises_regexp(
-            RemoteIntegrationException, "Network error accessing http://axis.test/accesstoken: Status code 412 while acquiring bearer token.", 
+            RemoteIntegrationException, "Network error accessing http://axis.test/availability/v2: Got status code 500 from external server, cannot continue.", 
             api.availability
         )
 

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -74,7 +74,7 @@ class TestAxis360API(DatabaseTest):
         api = MockAxis360API(self._db)
         api.queue_response(500)
         assert_raises_regexp(
-            RemoteIntegrationException, "Network error accessing http://axis.test/availability/v2: Got status code 500 from external server, cannot continue.", 
+            RemoteIntegrationException, "Bad response from http://axis.test/availability/v2: Got status code 500 from external server, cannot continue.", 
             api.availability
         )
 
@@ -96,7 +96,7 @@ class TestAxis360API(DatabaseTest):
         api = MockAxis360API(self._db, with_token=False)
         api.queue_response(412)
         assert_raises_regexp(
-            RemoteIntegrationException, "Network error accessing http://axis.test/accesstoken: Got status code 412 from external server, but can only continue on: 200.", 
+            RemoteIntegrationException, "Bad response from http://axis.test/accesstoken: Got status code 412 from external server, but can only continue on: 200.", 
             api.refresh_bearer_token
         )
 

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -52,7 +52,8 @@ class MockAxis360API(Axis360API):
         )
 
     def _make_request(self, *args, **kwargs):
-        return self.responses.pop()
+        response = self.responses.pop()
+        return HTTP._process_response(response, kwargs.get['require_200'])
 
 
 class TestAxis360API(DatabaseTest):

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -9,6 +9,7 @@ from config import (
 )
 
 import datetime
+import json
 import os
 
 from model import (
@@ -69,14 +70,6 @@ class TestAxis360API(DatabaseTest):
         values = Axis360API.create_identifier_strings(["foo", identifier])
         eq_(["foo", identifier.identifier], values)
 
-    def test_refresh_bearer_token_error(self):
-        api = MockAxis360API(self._db, with_token=False)
-        api.queue_response(412)
-        assert_raises_regexp(
-            RemoteIntegrationException, "Network error accessing http://axis.test/accesstoken: Got status code 412 from external server, but can only continue on: 200.", 
-            api.refresh_bearer_token
-        )
-
     def test_availability_exception(self):
         api = MockAxis360API(self._db)
         api.queue_response(500)
@@ -84,6 +77,48 @@ class TestAxis360API(DatabaseTest):
             RemoteIntegrationException, "Network error accessing http://axis.test/availability/v2: Got status code 500 from external server, cannot continue.", 
             api.availability
         )
+
+    def test_refresh_bearer_token_after_401(self):
+        """If we get a 401, we will fetch a new bearer token and try the
+        request again.
+        """
+        api = MockAxis360API(self._db)
+        api.queue_response(401)
+        api.queue_response(200, content=json.dumps(dict(access_token="foo")))
+        api.queue_response(200, content="The data")
+        response = api.request("http://url/")
+        eq_("The data", response.content)
+
+    def test_refresh_bearer_token_error(self):
+        """Raise an exception if we don't get a 200 status code when
+        refreshing the bearer token.
+        """
+        api = MockAxis360API(self._db, with_token=False)
+        api.queue_response(412)
+        assert_raises_regexp(
+            RemoteIntegrationException, "Network error accessing http://axis.test/accesstoken: Got status code 412 from external server, but can only continue on: 200.", 
+            api.refresh_bearer_token
+        )
+
+    def test_exception_after_401_with_fresh_token(self):
+        """If we get a 401 immediately after refreshing the token, we will
+        raise an exception.
+        """
+        api = MockAxis360API(self._db)
+        api.queue_response(401)
+        api.queue_response(200, content=json.dumps(dict(access_token="foo")))
+        api.queue_response(401)
+
+        api.queue_response(301)
+
+        assert_raises_regexp(
+            RemoteIntegrationException,
+            ".*Got status code 401 from external server, cannot continue.",
+            api.request, "http://url/"
+        )
+
+        # The fourth request never got made.
+        eq_([301], [x.status_code for x in api.responses])
 
 class TestParsers(object):
 

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -53,7 +53,10 @@ class MockAxis360API(Axis360API):
 
     def _make_request(self, *args, **kwargs):
         response = self.responses.pop()
-        return HTTP._process_response(response, kwargs.get['require_200'])
+        return HTTP._process_response(
+            response, kwargs.get('allowed_response_codes'),
+            kwargs.get('disallowed_response_codes')
+        )
 
 
 class TestAxis360API(DatabaseTest):

--- a/tests/test_util_http.py
+++ b/tests/test_util_http.py
@@ -62,6 +62,9 @@ class TestHTTP(object):
         )
 
     def test_allowed_response_codes(self):
+        """Test our ability to raise RemoteIntegrationException when
+        an HTTP-based integration does not behave as we'd expect.
+        """
 
         def fake_401_response(*args, **kwargs):
             return MockRequestsResponse(401, content="Weird")

--- a/tests/test_util_http.py
+++ b/tests/test_util_http.py
@@ -1,6 +1,7 @@
 import requests
 from util.http import (
     HTTP, 
+    BadResponseException,
     RemoteIntegrationException,
     RequestNetworkException,
     RequestTimedOut,
@@ -55,14 +56,14 @@ class TestHTTP(object):
             return MockRequestsResponse(500, content="Failure!")
 
         assert_raises_regexp(
-            RemoteIntegrationException,
-            "Network error accessing http://url/: Got status code 500 from external server.",
+            BadResponseException,
+            "Bad response from http://url/: Got status code 500 from external server.",
             HTTP._request_with_timeout, "http://url/", fake_500_response,
             "a", "b"
         )
 
     def test_allowed_response_codes(self):
-        """Test our ability to raise RemoteIntegrationException when
+        """Test our ability to raise BadResponseException when
         an HTTP-based integration does not behave as we'd expect.
         """
 
@@ -82,8 +83,8 @@ class TestHTTP(object):
         # You can say that certain codes are specifically allowed, and
         # all others are forbidden.
         assert_raises_regexp(
-            RemoteIntegrationException,
-            "Network error.*Got status code 401 from external server, but can only continue on: 200, 201.", 
+            BadResponseException,
+            "Bad response.*Got status code 401 from external server, but can only continue on: 200, 201.", 
             m, url, fake_401_response, 
             allowed_response_codes=[201, 200]
         )
@@ -93,8 +94,8 @@ class TestHTTP(object):
 
         # In this way you can even raise an exception on a 200 response code.
         assert_raises_regexp(
-            RemoteIntegrationException,
-            "Network error.*Got status code 200 from external server, but can only continue on: 401.", 
+            BadResponseException,
+            "Bad response.*Got status code 200 from external server, but can only continue on: 401.", 
             m, url, fake_200_response, 
             allowed_response_codes=[401]
         )
@@ -102,15 +103,15 @@ class TestHTTP(object):
         # You can say that certain codes are explicitly forbidden, and
         # all others are allowed.
         assert_raises_regexp(
-            RemoteIntegrationException,
-            "Network error.*Got status code 401 from external server, cannot continue.", 
+            BadResponseException,
+            "Bad response.*Got status code 401 from external server, cannot continue.", 
             m, url, fake_401_response, 
             disallowed_response_codes=[401]
         )
 
         assert_raises_regexp(
-            RemoteIntegrationException,
-            "Network error.*Got status code 200 from external server, cannot continue.", 
+            BadResponseException,
+            "Bad response.*Got status code 200 from external server, cannot continue.", 
             m, url, fake_200_response, 
             disallowed_response_codes=["2xx", 301]
         )

--- a/util/http.py
+++ b/util/http.py
@@ -39,11 +39,11 @@ class RemoteIntegrationException(Exception):
             detail=message, title=self.title, debug_message=debug_message
         )
 
-class MalformedResponseException(RemoteIntegrationException):
-    """The request seemingly went okay, but we got a malformed response."""
+class BadResponseException(RemoteIntegrationException):
+    """The request seemingly went okay, but we got a bad response."""
     title = "Bad response"
-    detail = "The server made a request to %s, and got an improperly formatted response."
-    internal_message = "Malformed response from %s: %s"
+    detail = "The server made a request to %s, and got an unexpected or invalid response."
+    internal_message = "Bad response from %s: %s"
 
 class RequestNetworkException(RemoteIntegrationException,
                               requests.exceptions.RequestException):
@@ -157,7 +157,7 @@ class HTTP(object):
             error_message = status_code_not_in_allowed
 
         if error_message:
-            raise RemoteIntegrationException(
+            raise BadResponseException(
                 url,
                 error_message % code, 
                 debug_message=response.content

--- a/util/http.py
+++ b/util/http.py
@@ -125,7 +125,7 @@ class HTTP(object):
         status_code_in_disallowed = "Got status code %s from external server, cannot continue."
         if allowed_response_codes:
             allowed_response_codes = map(str, allowed_response_codes)
-            status_code_not_in_allowed = "Got status code %%s from external server, but can only continue on: %s." % ", ".join(allowed_response_codes)
+            status_code_not_in_allowed = "Got status code %%s from external server, but can only continue on: %s." % ", ".join(sorted(allowed_response_codes))
         if disallowed_response_codes:
             disallowed_response_codes = map(str, disallowed_response_codes)
         else:

--- a/util/http.py
+++ b/util/http.py
@@ -91,11 +91,11 @@ class HTTP(object):
 
         The core of `request_with_timeout` made easy to test.
         """
+        allowed_response_codes = kwargs.get('allowed_response_codes')
         if 'allowed_response_codes' in kwargs:
-            allowed_response_codes = kwargs.get('allowed_response_codes')
             del kwargs['allowed_response_codes']
+        disallowed_response_codes = kwargs.get('disallowed_response_codes')
         if 'disallowed_response_codes' in kwargs:
-            disallowed_response_codes = kwargs.get('disallowed_response_codes')
             del kwargs['disallowed_response_codes']
 
         if not 'timeout' in kwargs:

--- a/util/http.py
+++ b/util/http.py
@@ -111,7 +111,7 @@ class HTTP(object):
             # a generic RequestNetworkException.
             raise RequestNetworkException(url, e.message)
 
-        cls._process_response(
+        return cls._process_response(
             url, response, allowed_response_codes, disallowed_response_codes
         )
 


### PR DESCRIPTION
This branch introduces `BadResponseException`, which is used in cases where there was no network-level problem communicating with an external HTTP server, but the response was bad. What is meant by "bad" is highly variable, but it generally means "we got a 5xx response code".

However, there are cases where anything other than a 200 response code is unacceptable, or where the only unacceptable response code is a 401. I've gotten all these cases working and tested, and it lets me save little bits of code here and there.

Since `BadResponseException` has a real HTTP response to work with, I changed its `debug_message` to include the text of the response, which can sometimes be helpful.