### PR TITLE
Metadata source may differ from circulation source

### DIFF
--- a/tests/files/opds/unrecognized_distributor.opds
+++ b/tests/files/opds/unrecognized_distributor.opds
@@ -1,0 +1,24 @@
+<feed xmlns:simplified="http://librarysimplified.org/terms/" xmlns:app="http://www.w3.org/2007/app" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom" xmlns:bibframe="http://bibframe.org/vocab/">
+  <id>http://localhost:5000/</id>
+  <title>Open-Access Content</title>
+  <updated>2015-01-02T16:56:40Z</updated>
+  <link href="http://localhost:5000/"/>
+  <link href="http://localhost:5000/" rel="self"/>
+  <entry schema:additionalType="http://schema.org/PublicationIssue">
+    <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441</id>
+    <bibframe:distribution bibframe:ProviderName="Unknown Source"/>
+    <title>The Green Mouse</title>
+    <schema:alternativeHeadline>A Tale of Mousy Terror</schema:alternativeHeadline>
+    <author>
+      <name></name>
+      <simplified:sort_name>Chambers, Robert W. (Robert William)</simplified:sort_name>
+    </author>
+    <summary>This is a summary!</summary>
+    <updated>2015-01-02T16:56:40Z</updated>
+    <published>2014-01-02T16:56:40Z</published>
+    <simplified:pwid>6db4cf90-0129-0eaf-410a-502b20a45e67</simplified:pwid>
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Project Gutenberg</dcterms:publisher>
+    <link href="http://www.gutenberg.org/ebooks/10441.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
+  </entry>
+</feed>

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -809,7 +809,17 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
         eq_("I am 10557.epub.images", s3.content[3])
 
         # Each resource was 'mirrored' to an Amazon S3 bucket.
-        url0 = 'http://s3.amazonaws.com/test.content.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441/The%20Green%20Mouse.epub.images'
+        #
+        # The "mouse" book was mirrored to a bucket corresponding to
+        # Project Gutenberg, its data source.
+        #
+        # The images were mirrored to a bucket corresponding to the
+        # open-access content server, _their_ data source.
+        #
+        # The "crow" book was mirrored to a bucket corresponding to
+        # the open-access content source, the default data source used
+        # when no distributor was specified for a book.
+        url0 = 'http://s3.amazonaws.com/test.content.bucket/Gutenberg/Gutenberg%20ID/10441/The%20Green%20Mouse.epub.images'
         url1 = u'http://s3.amazonaws.com/test.cover.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441/cover_10441_9.png'
         url2 = u'http://s3.amazonaws.com/test.cover.bucket/scaled/300/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441/cover_10441_9.png'
         url3 = 'http://s3.amazonaws.com/test.content.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10557/Johnny%20Crow%27s%20Party.epub.images'

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -115,8 +115,6 @@ class OPDSImporterTest(DatabaseTest):
             os.path.join(self.resource_path, "content_server.opds")).read()
         self.content_server_mini_feed = open(
             os.path.join(self.resource_path, "content_server_mini.opds")).read()
-        self.metadata_wrangler_mini_feed = open(
-            os.path.join(self.resource_path, "metadata_wrangler_mini.opds")).read()
 
 
 class TestOPDSImporter(OPDSImporterTest):

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -115,6 +115,8 @@ class OPDSImporterTest(DatabaseTest):
             os.path.join(self.resource_path, "content_server.opds")).read()
         self.content_server_mini_feed = open(
             os.path.join(self.resource_path, "content_server_mini.opds")).read()
+        self.metadata_wrangler_mini_feed = open(
+            os.path.join(self.resource_path, "metadata_wrangler_mini.opds")).read()
 
 
 class TestOPDSImporter(OPDSImporterTest):
@@ -186,7 +188,7 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_('Project Gutenberg', metadata['publisher'])
 
         circulation = metadata['circulation']
-        eq_(DataSource.OA_CONTENT_SERVER, circulation['data_source'])
+        eq_(DataSource.GUTENBERG, circulation['data_source'])
 
         failure = failures['http://www.gutenberg.org/ebooks/1984']
         eq_(u"202: I'm working to locate a source for this identifier.", failure.exception)
@@ -416,23 +418,25 @@ class TestOPDSImporter(OPDSImporterTest):
             OPDSImporter(self._db, data_source_name=DataSource.OA_CONTENT_SERVER).import_from_feed(feed)
         )
 
-        [crow, mouse] = sorted(imported_editions, key=lambda x: x.title)
+        [crow_pool, mouse_pool] = sorted(
+            pools, key=lambda x: x.presentation_edition.title
+        )
 
         # Work was created for both books.
-        assert crow.license_pool.work is not None
-        eq_(Edition.BOOK_MEDIUM, crow.medium)
+        assert crow_pool.work is not None
+        eq_(Edition.BOOK_MEDIUM, crow_pool.presentation_edition.medium)
 
-        assert mouse.license_pool.work is not None
-        eq_(Edition.PERIODICAL_MEDIUM, mouse.medium)
+        assert mouse_pool.work is not None
+        eq_(Edition.PERIODICAL_MEDIUM, mouse_pool.presentation_edition.medium)
 
-        work = mouse.license_pool.work
+        work = mouse_pool.work
         work.calculate_presentation()
         eq_(0.4142, round(work.quality, 4))
         eq_(Classifier.AUDIENCE_CHILDREN, work.audience)
         eq_(NumericRange(7,7, '[]'), work.target_age)
 
         # Bonus: make sure that delivery mechanisms are set appropriately.
-        [mech] = mouse.license_pool.delivery_mechanisms
+        [mech] = mouse_pool.delivery_mechanisms
         eq_(Representation.EPUB_MEDIA_TYPE, mech.delivery_mechanism.content_type)
         eq_(DeliveryMechanism.NO_DRM, mech.delivery_mechanism.drm_scheme)
         eq_('http://www.gutenberg.org/ebooks/10441.epub.images', 
@@ -485,7 +489,27 @@ class TestOPDSImporter(OPDSImporterTest):
         for pool in pools_g:
             eq_(pool.data_source.name, DataSource.GUTENBERG)
 
-
+    def test_import_with_unrecognized_distributor_fails(self):
+        """We get a book from the open-access content server but the license
+        comes from an unrecognized data source. We can't import the book
+        because we can't record its provenance accurately.
+        """
+        feed = open(
+            os.path.join(self.resource_path, "unrecognized_distributor.opds")).read()
+        importer = OPDSImporter(
+            self._db, 
+            data_source_name=DataSource.OA_CONTENT_SERVER
+        )
+        imported_editions, pools, works, failures = (
+            importer.import_from_feed(feed)
+        )
+        # No editions, licensepools, or works were imported.
+        eq_([], imported_editions)
+        eq_([], pools)
+        eq_([], works)
+        [failure] = failures.values()
+        eq_(True, failure.transient)
+        assert "Unrecognized circulation data source: Unknown Source" in failure.exception
 
     def test_import_with_cutoff(self):
         cutoff = datetime.datetime(2016, 1, 2, 16, 56, 40)
@@ -566,38 +590,43 @@ class TestOPDSImporter(OPDSImporterTest):
             importer.import_from_feed(feed)
         )
 
-        [crow, mouse] = sorted(imported_editions, key=lambda x: x.title)
+        # Two works have been created, because the content server
+        # actually tells you how to get copies of these books.
+        [crow, mouse] = sorted(imported_works, key=lambda x: x.title)
 
-        # Because the content server actually tells you how to get a
-        # copy of the 'mouse' book, a work and licensepool have been
-        # created for it.
-        assert mouse.license_pool != None
-        assert mouse.license_pool.work != None
+        # Each work has one license pool.
+        [crow_pool] = crow.license_pools
+        [mouse_pool] = mouse.license_pools
 
-        # The OPDS importer no longer worries about the underlying license source, 
-        # and correctly sets the data source to the content server, without guessing the 
-        # original source of Project Gutenberg.
-        eq_(DataSource.OA_CONTENT_SERVER, mouse.data_source.name)
+        # The OPDS importer sets the data source of the license pool
+        # to Project Gutenberg, since that's the authority that grants
+        # access to the book.
+        eq_(DataSource.GUTENBERG, mouse_pool.data_source.name)
+
+        # But the license pool's presentation edition has a data
+        # source associated with the Library Simplified open-access
+        # content server, since that's where the metadata comes from.
+        eq_(DataSource.OA_CONTENT_SERVER, 
+            mouse_pool.presentation_edition.data_source.name
+        )
 
         # Since the 'mouse' book came with an open-access link, the license
         # pool delivery mechanism has been marked as open access.
-        eq_(True, mouse.license_pool.open_access)
+        eq_(True, mouse_pool.open_access)
         eq_(RightsStatus.GENERIC_OPEN_ACCESS, 
-            mouse.license_pool.delivery_mechanisms[0].rights_status.uri)
+            mouse_pool.delivery_mechanisms[0].rights_status.uri)
 
         # The 'mouse' work has not been marked presentation-ready,
         # because the OPDS importer was not told to make works
         # presentation-ready as they're imported.
-        eq_(False, mouse.license_pool.work.presentation_ready)
+        eq_(False, mouse_pool.work.presentation_ready)
 
         # The OPDS feed didn't actually say where the 'crow' book
         # comes from, but we did tell the importer to use the open access 
         # content server as the data source, so both a Work and a LicensePool 
         # were created, and their data source is the open access content server,
         # not Project Gutenberg.
-        assert crow.work is not None
-        assert crow.license_pool is not None
-        eq_(DataSource.OA_CONTENT_SERVER, crow.data_source.name)
+        eq_(DataSource.OA_CONTENT_SERVER, crow_pool.data_source.name)
 
 
     def test_import_and_make_presentation_ready(self):
@@ -611,11 +640,11 @@ class TestOPDSImporter(OPDSImporterTest):
             importer.import_from_feed(feed, immediately_presentation_ready=True)
         )
 
-        [crow, mouse] = sorted(imported_editions, key=lambda x: x.title)
+        [crow, mouse] = sorted(imported_works, key=lambda x: x.title)
 
         # Both the 'crow' and the 'mouse' book had presentation-ready works created.
-        eq_(True, crow.license_pool.work.presentation_ready)
-        eq_(True, mouse.license_pool.work.presentation_ready)
+        eq_(True, crow.presentation_ready)
+        eq_(True, mouse.presentation_ready)
 
 
     def test_status_and_message(self):


### PR DESCRIPTION
This branch reintroduces the idea that, when importing data from an OPDS feed, the actual book might come from a different source than the OPDS feed, and that the <bibframe:distribution> tag says where the actual book comes from.

Currently this only happens on the open-access content server. The Metadata created as part of the import is associated with the source of the OPDS feed (this includes any image links), but the CirculationData is associated with the source of the book. This means that you can end up with a Work whose LicensePool comes from Gutenberg, but the presentation Edition of that LicensePool comes from the open-access content server.

The motivating case here is that if a circ manager finds six editions of a book from the open-access content server, and every one of them has the same data source ("content server"), the circ manager has no way of knowing which edition it should use. When the data sources get passed through, the circ manager can make a rough judgement that certain data sources produce higher-quality books than others.