### PR TITLE
Move works in and out of the search index as they become presentation-ready or stop being presentation-ready

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -49,17 +49,8 @@ class ExternalSearchIndex(object):
         self.index = self.__client.index
         self.delete = self.__client.delete
         self.exists = self.__client.exists
-        if setup and not self.indices.exists(self.works_index):
+        if not self.indices.exists(self.works_index):
             self.setup_index()
-
-    @classmethod
-    def retrieve(self, obj=None, **kwargs):
-        """If the given object is None, construct a new ExternalSearchIndex.
-        Otherwise, return the given object.
-        """
-        if obj:
-            return obj
-        return ExternalSearchIndex(**kwargs)
 
     def setup_index(self):
         """

--- a/external_search.py
+++ b/external_search.py
@@ -15,7 +15,7 @@ class ExternalSearchIndex(object):
     work_document_type = 'work-type'
     __client = None
 
-    def __init__(self, url=None, works_index=None, setup=True):
+    def __init__(self, url=None, works_index=None):
     
         self.log = logging.getLogger("External search index")
 

--- a/model.py
+++ b/model.py
@@ -3627,7 +3627,7 @@ class Work(Base):
 
 
     def update_external_index(self, client):
-        client = ExternalSearchIndex.retrieve(client)
+        client = client or ExternalSearchIndex()
 
         args = dict(index=client.works_index,
                     doc_type=client.work_document_type,

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -22,6 +22,26 @@ from external_search import (
 )
 from classifier import Classifier
 
+class TestRetrieveExternalSearch(object):
+
+    def test_retrieve(self):
+        # If you pass any object into ExternalSearch, it returns that
+        # object.
+        dummy = object()
+        eq_(dummy, ExternalSearchIndex.retrieve(dummy))
+
+        # If you pass in nothing, it returns an ExternalSearch set up for your
+        # configuration.
+        with temp_config() as config:
+            
+            data = {}
+            config[Configuration.INTEGRATIONS][Configuration.ELASTICSEARCH_INTEGRATION] = data
+            data[Configuration.URL] = "http://localhost:9200"
+            data[Configuration.ELASTICSEARCH_INDEX_KEY] = "test_index"
+            search = ExternalSearchIndex.retrieve(setup=False)
+            eq_("test_index", search.works_index)
+
+
 class TestExternalSearch(DatabaseTest):
     """
     These tests require elasticsearch to be running locally. If it's not, or there's

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -22,25 +22,6 @@ from external_search import (
 )
 from classifier import Classifier
 
-class TestRetrieveExternalSearch(object):
-
-    def test_retrieve(self):
-        # If you pass any object into ExternalSearch, it returns that
-        # object.
-        dummy = object()
-        eq_(dummy, ExternalSearchIndex.retrieve(dummy))
-
-        # If you pass in nothing, it returns an ExternalSearch set up for your
-        # configuration.
-        with temp_config() as config:
-            
-            data = {}
-            config[Configuration.INTEGRATIONS][Configuration.ELASTICSEARCH_INTEGRATION] = data
-            data[Configuration.URL] = "http://localhost:9200"
-            data[Configuration.ELASTICSEARCH_INDEX_KEY] = "test_index"
-            search = ExternalSearchIndex.retrieve(setup=False)
-            eq_("test_index", search.works_index)
-
 
 class TestExternalSearch(DatabaseTest):
     """


### PR DESCRIPTION
Without this code, a work that stops being presentation ready will stay in the index. More importantly, there are cases where a work will become presentation-ready without any of its metadata changing, and when that happens it will not be added to the search index.