### PR TITLE
Create recommendation data

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -745,7 +745,6 @@ class Lane(object):
             list_ids = None
         return list_data_source_id, list_ids
 
-
     @classmethod
     def from_description(cls, _db, parent, description):
         genre = None

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -400,8 +400,8 @@ class RecommendationData(object):
 
         equivalent_identifier = aliased(Identifier)
         works_q = Work.feed_query(_db)
-        works_q = works_q.join(Identifier.equivalencies).\
-            join(equivalent_identifier, Equivalency.output).\
+        works_q = works_q.outerjoin(Identifier.equivalencies).\
+            outerjoin(equivalent_identifier, Equivalency.output).\
             filter(or_(
                 Identifier.id.in_(identifier_ids),
                 equivalent_identifier.id.in_(identifier_ids)

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -377,6 +377,9 @@ class RecommendationData(object):
 
     @property
     def recommended_works(self):
+        """:return: a query of all of the recommended works in self.identifiers
+        or None
+        """
         identifier_ids = []
         _db = Session.object_session(self.data_source)
         for identifier_data in self.identifiers[:]:
@@ -392,6 +395,9 @@ class RecommendationData(object):
                 continue
             identifier_ids.append(identifier.id)
 
+        if not identifier_ids:
+            return None
+
         equivalent_identifier = aliased(Identifier)
         works_q = Work.feed_query(_db)
         works_q = works_q.join(Identifier.equivalencies).\
@@ -400,9 +406,7 @@ class RecommendationData(object):
                 Identifier.id.in_(identifier_ids),
                 equivalent_identifier.id.in_(identifier_ids)
             ))
-
         return works_q
-
 
 class CirculationData(object):
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -126,6 +126,7 @@ class ReplacementPolicy(object):
             **args
         )
 
+
 class SubjectData(object):
     def __init__(self, type, identifier, name=None, weight=1):
         self.type = type
@@ -301,6 +302,7 @@ class IdentifierData(object):
             _db, self.type, self.identifier
         )
 
+
 class LinkData(object):
     def __init__(self, rel, href=None, media_type=None, content=None,
                  thumbnail=None, rights_uri=None):
@@ -332,6 +334,7 @@ class LinkData(object):
             content
         )
 
+
 class MeasurementData(object):
     def __init__(self,
                  quantity_measured,
@@ -353,6 +356,7 @@ class MeasurementData(object):
         return '<MeasurementData quantity="%s" value=%f weight=%d taken=%s>' % (
             self.quantity_measured, self.value, self.weight, self.taken_at
         )
+
 
 class FormatData(object):
     def __init__(self, content_type, drm_scheme, link=None):
@@ -476,6 +480,7 @@ class CirculationData(object):
             self.last_checked
         )
         return changed
+
 
 class Metadata(object):
 
@@ -648,7 +653,6 @@ class Metadata(object):
                 break
         return primary_author
 
-
     def update(self, metadata):
         """Update this Metadata object with values from the given Metadata
         object.
@@ -661,7 +665,6 @@ class Metadata(object):
             new_value = getattr(metadata, field)
             if new_value:
                 setattr(self, field, new_value)
-
 
     def calculate_permanent_work_id(self, _db, metadata_client):
         """Try to calculate a permanent work ID from this metadata.
@@ -775,7 +778,6 @@ class Metadata(object):
         if self.rights_uri == None:
             # We still haven't determined rights, so it's unknown.
             self.rights_uri = RightsStatus.UNKNOWN
-
 
     def license_pool(self, _db):
         if not self.primary_identifier:
@@ -897,8 +899,6 @@ class Metadata(object):
                 potentials[lp] = confidence
                 success = True
         return success
-
-
 
     # TODO: We need to change all calls to apply() to use a ReplacementPolicy
     # instead of passing in individual `replace` arguments. Once that's done,
@@ -1145,9 +1145,6 @@ class Metadata(object):
         )
         return edition, made_core_changes
 
-
-
-
     def mirror_link(self, pool, data_source, link, link_obj, policy):
         """Retrieve a copy of the given link and make sure it gets
         mirrored. If it's a full-size image, create a thumbnail and
@@ -1263,7 +1260,6 @@ class Metadata(object):
             if representation.mirrored_at and not representation.mirror_exception:
                 representation.content = None
 
-
     def make_thumbnail(self, pool, data_source, link, link_obj):
         """Make sure a Hyperlink representing an image is connected
         to its thumbnail.
@@ -1334,6 +1330,7 @@ class Metadata(object):
 
 class CSVFormatError(csv.Error):
     pass
+
 
 class CSVMetadataImporter(object):
 

--- a/model.py
+++ b/model.py
@@ -3100,19 +3100,18 @@ class Work(Base):
         )
 
     @classmethod
-    def feed_query(cls, _db, languages, availability=CURRENTLY_AVAILABLE):
-        """Return a query against Work suitable for using in OPDS feeds."""
+    def feed_query(cls, _db, languages=None, availability=ALL):
+        """Return a query against Work suitable for using in an OPDS feed."""
+
         q = _db.query(Work).join(Work.presentation_edition)
         q = q.join(Work.license_pools).join(LicensePool.data_source).join(LicensePool.identifier)
         q = q.options(
             contains_eager(Work.license_pools),
             contains_eager(Work.presentation_edition),
             contains_eager(Work.license_pools, LicensePool.data_source),
-            contains_eager(Work.license_pools, LicensePool.edition),
             contains_eager(Work.license_pools, LicensePool.identifier),
             defer(Work.verbose_opds_entry),
             defer(Work.presentation_edition, Edition.extra),
-            defer(Work.license_pools, LicensePool.edition, Edition.extra),
         )
         if availability == cls.CURRENTLY_AVAILABLE:
             or_clause = or_(
@@ -3123,8 +3122,9 @@ class Work(Base):
                 LicensePool.open_access==True,
                 LicensePool.licenses_owned > 0)
         q = q.filter(or_clause)
+        if languages:
+            q = q.filter(Edition.language.in_(languages))
         q = q.filter(
-            Edition.language.in_(languages),
             Work.presentation_ready == True,
             Edition.medium == Edition.BOOK_MEDIUM,
         )

--- a/model.py
+++ b/model.py
@@ -1162,7 +1162,7 @@ class Identifier(Base):
     def for_foreign_id(cls, _db, foreign_identifier_type, foreign_id,
                        autocreate=True):
         """Turn a foreign ID into an Identifier."""
-        was_new = None
+
         if foreign_identifier_type in (
                 Identifier.OVERDRIVE_ID, Identifier.THREEM_ID):
             foreign_id = foreign_id.lower()
@@ -1170,7 +1170,6 @@ class Identifier(Base):
             m = get_one_or_create
         else:
             m = get_one
-            was_new = False
 
         result = m(_db, cls, type=foreign_identifier_type,
                    identifier=foreign_id)

--- a/model.py
+++ b/model.py
@@ -4892,13 +4892,12 @@ class CachedFeed(Base):
             self.facets, self.pagination,
             self.timestamp, length
         )
-    
+
 
 Index(
     "ix_cachedfeeds_lane_name_type_facets_pagination", CachedFeed.lane_name, CachedFeed.type,
     CachedFeed.facets, CachedFeed.pagination
 )
-
 
 
 class LicensePool(Base):
@@ -5138,7 +5137,6 @@ class LicensePool(Base):
                 return True
         return False
 
-
     def editions_in_priority_order(self):
         """Return all Editions that describe the Identifier associated with
         this LicensePool, in the order they should be used to create a
@@ -5165,7 +5163,6 @@ class LicensePool(Base):
                 return -2
 
         return sorted(self.identifier.primarily_identifies, key=sort_key)
-
 
     # TODO:  policy is not used in this method.  Removing argument
     # breaks many-many tests, and needs own branch.
@@ -5359,7 +5356,6 @@ class LicensePool(Base):
                 _db.commit()
         _db.commit()
 
-
     def calculate_work(self, even_if_no_author=False, known_edition=None):
         """Try to find an existing Work for this LicensePool.
 
@@ -5515,7 +5511,6 @@ class LicensePool(Base):
 
         return best
 
-
     @property
     def best_license_link(self):
         """Find the best available licensing link for the work associated
@@ -5552,7 +5547,7 @@ class LicensePool(Base):
         )
         lpdm.resource = resource
         return lpdm
-        
+
 
 Index("ix_licensepools_data_source_id_identifier_id", LicensePool.data_source_id, LicensePool.identifier_id, unique=True)
 
@@ -6805,6 +6800,7 @@ class CustomList(Base):
         if edition.license_pool and not entry.license_pool:
             entry.license_pool = edition.license_pool
         return entry, was_new
+
 
 class CustomListEntry(Base):
 

--- a/testing.py
+++ b/testing.py
@@ -359,7 +359,6 @@ class DatabaseTest(object):
 
         return pool
 
-
     def _representation(self, url=None, media_type=None, content=None,
                         mirrored=False):
         url = url or "http://foo.com/" + self._str

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -571,6 +571,12 @@ class TestRecommendationData(DatabaseTest):
         result = recommendations.recommended_works
         eq_(None, result)
 
+        # It can also find a work if the identifier itself is passed, instead
+        # of an equivalency.
+        recommendations.identifiers = [work.license_pools[0].identifier]
+        result = recommendations.recommended_works
+        eq_(1, len(result.all()))
+
 
 class TestMetadata(DatabaseTest):
     def test_from_edition(self):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -580,7 +580,6 @@ class TestMetadata(DatabaseTest):
         for field in Metadata.BASIC_EDITION_FIELDS:
             eq_(getattr(edition, field), getattr(metadata, field))
 
-
         e_contribution = edition.contributions[0]
         m_contributor_data = metadata.contributors[0]
         eq_(e_contribution.contributor.name, m_contributor_data.sort_name)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -561,10 +561,15 @@ class TestRecommendationData(DatabaseTest):
         result = recommendations.recommended_works
         eq_(1, len(result.all()))
 
-        # Two of the same/similar identifiers still only lead to one result.
+        # Two of the same identifiers still only lead to one result.
         recommendations.identifiers.append(isbn)
         result = recommendations.recommended_works
         eq_(1, len(result.all()))
+
+        # No identifiers returns None.
+        recommendations.identifiers = []
+        result = recommendations.recommended_works
+        eq_(None, result)
 
 
 class TestMetadata(DatabaseTest):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -980,8 +980,6 @@ class TestLicensePool(DatabaseTest):
         # Only the two open-access download links show up.
         eq_(set([oa1, oa2]), set(pool.open_access_links))
 
-
-
     def test_better_open_access_pool_than(self):
 
         gutenberg_1 = self._licensepool(
@@ -1042,7 +1040,6 @@ class TestLicensePool(DatabaseTest):
         )
         eq_(True, better(no_resource, None))
         eq_(False, better(no_resource, gutenberg_1))
-        
 
     def test_with_complaint(self):
         type = iter(Complaint.VALID_TYPES)
@@ -1144,7 +1141,6 @@ class TestLicensePool(DatabaseTest):
         eq_(lp_ids, set([lp1.id, lp2.id, lp3.id]))
         eq_(counts, set([1]))
 
-
     def test_editions_in_priority_order(self):
         edition_admin = self._edition(data_source_name=DataSource.LIBRARY_STAFF, with_license_pool=False)
         edition_od, pool = self._edition(data_source_name=DataSource.OVERDRIVE, with_license_pool=True)
@@ -1165,7 +1161,6 @@ class TestLicensePool(DatabaseTest):
 
         for index, edition in enumerate(editions_correct):
             eq_(editions_contender[index].title, editions_correct[index].title)
-
 
     def test_set_presentation_edition(self):
         """
@@ -1352,8 +1347,6 @@ class TestWork(DatabaseTest):
         # The last update time has been set.
         # Updating availability also modified work.last_update_time.
         assert (datetime.datetime.utcnow() - work.last_update_time) < datetime.timedelta(seconds=2)
-        
-
 
     def test_set_presentation_ready(self):
         work = self._work(with_license_pool=True)
@@ -1420,7 +1413,6 @@ class TestWork(DatabaseTest):
         results = work.classifications_with_genre().all()
         
         eq_([classification2, classification1], results)
-
 
     def test_mark_licensepools_as_superceded(self):
         # A commercial LP that somehow got superceded will be
@@ -1502,7 +1494,6 @@ class TestWork(DatabaseTest):
         eq_(gitenberg1.superceded, True)
         eq_(gitenberg2.superceded, False)
 
-
     def test_work_remains_viable_on_pools_suppressed(self):
         """ If a work has all of its pools suppressed, the work's author, title, 
         and subtitle still have the last best-known info in them.
@@ -1557,9 +1548,6 @@ class TestWork(DatabaseTest):
         eq_("Alice Adder", work.author)
         eq_("Adder, Alice", work.sort_author)
 
-
-
-
     def test_work_updates_info_on_pool_suppressed(self):
         """ If the provider of the work's presentation edition gets suppressed, 
         the work will choose another child license pool's presentation edition as 
@@ -1612,7 +1600,6 @@ class TestWork(DatabaseTest):
         # The author of the Work is still the author of its last viable presentation edition.
         eq_("Alice Adder, Bob Bitshifter", work.author)
         eq_("Adder, Alice ; Bitshifter, Bob", work.sort_author)
-
 
 
 class TestCirculationEvent(DatabaseTest):


### PR DESCRIPTION
This branch translates between various Recommendation APIs (which is to say, NoveList, for now) and the works that we have available.

Also `Work.feed_query` wasn't being used anywhere, but it seems pretty useful, and looks like it overlaps with the work being done by `Lane.only_show_ready_deliverable_works`. I made some slight tweaks so it could work on a broader scale than just the feed, since I needed it to make sure the that print and audiobook ISBNs that NoveList sends back don't count as a recommendation.

Supports NYPL-Simplified/circulation#227.