### PR TITLE
Refactor and mock OPDS lookup class

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -438,3 +438,5 @@ class BibliographicCoverageProvider(CoverageProvider):
     def process_batch(self):
         """Returns a list of successful identifiers and CoverageFailures"""
         raise NotImplementedError
+
+

--- a/coverage.py
+++ b/coverage.py
@@ -438,5 +438,3 @@ class BibliographicCoverageProvider(CoverageProvider):
     def process_batch(self):
         """Returns a list of successful identifiers and CoverageFailures"""
         raise NotImplementedError
-
-

--- a/opds_import.py
+++ b/opds_import.py
@@ -99,7 +99,8 @@ class SimplifiedOPDSLookup(object):
     def authenticated(self):
         return bool(self.client_id and self.client_secret)
 
-    def _get(self, url):
+    def _get(self, url, **kwargs):
+        """Make an HTTP request. This method is overridden in the mock class."""
         return HTTP.get_with_timeout(url, **kwargs)
 
     def opds_get(self, url):
@@ -107,11 +108,10 @@ class SimplifiedOPDSLookup(object):
 
         Long timeout, raise error on anything but 2xx or 3xx.
         """
-        kwargs = dict(timeout=120)
+        kwargs = dict(timeout=120, allowed_response_codes=['2xx', '3xx'])
         if self.client_id and self.client_secret:
             kwargs['auth'] = (self.client_id, self.client_secret)
-        kwargs['allowed_response_codes']=['2xx', '3xx']
-        return HTTP.get_with_timeout(url, **kwargs)
+        return self._get(url, **kwargs)
 
     def lookup(self, identifiers):
         """Retrieve an OPDS feed with metadata for the given identifiers."""

--- a/opds_import.py
+++ b/opds_import.py
@@ -56,7 +56,7 @@ class AccessNotAuthenticated(Exception):
     pass
 
 
-class SimplifiedOPDSLookup(OPDSHTTPClient):
+class SimplifiedOPDSLookup(object):
     """Tiny integration class for the Simplified 'lookup' protocol."""
 
     LOOKUP_ENDPOINT = "lookup"
@@ -733,7 +733,7 @@ class OPDSImporter(object):
             return None
 
 
-class OPDSImportMonitor(Monitor, OPDSHTTPClient):
+class OPDSImportMonitor(Monitor):
 
     """Periodically monitor an OPDS archive feed and import every edition
     it mentions.

--- a/testing.py
+++ b/testing.py
@@ -678,10 +678,11 @@ class MockRequestsResponse(object):
     """A mock object that simulates an HTTP response from the
     `requests` library.
     """
-    def __init__(self, status_code, headers={}, content=None):
+    def __init__(self, status_code, headers={}, content=None, url=None):
         self.status_code = status_code
         self.headers = headers
         self.content = content
+        self.url = url or "http://url/"
 
     def json(self):
         return json.loads(self.content)

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -100,8 +100,8 @@ class TestSimplifiedOPDSLookup(object):
                 url = "http://whatevz"
             )
             importer = SimplifiedOPDSLookup.from_config("Content Server")
-            eq_(False, hasattr(importer, "client_id"))
-            eq_(False, hasattr(importer, "client_secret"))
+            eq_(None, importer.client_id)
+            eq_(None, importer.client_secret)
 
 
 class OPDSImporterTest(DatabaseTest):


### PR DESCRIPTION
This branch refactors the class that implements the Simplified OPDS lookup protocol so that it uses the HTTP helper class. I also created a mock version of `SimplifiedOPDSLookup`, though I ended up not needing it.