### PR TITLE
Handle book that loses identifier

### DIFF
--- a/model.py
+++ b/model.py
@@ -5698,6 +5698,10 @@ class LicensePool(Base):
         that's really the case, pass in even_if_no_author=True and the
         Work will be created.
         """
+        if not self.identifier:
+            # A LicensePool with no Identifier should never have a Work.
+            self.work = None
+            return None, False
         if known_edition:
             presentation_edition = known_edition
         else:

--- a/opds.py
+++ b/opds.py
@@ -784,6 +784,10 @@ class AcquisitionFeed(OPDSFeed):
             logging.warn("NO ACTIVE EDITION FOR %r", active_license_pool)
             return None
 
+        if not identifier:
+            logging.warn("%r HAS NO IDENTIFIER", work)
+            return None
+
         return self._create_entry(work, active_license_pool, active_edition,
                                   identifier, lane_link, force_create, 
                                   use_cache)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2622,6 +2622,11 @@ class TestWorkConsolidation(DatabaseTest):
             work2
         )
 
+    def test_licensepool_without_identifier_gets_no_work(self):
+        edition, lp = self._edition(with_license_pool=True)
+        lp.identifier = None
+        eq_((None, False), lp.calculate_work())
+
 class TestLoans(DatabaseTest):
 
     def test_open_access_loan(self):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1048,6 +1048,18 @@ class TestAcquisitionFeed(DatabaseTest):
         assert original_pool.presentation_edition.title in entry
         assert new_pool.presentation_edition.title not in entry
 
+    def test_error_when_work_has_no_identifier(self):
+        """We cannot create an OPDS entry for a Work that cannot be associated
+        with an Identifier.
+        """
+        work = self._work(title=u"Hello, World!", with_license_pool=True)
+        work.license_pools[0].identifier = None
+        work.presentation_edition.primary_identifier = None
+        entry = AcquisitionFeed.single_entry(
+            self._db, work, TestAnnotator
+        )
+        eq_(entry, None)
+
     def test_cache_usage(self):
         work = self._work(with_open_access_download=True)
         feed = AcquisitionFeed(
@@ -1075,6 +1087,8 @@ class TestAcquisitionFeed(DatabaseTest):
         entry_string = etree.tostring(entry) 
         assert entry_string != tiny_entry
         eq_(entry_string, work.simple_opds_entry)
+
+
 
 class TestLookupAcquisitionFeed(DatabaseTest):
 


### PR DESCRIPTION
I've noticed that when doing OPDS imports from an open-access source, sometimes a Work's LicensePool is replaced with a new LicensePool, leaving the old pool with no identifier. (https://github.com/NYPL-Simplified/server_core/issues/316). This branch stops this undesirable case from causing patron-visible errors.