### PR TITLE
Changed default pagination size for search to 10.

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -107,10 +107,10 @@ def load_facets_from_request(config=Configuration):
     collection = arg(g, config.default_facet(g))
     return load_facets(order, availability, collection, config)
 
-def load_pagination_from_request():
-    """Figure out which Facets object this request is asking for."""
+def load_pagination_from_request(default_size=Pagination.DEFAULT_SIZE):
+    """Figure out which Pagination object this request is asking for."""
     arg = flask.request.args.get
-    size = arg('size', Pagination.DEFAULT_SIZE)
+    size = arg('size', default_size)
     offset = arg('after', 0)
     return load_pagination(size, offset)
 

--- a/lane.py
+++ b/lane.py
@@ -310,6 +310,7 @@ class Facets(FacetConstants):
 class Pagination(object):
 
     DEFAULT_SIZE = 50
+    DEFAULT_SEARCH_SIZE = 10
     DEFAULT_FEATURED_SIZE = 10
 
     @classmethod
@@ -1107,7 +1108,7 @@ class Lane(object):
         """        
            
         if not pagination:
-            pagination = Pagination.default()
+            pagination = Pagination(offset=0, size=Pagination.DEFAULT_SEARCH_SIZE)
 
         search_lane = self.search_target
         if not search_lane:

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -236,6 +236,17 @@ class TestLoadMethods(object):
             pagination = load_pagination_from_request()
             eq_(100, pagination.size)
 
+    def test_load_pagination_from_request_default_size(self):
+        with self.app.test_request_context('/?size=50&after=10'):
+            pagination = load_pagination_from_request(default_size=10)
+            eq_(50, pagination.size)
+            eq_(10, pagination.offset)
+
+        with self.app.test_request_context('/'):
+            pagination = load_pagination_from_request(default_size=10)
+            eq_(10, pagination.size)
+            eq_(0, pagination.offset)
+
 
 class TestErrorHandler(object):
 


### PR DESCRIPTION
For me locally, it takes about 2.5 seconds to create 50 OPDS entries in a search request - which can be longer than the time elasticsearch takes. A smaller page size will be much faster, and hopefully the first results will often be enough anyway.