### PR TITLE
More robust merges

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -60,7 +60,7 @@ class CoverageProvider(object):
         self._db = Session.object_session(output_source)
         self.service_name = service_name
 
-        if not isinstance(input_identifier_types, list):
+        if input_identifier_types and not isinstance(input_identifier_types, list):
             input_identifier_types = [input_identifier_types]
         self.input_identifier_types = input_identifier_types
         self.output_source_name = output_source.name

--- a/model.py
+++ b/model.py
@@ -3232,10 +3232,10 @@ class Work(Base):
         my_pwids = self.pwids
         other_pwids = other_work.pwids
         if not my_pwids == other_pwids:
-            difference = my_pwids.symmetric_difference(other_pwids)
             raise ValueError(
-                "Refusing to merge %r into %r because it has permanent work IDs not present in the target work: %s" % (
-                    self, other_work, ",".join(difference)
+                "Refusing to merge %r into %r because permanent work IDs don't match: %s vs. %s" % (
+                    self, other_work, ",".join(sorted(my_pwids)),
+                    ",".join(sorted(other_pwids))
                 )
             )
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -513,6 +513,15 @@ class TestCoverageProvider(DatabaseTest):
             operations()
         )
 
+    def test_no_input_identifier_types(self):
+        # It's okay to pass in None to the constructor--it means you
+        # are looking for all identifier types.
+        provider = AlwaysSuccessfulCoverageProvider(
+            "Always successful", None, self.output_source
+        )
+        eq_(None, provider.input_identifier_types)
+
+
 class TestBibliographicCoverageProvider(DatabaseTest):
 
     BIBLIOGRAPHIC_DATA = Metadata(
@@ -669,4 +678,3 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         ed, lp = self._edition(with_license_pool=True)
         result = provider.set_presentation_ready(ed.primary_identifier)
         eq_(result, ed.primary_identifier)
-

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2397,7 +2397,7 @@ class TestWorkConsolidation(DatabaseTest):
         # it doesn't put us into an infinite loop.
         assert_raises_regexp(
             ValueError,
-            "Refusing to merge .* into .* because it has permanent work IDs not present in the target work: efgh",
+            "Refusing to merge .* into .* because permanent work IDs don't match: abcd,efgh vs. abcd",
             Work.open_access_for_permanent_work_id, self._db, "abcd"
         )
 
@@ -2436,7 +2436,7 @@ class TestWorkConsolidation(DatabaseTest):
 
         assert_raises_regexp(
             ValueError,
-            "Refusing to merge .* into .* because it has permanent work IDs not present in the target work: abcd",
+            "Refusing to merge .* into .* because permanent work IDs don't match: abcd vs. efgh",
             work1.merge_into, 
             work2
         )


### PR DESCRIPTION
This branch improves the robustness of Work.open_access_for_permanent_work_id. It correctly unifies works even if they both contain LicensePools for totally unrelated works.

There's one case I couldn't fix, in which Work A has a LicensePool that belongs in Work B, and Work B has a LicensePool that belongs in Work A. I wrote a test to verify that this case results in an exception, rather than a (much worse) infinite loop. Because fixing this is a lot of work and this particular use case is incredibly unlikely, I'm not addressing it now. If you have suggestions about how to address this I'd be interested in hearing them.

I also made a very minor, unrelated bugfix to the CoverageProvider constructor, and added a tiny test for it.