### PR TITLE
LookupAcquisitionFeed

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -1224,9 +1224,9 @@ class LookupAcquisitionFeed(AcquisitionFeed):
         if self.require_active_licensepool and not active_licensepool:
             error_status = 404
             error_message = "Identifier not found in collection"
-
-        if (not identifier.licensed_through
-            or identifier.licensed_through.work != work):
+        
+        if (identifier.licensed_through and 
+            identifier.licensed_through.work != work):
             error_status = 500
             error_message = 'I tried to generate an OPDS entry for the identifier "%s" using a Work not associated with that identifier.' % identifier.urn
            

--- a/opds.py
+++ b/opds.py
@@ -773,7 +773,7 @@ class AcquisitionFeed(OPDSFeed):
         return entry
 
     def create_entry(self, work, lane_link, even_if_no_license_pool=False,
-                     force_create=False):
+                     force_create=False, use_cache=True):
         """Turn a work into an entry for an acquisition feed."""
         if isinstance(work, Edition):
             active_edition = work
@@ -807,7 +807,8 @@ class AcquisitionFeed(OPDSFeed):
             return None
 
         return self._create_entry(work, active_license_pool, active_edition,
-                                  identifier, lane_link, force_create)
+                                  identifier, lane_link, force_create, 
+                                  use_cache)
 
     def _create_entry(self, work, license_pool, edition, identifier, lane_link,
                       force_create=False, use_cache=True):

--- a/opds.py
+++ b/opds.py
@@ -810,12 +810,12 @@ class AcquisitionFeed(OPDSFeed):
                                   identifier, lane_link, force_create)
 
     def _create_entry(self, work, license_pool, edition, identifier, lane_link,
-                      force_create=False):
+                      force_create=False, use_cache=True):
 
         xml = None
         cache_hit = False
         field = self.annotator.opds_cache_field
-        if field and work and not force_create:
+        if field and work and not force_create and use_cache:
             xml = getattr(work, field)
 
         if xml:
@@ -828,7 +828,7 @@ class AcquisitionFeed(OPDSFeed):
             xml = self._make_entry_xml(
                 work, license_pool, edition, identifier, lane_link)
             data = etree.tostring(xml)
-            if field:
+            if field and use_cache:
                 setattr(work, field, data)
 
         self.annotator.annotate_work_entry(
@@ -1189,11 +1189,10 @@ class AcquisitionFeed(OPDSFeed):
 
 
 class LookupAcquisitionFeed(AcquisitionFeed):
-
-    """Used when the work's primary identifier may be different
-    from the identifier we should use in the feed.
+    """Used when the user has requested a lookup of a specific identifier,
+    which may be different from the identifier used by the Work's
+    default LicensePool.
     """
-
     def __init__(self, _db, title, url, works, annotator=None,
                  messages_by_urn={}, precomposed_entries=[],
                  require_active_licensepool=True):
@@ -1205,17 +1204,41 @@ class LookupAcquisitionFeed(AcquisitionFeed):
         )
 
     def create_entry(self, work, lane_link):
-        """Turn a work into an entry for an acquisition feed."""
+        """Turn an Identifier and a Work into an entry for an acquisition
+        feed.
+        """
         identifier, work = work
-        active_license_pool = self.annotator.active_licensepool_for(work)
 
-        if self.require_active_licensepool and not active_license_pool:
-            message = { identifier.urn : (404, "Identifier not found in collection")}
-            entry = list(self.render_messages(message))[0]
-            self.feed.append(entry)
-            return None
+        # Most of the time we can use the cached OPDS entry for the
+        # work.  However, that cached OPDS feed is designed around one
+        # specific LicensePool, and it's possible that the client is
+        # asking for a lookup centered around a different LicensePool.
+        default_licensepool = self.annotator.active_licensepool_for(work)
+        active_licensepool = identifier.licensed_through
 
-        edition = work.presentation_edition
+        # In that case, we can't use the cached OPDS entry. We need to
+        # create a new one (and not store it in the cache).
+        use_cache = (active_licensepool == default_licensepool)
+
+        error_status = error_message = None
+        if self.require_active_licensepool and not active_licensepool:
+            error_status = 404
+            error_message = "Identifier not found in collection"
+
+        if (not identifier.licensed_through
+            or identifier.licensed_through.work != work):
+            error_status = 500
+            error_message = 'I tried to generate an OPDS entry for the identifier "%s" using a Work not associated with that identifier.' % identifier.urn
+           
+        if error_status:
+            message = { identifier.urn : (error_status, error_message)}
+            return list(self.render_messages(message))[0]
+
+        if active_licensepool:
+            edition = active_licensepool.presentation_edition
+        else:
+            edition = work.presentation_edition
         return self._create_entry(
-            work, active_license_pool, edition, identifier, lane_link
+            work, active_licensepool, edition, identifier, lane_link,
+            use_cache=use_cache
         )


### PR DESCRIPTION
This branch gives the LookupAcquisitionFeed a limited ability to provide information about a LicensePool that is not the primary LicensePool for its Work. I've tried to do the minimal amount of work necessary (I kind of want to tear this whole thing up and start over) while solving the immediate problem and adding tests to an under-tested part of our architecture.

The input to LookupAcquisitionFeed is a list of 2-tuples (Identifier, Work). But before this branch, the Identifier was more or less ignored. The `<id>` of the resulting OPDS <entry> was taken from the Work's primary LicensePool. The open-access link (if any) was taken from the Work's primary LicensePool. 

With this branch, information associated directly with the work (cover image, description) will still be derived from the presentation edition of the Work's primary LicensePool, but the `<id>`, the open-access links, and basic bibliographic information such as the title will be derived from the presentation edition of the LicensePool associated with the lookup request.

If you look up an Identifier that's not the primary for a Work, the Work's simple_opds_entry cache is bypassed and not updated.