### PR TITLE
Fixed the mock OPDS lookup client now that we're using it in a test.

### DIFF
--- a/opds_import.py
+++ b/opds_import.py
@@ -152,8 +152,9 @@ class SimplifiedOPDSLookup(object):
 
 class MockSimplifiedOPDSLookup(SimplifiedOPDSLookup):
 
-    def __init__(self, _db, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         self.responses = []
+        super(MockSimplifiedOPDSLookup, self).__init__(*args, **kwargs)
 
     def queue_response(self, status_code, headers={}, content=None):
         from testing import MockRequestsResponse

--- a/testing.py
+++ b/testing.py
@@ -686,3 +686,7 @@ class MockRequestsResponse(object):
 
     def json(self):
         return json.loads(self.content)
+
+    @property
+    def text(self):
+        return self.content.decode("utf8")


### PR DESCRIPTION
This branch makes some very small changes to mock classes used in circulation tests. The mock OPDS lookup client was never used before, which is how the constructor error slipped through.