### PR TITLE
Calling LicensePool.calculate_work() will automatically merge and split LicensePools to enforce the rules on Works

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -334,9 +334,7 @@ class CoverageProvider(object):
         if not license_pool:
             e = "No license pool available"
             return CoverageFailure(self, identifier, e, transient=True)
-        work, created = license_pool.calculate_work(
-            even_if_no_author=True, known_edition=self.edition(identifier)
-        )
+        work, created = license_pool.calculate_work(even_if_no_author=True)
         if not work:
             e = "Work could not be calculated"
             return CoverageFailure(self, identifier, e, transient=True)

--- a/coverage.py
+++ b/coverage.py
@@ -195,6 +195,7 @@ class CoverageProvider(object):
                 if item.transient:
                     # Ignore this error for now, but come back to it
                     # on the next run.
+                    self.log.warn("Transient failure: %s", item.exception)
                     transient_failures += 1
                     record = item
                 else:

--- a/model.py
+++ b/model.py
@@ -3161,7 +3161,6 @@ class Work(Base):
         """
         _db = Session.object_session(self)
         for pool in list(self.license_pools):
-            print pool.presentation_edition.permanent_work_id
             other_work = is_new = None
             if not pool.open_access:
                 # This needs to have its own Work--we don't mix
@@ -3175,7 +3174,6 @@ class Work(Base):
                 this_pwid = pool.presentation_edition.permanent_work_id
                 if not this_pwid:
                     continue
-                print this_pwid, pwid
                 if this_pwid != pwid:
                     # This LicensePool should not belong to this Work.
                     # Make sure it gets its own Work, creating a new one

--- a/model.py
+++ b/model.py
@@ -3215,8 +3215,6 @@ class Work(Base):
             _db.delete(wg)
         for cr in self.coverage_records:
             _db.delete(cr)
-        for contribution in self.contributions:
-            _db.delete(contribution)
         _db.delete(self)
 
     def set_summary(self, resource):

--- a/model.py
+++ b/model.py
@@ -3125,9 +3125,8 @@ class Work(Base):
         work = None
         if len(licensepools_for_work) == 0:
             # None of these LicensePools have a Work. Create a new one.
-            for pool in licensepools:
-                work = Work()
-                is_new = True
+            work = Work()
+            is_new = True
         else:
             # Pick the Work with the most LicensePools.
             work, count = licensepools_for_work.most_common(1)[0]
@@ -5631,7 +5630,6 @@ class LicensePool(Base):
             # setting pool.work to None before calling
             # pool.calculate_work(), and the recursive call only
             # happens if self.work is set.
-            my_pwid = self.presentation_edition
             for pool in list(work.license_pools):
                 if pool is self:
                     continue
@@ -5661,8 +5659,14 @@ class LicensePool(Base):
         # Recalculate the display information for the Work, since the
         # associated LicensePools have changed, which may have caused
         # the Work's presentation Edition to change.
-        if licensepools_changed:
-            work.calculate_presentation()
+        #
+        # TODO: In theory we can speed things up by only calling
+        # calculate_presentation if licensepools_changed is
+        # True. However, some bits of other code call calculate_work()
+        # under the assumption that it always calls
+        # calculate_presentation(), so we'd need to evaluate those
+        # call points first.
+        work.calculate_presentation()
 
         if is_new:
             logging.info("Created a new work: %r", work)

--- a/model.py
+++ b/model.py
@@ -5135,8 +5135,13 @@ class LicensePool(Base):
     )
 
     def __repr__(self):
-        return "<LicensePool #%s owned=%d available=%d reserved=%d holds=%d>" % (
-            self.id, self.licenses_owned, self.licenses_available, 
+        if self.identifier:
+            identifier = "%s/%s" % (self.identifier.type, 
+                                    self.identifier.identifier)
+        else:
+            identifier = "unknown identifier"
+        return "<LicensePool #%s for %s: owned=%d available=%d reserved=%d holds=%d>" % (
+            self.id, identifier, self.licenses_owned, self.licenses_available, 
             self.licenses_reserved, self.patrons_in_hold_queue
         )
 
@@ -5533,9 +5538,11 @@ class LicensePool(Base):
         that's really the case, pass in even_if_no_author=True and the
         Work will be created.
         """
-        self.set_presentation_edition(None)
-
-        presentation_edition = known_edition or self.presentation_edition
+        if known_edition:
+            presentation_edition = known_edition
+        else:
+            self.set_presentation_edition(None)
+            presentation_edition = self.presentation_edition
 
         logging.info("Calculating work for %r", presentation_edition)
         if not presentation_edition:

--- a/opds_import.py
+++ b/opds_import.py
@@ -185,7 +185,6 @@ class OPDSXMLParser(XMLParser):
 class StatusMessage(object):
 
     def __init__(self, status_code, message):
-        set_trace()
         try:
             status_code = int(status_code)
             success = (status_code == 200)

--- a/opds_import.py
+++ b/opds_import.py
@@ -185,6 +185,7 @@ class OPDSXMLParser(XMLParser):
 class StatusMessage(object):
 
     def __init__(self, status_code, message):
+        set_trace()
         try:
             status_code = int(status_code)
             success = (status_code == 200)

--- a/scripts.py
+++ b/scripts.py
@@ -418,7 +418,16 @@ class WorkProcessingScript(IdentifierInputScript):
     def process_work(self, work):
         raise NotImplementedError()      
 
-class WorkConsolidationScript(WorkProcessingScript):
+class WorkCalculationScript(WorkProcessingScript):
+    """Given an Identifier, make sure all the LicensePools for that
+    Identifier are in the correct Works, and that those Works follow
+    these rules:
+
+    a) For a given permanent work ID, there may be at most one Work
+    containing open-access LicensePools.
+
+    b) Each non-open-access LicensePool has its own Work.
+    """
 
     name = "Work consolidation script"
 
@@ -436,6 +445,11 @@ class WorkConsolidationScript(WorkProcessingScript):
                     continue
 
                 if pool.work:
+
+                    if pool.open_access:
+                        pool.make_
+
+                    pool.work = None
                     # We're about to delete a preexisting work. If the
                     # problem is that this LicensePool is incorrectly
                     # grouped together with some other LicensePool,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2063,7 +2063,7 @@ class TestWorkConsolidation(DatabaseTest):
 
     def test_open_access_for_permanent_work_id_no_licensepools(self):
         eq_(
-            None, Work.open_access_for_permanent_work_id(
+            (None, False), Work.open_access_for_permanent_work_id(
                 self._db, "No such permanent work ID"
             )
         )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1957,6 +1957,25 @@ class TestWorkConsolidation(DatabaseTest):
         assert restricted3.work != restricted4.work
         assert restricted3.work != open1.work
 
+
+    def test_pwids(self):
+        """Test the property that finds all permanent work IDs
+        associated with a Work.
+        """
+        # Create a (bad) situation in which LicensePools associated
+        # with two different PWIDs are associated with the same work.
+        work = self._work(with_license_pool=True)
+        [lp1] = work.license_pools
+        eq_(set([lp1.presentation_edition.permanent_work_id]),
+            work.pwids)
+        edition, lp2 = self._edition(with_license_pool=True)
+        work.license_pools.append(lp2)
+
+        eq_(set([lp1.presentation_edition.permanent_work_id,
+                 lp2.presentation_edition.permanent_work_id]),
+            work.pwids)
+
+
 class TestLoans(DatabaseTest):
 
     def test_open_access_loan(self):


### PR DESCRIPTION
Our production data has a lot of Works that contain LicensePools they shouldn't contain. Rather than try to tease out all the past bugs that led to this situation, this branch makes LicensePool.calculate_work() create new Works, destroy existing Works, and move LicensePools between works to enforce these two rules:

1. Every commercially-licensed LicensePool has its own unique Work.
2. Every open-access LicensePool associated with a given permanent work ID is grouped together in a single Work, which contains _only_ LicensePools associated with that specific PWID.