### PR TITLE
Fix 3m signature

### DIFF
--- a/overdrive.py
+++ b/overdrive.py
@@ -322,9 +322,9 @@ class OverdriveAPI(object):
             url, headers
         )
 
-    def _do_post(self, url, payload, headers):
+    def _do_post(self, url, payload, headers, **kwargs):
         """This method is overridden in MockOverdriveAPI."""
-        return HTTP.post_with_timeout(url, payload, headers=headers)
+        return HTTP.post_with_timeout(url, payload, headers=headers, **kwargs)
 
 
 class MockOverdriveAPI(OverdriveAPI):

--- a/overdrive.py
+++ b/overdrive.py
@@ -48,8 +48,6 @@ from config import (
     CannotLoadConfiguration,
 )
 
-from testing import MockRequestsResponse
-
 from util.http import (
     HTTP,
     BadResponseException,
@@ -355,6 +353,7 @@ class MockOverdriveAPI(OverdriveAPI):
         return json.dumps(dict(collectionToken=token))
 
     def queue_response(self, status_code, headers={}, content=None):
+        from testing import MockRequestsResponse
         self.responses.insert(
             0, MockRequestsResponse(status_code, headers, content)
         )

--- a/tests/test_3m.py
+++ b/tests/test_3m.py
@@ -38,6 +38,21 @@ class TestThreeMAPI(DatabaseTest, BaseThreeMTest):
         super(TestThreeMAPI, self).setup()
         self.api = MockThreeMAPI(self._db)
 
+    def test_full_path(self):
+        id = self.api.library_id
+        eq_("/cirrus/library/%s/foo" % id, self.api.full_path("foo"))
+        eq_("/cirrus/library/%s/foo" % id, self.api.full_path("/foo"))
+        eq_("/cirrus/library/%s/foo" % id, 
+            self.api.full_path("/cirrus/library/%s/foo" % id)
+        )
+
+    def test_full_url(self):
+        id = self.api.library_id
+        eq_("http://3m.test/cirrus/library/%s/foo" % id,
+            self.api.full_url("foo"))
+        eq_("http://3m.test/cirrus/library/%s/foo" % id, 
+            self.api.full_url("/foo"))
+
     def test_request_signing(self):
         """Confirm a known correct result for the 3M request signing
         algorithm.

--- a/threem.py
+++ b/threem.py
@@ -40,8 +40,6 @@ from metadata_layer import (
     SubjectData,
 )
 
-from testing import MockRequestsResponse
-
 from util.http import HTTP
 from util.xmlparser import XMLParser
 
@@ -224,6 +222,7 @@ class MockThreeMAPI(ThreeMAPI):
         )
 
     def queue_response(self, status_code, headers={}, content=None):
+        from testing import MockRequestsResponse
         self.responses.insert(
             0, MockRequestsResponse(status_code, headers, content)
         )

--- a/threem.py
+++ b/threem.py
@@ -213,7 +213,9 @@ class MockThreeMAPI(ThreeMAPI):
                 'account_id' : 'b',
                 'account_key' : 'c',
             }
-            super(MockThreeMAPI, self).__init__(_db, *args, **kwargs)
+            super(MockThreeMAPI, self).__init__(
+                _db, *args, base_url="http://3m.test", **kwargs
+            )
 
     def now(self):
         """Return an unvarying time in the format 3M expects."""

--- a/threem.py
+++ b/threem.py
@@ -215,6 +215,12 @@ class MockThreeMAPI(ThreeMAPI):
             }
             super(MockThreeMAPI, self).__init__(_db, *args, **kwargs)
 
+    def now(self):
+        """Return an unvarying time in the format 3M expects."""
+        return datetime.strftime(
+            datetime(2016, 1, 1), self.AUTH_TIME_FORMAT
+        )
+
     def queue_response(self, status_code, headers={}, content=None):
         self.responses.insert(
             0, MockRequestsResponse(status_code, headers, content)

--- a/threem.py
+++ b/threem.py
@@ -131,13 +131,22 @@ class ThreeMAPI(object):
         signature = base64.b64encode(digest)
         return signature, now
 
-    def request(self, path, body=None, method="GET", identifier=None,
-                max_age=None):
+    def full_url(self, path):
+        if not path.startswith("/cirrus"):
+            path = self.full_path(path)
+        return urlparse.urljoin(self.base_url, path)
+
+    def full_path(self, path):
         if not path.startswith("/"):
             path = "/" + path
         if not path.startswith("/cirrus"):
             path = "/cirrus/library/%s%s" % (self.library_id, path)
-        url = urlparse.urljoin(self.base_url, path)
+        return path
+
+    def request(self, path, body=None, method="GET", identifier=None,
+                max_age=None):
+        path = self.full_path(path)
+        url = self.full_url(path)
         if method == 'GET':
             headers = {"Accept" : "application/xml"}
         else:

--- a/util/http.py
+++ b/util/http.py
@@ -117,8 +117,9 @@ class HTTP(object):
         return cls.request_with_timeout("GET", url, *args, **kwargs)
 
     @classmethod
-    def post_with_timeout(cls, url, *args, **kwargs):
+    def post_with_timeout(cls, url, payload, *args, **kwargs):
         """Make a POST request with timeout handling."""
+        kwargs['data'] = payload
         return cls.request_with_timeout("POST", url, *args, **kwargs)
 
     @classmethod


### PR DESCRIPTION
This branch fixes the inputs into the code that calculates the cryptographic signature for a 3M HTTP request. I screwed them up when I created `ThreeMAPI.full_url`. The thing that gets signed is not the URL, it's just the path part of the URL, and my implementation of `full_url` changed the path in a way that wasn't propagated back to the caller.
