### PR TITLE
Fix fast query count

### DIFF
--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -652,7 +652,7 @@ class TestLanesQuery(DatabaseTest):
         self.spanish.simple_opds_entry = '<entry>'
 
         # Refresh the materialized views so that all these books are present
-        # in the 
+        # in them.
         SessionManager.refresh_materialized_views(self._db)
 
     def test_lanes(self):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -762,9 +762,10 @@ class TestOPDS(DatabaseTest):
         pagination = Pagination(size=1)
 
         def make_page(pagination):
+            SessionManager.refresh_materialized_views(self._db)
             return AcquisitionFeed.page(
                 self._db, "test", self._url, fantasy_lane, TestAnnotator, 
-                pagination=pagination, use_materialized_works=False
+                pagination=pagination, use_materialized_works=True
             )
         cached_works = make_page(pagination)
         parsed = feedparser.parse(unicode(cached_works.content))
@@ -824,19 +825,21 @@ class TestOPDS(DatabaseTest):
             # an attempt to generate them will fail. You'll get a
             # page-type feed as a consolation prize.
 
+            SessionManager.refresh_materialized_views(self._db)
             feed = AcquisitionFeed.groups(
                 self._db, "test", self._url, fantasy_lane, annotator, 
-                force_refresh=False, use_materialized_works=False
+                force_refresh=False, use_materialized_works=True
             )
             eq_(CachedFeed.PAGE_TYPE, feed.type)
 
             cached_groups = AcquisitionFeed.groups(
                 self._db, "test", self._url, fantasy_lane, annotator, 
-                force_refresh=True, use_materialized_works=False
+                force_refresh=True, use_materialized_works=True
             )
             parsed = feedparser.parse(cached_groups.content)
             
             # There are two entries, one for each work.
+            set_trace()
             e1, e2 = parsed['entries']
 
             # Each entry has one and only one link.
@@ -892,9 +895,10 @@ class TestOPDS(DatabaseTest):
             config['policies'][Configuration.GROUPS_MAX_AGE_POLICY] = Configuration.CACHE_FOREVER
             annotator = TestAnnotator()
 
+            SessionManager.refresh_materialized_views(self._db)
             feed = AcquisitionFeed.groups(
                 self._db, "test", self._url, test_lane, annotator,
-                force_refresh=True, use_materialized_works=False
+                force_refresh=True, use_materialized_works=True
             )
 
             # The feed is filed as a groups feed, even though in
@@ -981,9 +985,10 @@ class TestOPDS(DatabaseTest):
         fantasy_lane = self.lanes.by_languages['']['Fantasy']
 
         def make_page():
+            SessionManager.refresh_materialized_views(self._db)
             return AcquisitionFeed.page(
                 self._db, "test", self._url, fantasy_lane, TestAnnotator, 
-                pagination=Pagination.default(), use_materialized_works=False
+                pagination=Pagination.default(), use_materialized_works=True
             )
 
         with temp_config() as config:

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -762,10 +762,9 @@ class TestOPDS(DatabaseTest):
         pagination = Pagination(size=1)
 
         def make_page(pagination):
-            SessionManager.refresh_materialized_views(self._db)
             return AcquisitionFeed.page(
                 self._db, "test", self._url, fantasy_lane, TestAnnotator, 
-                pagination=pagination, use_materialized_works=True
+                pagination=pagination, use_materialized_works=False
             )
         cached_works = make_page(pagination)
         parsed = feedparser.parse(unicode(cached_works.content))
@@ -825,16 +824,15 @@ class TestOPDS(DatabaseTest):
             # an attempt to generate them will fail. You'll get a
             # page-type feed as a consolation prize.
 
-            SessionManager.refresh_materialized_views(self._db)
             feed = AcquisitionFeed.groups(
                 self._db, "test", self._url, fantasy_lane, annotator, 
-                force_refresh=False, use_materialized_works=True
+                force_refresh=False, use_materialized_works=False
             )
             eq_(CachedFeed.PAGE_TYPE, feed.type)
 
             cached_groups = AcquisitionFeed.groups(
                 self._db, "test", self._url, fantasy_lane, annotator, 
-                force_refresh=True, use_materialized_works=True
+                force_refresh=True, use_materialized_works=False
             )
             parsed = feedparser.parse(cached_groups.content)
             
@@ -894,10 +892,9 @@ class TestOPDS(DatabaseTest):
             config['policies'][Configuration.GROUPS_MAX_AGE_POLICY] = Configuration.CACHE_FOREVER
             annotator = TestAnnotator()
 
-            SessionManager.refresh_materialized_views(self._db)
             feed = AcquisitionFeed.groups(
                 self._db, "test", self._url, test_lane, annotator,
-                force_refresh=True, use_materialized_works=True
+                force_refresh=True, use_materialized_works=False
             )
 
             # The feed is filed as a groups feed, even though in
@@ -984,10 +981,9 @@ class TestOPDS(DatabaseTest):
         fantasy_lane = self.lanes.by_languages['']['Fantasy']
 
         def make_page():
-            SessionManager.refresh_materialized_views(self._db)
             return AcquisitionFeed.page(
                 self._db, "test", self._url, fantasy_lane, TestAnnotator, 
-                pagination=Pagination.default(), use_materialized_works=True
+                pagination=Pagination.default(), use_materialized_works=False
             )
 
         with temp_config() as config:

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -839,7 +839,6 @@ class TestOPDS(DatabaseTest):
             parsed = feedparser.parse(cached_groups.content)
             
             # There are two entries, one for each work.
-            set_trace()
             e1, e2 = parsed['entries']
 
             # Each entry has one and only one link.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,7 +8,6 @@ from nose.tools import (
 )
 
 from model import (
-    CustomListEntry,
     Identifier,
     Edition
 )

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -28,6 +28,11 @@ def fast_query_count(query):
     new_columns = [func.count()]
     count_q = statement.with_only_columns(new_columns).order_by(None)
     if isinstance(distinct_columns, list):
+        # TODO: We currently can't create a reliable count for queries
+        # that include specific distinct columns.  Just calculate the
+        # count the normal way.
+        return query.count()
+
         # We didn't need GROUP BY when we were selecting rows made
         # distinct by a list of columns, but now that we're selecting
         # an aggregate function we do need to GROUP BY those columns.

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -10,8 +10,6 @@ import os
 import re
 import string
 from sqlalchemy.sql.functions import func
-from sqlalchemy import distinct
-
 
 def batch(iterable, size=1):
     """Split up `iterable` into batches of size `size`."""

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -25,7 +25,8 @@ def fast_query_count(query):
 
     statement = query.enable_eagerloads(False).statement
     distinct_columns = statement._distinct
-    count_q = statement.with_only_columns([func.count()]).order_by(None)
+    new_columns = [func.count()]
+    count_q = statement.with_only_columns(new_columns).order_by(None)
     if isinstance(distinct_columns, list):
         # We didn't need GROUP BY when we were selecting rows made
         # distinct by a list of columns, but now that we're selecting

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -36,7 +36,7 @@ def fast_query_count(query):
         # We didn't need GROUP BY when we were selecting rows made
         # distinct by a list of columns, but now that we're selecting
         # an aggregate function we do need to GROUP BY those columns.
-        count_q = count_q.group_by(*distinct_columns)
+        # count_q = count_q.group_by(*distinct_columns)
     count = query.session.execute(count_q).scalar()
     return count
 


### PR DESCRIPTION
fast_query_count crashes when asked to calculate the size of a query that includes a DISTINCT statement applied to a subset of the columns. This branch stops the crash and adds some tests but as yet Courteney and I have not been able to find a way to always make fast_query_count return the correct values.

As a stopgap measure I've changed fast_query_count so that if it detects the kind of query that's going to cause problems, it falls back to the slower .count() behavior.