### PR TITLE
Bad entry shouldnt break feed

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -1,4 +1,5 @@
 import importlib
+import contextlib
 import datetime
 from config import Configuration
 
@@ -6,7 +7,18 @@ class Analytics(object):
 
     __instance = None
 
-    DEFAULT_PROVIDERS = ["core.local_analytics_provider"]
+    if '.' in __module__:
+        # We are operating in an application that imports this product
+        # as a package (probably called 'core'). The module name of
+        # the analytics provider should be scoped to the name of the
+        # package, i.e.  'core.local_analytics_provider'.
+        package_name = __module__[:__module__.rfind('.')+1]
+    else:
+        # This application is not imported as a package, probably
+        # because we're running its unit tests.
+        package_name = ''
+
+    DEFAULT_PROVIDERS = [package_name + "local_analytics_provider"]
 
     @classmethod
     def instance(cls):
@@ -45,3 +57,15 @@ class Analytics(object):
     def load_providers_from_config(cls, config):
         policies = config.get(Configuration.POLICIES, {})
         return policies.get(Configuration.ANALYTICS_POLICY, cls.DEFAULT_PROVIDERS)
+
+
+@contextlib.contextmanager
+def temp_analytics(providers, config):
+    """A context manager to temporarily replace the analytics providers
+    used by a test.
+    """
+    old_instance = Analytics._Analytics__instance
+    Analytics.initialize(providers, config)
+    yield
+    Analytics._Analytics__instance = old_instance
+

--- a/opds.py
+++ b/opds.py
@@ -715,9 +715,16 @@ class AcquisitionFeed(OPDSFeed):
             logging.warn("%r HAS NO IDENTIFIER", work)
             return None
 
-        return self._create_entry(work, active_license_pool, active_edition,
-                                  identifier, lane_link, force_create, 
-                                  use_cache)
+        try:
+            return self._create_entry(work, active_license_pool, active_edition,
+                                      identifier, lane_link, force_create, 
+                                      use_cache)
+        except Exception, e:
+            logging.error(
+                "Exception generating OPDS entry for %r", work,
+                exc_info = e
+            )
+            return None
 
     def _create_entry(self, work, license_pool, edition, identifier, lane_link,
                       force_create=False, use_cache=True):
@@ -1024,6 +1031,8 @@ class AcquisitionFeed(OPDSFeed):
         since = None
         until = None
 
+        if not license_pool:
+            return
         if license_pool.open_access:
             default_loan_period = default_reservation_period = None
         else:

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -47,4 +47,4 @@ class TestAnalytics(DatabaseTest):
 
     def test_load_providers_from_config_without_analytics(self):
         providers = Analytics.load_providers_from_config({})
-        eq_("core.local_analytics_provider", providers[0])
+        eq_("local_analytics_provider", providers[0])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -74,7 +74,10 @@ from . import (
     DummyHTTPClient,
 )
 
-from analytics import Analytics
+from analytics import (
+    Analytics,
+    temp_analytics
+)
 from mock_analytics_provider import MockAnalyticsProvider
 
 class TestDataSource(DatabaseTest):
@@ -947,8 +950,7 @@ class TestLicensePool(DatabaseTest):
         assert (datetime.datetime.utcnow() - work.last_update_time) < datetime.timedelta(seconds=2)
 
     def test_update_availability_triggers_analytics(self):
-        with temp_config() as config:
-            config[Configuration.POLICIES][Configuration.ANALYTICS_POLICY] = ["mock_analytics_provider"]
+        with temp_analytics("mock_analytics_provider", {}):
             work = self._work(with_license_pool=True)
             [pool] = work.license_pools
             pool.update_availability(30, 20, 2, 0)

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1092,6 +1092,21 @@ class TestAcquisitionFeed(DatabaseTest):
         eq_(entry_string, work.simple_opds_entry)
 
 
+    def test_exception_during_entry_creation_is_not_reraised(self):
+        # This feed will raise an exception whenever it's asked
+        # to create an entry.
+        class DoomedFeed(AcquisitionFeed):
+            def _create_entry(self, *args, **kwargs):
+                raise Exception("I'm doomed!")
+        feed = DoomedFeed(
+            self._db, self._str, self._url, [], annotator=Annotator
+        )
+        work = self._work()
+
+        # But calling create_entry() doesn't raise an exception, it
+        # just returns None.
+        entry = feed.create_entry(work, self._url)
+        eq_(entry, None)
 
 class TestLookupAcquisitionFeed(DatabaseTest):
 


### PR DESCRIPTION
This branch does two things:

1. Makes the instantiation of analytics providers more robust, so that the core tests will run under a wider variety of configurations.
2. Fixes https://github.com/NYPL-Simplified/server_core/issues/315 by making create_entry return None if _create_entry raises an exception.