### PR TITLE
Fix bibliographic coverage

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -364,6 +364,11 @@ class CoverageProvider(object):
         CoverageFailure (if not).
         """
 
+        if not metadata and not circulationdata:
+            e = "Received neither metadata nor circulation data from input source"
+            return CoverageFailure(self, identifier, e, transient=True)
+
+
         if metadata:
             result = self._set_metadata(identifier, metadata, metadata_replacement_policy)
             if isinstance(result, CoverageFailure):

--- a/coverage.py
+++ b/coverage.py
@@ -517,6 +517,18 @@ class BibliographicCoverageProvider(CoverageProvider):
             cutoff_time=cutoff_time
         )
 
-    def process_batch(self):
+    def process_batch(self, identifiers):
         """Returns a list of successful identifiers and CoverageFailures"""
-        raise NotImplementedError
+        results = []
+        for identifier in identifiers:
+            result = self.process_item(identifier)
+            if not isinstance(result, CoverageFailure):
+                self.handle_success(identifier)
+            results.append(result)
+        return results
+
+    def handle_success(self, identifier):
+        self.set_presentation_ready(identifier)
+
+    def process_item(self, identifier):
+        raise NotImplementedError()

--- a/coverage.py
+++ b/coverage.py
@@ -341,6 +341,12 @@ class CoverageProvider(object):
         return work
 
 
+    def set_metadata(self, identifier, metadata, 
+                     metadata_replacement_policy=None):
+        return self.set_metadata_and_circulation_data(
+            identifier, metadata, None, metadata_replacement_policy,
+        )
+
     def set_metadata_and_circulation_data(self, identifier, metadata, circulationdata, 
         metadata_replacement_policy=None, 
         circulationdata_replacement_policy=None, 
@@ -358,13 +364,15 @@ class CoverageProvider(object):
         CoverageFailure (if not).
         """
 
-        result = self._set_metadata(identifier, metadata, metadata_replacement_policy)
-        if isinstance(result, CoverageFailure):
-            return result
-        
-        result = self._set_circulationdata(identifier, circulationdata, circulationdata_replacement_policy)
-        if isinstance(result, CoverageFailure):
-            return result
+        if metadata:
+            result = self._set_metadata(identifier, metadata, metadata_replacement_policy)
+            if isinstance(result, CoverageFailure):
+                return result
+
+        if circulationdata:
+            result = self._set_circulationdata(identifier, circulationdata, circulationdata_replacement_policy)
+            if isinstance(result, CoverageFailure):
+                return result
 
         # now that made sure that have an edition and a pool on the identifier, 
         # can try to make work

--- a/coverage.py
+++ b/coverage.py
@@ -221,7 +221,7 @@ class CoverageProvider(object):
         num_ignored = max(0, batch_size - len(results))
 
         self.log.info(
-            "Batch processed with %d successes, %d transient failures, %d ignored, %d persistent failures.",
+            "Batch processed with %d successes, %d transient failures, %d persistent failures, %d ignored.",
             successes, transient_failures, persistent_failures, num_ignored
         )
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -649,14 +649,12 @@ class CirculationData(MetaToModelUtility):
             self.data_source_obj = obj
         return self.data_source_obj
 
-
     def license_pool(self, _db):
         """Find or create a LicensePool object for this CirculationData."""
         if not self.primary_identifier:
             raise ValueError(
                 "Cannot find license pool: CirculationData has no primary identifier."
             )
-
         license_pool = None
         is_new = False
         
@@ -666,7 +664,6 @@ class CirculationData(MetaToModelUtility):
             _db, LicensePool, data_source=data_source,
             identifier=identifier_obj
         )
-
         if not license_pool:
             rights_status = get_one(
                 _db, RightsStatus, uri=self.default_rights_uri

--- a/overdrive.py
+++ b/overdrive.py
@@ -871,15 +871,11 @@ class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
             workset_size=10, metadata_replacement_policy=metadata_replacement_policy, **kwargs
         )
 
-    def process_batch(self, identifiers):
-        return [self.process_item(identifier) for identifier in identifiers]
-
-
     def process_item(self, identifier):
         info = self.api.metadata_lookup(identifier)
         error = None
         if info.get('errorCode') == 'NotFound':
-            error = "ID %s not recognized by Overdrive" % identifier.identifier
+            error = "ID not recognized by Overdrive: %s" % identifier.identifier
         elif info.get('errorCode') == 'InvalidGuid':
             error = "Invalid Overdrive ID: %s" % identifier.identifier
 
@@ -894,10 +890,9 @@ class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
             e = "Could not extract metadata from Overdrive data: %r" % info
             return CoverageFailure(self, identifier, e, transient=True)
 
-        result = self.set_metadata_and_circulation_data(
-            identifier, metadata, metadata.circulation, 
-            metadata_replacement_policy=self.metadata_replacement_policy, 
-            circulationdata_replacement_policy=self.circulationdata_replacement_policy
+        result = self.set_metadata(
+            identifier, metadata, 
+            metadata_replacement_policy=self.metadata_replacement_policy
         )
 
         if not isinstance(result, CoverageFailure):

--- a/overdrive.py
+++ b/overdrive.py
@@ -877,12 +877,19 @@ class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
 
     def process_item(self, identifier):
         info = self.api.metadata_lookup(identifier)
+        error = None
         if info.get('errorCode') == 'NotFound':
-            e = "ID not recognized by Overdrive"
-            return CoverageFailure(self, identifier, e, transient=False)
+            error = "ID %s not recognized by Overdrive" % identifier.identifier
+        elif info.get('errorCode') == 'InvalidGuid':
+            error = "Invalid Overdrive ID: %s" % identifier.identifier
+
+        if error:
+            return CoverageFailure(self, identifier, error, transient=False)
+
         metadata = OverdriveRepresentationExtractor.book_info_to_metadata(
             info
         )
+
         if not metadata:
             e = "Could not extract metadata from Overdrive data: %r" % info
             return CoverageFailure(self, identifier, e, transient=True)

--- a/tests/test_3m.py
+++ b/tests/test_3m.py
@@ -7,16 +7,19 @@ import datetime
 import os
 from model import (
     Contributor,
+    DataSource,
     Resource,
     Hyperlink,
     Identifier,
     Edition,
     Subject,
     Measurement,
+    Work,
 )
 from threem import (
     ItemListParser,
     MockThreeMAPI,
+    ThreeMBibliographicCoverageProvider,
 )
 from . import DatabaseTest
 from util.http import BadResponseException
@@ -190,3 +193,40 @@ class TestItemListParser(BaseThreeMTest):
 
         eq_(Hyperlink.DESCRIPTION, description.rel)
         assert description.content.startswith("<b>Winner")
+
+
+class TestBibliographicCoverageProvider(TestThreeMAPI):
+
+    def test_process_item_creates_presentation_ready_work(self):
+        data = self.get_data("item_metadata_single.xml")
+        self.api.queue_response(200, content=data)
+
+        identifier = self._identifier(identifier_type=Identifier.THREEM_ID)
+        identifier.identifier = 'ddf4gr9'
+
+        # This book has no LicensePool.
+        eq_(None, identifier.licensed_through)
+
+        # Run it through the ThreeMBibliographicCoverageProvider
+        provider = ThreeMBibliographicCoverageProvider(
+            self._db, threem_api=self.api
+        )
+        [result] = provider.process_batch([identifier])
+        eq_(identifier, result)
+
+        # A LicensePool was created, not because we know anything
+        # about how we've licensed this book, but to have a place to
+        # store the information about what formats the book is
+        # available in.
+        pool = identifier.licensed_through
+        eq_(0, pool.licenses_owned)
+        [lpdm] = pool.delivery_mechanisms
+        eq_(
+            'application/epub+zip (vnd.adobe/adept+xml)', 
+            lpdm.delivery_mechanism.name
+        )
+
+        # A Work was created and made presentation ready.
+        eq_("The Incense Game", pool.work.title)
+        eq_(True, pool.work.presentation_ready)
+       

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -126,6 +126,33 @@ class TestCirculationData(DatabaseTest):
         eq_(Representation.PDF_MEDIA_TYPE, pdf.delivery_mechanism.content_type)
 
 
+    def test_license_pool_sets_default_license_values(self):
+        """We have no information about how many copies of the book we've
+        actually licensed, but a LicensePool can be created anyway,
+        so we can store format information.
+        """
+        identifier = IdentifierData(Identifier.OVERDRIVE_ID, "1")
+        drm_format = FormatData(
+            content_type=Representation.PDF_MEDIA_TYPE,
+            drm_scheme=DeliveryMechanism.ADOBE_DRM,
+        )
+        circulation = CirculationData(
+            data_source=DataSource.OVERDRIVE,
+            primary_identifier=identifier,
+            formats=[drm_format],
+        )
+        pool, is_new = circulation.license_pool(
+            self._db,
+        )
+        eq_(True, is_new)
+
+        # We start with the conservative assumption that we own no
+        # licenses for the book.
+        eq_(0, pool.licenses_owned)
+        eq_(0, pool.licenses_available)
+        eq_(0, pool.licenses_reserved)
+        eq_(0, pool.patrons_in_hold_queue)
+
     def test_implicit_format_for_open_access_link(self):
         # A format is a delivery mechanism.  We handle delivery on open access 
         # pools from our mirrored content in S3.  

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -662,11 +662,11 @@ class TestBibliographicCoverageProvider(DatabaseTest):
             identifier_id=self.BIBLIOGRAPHIC_DATA.primary_identifier.identifier, 
             with_license_pool=True)
 
-        # If no metadata is passed in, a CoverageRecord results.
+        # If no metadata is passed in, a CoverageFailure results.
         result = provider.set_metadata_and_circulation_data(edition.primary_identifier, None, None)
 
         assert isinstance(result, CoverageFailure)
-        eq_("Did not receive metadata from input source", result.exception)
+        eq_("Received neither metadata nor circulation data from input source", result.exception)
 
         # If no work can be created (in this case, because there's no title),
         # a CoverageFailure results.
@@ -689,6 +689,7 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         test_metadata.primary_identifier = self._identifier(
             identifier_type=Identifier.OVERDRIVE_ID
         )
+        set_trace()
         result = provider.set_metadata_and_circulation_data(lp.identifier, test_metadata, test_circulationdata)
         assert isinstance(result, CoverageFailure)
         assert "ValueError" in result.exception

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -533,6 +533,31 @@ class TestCoverageProvider(DatabaseTest):
         eq_(None, provider.input_identifier_types)
 
 
+class MockBibliographicCoverageProvider(BibliographicCoverageProvider):
+    """Simulates a BibliographicCoverageProvider that's always successful."""
+
+    def __init__(self, _db, **kwargs):
+        if not 'api' in kwargs:
+            kwargs['api'] = None
+        if not 'datasource' in kwargs:
+            kwargs['datasource'] = DataSource.OVERDRIVE
+        super(MockBibliographicCoverageProvider, self).__init__(
+            _db, **kwargs
+        )
+
+    def process_item(self, identifier):
+        return identifier
+
+
+class MockFailureBibliographicCoverageProvider(MockBibliographicCoverageProvider):
+    """Simulates a BibliographicCoverageProvider that's never successful."""
+
+    def process_item(self, identifier):
+        return CoverageFailure(
+            self, identifier, "Bitter failure", transient=True
+        )
+
+
 class TestBibliographicCoverageProvider(DatabaseTest):
 
     BIBLIOGRAPHIC_DATA = Metadata(
@@ -572,8 +597,7 @@ class TestBibliographicCoverageProvider(DatabaseTest):
 
 
     def test_edition(self):
-        provider = BibliographicCoverageProvider(self._db, None,
-                DataSource.OVERDRIVE)
+        provider = MockBibliographicCoverageProvider(self._db)
         provider.CAN_CREATE_LICENSE_POOLS = False
         identifier = self._identifier(identifier_type=Identifier.OVERDRIVE_ID)
         test_metadata = self.BIBLIOGRAPHIC_DATA
@@ -596,8 +620,7 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         assert isinstance(e2, Edition)
 
     def test_work(self):
-        provider = BibliographicCoverageProvider(self._db, None,
-                DataSource.OVERDRIVE)
+        provider = MockBibliographicCoverageProvider(self._db)
         identifier = self._identifier(identifier_type=Identifier.OVERDRIVE_ID)
         test_metadata = self.BIBLIOGRAPHIC_DATA
         provider.CAN_CREATE_LICENSE_POOLS = False
@@ -622,8 +645,7 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         eq_(result, lp.work)
 
     def test_set_metadata(self):
-        provider = BibliographicCoverageProvider(self._db, None,
-                DataSource.OVERDRIVE)
+        provider = MockBibliographicCoverageProvider(self._db)
         provider.CAN_CREATE_LICENSE_POOLS = False
         identifier = self._identifier(identifier_type=Identifier.OVERDRIVE_ID)
         test_metadata = self.BIBLIOGRAPHIC_DATA
@@ -673,8 +695,7 @@ class TestBibliographicCoverageProvider(DatabaseTest):
 
 
     def test_autocreate_licensepool(self):
-        provider = BibliographicCoverageProvider(self._db, None,
-                DataSource.OVERDRIVE)
+        provider = MockBibliographicCoverageProvider(self._db)
         identifier = self._identifier(identifier_type=Identifier.OVERDRIVE_ID)
 
         # If this constant is set to False, the coverage provider cannot
@@ -690,8 +711,7 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         eq_(pool.identifier, identifier)
        
     def test_set_presentation_ready(self):
-        provider = BibliographicCoverageProvider(self._db, None,
-                DataSource.OVERDRIVE)
+        provider = MockBibliographicCoverageProvider(self._db)
         identifier = self._identifier(identifier_type=Identifier.OVERDRIVE_ID)
         test_metadata = self.BIBLIOGRAPHIC_DATA
 
@@ -705,3 +725,31 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         ed, lp = self._edition(with_license_pool=True)
         result = provider.set_presentation_ready(ed.primary_identifier)
         eq_(result, ed.primary_identifier)
+
+    def test_process_batch_sets_work_presentation_ready(self):
+
+        work = self._work(with_license_pool=True, 
+                          with_open_access_download=True)
+        identifier = work.license_pools[0].identifier
+        work.presentation_ready = False
+        provider = MockBibliographicCoverageProvider(self._db)
+        [result] = provider.process_batch([identifier])
+        eq_(result, identifier)
+        eq_(True, work.presentation_ready)
+
+        # ensure_coverage does the same thing.
+        work.presentation_ready = False
+        result = provider.ensure_coverage(identifier)
+        assert isinstance(result, CoverageRecord)
+        eq_(result.identifier, identifier)
+        eq_(True, work.presentation_ready)
+
+    def test_failure_does_not_set_work_presentation_ready(self):
+        work = self._work(with_license_pool=True, 
+                          with_open_access_download=True)
+        identifier = work.license_pools[0].identifier
+        work.presentation_ready = False
+        provider = MockFailureBibliographicCoverageProvider(self._db)
+        [result] = provider.process_batch([identifier])
+        assert isinstance(result, CoverageFailure)
+        eq_(False, work.presentation_ready)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -689,7 +689,6 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         test_metadata.primary_identifier = self._identifier(
             identifier_type=Identifier.OVERDRIVE_ID
         )
-        set_trace()
         result = provider.set_metadata_and_circulation_data(lp.identifier, test_metadata, test_circulationdata)
         assert isinstance(result, CoverageFailure)
         assert "ValueError" in result.exception

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -672,14 +672,3 @@ class TestMetadata(DatabaseTest):
 
         circulation_pool, is_new = circulation.license_pool(self._db)
         eq_(thumbnail_link.license_pool, circulation_pool)
-
-
-
-
-
-
-
-
-
-
-

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -989,24 +989,6 @@ class TestLicensePool(DatabaseTest):
         eq_(None, work.last_update_time)
         eq_(None, pool.last_checked)
 
-    def test_set_rights_status(self):
-        edition, pool = self._edition(with_license_pool=True)
-        uri = "http://foo"
-        name = "bar"
-        status = pool.set_rights_status(uri, name)
-        eq_(status, pool.rights_status)
-        eq_(uri, status.uri)
-        eq_(name, status.name)
-
-        status2 = pool.set_rights_status(uri)
-        eq_(status, status2)
-
-        uri2 = "http://baz"
-        status3 = pool.set_rights_status(uri2)
-        assert status != status3
-        eq_(uri2, status3.uri)
-        eq_(None, status3.name)
-
     def test_open_access_links(self):
         edition, pool = self._edition(with_open_access_download=True)
         source = DataSource.lookup(self._db, DataSource.GUTENBERG)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -887,6 +887,10 @@ class TestLicensePool(DatabaseTest):
         eq_(DataSource.GUTENBERG, pool.data_source.name)
         eq_(Identifier.GUTENBERG_ID, pool.identifier.type)
         eq_("541", pool.identifier.identifier)        
+        eq_(0, pool.licenses_owned)
+        eq_(0, pool.licenses_available)
+        eq_(0, pool.licenses_reserved)
+        eq_(0, pool.patrons_in_hold_queue)
 
     def test_no_license_pool_for_data_source_that_offers_no_licenses(self):
         """OCLC doesn't offer licenses. It only provides metadata. We can get
@@ -953,6 +957,36 @@ class TestLicensePool(DatabaseTest):
             pool.update_availability(30, 21, 2, 1)
             eq_(count + 2, provider.count)
             eq_(CirculationEvent.HOLD_PLACE, provider.event_type)
+
+    def test_update_availability_does_nothing_if_given_no_data(self):
+        """Passing an empty set of data into update_availability is
+        a no-op.
+        """
+
+        # Set up a Work.
+        work = self._work(with_license_pool=True)
+        work.last_update_time = None
+
+        # Set up a LicensePool.
+        [pool] = work.license_pools
+        pool.last_checked = None
+        pool.licenses_owned = 10
+        pool.licenses_available = 20
+        pool.licenses_reserved = 30
+        pool.patrons_in_hold_queue = 40
+
+        # Pass empty values into update_availability.
+        pool.update_availability(None, None, None, None)
+
+        # The LicensePool's circulation data is what it was before.
+        eq_(10, pool.licenses_owned)
+        eq_(20, pool.licenses_available)
+        eq_(30, pool.licenses_reserved)
+        eq_(40, pool.patrons_in_hold_queue)
+
+        # Work.update_time and LicensePool.last_checked are unaffected.
+        eq_(None, work.last_update_time)
+        eq_(None, pool.last_checked)
 
     def test_set_rights_status(self):
         edition, pool = self._edition(with_license_pool=True)

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -322,10 +322,12 @@ class TestOverdriveBibliographicCoverageProvider(DatabaseTest):
         eq_(False, failure.transient)
         eq_("Invalid Overdrive ID: bad guid", failure.exception)
 
+        # This is for when the GUID is well-formed but doesn't
+        # correspond to any real Overdrive book.
         error = '{"errorCode": "NotFound", "message": "Not found in Overdrive collection.", "token": "7aebce0e-2e88-41b3-b6d3-82bf15f8e1a2"}'
         self.api.queue_response(200, content=error)
 
         failure = self.provider.process_item(identifier)
         assert isinstance(failure, CoverageFailure)
         eq_(False, failure.transient)
-        eq_("ID bad guid not recognized by Overdrive", failure.exception)
+        eq_("ID not recognized by Overdrive: bad guid", failure.exception)

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -12,6 +12,11 @@ from overdrive import (
     OverdriveAPI,
     MockOverdriveAPI,
     OverdriveRepresentationExtractor,
+    OverdriveBibliographicCoverageProvider,
+)
+
+from coverage import (
+    CoverageFailure,
 )
 
 from model import (
@@ -294,3 +299,33 @@ class TestOverdriveRepresentationExtractor(object):
         ]
         eq_(1, awards.value)
         eq_(1, awards.weight)
+
+
+class TestOverdriveBibliographicCoverageProvider(DatabaseTest):
+
+    def setup(self):
+        super(TestOverdriveBibliographicCoverageProvider, self).setup()
+        self.api = MockOverdriveAPI(self._db)
+        self.provider = OverdriveBibliographicCoverageProvider(
+            self._db, overdrive_api=self.api
+        )
+
+    def test_invalid_or_unrecognized_guid(self):
+        identifier = self._identifier()
+        identifier.identifier = 'bad guid'
+        
+        error = '{"errorCode": "InvalidGuid", "message": "An invalid guid was given.", "token": "7aebce0e-2e88-41b3-b6d3-82bf15f8e1a2"}'
+        self.api.queue_response(200, content=error)
+
+        failure = self.provider.process_item(identifier)
+        assert isinstance(failure, CoverageFailure)
+        eq_(False, failure.transient)
+        eq_("Invalid Overdrive ID: bad guid", failure.exception)
+
+        error = '{"errorCode": "NotFound", "message": "Not found in Overdrive collection.", "token": "7aebce0e-2e88-41b3-b6d3-82bf15f8e1a2"}'
+        self.api.queue_response(200, content=error)
+
+        failure = self.provider.process_item(identifier)
+        assert isinstance(failure, CoverageFailure)
+        eq_(False, failure.transient)
+        eq_("ID bad guid not recognized by Overdrive", failure.exception)

--- a/threem.py
+++ b/threem.py
@@ -426,16 +426,11 @@ class ThreeMBibliographicCoverageProvider(BibliographicCoverageProvider):
             workset_size=25, metadata_replacement_policy=metadata_replacement_policy, **kwargs
         )
 
-    def process_batch(self, identifiers):
-        batch_results = []
-        for identifier in identifiers:
-            metadata = self.api.bibliographic_lookup(identifier)
-            result = self.set_metadata(identifier, metadata)
-            if not isinstance(result, CoverageFailure):
-                # Success!
-                result = self.set_presentation_ready(result)
-            batch_results.append(result)
-        return batch_results
-
     def process_item(self, identifier):
-        return self.process_batch([identifier])[0]
+        metadata = self.api.bibliographic_lookup(identifier)
+        if not metadata:
+            return CoverageFailure(
+                self, identifier, "3M bibliographic lookup failed.",
+                transient=True
+            )
+        return self.set_metadata(identifier, metadata)


### PR DESCRIPTION
This branch makes the 3MBibliographicCoverageProvider testable, and in doing so fixes some minor problems introduced by the big CirculationData branch.