### PR TITLE
Keep track of special Overdrive formats.

### DIFF
--- a/overdrive.py
+++ b/overdrive.py
@@ -92,7 +92,7 @@ class OverdriveAPI(object):
     # in any format.
     INCOMPATIBLE_PLATFORM_FORMATS = set(["ebook-kindle"])
 
-    OVERDRIVE_READ_FORMAT = "overdrive-read"
+    OVERDRIVE_READ_FORMAT = "ebook-overdrive"
 
     TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 

--- a/overdrive.py
+++ b/overdrive.py
@@ -84,6 +84,14 @@ class OverdriveAPI(object):
     # The ebook formats we care about.
     FORMATS = "ebook-epub-open,ebook-epub-adobe,ebook-pdf-adobe,ebook-pdf-open"
 
+    # The formats that can be read by the default Library Simplified reader.
+    DEFAULT_READABLE_FORMATS = set(["ebook-epub-open", "ebook-epub-adobe"])
+
+    # The formats that indicate the book has been fulfilled on an
+    # incompatible platform and just can't be fulfilled on Simplified
+    # in any format.
+    INCOMPATIBLE_PLATFORM_FORMATS = set(["ebook-kindle"])
+
     TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
    

--- a/overdrive.py
+++ b/overdrive.py
@@ -92,6 +92,8 @@ class OverdriveAPI(object):
     # in any format.
     INCOMPATIBLE_PLATFORM_FORMATS = set(["ebook-kindle"])
 
+    OVERDRIVE_READ_FORMAT = "overdrive-read"
+
     TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
    


### PR DESCRIPTION
These constants are used by the circ manager to detect whether a book has already been fulfilled on an incompatible platform (i.e. Kindle) and whether or not a loan is available in a format readable by the default reader.