### PR TITLE
Support recommendation lanes

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -745,7 +745,6 @@ class Lane(object):
             list_ids = None
         return list_data_source_id, list_ids
 
-
     @classmethod
     def from_description(cls, _db, parent, description):
         genre = None

--- a/lane.py
+++ b/lane.py
@@ -903,7 +903,9 @@ class Lane(object):
             q = q.filter(WorkGenre.genre_id.in_(self.genre_ids))
 
         q = self.apply_filters(q, facets, pagination, Work, Edition)
-
+        if not q:
+            # apply_filters may return None in subclasses of Lane
+            return None
         return q
 
     def materialized_works(self, facets=None, pagination=None):
@@ -932,7 +934,9 @@ class Lane(object):
         q = q.join(LicensePool, LicensePool.id==mw.license_pool_id)
         q = q.options(contains_eager(mw.license_pool))
         q = self.apply_filters(q, facets, pagination, mw, mw)
-
+        if not q:
+            # apply_filters may return None in subclasses of Lane
+            return None
         return q
 
     def apply_filters(self, q, facets=None, pagination=None, work_model=Work, edition_model=Edition):

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -400,8 +400,8 @@ class RecommendationData(object):
 
         equivalent_identifier = aliased(Identifier)
         works_q = Work.feed_query(_db)
-        works_q = works_q.join(Identifier.equivalencies).\
-            join(equivalent_identifier, Equivalency.output).\
+        works_q = works_q.outerjoin(Identifier.equivalencies).\
+            outerjoin(equivalent_identifier, Equivalency.output).\
             filter(or_(
                 Identifier.id.in_(identifier_ids),
                 equivalent_identifier.id.in_(identifier_ids)

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -377,6 +377,9 @@ class RecommendationData(object):
 
     @property
     def recommended_works(self):
+        """:return: a query of all of the recommended works in self.identifiers
+        or None
+        """
         identifier_ids = []
         _db = Session.object_session(self.data_source)
         for identifier_data in self.identifiers[:]:
@@ -392,6 +395,9 @@ class RecommendationData(object):
                 continue
             identifier_ids.append(identifier.id)
 
+        if not identifier_ids:
+            return None
+
         equivalent_identifier = aliased(Identifier)
         works_q = Work.feed_query(_db)
         works_q = works_q.join(Identifier.equivalencies).\
@@ -400,9 +406,7 @@ class RecommendationData(object):
                 Identifier.id.in_(identifier_ids),
                 equivalent_identifier.id.in_(identifier_ids)
             ))
-
         return works_q
-
 
 class CirculationData(object):
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -126,6 +126,7 @@ class ReplacementPolicy(object):
             **args
         )
 
+
 class SubjectData(object):
     def __init__(self, type, identifier, name=None, weight=1):
         self.type = type
@@ -301,6 +302,7 @@ class IdentifierData(object):
             _db, self.type, self.identifier
         )
 
+
 class LinkData(object):
     def __init__(self, rel, href=None, media_type=None, content=None,
                  thumbnail=None, rights_uri=None):
@@ -332,6 +334,7 @@ class LinkData(object):
             content
         )
 
+
 class MeasurementData(object):
     def __init__(self,
                  quantity_measured,
@@ -353,6 +356,7 @@ class MeasurementData(object):
         return '<MeasurementData quantity="%s" value=%f weight=%d taken=%s>' % (
             self.quantity_measured, self.value, self.weight, self.taken_at
         )
+
 
 class FormatData(object):
     def __init__(self, content_type, drm_scheme, link=None):
@@ -476,6 +480,7 @@ class CirculationData(object):
             self.last_checked
         )
         return changed
+
 
 class Metadata(object):
 
@@ -648,7 +653,6 @@ class Metadata(object):
                 break
         return primary_author
 
-
     def update(self, metadata):
         """Update this Metadata object with values from the given Metadata
         object.
@@ -661,7 +665,6 @@ class Metadata(object):
             new_value = getattr(metadata, field)
             if new_value:
                 setattr(self, field, new_value)
-
 
     def calculate_permanent_work_id(self, _db, metadata_client):
         """Try to calculate a permanent work ID from this metadata.
@@ -775,7 +778,6 @@ class Metadata(object):
         if self.rights_uri == None:
             # We still haven't determined rights, so it's unknown.
             self.rights_uri = RightsStatus.UNKNOWN
-
 
     def license_pool(self, _db):
         if not self.primary_identifier:
@@ -897,8 +899,6 @@ class Metadata(object):
                 potentials[lp] = confidence
                 success = True
         return success
-
-
 
     # TODO: We need to change all calls to apply() to use a ReplacementPolicy
     # instead of passing in individual `replace` arguments. Once that's done,
@@ -1145,9 +1145,6 @@ class Metadata(object):
         )
         return edition, made_core_changes
 
-
-
-
     def mirror_link(self, pool, data_source, link, link_obj, policy):
         """Retrieve a copy of the given link and make sure it gets
         mirrored. If it's a full-size image, create a thumbnail and
@@ -1263,7 +1260,6 @@ class Metadata(object):
             if representation.mirrored_at and not representation.mirror_exception:
                 representation.content = None
 
-
     def make_thumbnail(self, pool, data_source, link, link_obj):
         """Make sure a Hyperlink representing an image is connected
         to its thumbnail.
@@ -1334,6 +1330,7 @@ class Metadata(object):
 
 class CSVFormatError(csv.Error):
     pass
+
 
 class CSVMetadataImporter(object):
 

--- a/migration/20160602-add-license-pool-id-to-cachedfeeds.sql
+++ b/migration/20160602-add-license-pool-id-to-cachedfeeds.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cachedfeeds add COLUMN license_pool_id integer;

--- a/model.py
+++ b/model.py
@@ -1162,7 +1162,7 @@ class Identifier(Base):
     def for_foreign_id(cls, _db, foreign_identifier_type, foreign_id,
                        autocreate=True):
         """Turn a foreign ID into an Identifier."""
-        was_new = None
+
         if foreign_identifier_type in (
                 Identifier.OVERDRIVE_ID, Identifier.THREEM_ID):
             foreign_id = foreign_id.lower()
@@ -1170,7 +1170,6 @@ class Identifier(Base):
             m = get_one_or_create
         else:
             m = get_one
-            was_new = False
 
         result = m(_db, cls, type=foreign_identifier_type,
                    identifier=foreign_id)

--- a/model.py
+++ b/model.py
@@ -3436,8 +3436,6 @@ class Work(Base):
         )
         return changed
 
-
-
     def calculate_presentation(self, policy=None, search_index_client=None):
         """Make a Work ready to show to patrons.
 
@@ -3559,8 +3557,6 @@ class Work(Base):
                 representation = repr(self)                
             logging.info("Presentation %s for work: %s", changed, representation)
 
-
-
     @property
     def detailed_representation(self):
         """A description of this work more detailed than repr()"""
@@ -3622,7 +3618,6 @@ class Work(Base):
         WorkCoverageRecord.add_for(
             self, operation=WorkCoverageRecord.GENERATE_OPDS_OPERATION
         )
-        # print self.id, self.simple_opds_entry, self.verbose_opds_entry
 
     def update_external_index(self, client):
         args = dict(index=client.works_index,
@@ -3770,7 +3765,6 @@ class Work(Base):
         self.work_genres = workgenres
 
         return workgenres, changed
-
 
     def assign_appeals(self, character, language, setting, story,
                        cutoff=0.20):

--- a/model.py
+++ b/model.py
@@ -4929,7 +4929,7 @@ class CachedFeed(Base):
     # The content of the feed.
     content = Column(Unicode, nullable=True)
 
-    # A LicensePool for feeds associated with a certain work.
+    # A feed may be associated with a LicensePool.
     license_pool_id = Column(Integer, ForeignKey('licensepools.id'),
         nullable=True, index=True)
 

--- a/model.py
+++ b/model.py
@@ -3267,8 +3267,10 @@ class Work(Base):
 
     @classmethod
     def from_identifiers(cls, _db, identifiers, base_query=None):
-        """Finds all of the works indicated by a list of identifiers"""
-
+        """Returns all of the works that have one or more license_pools
+        associated with either an identifier in the given list or an
+        identifier considered equivalent to one of those listed
+        """
         identifier_ids = [identifier.id for identifier in identifiers]
         if not identifier_ids:
             return None
@@ -3284,7 +3286,8 @@ class Work(Base):
                 outerjoin(equivalent_identifier, Equivalency.output).\
                 filter(or_(
                     Identifier.id.in_(identifier_ids),
-                    equivalent_identifier.id.in_(identifier_ids)
+                    and_(equivalent_identifier.id.in_(identifier_ids),
+                    Equivalency.strength>=1)
                 ))
         return query
 

--- a/model.py
+++ b/model.py
@@ -4932,6 +4932,7 @@ class CachedFeed(Base):
 
     GROUPS_TYPE = 'groups'
     PAGE_TYPE = 'page'
+    RECOMMENDATIONS_TYPE = 'recommendations'
 
     log = logging.getLogger("CachedFeed")
 
@@ -4939,7 +4940,9 @@ class CachedFeed(Base):
     def fetch(cls, _db, lane, type, facets, pagination, annotator,
               force_refresh=False, max_age=None):
         if max_age is None:
-            if type == cls.GROUPS_TYPE:
+            if lane and hasattr(lane, 'MAX_CACHE_AGE'):
+                max_age = lane.MAX_CACHE_AGE
+            elif type == cls.GROUPS_TYPE:
                 max_age = Configuration.groups_max_age()
             elif type == cls.PAGE_TYPE:
                 max_age = Configuration.page_max_age()

--- a/model.py
+++ b/model.py
@@ -5042,13 +5042,12 @@ class CachedFeed(Base):
             self.facets, self.pagination,
             self.timestamp, length
         )
-    
+
 
 Index(
     "ix_cachedfeeds_lane_name_type_facets_pagination", CachedFeed.lane_name, CachedFeed.type,
     CachedFeed.facets, CachedFeed.pagination
 )
-
 
 
 class LicensePool(Base):
@@ -5298,7 +5297,6 @@ class LicensePool(Base):
                 return True
         return False
 
-
     def editions_in_priority_order(self):
         """Return all Editions that describe the Identifier associated with
         this LicensePool, in the order they should be used to create a
@@ -5325,7 +5323,6 @@ class LicensePool(Base):
                 return -2
 
         return sorted(self.identifier.primarily_identifies, key=sort_key)
-
 
     # TODO:  policy is not used in this method.  Removing argument
     # breaks many-many tests, and needs own branch.
@@ -5519,7 +5516,6 @@ class LicensePool(Base):
             if a and not a % batch_size:
                 _db.commit()
         _db.commit()
-
 
     def calculate_work(self, even_if_no_author=False, known_edition=None):
         """Find or create a Work for this LicensePool.
@@ -5721,7 +5717,6 @@ class LicensePool(Base):
 
         return best
 
-
     @property
     def best_license_link(self):
         """Find the best available licensing link for the work associated
@@ -5758,7 +5753,7 @@ class LicensePool(Base):
         )
         lpdm.resource = resource
         return lpdm
-        
+
 
 Index("ix_licensepools_data_source_id_identifier_id", LicensePool.data_source_id, LicensePool.identifier_id, unique=True)
 
@@ -7012,6 +7007,7 @@ class CustomList(Base):
         if edition.license_pool and not entry.license_pool:
             entry.license_pool = edition.license_pool
         return entry, was_new
+
 
 class CustomListEntry(Base):
 

--- a/opds.py
+++ b/opds.py
@@ -488,17 +488,15 @@ class AcquisitionFeed(OPDSFeed):
 
     @classmethod
     def groups(cls, _db, title, url, lane, annotator, 
-               force_refresh=False, cache_type=None,
-               use_materialized_works=True):
+               force_refresh=False, use_materialized_works=True):
         """The acquisition feed for 'featured' items from a given lane's
         sublanes, organized into per-lane groups.
         """
         # Find or create a CachedFeed.
-        cache_type = cache_type or CachedFeed.GROUPS_TYPE
         cached, usable = CachedFeed.fetch(
             _db,
             lane=lane,
-            type=cache_type,
+            type=CachedFeed.GROUPS_TYPE,
             facets=None,
             pagination=None,
             annotator=annotator,

--- a/testing.py
+++ b/testing.py
@@ -359,7 +359,6 @@ class DatabaseTest(object):
 
         return pool
 
-
     def _representation(self, url=None, media_type=None, content=None,
                         mirrored=False):
         url = url or "http://foo.com/" + self._str

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -571,6 +571,12 @@ class TestRecommendationData(DatabaseTest):
         result = recommendations.recommended_works
         eq_(None, result)
 
+        # It can also find a work if the identifier itself is passed, instead
+        # of an equivalency.
+        recommendations.identifiers = [work.license_pools[0].identifier]
+        result = recommendations.recommended_works
+        eq_(1, len(result.all()))
+
 
 class TestMetadata(DatabaseTest):
     def test_from_edition(self):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -580,7 +580,6 @@ class TestMetadata(DatabaseTest):
         for field in Metadata.BASIC_EDITION_FIELDS:
             eq_(getattr(edition, field), getattr(metadata, field))
 
-
         e_contribution = edition.contributions[0]
         m_contributor_data = metadata.contributors[0]
         eq_(e_contribution.contributor.name, m_contributor_data.sort_name)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -561,10 +561,15 @@ class TestRecommendationData(DatabaseTest):
         result = recommendations.recommended_works
         eq_(1, len(result.all()))
 
-        # Two of the same/similar identifiers still only lead to one result.
+        # Two of the same identifiers still only lead to one result.
         recommendations.identifiers.append(isbn)
         result = recommendations.recommended_works
         eq_(1, len(result.all()))
+
+        # No identifiers returns None.
+        recommendations.identifiers = []
+        result = recommendations.recommended_works
+        eq_(None, result)
 
 
 class TestMetadata(DatabaseTest):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -686,7 +686,11 @@ class TestMetadata(DatabaseTest):
         )
         metadata.recommendations = [known_identifier_data, unknown_identifier]
         metadata.filter_recommendations(self._db)
-        eq_([known_identifier_data], metadata.recommendations)
+        [result] = metadata.recommendations
+        # The IdentifierData has been replaced by a bonafide Identifier.
+        eq_(True, isinstance(result, Identifier))
+        # The genuwine article.
+        eq_(known_identifier, result)
 
     def test_metadata_can_be_deepcopied(self):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -998,8 +998,6 @@ class TestLicensePool(DatabaseTest):
         # Only the two open-access download links show up.
         eq_(set([oa1, oa2]), set(pool.open_access_links))
 
-
-
     def test_better_open_access_pool_than(self):
 
         gutenberg_1 = self._licensepool(
@@ -1060,7 +1058,6 @@ class TestLicensePool(DatabaseTest):
         )
         eq_(True, better(no_resource, None))
         eq_(False, better(no_resource, gutenberg_1))
-        
 
     def test_with_complaint(self):
         type = iter(Complaint.VALID_TYPES)
@@ -1162,7 +1159,6 @@ class TestLicensePool(DatabaseTest):
         eq_(lp_ids, set([lp1.id, lp2.id, lp3.id]))
         eq_(counts, set([1]))
 
-
     def test_editions_in_priority_order(self):
         edition_admin = self._edition(data_source_name=DataSource.LIBRARY_STAFF, with_license_pool=False)
         edition_od, pool = self._edition(data_source_name=DataSource.OVERDRIVE, with_license_pool=True)
@@ -1183,7 +1179,6 @@ class TestLicensePool(DatabaseTest):
 
         for index, edition in enumerate(editions_correct):
             eq_(editions_contender[index].title, editions_correct[index].title)
-
 
     def test_set_presentation_edition(self):
         """
@@ -1370,8 +1365,6 @@ class TestWork(DatabaseTest):
         # The last update time has been set.
         # Updating availability also modified work.last_update_time.
         assert (datetime.datetime.utcnow() - work.last_update_time) < datetime.timedelta(seconds=2)
-        
-
 
     def test_set_presentation_ready(self):
         work = self._work(with_license_pool=True)
@@ -1438,7 +1431,6 @@ class TestWork(DatabaseTest):
         results = work.classifications_with_genre().all()
         
         eq_([classification2, classification1], results)
-
 
     def test_mark_licensepools_as_superceded(self):
         # A commercial LP that somehow got superceded will be
@@ -1520,7 +1512,6 @@ class TestWork(DatabaseTest):
         eq_(gitenberg1.superceded, True)
         eq_(gitenberg2.superceded, False)
 
-
     def test_work_remains_viable_on_pools_suppressed(self):
         """ If a work has all of its pools suppressed, the work's author, title, 
         and subtitle still have the last best-known info in them.
@@ -1575,9 +1566,6 @@ class TestWork(DatabaseTest):
         eq_("Alice Adder", work.author)
         eq_("Adder, Alice", work.sort_author)
 
-
-
-
     def test_work_updates_info_on_pool_suppressed(self):
         """ If the provider of the work's presentation edition gets suppressed, 
         the work will choose another child license pool's presentation edition as 
@@ -1630,7 +1618,6 @@ class TestWork(DatabaseTest):
         # The author of the Work is still the author of its last viable presentation edition.
         eq_("Alice Adder, Bob Bitshifter", work.author)
         eq_("Adder, Alice ; Bitshifter, Bob", work.sort_author)
-
 
 
 class TestCirculationEvent(DatabaseTest):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1257,6 +1257,12 @@ class TestWork(DatabaseTest):
         eq_(1, len(result))
         eq_([work], result)
 
+        # Unless the strength is too low.
+        lp.identifier.equivalencies[0].strength = 0.8
+        identifiers = [isbn]
+        result = Work.from_identifiers(self._db, identifiers).all()
+        eq_([], result)
+
         # Two+ of the same or equivalent identifiers lead to one result.
         identifiers = [lp.identifier, isbn, lp.identifier]
         result = Work.from_identifiers(self._db, identifiers).all()

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -826,13 +826,13 @@ class TestOPDS(DatabaseTest):
 
             feed = AcquisitionFeed.groups(
                 self._db, "test", self._url, fantasy_lane, annotator, 
-                False, False
+                force_refresh=False, use_materialized_works=False
             )
             eq_(CachedFeed.PAGE_TYPE, feed.type)
 
             cached_groups = AcquisitionFeed.groups(
                 self._db, "test", self._url, fantasy_lane, annotator, 
-                True, False
+                force_refresh=True, use_materialized_works=False
             )
             parsed = feedparser.parse(cached_groups.content)
             
@@ -894,7 +894,7 @@ class TestOPDS(DatabaseTest):
 
             feed = AcquisitionFeed.groups(
                 self._db, "test", self._url, test_lane, annotator,
-                True, False
+                force_refresh=True, use_materialized_works=False
             )
 
             # The feed is filed as a groups feed, even though in


### PR DESCRIPTION
Replacing #281, this branch supports NYPL-Simplified/circulation#227. As suggested in that PR, this branch:

- creates `Work.from_identifiers`, a schweet method to return all of the works related to a list of identifiers
- tosses a list of recommendations (Identifiers or IdentifierDatas) into the metadata layer and gives Metadata the ability to filter out identifiers that aren't available in circulation
- Makes some slightly-awkward caveats around CachedFeeds, including connecting them to LicensePools and letting Lanes indicate their own `MAX_CACHE_AGE`
- Also let's Lane subclasses set an `apply_filters()` method that just cancels out the whole dang thing.

In general, lanes are on the come up. I think this is moving towards a `WorkBasedLane` or `LicensePoolBasedLane` parent class (for books in a series, other works by an author, etc.), in which case `Lane` will likely change a bit more. I wanted to do minimal damage here, though.