### PR TITLE
Make WorkCoverageProvider work on similar terms to CoverageProvider

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -237,7 +237,7 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
         axis_360_api = axis_360_api or Axis360API(_db)
         super(Axis360BibliographicCoverageProvider, self).__init__(
             _db, axis_360_api, DataSource.AXIS_360,
-            workset_size=25, 
+            batch_size=25, 
             metadata_replacement_policy=metadata_replacement_policy,
             **kwargs
         )

--- a/coverage.py
+++ b/coverage.py
@@ -325,10 +325,10 @@ class CoverageProvider(BaseCoverageProvider):
 
     def __init__(self, service_name, input_identifier_types, output_source,
                  batch_size=100, cutoff_time=None, operation=None):
+        _db = Session.object_session(output_source)
         super(CoverageProvider, self).__init__(
-            service_name, operation, batch_size, cutoff_time
+            _db, service_name, operation, batch_size, cutoff_time
         )
-        self._db = Session.object_session(output_source)
         if input_identifier_types and not isinstance(input_identifier_types, list):
             input_identifier_types = [input_identifier_types]
         self.input_identifier_types = input_identifier_types

--- a/coverage.py
+++ b/coverage.py
@@ -251,7 +251,9 @@ class BaseCoverageProvider(object):
             # create a CoverageRecord we never update it.
             return False
 
-        return self.cutoff_time > coverage_record.timestamp
+        # We update a CoverageRecord if it was last updated before
+        # cutoff_time.
+        return coverage_record.timestamp < self.cutoff_time
 
     def finalize_batch(self):
         """Do whatever is necessary to complete this batch before moving on to
@@ -359,10 +361,6 @@ class CoverageProvider(BaseCoverageProvider):
         else:
             coverage_record = None
         return coverage_record
-
-        # We update a CoverageRecord if it was last updated before
-        # cutoff_time.
-        return coverage_record.timestamp < self.cutoff_time
 
     @property
     def output_source(self):

--- a/coverage.py
+++ b/coverage.py
@@ -194,7 +194,7 @@ class BaseCoverageProvider(object):
                     # on the next run.
                     self.log.warn(
                         "Transient failure covering %r: %s", 
-                        item, item.exception
+                        item.obj, item.exception
                     )
                     transient_failures += 1
                     record = item

--- a/external_search.py
+++ b/external_search.py
@@ -35,7 +35,10 @@ class ExternalSearchIndex(object):
 
             url = integration[Configuration.URL]
             use_ssl = url and url.startswith('https://')
-            self.log.info("Connecting to Elasticsearch cluster at %s", url)
+            self.log.info(
+                "Connecting to index %s in Elasticsearch cluster at %s", 
+                works_index, url
+            )
             ExternalSearchIndex.__client = Elasticsearch(
                 url, use_ssl=use_ssl, timeout=20, maxsize=25
             )

--- a/model.py
+++ b/model.py
@@ -3086,6 +3086,26 @@ class Work(Base):
                 len(self.license_pools))).encode("utf8")
 
     @classmethod
+    def missing_coverage_from(
+            cls, _db, operation=None, count_as_missing_before=None
+    ):
+        """Find Works which have no WorkCoverageRecord for the given
+        `operation`.
+        """
+        clause = and_(Work.id==WorkCoverageRecord.work_id,
+                      WorkCoverageRecord.operation==operation)
+        q = _db.query(Work).outerjoin(WorkCoverageRecord, clause)
+
+        missing = WorkCoverageRecord.id==None
+        if count_as_missing_before:
+            missing = or_(
+                missing, WorkCoverageRecord.timestamp < count_as_missing_before
+            )
+
+        q2 = q.filter(missing)
+        return q2
+
+    @classmethod
     def open_access_for_permanent_work_id(cls, _db, pwid):
         """Find or create the Work encompassing all open-access LicensePools
         whose presentation Editions have the given permanent work ID.
@@ -3626,7 +3646,7 @@ class Work(Base):
         )
 
 
-    def update_external_index(self, client):
+    def update_external_index(self, client, add_coverage_record=True):
         client = client or ExternalSearchIndex()
 
         args = dict(index=client.works_index,
@@ -3654,9 +3674,10 @@ class Work(Base):
         else:
             if client.exists(**args):
                 client.delete(**args)
-        WorkCoverageRecord.add_for(
-            self, operation=(WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION + "-" + client.works_index)
-        )
+        if add_coverage_record:
+            WorkCoverageRecord.add_for(
+                self, operation=(WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION + "-" + client.works_index)
+            )
 
     def set_presentation_ready(self, as_of=None, search_index_client=None):
         as_of = as_of or datetime.datetime.utcnow()

--- a/model.py
+++ b/model.py
@@ -3101,7 +3101,6 @@ class Work(Base):
             missing = or_(
                 missing, WorkCoverageRecord.timestamp < count_as_missing_before
             )
-
         q2 = q.filter(missing)
         return q2
 

--- a/model.py
+++ b/model.py
@@ -3654,6 +3654,7 @@ class Work(Base):
         if not client.works_index:
             # There is no index set up on this instance.
             return
+        present_in_index = False
         if self.presentation_ready:
             doc = self.to_search_document()
             if doc:
@@ -3665,6 +3666,7 @@ class Work(Base):
                 else:
                     logging.info("Indexed work %d (%s)", self.id, self.title)
                 client.index(**args)
+                present_in_index = True
             else:
                 logging.warn(
                     "Could not generate a search document for allegedly presentation-ready work %d (%s).",
@@ -3673,10 +3675,11 @@ class Work(Base):
         else:
             if client.exists(**args):
                 client.delete(**args)
-        if add_coverage_record:
+        if add_coverage_record and present_in_index:
             WorkCoverageRecord.add_for(
                 self, operation=(WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION + "-" + client.works_index)
             )
+        return present_in_index
 
     def set_presentation_ready(self, as_of=None, search_index_client=None):
         as_of = as_of or datetime.datetime.utcnow()

--- a/overdrive.py
+++ b/overdrive.py
@@ -868,7 +868,7 @@ class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
         # part of the signature.
         super(OverdriveBibliographicCoverageProvider, self).__init__(
             _db, overdrive_api, DataSource.OVERDRIVE,
-            workset_size=10, metadata_replacement_policy=metadata_replacement_policy, **kwargs
+            batch_size=10, metadata_replacement_policy=metadata_replacement_policy, **kwargs
         )
 
     def process_item(self, identifier):

--- a/scripts.py
+++ b/scripts.py
@@ -276,17 +276,32 @@ class RunCoverageProviderScript(IdentifierInputScript):
             else:
                 self.identifier_type = None
                 self.identifier_types = []
+            kwargs = self.extract_additional_command_line_arguments(args)
             provider = provider(
-                self._db, input_identifier_types=self.identifier_types, 
-                cutoff_time=args.cutoff_time
+                self._db, 
+                cutoff_time=args.cutoff_time,
+                **kwargs
             )
         self.provider = provider
         self.name = self.provider.service_name
         self.identifiers = args.identifiers
 
+    def extract_additional_command_line_arguments(self, args):
+        """A hook method for subclasses.
+        
+        Turns command-line arguments into additional keyword arguments
+        to the CoverageProvider constructor.
+
+        By default, pass in a value used only by CoverageProvider
+        (as opposed to WorkCoverageProvider).
+        """
+        return {
+            "input_identifier_types" : self.identifier_types, 
+        }
+
     def do_run(self):
         if self.identifiers:
-            self.provider.run_on_identifiers(self.identifiers)
+            self.provider.run_on_specific_identifiers(self.identifiers)
         else:
             self.provider.run()
 

--- a/scripts.py
+++ b/scripts.py
@@ -153,11 +153,22 @@ class IdentifierInputScript(Script):
     """A script that takes identifiers as command line inputs."""
 
     @classmethod
+    def read_stdin_lines(self, stdin):
+        """Read lines from a (possibly mocked, possibly empty) standard input."""
+        if stdin is not sys.stdin or not os.isatty(0):
+            # A file has been redirected into standard input. Grab its
+            # lines.
+            lines = [x.strip() for x in stdin.readlines()]
+        else:
+            lines = []
+        return lines
+
+    @classmethod
     def parse_command_line(cls, _db=None, cmd_args=None, stdin=sys.stdin, 
                            *args, **kwargs):
         parser = cls.arg_parser()
         parsed = parser.parse_args(cmd_args)
-        stdin = [x.strip() for x in stdin.readlines()]
+        stdin = cls.read_stdin_lines(stdin)
         return cls.look_up_identifiers(_db, parsed, stdin, *args, **kwargs)
 
     @classmethod
@@ -270,7 +281,7 @@ class RunCoverageProviderScript(IdentifierInputScript):
                            *args, **kwargs):
         parser = cls.arg_parser()
         parsed = parser.parse_args(cmd_args)
-        stdin = [x.strip() for x in stdin.readlines()]
+        stdin = cls.read_stdin_lines(stdin)
         parsed = cls.look_up_identifiers(_db, parsed, stdin, *args, **kwargs)
         if parsed.cutoff_time:
             parsed.cutoff_time = cls.parse_time(parsed.cutoff_time)

--- a/testing.py
+++ b/testing.py
@@ -644,8 +644,8 @@ class InstrumentedWorkCoverageProvider(WorkCoverageProvider):
     """A CoverageProvider that keeps track of every item it tried
     to cover.
     """
-    def __init__(self, *args, **kwargs):
-        super(InstrumentedWorkCoverageProvider, self).__init__(*args, **kwargs)
+    def __init__(self, _db, *args, **kwargs):
+        super(InstrumentedWorkCoverageProvider, self).__init__(_db, *args, **kwargs)
         self.attempts = []
 
     def process_item(self, item):

--- a/testing.py
+++ b/testing.py
@@ -42,6 +42,7 @@ from classifier import Classifier
 from coverage import (
     CoverageProvider,
     CoverageFailure,
+    WorkCoverageProvider,
 )
 from external_search import DummyExternalSearchIndex
 import mock
@@ -635,9 +636,17 @@ class InstrumentedCoverageProvider(CoverageProvider):
         super(InstrumentedCoverageProvider, self).__init__(*args, **kwargs)
         self.attempts = []
 
-    def run_once(self, offset):
-        super(InstrumentedCoverageProvider, self).run_once(offset)
-        return None
+    def process_item(self, item):
+        self.attempts.append(item)
+        return item
+
+class InstrumentedWorkCoverageProvider(WorkCoverageProvider):
+    """A CoverageProvider that keeps track of every item it tried
+    to cover.
+    """
+    def __init__(self, *args, **kwargs):
+        super(InstrumentedWorkCoverageProvider, self).__init__(*args, **kwargs)
+        self.attempts = []
 
     def process_item(self, item):
         self.attempts.append(item)
@@ -646,7 +655,15 @@ class InstrumentedCoverageProvider(CoverageProvider):
 class AlwaysSuccessfulCoverageProvider(InstrumentedCoverageProvider):
     """A CoverageProvider that does nothing and always succeeds."""
 
+class AlwaysSuccessfulWorkCoverageProvider(InstrumentedWorkCoverageProvider):
+    """A WorkCoverageProvider that does nothing and always succeeds."""
+
 class NeverSuccessfulCoverageProvider(InstrumentedCoverageProvider):
+    def process_item(self, item):
+        self.attempts.append(item)
+        return CoverageFailure(self, item, "What did you expect?", False)
+
+class NeverSuccessfulWorkCoverageProvider(InstrumentedWorkCoverageProvider):
     def process_item(self, item):
         self.attempts.append(item)
         return CoverageFailure(self, item, "What did you expect?", False)
@@ -656,6 +673,11 @@ class BrokenCoverageProvider(InstrumentedCoverageProvider):
         raise Exception("I'm too broken to even return a CoverageFailure.")
 
 class TransientFailureCoverageProvider(InstrumentedCoverageProvider):
+    def process_item(self, item):
+        self.attempts.append(item)
+        return CoverageFailure(self, item, "Oops!", True)
+
+class TransientFailureWorkCoverageProvider(InstrumentedWorkCoverageProvider):
     def process_item(self, item):
         self.attempts.append(item)
         return CoverageFailure(self, item, "Oops!", True)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -129,7 +129,7 @@ class TestCoverageProvider(DatabaseTest):
             "Always successful", self.input_identifier_types, 
             self.output_source, cutoff_time=cutoff_time
         )
-        eq_([], provider.items_that_need_coverage.all())
+        eq_([], provider.items_that_need_coverage().all())
 
         one_second_after = cutoff_time + datetime.timedelta(seconds=1)
         provider = AlwaysSuccessfulCoverageProvider(
@@ -137,13 +137,13 @@ class TestCoverageProvider(DatabaseTest):
             self.output_source, cutoff_time=one_second_after
         )
         eq_([self.edition.primary_identifier], 
-            provider.items_that_need_coverage.all())
+            provider.items_that_need_coverage().all())
 
         provider = AlwaysSuccessfulCoverageProvider(
             "Always successful", self.input_identifier_types, 
             self.output_source
         )
-        eq_([], provider.items_that_need_coverage.all())
+        eq_([], provider.items_that_need_coverage().all())
 
     def test_items_that_need_coverage_respects_operation(self):
 
@@ -160,7 +160,7 @@ class TestCoverageProvider(DatabaseTest):
         # It is missing coverage for self.identifier, because the
         # CoverageRecord we created at the start of this test has no
         # operation.
-        eq_([self.identifier], provider.items_that_need_coverage.all())
+        eq_([self.identifier], provider.items_that_need_coverage().all())
 
         # Here's a provider that has no operation set.
         provider = AlwaysSuccessfulCoverageProvider(
@@ -171,7 +171,7 @@ class TestCoverageProvider(DatabaseTest):
         # It is not missing coverage for self.identifier, because the
         # CoverageRecord we created at the start of the test takes
         # care of it.
-        eq_([], provider.items_that_need_coverage.all())
+        eq_([], provider.items_that_need_coverage().all())
 
     def test_should_update(self):
         cutoff = datetime.datetime(2016, 1, 1)
@@ -211,14 +211,14 @@ class TestCoverageProvider(DatabaseTest):
         # Timestamp was not updated.
         eq_([], self._db.query(Timestamp).all())
 
-    def test_run_on_identifiers(self):
+    def test_run_on_specific_identifiers(self):
         provider = AlwaysSuccessfulCoverageProvider(
             "Always successful", self.input_identifier_types, self.output_source
         )
         provider.workset_size = 3
         to_be_tested = [self._identifier() for i in range(6)]
         not_to_be_tested = [self._identifier() for i in range(6)]
-        counts, records = provider.run_on_identifiers(to_be_tested)
+        counts, records = provider.run_on_specific_identifiers(to_be_tested)
 
         # Six identifiers were covered in two batches.
         eq_((6,0,0), counts)
@@ -232,7 +232,7 @@ class TestCoverageProvider(DatabaseTest):
         for i in not_to_be_tested:
             assert i not in provider.attempts
 
-    def test_run_on_identifiers_respects_cutoff_time(self):
+    def test_run_on_specific_identifiers_respects_cutoff_time(self):
 
         last_run = datetime.datetime(2016, 1, 1)
 
@@ -252,7 +252,7 @@ class TestCoverageProvider(DatabaseTest):
 
         # You might think this would result in a persistent failure...
         (success, transient_failure, persistent_failure), records = (
-            provider.run_on_identifiers([self.identifier])
+            provider.run_on_specific_identifiers([self.identifier])
         )
 
         # ...but we get an automatic success. We didn't even try to 
@@ -266,7 +266,7 @@ class TestCoverageProvider(DatabaseTest):
         # on self.identifier and fail.
         provider.cutoff_time = datetime.datetime(2016, 2, 1)
         (success, transient_failure, persistent_failure), records = (
-            provider.run_on_identifiers([self.identifier])
+            provider.run_on_specific_identifiers([self.identifier])
         )
         eq_(0, success)
         eq_(1, persistent_failure)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -656,6 +656,7 @@ class TestWorkCoverageProvider(DatabaseTest):
             set(provider.items_that_need_coverage([i2, i3]).all())
         )
 
+
 class MockFailureBibliographicCoverageProvider(MockBibliographicCoverageProvider):
     """Simulates a BibliographicCoverageProvider that's never successful."""
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -328,7 +328,8 @@ class TestCoverageProvider(DatabaseTest):
         eq_([], self._db.query(Timestamp).all())
 
         provider = NeverSuccessfulCoverageProvider(
-            "Never successful", self.input_identifier_types, self.output_source
+            "Never successful", self.input_identifier_types, 
+            self.output_source
         )
         provider.run()
 
@@ -349,7 +350,8 @@ class TestCoverageProvider(DatabaseTest):
         eq_([], self._db.query(Timestamp).all())
 
         provider = TransientFailureCoverageProvider(
-            "Transient failure", self.input_identifier_types, self.output_source
+            "Transient failure", self.input_identifier_types, 
+            self.output_source
         )
         provider.run()
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1758,6 +1758,31 @@ class TestWork(DatabaseTest):
         eq_("Alice Adder, Bob Bitshifter", work.author)
         eq_("Adder, Alice ; Bitshifter, Bob", work.sort_author)
 
+    def test_missing_coverage_from(self):
+        operation = 'the_operation'
+
+        # Here's a work with a coverage record.
+        work = self._work(with_license_pool=True)
+
+        # It needs coverage.
+        eq_([work], Work.missing_coverage_from(self._db, operation).all())
+
+        # Let's give it coverage.
+        record = self._work_coverage_record(work, operation)
+
+        # It no longer needs coverage!
+        eq_([], Work.missing_coverage_from(self._db, operation).all())
+
+        # But if we disqualify coverage records created before a 
+        # certain time, it might need coverage again.
+        cutoff = record.timestamp + datetime.timedelta(seconds=1)
+
+        eq_(
+            [work], Work.missing_coverage_from(
+                self._db, operation, count_as_missing_before=cutoff
+            ).all()
+        )
+
 
 class TestCirculationEvent(DatabaseTest):
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -21,6 +21,7 @@ from scripts import (
     IdentifierInputScript,
     RunCoverageProviderScript,
     WorkProcessingScript,
+    MockStdin,
 )
 
 class TestScript(DatabaseTest):
@@ -68,10 +69,13 @@ class TestIdentifierInputScript(DatabaseTest):
     def test_parse_command_line(self):
         i1 = self._identifier()
         i2 = self._identifier()
+        # We pass in one identifier on the command line...
         cmd_args = ["--identifier-type",
-                    i1.type, i1.identifier, i2.identifier]
+                    i1.type, i1.identifier]
+        # ...and another one into standard input.
+        stdin = MockStdin(i2.identifier)
         parsed = IdentifierInputScript.parse_command_line(
-            self._db, cmd_args
+            self._db, cmd_args, stdin
         )
         eq_([i1, i2], parsed.identifiers)
         eq_(i1.type, parsed.identifier_type)
@@ -79,7 +83,7 @@ class TestIdentifierInputScript(DatabaseTest):
     def test_parse_command_line_no_identifiers(self):
         cmd_args = ["--identifier-type", Identifier.OVERDRIVE_ID]
         parsed = IdentifierInputScript.parse_command_line(
-            self._db, cmd_args
+            self._db, cmd_args, MockStdin()
         )
         eq_([], parsed.identifiers)
         eq_(Identifier.OVERDRIVE_ID, parsed.identifier_type)
@@ -92,7 +96,7 @@ class TestRunCoverageProviderScript(DatabaseTest):
         cmd_args = ["--cutoff-time", "2016-05-01", "--identifier-type", 
                     identifier.type, identifier.identifier]
         parsed = RunCoverageProviderScript.parse_command_line(
-            self._db, cmd_args
+            self._db, cmd_args, MockStdin()
         )
         eq_(datetime.datetime(2016, 5, 1), parsed.cutoff_time)
         eq_([identifier], parsed.identifiers)

--- a/threem.py
+++ b/threem.py
@@ -423,7 +423,7 @@ class ThreeMBibliographicCoverageProvider(BibliographicCoverageProvider):
         threem_api = threem_api or ThreeMAPI(_db)
         super(ThreeMBibliographicCoverageProvider, self).__init__(
             _db, threem_api, DataSource.THREEM,
-            workset_size=25, metadata_replacement_policy=metadata_replacement_policy, **kwargs
+            batch_size=25, metadata_replacement_policy=metadata_replacement_policy, **kwargs
         )
 
     def process_item(self, identifier):


### PR DESCRIPTION
This branch refactors the CoverageProvider class into BaseCoverageProvider, with two subclasses, CoverageProvider (which takes Identifiers or Editions, runs an algorithm, and produces CoverageRecords) and WorkCoverageProvider (which takes Works, runs an algorithm, and produces WorkCoverageRecords). In both cases, most of the time you only have to implement a method called `process_item()` which handles one item. CoverageProvider/WorkCoverageProvider takes care of splitting the work into batches, handling the results, and interfacing with IdentifierInputScript.

The first WorkCoverageProvider is coming in circulation--it's a provider that updates the search index. Because of this I've also made some minor changes to the code surrounding updating the search index.