### PR TITLE
Overdrive uses http helper

### DIFF
--- a/model.py
+++ b/model.py
@@ -108,7 +108,10 @@ from util import (
     MetadataSimilarity,
     TitleProcessor,
 )
-from util.http import HTTP
+from util.http import (
+    HTTP,
+    RemoteIntegrationException,
+)
 from util.permanent_work_id import WorkIDCalculator
 from util.summary import SummaryEvaluator
 
@@ -6122,6 +6125,12 @@ class Representation(Base):
                 media_type = presumed_media_type
             if isinstance(content, unicode):
                 content = content.encode("utf8")
+        except RemoteIntegrationException, e:
+            # This indicates that the HTTP request was made but timed
+            # out, dropped the connection, returned an unusable
+            # response, etc. No usable representation was found and
+            # the caller needs to decide how to handle this.
+            raise e
         except Exception, e:
             # This indicates there was a problem with making the HTTP
             # request, not that the HTTP request returned an error

--- a/overdrive.py
+++ b/overdrive.py
@@ -208,7 +208,10 @@ class OverdriveAPI(object):
 
     def get_library(self):
         url = self.LIBRARY_ENDPOINT % dict(library_id=self.library_id)
-        representation, cached = Representation.get(self._db, url, self.get)
+        representation, cached = Representation.get(
+            self._db, url, self.get, 
+            exception_handler=Representation.reraise_exception,
+        )
         return json.loads(representation.content)
 
     def all_ids(self):

--- a/testing.py
+++ b/testing.py
@@ -2,6 +2,7 @@ from datetime import (
     datetime,
     timedelta,
 )
+import json
 import logging
 import os
 import shutil
@@ -681,3 +682,6 @@ class MockRequestsResponse(object):
         self.status_code = status_code
         self.headers = headers
         self.content = content
+
+    def json(self):
+        return json.loads(self.content)

--- a/tests/files/3m/item_metadata_single.xml
+++ b/tests/files/3m/item_metadata_single.xml
@@ -1,0 +1,28 @@
+<ArrayOfItem xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Item>
+    <ItemId>ddf4gr9</ItemId>
+    <Title>The Incense Game</Title>
+    <SubTitle>A Novel of Feudal Japan</SubTitle>
+    <Authors>Rowland, Laura Joh</Authors>
+    <Description>&lt;b&gt;Winner of&#160;RT Magazine's Reviewers' Choice Award for Best Historical Mystery&lt;/b&gt;&lt;br&gt;&lt;/br&gt;&lt;br&gt;&lt;/br&gt;In the wake of a terrifying earthquake,&#160;Sano Ichir&#333;&#160;races to solve a crime that could bring down the shogun's regimeWhen a massive earthquake devastates Japan in 1703, even the shogun's carefully regulated court is left teetering on the brink of chaos.&#160;This is no time for a murder investigation&#8212;except when a nobleman's daughters are found dead from incense poisoning and&#160;their father threatens to topple the regime unless&#160;Sano Ichiro&#160;tracks down the killer.As Sano and&#160;his wife strive to solve the case in a world that is crumbling around them, Laura Joh Rowland&#8212;author of one of the "five best historical mystery novels" &lt;i&gt;(The Wall Street Journal)&#8212;&lt;/i&gt;brings us her most powerful and evocative thriller set in Feudal Japan&#160;yet, &lt;i&gt;The Incense Game&lt;/i&gt;.&#160;&lt;br&gt;&lt;/br&gt;&lt;br/&gt;</Description>
+    <Publisher>St. Martin's Press</Publisher>
+    <PubDate>2012-09-17</PubDate>
+    <PubYear>2012</PubYear>
+    <Size>1.2 MB</Size>
+    <Language>en</Language>
+    <PhysicalISBN>9781250031112</PhysicalISBN>
+    <ISBN13>9781250015280</ISBN13>
+    <BookFormat>EPUB</BookFormat>
+    <NumberOfPages>304</NumberOfPages>
+    <CanCheckout>TRUE</CanCheckout>
+    <CanHold>FALSE</CanHold>
+    <OnHold>FALSE</OnHold>
+    <TotalCopies>1</TotalCopies>
+    <AvailableCopies>1</AvailableCopies>
+    <OnHoldCount>0</OnHoldCount>
+    <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-ddf4gr9</BookLinkURL>
+    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=ddf4gr9&amp;amp;token=nobody</CoverLinkURL>
+    <LibraryUrlName>nypl</LibraryUrlName>
+    <Genre>Children&amp;#39;s Health, Mystery &amp;amp; Detective,</Genre>
+  </Item>
+</ArrayOfItem>

--- a/tests/test_3m.py
+++ b/tests/test_3m.py
@@ -1,4 +1,8 @@
-from nose.tools import set_trace, eq_
+from nose.tools import (
+    assert_raises_regexp,
+    set_trace, 
+    eq_,
+)
 import datetime
 import os
 from model import (
@@ -15,7 +19,7 @@ from threem import (
     MockThreeMAPI,
 )
 from . import DatabaseTest
-
+from util.http import BadResponseException
 
 class BaseThreeMTest(object):
 
@@ -41,6 +45,15 @@ class TestThreeMAPI(DatabaseTest, BaseThreeMTest):
         identifier = self._identifier()
         metadata = self.api.bibliographic_lookup(identifier)
         eq_("The Incense Game", metadata.title)
+
+    def test_bad_response_raises_exception(self):
+        self.api.queue_response(500, content="oops")
+        identifier = self._identifier()
+        assert_raises_regexp(
+            BadResponseException, 
+            ".*Got status code 500.*",
+            self.api.bibliographic_lookup, identifier
+        )
 
     def test_put_request(self):
         """This is a basic test to make sure the method calls line up

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -8,13 +8,9 @@ import os
 import json
 import pkgutil
 
-from config import (
-    temp_config, 
-    Configuration,
-)
-
 from overdrive import (
     OverdriveAPI,
+    MockOverdriveAPI,
     OverdriveRepresentationExtractor,
 )
 
@@ -35,54 +31,7 @@ from util.http import (
 )
 
 from . import DatabaseTest
-from testing import MockRequestsResponse
 
-class MockOverdriveAPI(OverdriveAPI):
-
-    def __init__(self, _db, *args, **kwargs):
-        self.responses = []
-
-        # The constructor will make a request for the access token,
-        # and then a request for the collection token.
-        self.queue_response(200, content=self.mock_access_token("bearer token"))
-        self.queue_response(
-            200, content=self.mock_collection_token("collection token")
-        )
-
-        with temp_config() as config:
-            config[Configuration.INTEGRATIONS]['Overdrive'] = {
-                'client_key' : 'a',
-                'client_secret' : 'b',
-                'website_id' : 'c',
-                'library_id' : 'd',
-            }
-            super(MockOverdriveAPI, self).__init__(_db, *args, **kwargs)
-
-    def mock_access_token(self, credential):
-        return json.dumps(dict(access_token=credential, expires_in=3600))
-
-    def mock_collection_token(self, token):
-        return json.dumps(dict(collectionToken=token))
-
-    def queue_response(self, status_code, headers={}, content=None):
-        self.responses.insert(
-            0, MockRequestsResponse(status_code, headers, content)
-        )
-
-    def _do_get(self, url, *args, **kwargs):
-        """Simulate Representation.simple_http_get."""
-        response = self._make_request(url, *args, **kwargs)
-        return response.status_code, response.headers, response.content
-
-    def _do_post(self, url, *args, **kwargs):
-        return self._make_request(url, *args, **kwargs)
-
-    def _make_request(self, url, *args, **kwargs):
-        response = self.responses.pop()
-        return HTTP._process_response(
-            url, response, kwargs.get('allowed_response_codes'),
-            kwargs.get('disallowed_response_codes')
-        )
 
 class TestOverdriveAPI(DatabaseTest):
 

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -55,6 +55,22 @@ class TestOverdriveAPI(DatabaseTest):
         eq_(200, status_code)
         eq_("some content", content)
 
+    def test_failure_to_get_library_is_fatal(self):
+        # We already called get_library while initializing the
+        # Overdrive API, and when that happened we cached its
+        # Representation. Delete the Representation so we stop using
+        # the cached version.
+        for r in self._db.query(Representation):
+            self._db.delete(r)
+        self._db.commit()
+
+        self.api.queue_response(500)
+        assert_raises_regexp(
+            BadResponseException, 
+            ".*Got status code 500.*",
+            self.api.get_library
+        )
+
     def test_401_on_get_refreshes_bearer_token(self):
 
         eq_("bearer token", self.api.token)

--- a/threem.py
+++ b/threem.py
@@ -131,13 +131,16 @@ class ThreeMAPI(object):
         signature = base64.b64encode(digest)
         return signature, now
 
-    def request(self, path, body=None, method="GET", identifier=None,
-                max_age=None):
+    def full_url(self, path):
         if not path.startswith("/"):
             path = "/" + path
         if not path.startswith("/cirrus"):
             path = "/cirrus/library/%s%s" % (self.library_id, path)
-        url = urlparse.urljoin(self.base_url, path)
+        return urlparse.urljoin(self.base_url, path)
+
+    def request(self, path, body=None, method="GET", identifier=None,
+                max_age=None):
+        path = self.full_url(path)
         if method == 'GET':
             headers = {"Accept" : "application/xml"}
         else:

--- a/threem.py
+++ b/threem.py
@@ -1,4 +1,4 @@
-from pdb import set_trace
+from nose.tools import set_trace
 import base64
 import urlparse
 import time
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta
 from config import (
     Configuration,
     CannotLoadConfiguration,
+    temp_config,
 )
 from coverage import (
     BibliographicCoverageProvider,
@@ -38,6 +39,8 @@ from metadata_layer import (
     MeasurementData,
     SubjectData,
 )
+
+from testing import MockRequestsResponse
 
 from util.http import HTTP
 from util.xmlparser import XMLParser
@@ -140,7 +143,7 @@ class ThreeMAPI(object):
 
     def request(self, path, body=None, method="GET", identifier=None,
                 max_age=None):
-        path = self.full_url(path)
+        url = self.full_url(path)
         if method == 'GET':
             headers = {"Accept" : "application/xml"}
         else:
@@ -151,16 +154,16 @@ class ThreeMAPI(object):
         if max_age and method=='GET':
             representation, cached = Representation.get(
                 self._db, url, extra_request_headers=headers,
-                max_age=max_age
+                do_get=self._simple_http_get, max_age=max_age
             )
             content = representation.content
             return content
         else:
-            return HTTP.request_with_timeout(
+            return self._request_with_timeout(
                 method, url, data=body, headers=headers, 
                 allow_redirects=False
             )
-        
+      
     def get_bibliographic_info_for(self, editions, max_age=None):
         results = dict()
         for edition in editions:
@@ -180,6 +183,51 @@ class ThreeMAPI(object):
         else:
             [metadata] = response
         return metadata
+
+    def _request_with_timeout(self, method, url, *args, **kwargs):
+        """This will be overridden in MockThreeMAPI."""
+        return HTTP.request_with_timeout(method, url, *args, **kwargs)
+
+    def _simple_http_get(self, url, headers, *args, **kwargs):
+        """This will be overridden in MockThreeMAPI."""
+        return Representation.simple_http_get(url, headers, *args, **kwargs)
+
+
+class MockThreeMAPI(ThreeMAPI):
+
+    def __init__(self, _db, *args, **kwargs):
+        self.responses = []
+        self.requests = []
+
+        with temp_config() as config:
+            config[Configuration.INTEGRATIONS]['3M'] = {
+                'library_id' : 'a',
+                'account_id' : 'b',
+                'account_key' : 'c',
+            }
+            super(MockThreeMAPI, self).__init__(_db, *args, **kwargs)
+
+    def queue_response(self, status_code, headers={}, content=None):
+        self.responses.insert(
+            0, MockRequestsResponse(status_code, headers, content)
+        )
+
+    def _request_with_timeout(self, method, url, *args, **kwargs):
+        """Simulate HTTP.request_with_timeout."""
+        self.requests.append([method, url, args, kwargs])
+        response = self.responses.pop()
+        return HTTP._process_response(
+            url, response, kwargs.get('allowed_response_codes'),
+            kwargs.get('disallowed_response_codes')
+        )
+
+    def _simple_http_get(self, url, headers, *args, **kwargs):
+        """Simulate Representation.simple_http_get."""
+        response = self._request_with_timeout('GET', url, *args, **kwargs)
+        return response.status_code, response.headers, response.content
+
+    
+
 
 class ItemListParser(XMLParser):
 

--- a/threem.py
+++ b/threem.py
@@ -176,7 +176,8 @@ class ThreeMAPI(object):
     def bibliographic_lookup(self, identifier, max_age=None):
         data = self.request(
             "/items/%s" % identifier.identifier,
-            max_age=max_age or self.MAX_METADATA_AGE)
+            max_age=max_age or self.MAX_METADATA_AGE
+        )
         response = list(self.item_list_parser.parse(data))
         if not response:
             return None

--- a/threem.py
+++ b/threem.py
@@ -151,7 +151,7 @@ class ThreeMAPI(object):
         if max_age and method=='GET':
             representation, cached = Representation.get(
                 self._db, url, extra_request_headers=headers,
-                do_get=Representation.http_get_no_timeout, max_age=max_age
+                max_age=max_age
             )
             content = representation.content
             return content

--- a/threem.py
+++ b/threem.py
@@ -154,7 +154,8 @@ class ThreeMAPI(object):
         if max_age and method=='GET':
             representation, cached = Representation.get(
                 self._db, url, extra_request_headers=headers,
-                do_get=self._simple_http_get, max_age=max_age
+                do_get=self._simple_http_get, max_age=max_age,
+                exception_handler=Representation.reraise_exception,
             )
             content = representation.content
             return content

--- a/util/http.py
+++ b/util/http.py
@@ -50,6 +50,8 @@ class BadResponseException(RemoteIntegrationException):
     detail = "The server made a request to %s, and got an unexpected or invalid response."
     internal_message = "Bad response from %s: %s"
 
+    BAD_STATUS_CODE = "Got status code %s from external server, cannot continue."
+
     def document_debug_message(self, debug=True):
         if debug:
             msg = self.message
@@ -57,6 +59,15 @@ class BadResponseException(RemoteIntegrationException):
                 msg += "\n\n" + self.debug_message
             return msg
         return None
+
+    @classmethod
+    def bad_status_code(cls, url, response):
+        """The response is bad because the status code is wrong."""
+        return BadResponseException(
+            url,
+            cls.BAD_STATUS_CODE % response.status_code, 
+            debug_message="Response content: %s" % response.content
+        )
 
 
 class RequestNetworkException(RemoteIntegrationException,
@@ -136,7 +147,6 @@ class HTTP(object):
         server-side failure, or behavior so unpredictable that we can't
         continue.
         """
-        status_code_in_disallowed = "Got status code %s from external server, cannot continue."
         if allowed_response_codes:
             allowed_response_codes = map(str, allowed_response_codes)
             status_code_not_in_allowed = "Got status code %%s from external server, but can only continue on: %s." % ", ".join(sorted(allowed_response_codes))
@@ -163,7 +173,7 @@ class HTTP(object):
         ):
             # Unless explicitly allowed, the 5xx series always results in
             # an exception.
-            error_message = status_code_in_disallowed
+            error_message = cls.BAD_STATUS_CODE
         elif (allowed_response_codes and not (
                 code in allowed_response_codes 
                 or series in allowed_response_codes


### PR DESCRIPTION
This branch fixes a problem where the Overdrive API was not properly using the util.http.HTTP class to make POST requests. To make sure the problem has been fixed I created a MockOverdriveAPI class and for the first time wrote tests for the procedure by which Overdrive creates and maintains its bearer token, as well as the various failures that might happen.

I also created a MockThreeMAPI class and wrote some basic tests for it. The real tests of the 3M API will be in the circulation manager.