### PR TITLE
Set up CDNs based on the hostname, not the type of resource

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -45,10 +45,10 @@ from lane import (
 )
 from problem_details import *
 
-opds_cdn_host = Configuration.cdn_host(Configuration.CDN_OPDS_FEEDS)
+cdns = Configuration.cdns()
 def cdn_url_for(*args, **kwargs):
     base_url = url_for(*args, **kwargs)
-    return cdnify(base_url, opds_cdn_host)
+    return cdnify(base_url, cdns)
 
 def load_lending_policy(policy):
     if not policy:

--- a/config.py
+++ b/config.py
@@ -147,9 +147,6 @@ class Configuration(object):
     S3_BOOK_COVERS_BUCKET = "book_covers_bucket"
 
     CDN_INTEGRATION = "CDN"
-    CDN_BOOK_COVERS = "book_covers"
-    CDN_OPDS_FEEDS = "opds"
-    CDN_OPEN_ACCESS_CONTENT = "open_access_books"
 
     BASE_OPDS_AUTHENTICATION_DOCUMENT = "base_opds_authentication_document"
     SHOW_STAFF_PICKS_ON_TOP_LEVEL = "show_staff_picks_on_top_level"
@@ -202,9 +199,8 @@ class Configuration(object):
         return v
 
     @classmethod
-    def cdn_host(cls, type):
-        integration = cls.integration(cls.CDN_INTEGRATION)
-        return integration.get(type)
+    def cdns(cls):
+        return cls.integration(cls.CDN_INTEGRATION)
 
     @classmethod
     def s3_bucket(cls, bucket_name):

--- a/opds.py
+++ b/opds.py
@@ -106,16 +106,16 @@ class Annotator(object):
         """
         thumbnails = []
         full = []
-        cdn_host = Configuration.cdn_host(Configuration.CDN_BOOK_COVERS)
+        cdns = Configuration.cdns()
         if work:
             if work.cover_thumbnail_url:
                 thumb = work.cover_thumbnail_url
                 old_thumb = thumb
-                thumbnails = [cdnify(thumb, cdn_host)]
+                thumbnails = [cdnify(thumb, cdns)]
 
             if work.cover_full_url:
                 full = work.cover_full_url
-                full = [cdnify(full, cdn_host)]
+                full = [cdnify(full, cdns)]
         return thumbnails, full
 
     @classmethod

--- a/tests/test_cdn.py
+++ b/tests/test_cdn.py
@@ -1,0 +1,48 @@
+# encoding: utf-8
+from nose.tools import (
+    eq_, 
+    set_trace,
+)
+
+from util.cdn import cdnify
+
+class TestCDN(object):
+
+    def unchanged(self, url, cdns):
+        self.ceq(url, url, cdns)
+
+    def ceq(self, expect, url, cdns):
+        eq_(expect, cdnify(url, cdns))
+
+    def test_no_cdns(self):
+        url = "http://foo/"
+        self.unchanged(url, None)
+
+    def test_non_matching_cdn(self):
+        url = "http://foo.com/bar"
+        self.unchanged(url, {"bar.com" : "cdn.com"})
+
+    def test_matching_cdn(self):
+        url = "http://foo.com/bar#baz"
+        self.ceq("https://cdn.org/bar#baz", url, 
+                 {"foo.com" : "https://cdn.org",
+                  "bar.com" : "http://cdn2.net/"}
+        )
+
+    def test_s3_bucket(self):
+        # Instead of the foo.com URL we accidentally used the full S3
+        # address for the bucket that hosts S3. cdnify() handles this
+        # with no problem.
+        url = "http://s3.amazonaws.com/foo.com/bar#baz"
+        self.ceq("https://cdn.org/bar#baz", url, 
+                 {"foo.com" : "https://cdn.org/"})
+
+    def test_relative_url(self):
+        # By default, relative URLs are untouched.
+        url = "/groups/"
+        self.unchanged(url, {"bar.com" : "cdn.com"})
+        
+        # But if the CDN list has an entry for the empty string, that
+        # URL is used for relative URLs.
+        self.ceq("https://cdn.org/groups/", url, 
+                 {"" : "https://cdn.org/"})

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -730,17 +730,18 @@ class TestOPDS(DatabaseTest):
     def test_acquisition_feed_image_links_respect_cdn(self):
         work = self._work(genre=Fantasy, language="eng",
                           with_open_access_download=True)
-        work.presentation_edition.cover_thumbnail_url = "http://thumbnail/b"
-        work.presentation_edition.cover_full_url = "http://full/a"
+        work.presentation_edition.cover_thumbnail_url = "http://thumbnail.com/b"
+        work.presentation_edition.cover_full_url = "http://full.com/a"
 
         with temp_config() as config:
             config['integrations'][Configuration.CDN_INTEGRATION] = {}
-            config['integrations'][Configuration.CDN_INTEGRATION][Configuration.CDN_BOOK_COVERS] = "http://foo/"
+            config['integrations'][Configuration.CDN_INTEGRATION]['thumbnail.com'] = "http://foo/"
+            config['integrations'][Configuration.CDN_INTEGRATION]['full.com'] = "http://bar/"
             work.calculate_opds_entries(verbose=False)
             feed = feedparser.parse(work.simple_opds_entry)
             links = sorted([x['href'] for x in feed['entries'][0]['links'] if 
                             'image' in x['rel']])
-            eq_(['http://foo/a', 'http://foo/b'], links)
+            eq_(['http://bar/a', 'http://foo/b'], links)
 
     def test_messages(self):
         """Test the ability to include messages (with HTTP-style status code)

--- a/util/cdn.py
+++ b/util/cdn.py
@@ -4,19 +4,22 @@ from nose.tools import set_trace
 import urlparse
 from s3 import S3Uploader
 
-def cdnify(url, cdn_host):
-    if not cdn_host:
+def cdnify(url, cdns):
+    if not cdns:
+        # No CDNs configured
         return url
     scheme, netloc, path, query, fragment = urlparse.urlsplit(url)
-    cdn_scheme, cdn_netloc, i1, i2, i3 = urlparse.urlsplit(cdn_host)
 
     if netloc == 's3.amazonaws.com':
         # This is a URL like "http://s3.amazonaws.com/bucket/foo".
         # It's equivalent to "http://bucket/foo".
-        # It should be CDNified to "http://cdn/foo".
-        #
-        # i.e. eliminate the bucket name.
-        bucket, path = S3Uploader.bucket_and_filename(
-            url)
+        # i.e. treat the bucket name as the netloc.
+        bucket, path = S3Uploader.bucket_and_filename(url)
+        netloc = bucket
+    if netloc not in cdns:
+        # This domain name is not covered by any of our CDNs.
+        return url
 
+    cdn_host = cdns[netloc]
+    cdn_scheme, cdn_netloc, i1, i2, i3 = urlparse.urlsplit(cdn_host)
     return urlparse.urlunsplit((cdn_scheme, cdn_netloc, path, query, fragment))


### PR DESCRIPTION
Currently we configure CDNs based on the type of thing being CDNed: cover images, OPDS feeds, open-access books. This was a mistake. Our CDNs are set up to cache access to specific hostnames, not types of things. The hostname https://d3pqhns20516vc.cloudfront.net/ is the CDN for the hostname book-covers.nypl.org, not the CDN for "book covers".

Under most circumstances this mistake isn't visible. All the book covers are on book-covers.nypl.org so the CDN always works. But sometimes the book cover isn't on book-covers.nypl.org. Sometimes it's a book we haven't run through the metadata wrangler yet, and its cover is on contentreserve.com. The `cdnify` function just goes ahead and changes a URL that would work fine (http://contentreserve.com/foo/bar.jpg)  to a URL that doesn't work (https://d3pqhns20516vc.cloudfront.net/foo/bar.jpg).

This branch changes CDN configuration to work by hostname. The empty string is used to CDN-ify relative URLs such as those generated by app servers.