### PR TITLE
Make it possible to test that RunCoverageProviderScript correctly instantiates a CoverageProvider.

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -287,8 +287,10 @@ class RunCoverageProviderScript(IdentifierInputScript):
             parsed.cutoff_time = cls.parse_time(parsed.cutoff_time)
         return parsed
 
-    def __init__(self, provider):
-        args = self.parse_command_line(self._db)
+    def __init__(self, provider, _db=None, cmd_args=None, **provider_arguments):
+        if _db:
+            self._session = _db
+        args = self.parse_command_line(self._db, cmd_args)
         if callable(provider):
             if args.identifier_type:
                 self.identifier_type = args.identifier_type
@@ -297,6 +299,7 @@ class RunCoverageProviderScript(IdentifierInputScript):
                 self.identifier_type = None
                 self.identifier_types = []
             kwargs = self.extract_additional_command_line_arguments(args)
+            kwargs.update(provider_arguments)
             provider = provider(
                 self._db, 
                 cutoff_time=args.cutoff_time,

--- a/tests/test_3m.py
+++ b/tests/test_3m.py
@@ -21,6 +21,7 @@ from threem import (
     MockThreeMAPI,
     ThreeMBibliographicCoverageProvider,
 )
+from scripts import RunCoverageProviderScript
 from . import DatabaseTest
 from util.http import BadResponseException
 
@@ -198,6 +199,18 @@ class TestItemListParser(BaseThreeMTest):
 class TestBibliographicCoverageProvider(TestThreeMAPI):
 
     """Test the code that looks up bibliographic information from 3M."""
+
+    def test_script_instantiation(self):
+        """Test that RunCoverageProviderScript can instantiate
+        the coverage provider.
+        """
+        script = RunCoverageProviderScript(
+            ThreeMBibliographicCoverageProvider, self._db, [],
+            threem_api=self.api
+        )
+        assert isinstance(script.provider, 
+                          ThreeMBibliographicCoverageProvider)
+        eq_(script.provider.api, self.api)
 
     def test_process_item_creates_presentation_ready_work(self):
         """Test the normal workflow where we ask 3M for data,

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -33,6 +33,7 @@ from util.http import (
 )
 
 from . import DatabaseTest
+from scripts import RunCoverageProviderScript
 from testing import MockRequestsResponse
 
 class AxisTest(DatabaseTest):
@@ -214,6 +215,20 @@ class TestParsers(AxisTest):
 
 class TestAxis360BibliographicCoverageProvider(AxisTest):
     """Test the code that looks up bibliographic information from Axis 360."""
+
+    def test_script_instantiation(self):
+        """Test that RunCoverageProviderScript can instantiate
+        the coverage provider.
+        """
+        api = MockAxis360API(self._db)
+        script = RunCoverageProviderScript(
+            Axis360BibliographicCoverageProvider, self._db, [],
+            axis_360_api=api
+        )
+        assert isinstance(script.provider, 
+                          Axis360BibliographicCoverageProvider)
+        eq_(script.provider.api, api)
+
 
     def test_process_item_creates_presentation_ready_work(self):
         """Test the normal workflow where we ask Axis for data,

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -784,7 +784,6 @@ class TestBibliographicCoverageProvider(DatabaseTest):
         primary_identifier=BIBLIOGRAPHIC_DATA.primary_identifier,
     )
 
-
     def test_edition(self):
         provider = MockBibliographicCoverageProvider(self._db)
         provider.CAN_CREATE_LICENSE_POOLS = False

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -29,6 +29,7 @@ from model import (
     Measurement,
     Hyperlink,
 )
+from scripts import RunCoverageProviderScript
 
 from util.http import (
     BadResponseException,
@@ -310,6 +311,18 @@ class TestOverdriveBibliographicCoverageProvider(OverdriveTest):
         self.provider = OverdriveBibliographicCoverageProvider(
             self._db, overdrive_api=self.api
         )
+
+    def test_script_instantiation(self):
+        """Test that RunCoverageProviderScript can instantiate
+        the coverage provider.
+        """
+        script = RunCoverageProviderScript(
+            OverdriveBibliographicCoverageProvider, self._db, [],
+            overdrive_api=self.api
+        )
+        assert isinstance(script.provider, 
+                          OverdriveBibliographicCoverageProvider)
+        eq_(script.provider.api, self.api)
 
     def test_invalid_or_unrecognized_guid(self):
         """A bad or malformed GUID can't get coverage."""


### PR DESCRIPTION
Every once in a while we add something to the CoverageProvider constructor signature. Then we have to go through all our CoverageProviders and change their constructors, even if all they do is pass the new variable through to the superclass. Tests don't help because tests only verify that the old signature still works. They don't test what happens when RunCoverageProviderScript passes in the new, unsupported signature.

What we _really_ want to test is that RunCoverageProviderScript correctly instantiates every CoverageProvider. That's the test that will break when we change something. This branch makes it possible to instantiate a RunCoverageProviderScript from a test and investigate the CoverageProvider it instantiates. I demonstrate this by adding tests for the coverage providers for Axis 360, Overdrive and 3M.