### PR TITLE
Correctly log circulation changes

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -817,29 +817,6 @@ class CirculationData(MetaToModelUtility):
                         as_of=self.last_checked
                     )
 
-        if changed_licenses:
-            edition = pool.presentation_edition
-            if edition:
-                self.log.info(
-                    'CHANGED %s "%s" %s (%s) OWN: %s=>%s AVAIL: %s=>%s HOLD: %s=>%s',
-                    edition.medium,
-                    edition.title or "[NO TITLE]",
-                    edition.author or "",
-                    edition.primary_identifier.identifier,
-                    pool.licenses_owned, self.licenses_owned,
-                    pool.licenses_available, self.licenses_available,
-                    pool.patrons_in_hold_queue, self.patrons_in_hold_queue
-                )
-            else:
-                self.log.info(
-                    'CHANGED %r OWN: %s=>%s AVAIL: %s=>%s HOLD: %s=>%s',
-                    pool.identifier,
-                    pool.licenses_owned, self.licenses_owned,
-                    pool.licenses_available, self.licenses_available,
-                    pool.patrons_in_hold_queue, self.patrons_in_hold_queue
-                )
-
-
         made_changes = made_changes or changed_licenses
 
         return pool, made_changes

--- a/model.py
+++ b/model.py
@@ -5670,7 +5670,6 @@ class LicensePool(Base):
         """
         edition = self.presentation_edition
         message = 'CHANGED '
-        blah = object()
         args = []
         if edition:
             message += '%s "%s" %s (%s)'

--- a/model.py
+++ b/model.py
@@ -5683,30 +5683,30 @@ class LicensePool(Base):
             message += '%s'
             args.append(self.identifier)
 
-        def _part(message, string, old_value, new_value):
-            if old_value == new_value:
-                # Nothing has changed.
-                return "", []
-            return ' %s: %s=>%s', [string, old_value, new_value]
+        def _part(message, args, string, old_value, new_value):
+            if old_value != new_value:
+                args.extend([string, old_value, new_value])
+                message += ' %s: %s=>%s'
+            return message, args
 
-        m, a = _part(message, "OWN", old_licenses_owned, self.licenses_owned)
-        message += m
-        args.extend(a)
+        message, args = _part(
+            message, args, "OWN", old_licenses_owned, self.licenses_owned
+        )
         
-        m, a = _part(message, "AVAIL", old_licenses_available, 
-                     self.licenses_available)
-        message += m
-        args.extend(a)
+        message, args = _part(
+            message, args, "AVAIL", old_licenses_available, 
+            self.licenses_available
+        )
 
-        m, a = _part(message, "RSRV", old_licenses_reserved, 
-                     self.licenses_reserved)
-        message += m
-        args.extend(a)
+        message, args = _part(
+            message, args, "RSRV", old_licenses_reserved, 
+            self.licenses_reserved
+        )
 
-        m, a =_part(message, "HOLD", old_patrons_in_hold_queue,
-                    self.patrons_in_hold_queue)
-        message += m
-        args.extend(a)
+        message, args =_part(
+            message, args, "HOLD", old_patrons_in_hold_queue, 
+            self.patrons_in_hold_queue
+        )
         return message, tuple(args)
 
     def loan_to(self, patron, start=None, end=None, fulfillment=None):

--- a/model.py
+++ b/model.py
@@ -5594,6 +5594,12 @@ class LicensePool(Base):
         _db = Session.object_session(self)
         if not as_of:
             as_of = datetime.datetime.utcnow()
+
+        old_licenses_owned = self.licenses_owned
+        old_licenses_available = self.licenses_available
+        old_licenses_reserved = self.licenses_reserved
+        old_patrons_in_hold_queue = self.patrons_in_hold_queue
+
         for old_value, new_value, more_event, fewer_event in (
                 [self.patrons_in_hold_queue,  new_patrons_in_hold_queue,
                  CirculationEvent.HOLD_PLACE, CirculationEvent.HOLD_RELEASE], 
@@ -5646,7 +5652,62 @@ class LicensePool(Base):
             if self.work:
                 self.work.last_update_time = as_of
 
+        if changes_made:
+            message, args = self.circulation_changelog(
+                old_licenses_owned, old_licenses_available,
+                old_licenses_reserved, old_patrons_in_hold_queue
+            )
+            self.log.info(message, *args)
+
         return changes_made
+
+    def circulation_changelog(self, old_licenses_owned, old_licenses_available,
+                              old_licenses_reserved, old_patrons_in_hold_queue):
+        """Generate a log message describing a change to the circulation.
+
+        :return: a 2-tuple (message, args) suitable for passing into 
+        logging.info or a similar method
+        """
+        edition = self.presentation_edition
+        message = 'CHANGED '
+        blah = object()
+        args = []
+        if edition:
+            message += '%s "%s" %s (%s)'
+            args.extend([edition.medium, 
+                         edition.title or "[NO TITLE]",
+                         edition.author or "[NO AUTHOR]",
+                         self.identifier]
+                    )
+        else:
+            message += '%s'
+            args.append(self.identifier)
+
+        def _part(message, string, old_value, new_value):
+            if old_value == new_value:
+                # Nothing has changed.
+                return "", []
+            return ' %s: %s=>%s', [string, old_value, new_value]
+
+        m, a = _part(message, "OWN", old_licenses_owned, self.licenses_owned)
+        message += m
+        args.extend(a)
+        
+        m, a = _part(message, "AVAIL", old_licenses_available, 
+                     self.licenses_available)
+        message += m
+        args.extend(a)
+
+        m, a = _part(message, "RSRV", old_licenses_reserved, 
+                     self.licenses_reserved)
+        message += m
+        args.extend(a)
+
+        m, a =_part(message, "HOLD", old_patrons_in_hold_queue,
+                    self.patrons_in_hold_queue)
+        message += m
+        args.extend(a)
+        return message, tuple(args)
 
     def loan_to(self, patron, start=None, end=None, fulfillment=None):
         _db = Session.object_session(patron)

--- a/model.py
+++ b/model.py
@@ -5657,7 +5657,7 @@ class LicensePool(Base):
                 old_licenses_owned, old_licenses_available,
                 old_licenses_reserved, old_patrons_in_hold_queue
             )
-            self.log.info(message, *args)
+            logging.info(message, *args)
 
         return changes_made
 


### PR DESCRIPTION
This branch fixes a problem I noticed with the log messages triggered when circulation information changes. Because the message was triggered after the LicensePool's fields had been changed, it was always saying "[new value] => [new value]".

This branch also refactors the log message generation into its own method, and adds a unit test for it.