### PR TITLE
Cover items with no coverage attempts first

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -39,30 +39,27 @@ class CoverageFailure(object):
                 "Cannot convert coverage failure to CoverageRecord because original coverage provider has no output source."
             )
 
-        # This is a persistent error. Turn it into a CoverageRecord
-        # so we don't keep trying to provide coverage that isn't
-        # gonna happen.
         record, ignore = CoverageRecord.add_for(
             self.obj, self.output_source, operation=operation
         )
         record.exception = self.exception
         if self.transient:
-            record.status == CoverageRecord.TRANSIENT_FAILURE
+            record.status = CoverageRecord.TRANSIENT_FAILURE
         else:
-            record.status == CoverageRecord.PERSISTENT_FAILURE
+            record.status = CoverageRecord.PERSISTENT_FAILURE
         return record
 
     def to_work_coverage_record(self, operation):
         """Convert this failure into a WorkCoverageRecord."""
-        if not self.transient:
-            # This is a persistent error. Turn it into a CoverageRecord
-            # so we don't keep trying to provide coverage that isn't
-            # gonna happen.
-            record, ignore = WorkCoverageRecord.add_for(
-                self.obj, operation=operation
-            )
-            record.exception = self.exception
-            return record
+        record, ignore = WorkCoverageRecord.add_for(
+            self.obj, operation=operation
+        )
+        record.exception = self.exception
+        if self.transient:
+            record.status = CoverageRecord.TRANSIENT_FAILURE
+        else:
+            record.status = CoverageRecord.PERSISTENT_FAILURE
+        return record
 
 class BaseCoverageProvider(object):
 

--- a/coverage.py
+++ b/coverage.py
@@ -357,6 +357,7 @@ class BaseCoverageProvider(object):
 
         Implemented in CoverageProvider and WorkCoverageProvider.
         """
+        raise NotImplementedError()
 
     def process_item(self, item):
         """Do the work necessary to give coverage to one specific item.

--- a/coverage.py
+++ b/coverage.py
@@ -38,15 +38,19 @@ class CoverageFailure(object):
             raise Exception(
                 "Cannot convert coverage failure to CoverageRecord because original coverage provider has no output source."
             )
-        if not self.transient:
-            # This is a persistent error. Turn it into a CoverageRecord
-            # so we don't keep trying to provide coverage that isn't
-            # gonna happen.
-            record, ignore = CoverageRecord.add_for(
-                self.obj, self.output_source, operation=operation
-            )
-            record.exception = self.exception
-            return record
+
+        # This is a persistent error. Turn it into a CoverageRecord
+        # so we don't keep trying to provide coverage that isn't
+        # gonna happen.
+        record, ignore = CoverageRecord.add_for(
+            self.obj, self.output_source, operation=operation
+        )
+        record.exception = self.exception
+        if self.transient:
+            record.status == CoverageRecord.TRANSIENT_FAILURE
+        else:
+            record.status == CoverageRecord.PERSISTENT_FAILURE
+        return record
 
     def to_work_coverage_record(self, operation):
         """Convert this failure into a WorkCoverageRecord."""

--- a/coverage.py
+++ b/coverage.py
@@ -178,7 +178,8 @@ class BaseCoverageProvider(object):
         covered_statuses_message = '(covered statuses=%s)' % (', '.join(covered_statuses))
 
         qu = self.items_that_need_coverage(covered_statuses=covered_statuses)
-        self.log.info("%d items need coverage%s", qu.count(), kwargs_message)
+        self.log.info("%d items need coverage%s", qu.count(), 
+                      covered_statuses_message)
         batch = qu.limit(self.batch_size).offset(offset)
 
         if not batch.count():

--- a/coverage.py
+++ b/coverage.py
@@ -325,7 +325,7 @@ class BaseCoverageProvider(object):
     # Subclasses must implement these virtual methods.
     #
 
-    def items_that_need_coverage(self, identifiers, *kwargs):
+    def items_that_need_coverage(self, identifiers, **kwargs):
         """Create a database query returning only those items that
         need coverage.
 

--- a/coverage.py
+++ b/coverage.py
@@ -173,7 +173,7 @@ class BaseCoverageProvider(object):
         count_as_covered = count_as_covered or BaseCoverageRecord.DEFAULT_COUNT_AS_COVERED
         # Make it clear which class of items we're covering on this
         # run.
-        count_as_covered_message = '(counting %s as covered)' % (', '.join(covered_statuses))
+        count_as_covered_message = '(counting %s as covered)' % (', '.join(count_as_covered))
 
         qu = self.items_that_need_coverage(count_as_covered=count_as_covered)
         self.log.info("%d items need coverage%s", qu.count(), 

--- a/migration/20160614-add-coverage-status.sql
+++ b/migration/20160614-add-coverage-status.sql
@@ -1,0 +1,17 @@
+CREATE TYPE coverage_status AS ENUM (
+    'success',
+    'transient failure',
+    'persistent failure'
+);
+
+alter table coveragerecords add column status coverage_status;
+alter table workcoveragerecords add column status coverage_status;
+
+CREATE INDEX ix_coveragerecords_status ON coveragerecords USING btree (status);
+CREATE INDEX ix_workcoveragerecords_status ON workcoveragerecords USING btree (status);
+
+update table coveragerecords set status='success' where exception is null;
+update table coveragerecords set status='persistent failure' where exception is not null;
+
+update table workcoveragerecords set status='success' where exception is null;
+update table workcoveragerecords set status='persistent failure' where exception is not null;

--- a/model.py
+++ b/model.py
@@ -847,6 +847,14 @@ class BaseCoverageRecord(object):
     SUCCESS = 'success'
     TRANSIENT_FAILURE = 'transient failure'
     PERSISTENT_FAILURE = 'persistent failure'    
+
+    ALL_STATUSES = [SUCCESS, TRANSIENT_FAILURE, PERSISTENT_FAILURE]
+
+    # By default, count coverage as present if it ended in
+    # success or in persistent failure. Do not count coverage
+    # as present if it ended in transient failure.
+    DEFAULT_COUNTS_AS_COVERED = [SUCCESS, PERSISTENT_FAILURE]
+
     status_enum = Enum(SUCCESS, TRANSIENT_FAILURE, PERSISTENT_FAILURE, 
                        name='coverage_status')
 
@@ -866,11 +874,7 @@ class BaseCoverageRecord(object):
         :return: A clause that can be passed in to Query.filter().
         """
         if not covered_statuses:
-            # By default, count coverage as present if it ended in
-            # success or in persistent failure. Do not count coverage
-            # as present if it ended in transient failure.
-            covered_statuses = [WorkCoverageRecord.SUCCESS, 
-                                WorkCoverageRecord.PERSISTENT_FAILURE]
+            covered_statuses = DEFAULT_COUNTS_AS_COVERED
         elif isinstance(covered_statuses, basestring):
             covered_statuses = [covered_statuses]
 

--- a/model.py
+++ b/model.py
@@ -874,7 +874,7 @@ class BaseCoverageRecord(object):
         :return: A clause that can be passed in to Query.filter().
         """
         if not covered_statuses:
-            covered_statuses = DEFAULT_COUNTS_AS_COVERED
+            covered_statuses = cls.DEFAULT_COUNTS_AS_COVERED
         elif isinstance(covered_statuses, basestring):
             covered_statuses = [covered_statuses]
 

--- a/model.py
+++ b/model.py
@@ -966,7 +966,8 @@ class CoverageRecord(Base, BaseCoverageRecord):
         )
 
     @classmethod
-    def add_for(self, edition, data_source, operation=None, timestamp=None):
+    def add_for(self, edition, data_source, operation=None, timestamp=None,
+                status=BaseCoverageRecord.SUCCESS):
         _db = Session.object_session(edition)
         if isinstance(edition, Identifier):
             identifier = edition
@@ -983,6 +984,7 @@ class CoverageRecord(Base, BaseCoverageRecord):
             operation=operation,
             on_multiple='interchangeable'
         )
+        coverage_record.status = status
         coverage_record.timestamp = timestamp
         return coverage_record, is_new
 
@@ -1004,10 +1006,6 @@ class WorkCoverageRecord(Base, BaseCoverageRecord):
     QUALITY_OPERATION = 'quality'
     GENERATE_OPDS_OPERATION = 'generate-opds'
     UPDATE_SEARCH_INDEX_OPERATION = 'update-search-index'
-
-    SUCCESS = CoverageRecord.SUCCESS
-    TRANSIENT_FAILURE = CoverageRecord.TRANSIENT_FAILURE
-    PERSISTENT_FAILURE = CoverageRecord.PERSISTENT_FAILURE
 
     id = Column(Integer, primary_key=True)
     work_id = Column(
@@ -1046,7 +1044,8 @@ class WorkCoverageRecord(Base, BaseCoverageRecord):
         )
 
     @classmethod
-    def add_for(self, work, operation, timestamp=None):
+    def add_for(self, work, operation, timestamp=None, 
+                status=CoverageRecord.SUCCESS):
         _db = Session.object_session(work)
         timestamp = timestamp or datetime.datetime.utcnow()
         coverage_record, is_new = get_one_or_create(
@@ -1055,6 +1054,7 @@ class WorkCoverageRecord(Base, BaseCoverageRecord):
             operation=operation,
             on_multiple='interchangeable'
         )
+        coverage_record.status = status
         coverage_record.timestamp = timestamp
         return coverage_record, is_new
 Index("ix_workcoveragerecords_operation_work_id", WorkCoverageRecord.operation, WorkCoverageRecord.work_id)

--- a/opds_import.py
+++ b/opds_import.py
@@ -970,8 +970,9 @@ class OPDSImportMonitor(Monitor):
         
         # Create CoverageRecords for the successful imports.
         for edition in imported_editions:
-            CoverageRecord.add_for(
-                edition, data_source, CoverageRecord.IMPORT_OPERATION
+            record = CoverageRecord.add_for(
+                edition, data_source, CoverageRecord.IMPORT_OPERATION,
+                status=CoverageRecord.SUCCESS
             )
 
         # Create CoverageRecords for the failures.

--- a/testing.py
+++ b/testing.py
@@ -294,21 +294,34 @@ class DatabaseTest(object):
             work.calculate_opds_entries(verbose=False)
         return work
 
-    def _coverage_record(self, edition, coverage_source, operation=None):
+    def _coverage_record(self, edition, coverage_source, operation=None,
+                         status=CoverageRecord.SUCCESS):
+        if isinstance(edition, Identifier):
+            identifier = edition
+        else:
+            identifier = edition.primary_identifier
         record, ignore = get_one_or_create(
             self._db, CoverageRecord,
-            identifier=edition.primary_identifier,
+            identifier=identifier,
             data_source=coverage_source,
             operation=operation,
-            create_method_kwargs = dict(timestamp=datetime.utcnow()))
+            create_method_kwargs = dict(
+                timestamp=datetime.utcnow(),
+                status=status,
+            )
+        )
         return record
 
-    def _work_coverage_record(self, work, operation=None):
+    def _work_coverage_record(self, work, operation=None, 
+                              status=CoverageRecord.SUCCESS):
         record, ignore = get_one_or_create(
             self._db, WorkCoverageRecord,
             work=work,
             operation=operation,
-            create_method_kwargs = dict(timestamp=datetime.utcnow())
+            create_method_kwargs = dict(
+                timestamp=datetime.utcnow(),
+                status=status,
+            )
         )
         return record
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -206,7 +206,7 @@ class TestCoverageProvider(DatabaseTest):
             "Transient failure", self.input_identifier_types, self.output_source
         )
         failure = provider.ensure_coverage(self.edition)
-        eq_(True, failure.transient)
+        eq_(CoverageRecord.TRANSIENT_FAILURE, failure.status)
         eq_("Oops!", failure.exception)
 
         # Because the error is transient we have no coverage record.

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -319,7 +319,8 @@ class TestCoverageProvider(DatabaseTest):
         eq_("Always successful", timestamp.service)
 
         # The identifier with no coverage and the identifier with a
-        # persistent failure now have coverage records.
+        # transient failure now have coverage records that indicate
+        # success.
 
         [transient_failure_has_gone] = self.identifier.coverage_records
         eq_(CoverageRecord.SUCCESS, transient_failure_has_gone.status)
@@ -329,8 +330,9 @@ class TestCoverageProvider(DatabaseTest):
 
         # The identifier that had the transient failure was processed
         # second, even though it was created first in the
-        # database. That's because we prioritize identifiers where
-        # coverage has never been attempted.
+        # database. That's because we do the work in two passes: first
+        # we process identifiers where coverage has never been
+        # attempted, then we process identifiers with transient failures.
         eq_([no_coverage, self.identifier], provider.attempts)
 
     def test_never_successful(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3521,6 +3521,13 @@ class TestCoverageRecord(DatabaseTest):
         record4 = CoverageRecord.lookup(edition.primary_identifier, source)
         eq_(record3, record4)
 
+        # We can change the status.
+        record5, is_new = CoverageRecord.add_for(
+            edition, source, operation, 
+            status=CoverageRecord.PERSISTENT_FAILURE
+        )
+        eq_(record5, record)
+        eq_(CoverageRecord.PERSISTENT_FAILURE, record.status)
 
 class TestWorkCoverageRecord(DatabaseTest):
 
@@ -3566,6 +3573,12 @@ class TestWorkCoverageRecord(DatabaseTest):
         record4 = WorkCoverageRecord.lookup(work, None)
         eq_(record3, record4)
 
+        # We can change the status.
+        record5, is_new = WorkCoverageRecord.add_for(
+            work, operation, status=WorkCoverageRecord.PERSISTENT_FAILURE
+        )
+        eq_(record5, record)
+        eq_(WorkCoverageRecord.PERSISTENT_FAILURE, record.status)
 
 class TestComplaint(DatabaseTest):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3442,7 +3442,7 @@ class TestBaseCoverageRecord(DatabaseTest):
         # to count as 'coverage'.
         check_not_covered(
             [no_coverage],
-            covered_statuses=[CoverageRecord.PERSISTENT_FAILURE, 
+            count_as_covered=[CoverageRecord.PERSISTENT_FAILURE, 
                               CoverageRecord.TRANSIENT_FAILURE,
                               CoverageRecord.SUCCESS]
         )
@@ -3450,7 +3450,7 @@ class TestBaseCoverageRecord(DatabaseTest):
         # Here, only success counts as 'coverage'.
         check_not_covered(
             [no_coverage, transient, persistent],
-            covered_statuses=CoverageRecord.SUCCESS
+            count_as_covered=CoverageRecord.SUCCESS
         )
 
         # We can also say that coverage doesn't count if it was achieved before

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -958,7 +958,7 @@ class TestOPDSImportMonitor(OPDSImporterTest):
             editions[0].primary_identifier, data_source,
             operation=CoverageRecord.IMPORT_OPERATION
         )
-        eq_(CoverageRecord.SUCCESS, status)
+        eq_(CoverageRecord.SUCCESS, record.status)
         eq_(None, record.exception)
 
         # The 202 status message in the feed caused a transient failure.

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -958,13 +958,21 @@ class TestOPDSImportMonitor(OPDSImporterTest):
             editions[0].primary_identifier, data_source,
             operation=CoverageRecord.IMPORT_OPERATION
         )
+        eq_(CoverageRecord.SUCCESS, status)
         eq_(None, record.exception)
 
-        # The other entry has a CoverageRecord for the failure.
-        # The 202 status message in the feed was transient and did
-        # not create a CoverageRecord.
+        # The 202 status message in the feed caused a transient failure.
+        # The exception caused a persistent failure.
 
-        eq_(2, self._db.query(CoverageRecord).filter(CoverageRecord.operation==CoverageRecord.IMPORT_OPERATION).count())
+        coverage_records = self._db.query(CoverageRecord).filter(
+            CoverageRecord.operation==CoverageRecord.IMPORT_OPERATION,
+            CoverageRecord.status != CoverageRecord.SUCCESS
+        )
+        eq_(
+            sorted([CoverageRecord.TRANSIENT_FAILURE, 
+                    CoverageRecord.PERSISTENT_FAILURE]),
+            sorted([x.status for x in coverage_records])
+        )
     
         identifier, ignore = Identifier.parse_urn(self._db, "urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441")
         failure = CoverageRecord.lookup(


### PR DESCRIPTION
This branch introduces the notion of storing transient failures in `CoverageRecord`s. Previously only successes and persistent failures were stored.

This branch also changes CoverageProvider so that `run()` runs in two steps. First, it tries to cover items that have no CoverageRecord at all. Then, it tries to cover items that already have CoverageRecords that ended in transient failure.

The goal is to fix https://github.com/NYPL-Simplified/circulation/issues/251, where a relatively small number of transient failures stacked up at the beginning of the work and were always processed first.

Finally, I fixed a bug I discovered which meant that a CoverageProvider could never _change_ `CoverageRecord.status` (e.g. from transient failure to success), it could only create a new `CoverageRecord`. We didn't notice this before because successful coverage records don't get retried, and we haven't yet tried to resolve any persistent failures.