### PR TITLE
Remove primary identifier types from database to match their removal in code

### DIFF
--- a/migration/20160615-remove-data-source-primary-identifier-types.sql
+++ b/migration/20160615-remove-data-source-primary-identifier-types.sql
@@ -1,0 +1,10 @@
+update datasources set primary_identifier_type=NULL where name in (
+       'Library Simplified Open Access Content Server', 
+       'OCLC Classify',
+       'OCLC Linked Data',
+       'Amazon',
+       'Library Simplified metadata wrangler',
+       'Library Staff'
+);
+update datasources set primary_identifier_type='NoveList ID' where name='NoveList Select';
+update datasources set primary_identifier_type='ISBN' where name='Content Cafe';


### PR DESCRIPTION
A number of data sources used to have a 'primary identifier type', which was the identifier type you would stereotypically expect to be associated with that data source (e.g. ASIN for Amazon).

Recently we changed things so that we would refuse to apply metadata from a data source if the data source defined a primary identifier type and the given identifier type didn't match. That is, 'primary identifier type' is now intended to describe the _only_ identifier type provided by a given data source. (e.g. Overdrive ID for Overdrive).

Some data sources offer information about multiple identifier types (especially the open-access content server, which currently knows about Gutenberg ID, URI, and ISBN). We changed their definitions in the `DataSource` to set their primary_identifier_type to None. But we didn't change the database records for those `DataSources`, which retained the old values.

This branch brings a database up to date with all recent changes to the `DataSource` class. In the long run we might want to get rid of the `primary_identifier_type` field altogether and just keep it in the code, but this will get things working for now.