### PR TITLE
When importing from an OPDS feed, don't create a LicensePool for a book that is not available in any formats.

### DIFF
--- a/tests/files/opds/book_with_license.opds
+++ b/tests/files/opds/book_with_license.opds
@@ -1,0 +1,30 @@
+<feed xmlns:bibframe="http://bibframe.org/vocab/" xmlns:simplified="http://librarysimplified.org/terms/" xmlns:app="http://www.w3.org/2007/app" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom">
+  <id>http://content/lookup?urn=https%3A%2F%2Funglue.it%2Fapi%2Fid%2Fwork%2F7775%2F</id>
+  <title>Lookup results</title>
+  <updated>2016-06-29T16:23:27Z</updated>
+  <link href="http://content/lookup?urn=https%3A%2F%2Funglue.it%2Fapi%2Fid%2Fwork%2F7775%2F" rel="self"/>
+  <entry schema:additionalType="http://schema.org/Book">
+    <id>https://unglue.it/api/id/work/7775/</id>
+    <title>Warbreaker</title>
+    <bibframe:distribution bibframe:ProviderName="unglue.it"/>
+    <author>
+      <name>Brandon Sanderson</name>
+      <simplified:sort_name>Sanderson, Brandon</simplified:sort_name>
+    </author>
+    <summary type="html">&lt;p&gt;WARBREAKER is the story of two sisters - who happen to be princesses, the God King one of them has to marry, a lesser god, and an immortal trying to undo the mistakes he made hundreds of years ago. Theirs is a world in which those who die in glory return as gods to live confined to a pantheon in Hallandren's capital city. A world transformed by BioChromatic magic, a power based on an essence known as breath. Using magic is arduous: breath can only be collected one unit at a time from individual people. But the rewards are great: by using breath and drawing upon the color in everyday objects, all manner of miracles and mischief can be performed. Brandon Sanderson proves again that he is a master of what Tolkien called 'secondary creation,' the invention of whole worlds, complete with magics and myths all their own.&lt;/p&gt;
+
+&lt;p&gt;Everything Brandon Sanderson is available &lt;a href="http://store.brandonsanderson.com/"&gt;at his store&lt;/a&gt;.&lt;/p&gt;</summary>
+    <updated>2016-05-06T15:06:26Z</updated>
+    <simplified:pwid>402e89ce-f3a6-210c-53f2-84f0b8b0a5f4</simplified:pwid>
+    <link href="http://covers/unglue.it/URI/https%3A//unglue.it/api/id/work/7775//books.jpg" type="image/jpeg" rel="http://opds-spec.org/image"/>
+    <link href="http://covers/unglue.it/URI/https%3A//unglue.it/api/id/work/7775//books.jpg" type="image/jpeg" rel="http://opds-spec.org/image/thumbnail"/>
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult"/>
+    <category term="18" scheme="http://schema.org/typicalAgeRange" label="18"/>
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction"/>
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Epic%20Fantasy" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Epic Fantasy"/>
+    <dcterms:language>en</dcterms:language>
+    <published>2016-05-06T15:06:20Z</published>
+    <schema:Rating schema:ratingValue="1.0000" schema:additionalType="http://librarysimplified.org/terms/rel/quality"/>
+    <link href="http://books/unglue.it/URI/https%3A//unglue.it/api/id/work/7775//Warbreaker.epub" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
+  </entry>
+</feed>

--- a/tests/files/opds/book_without_license.opds
+++ b/tests/files/opds/book_without_license.opds
@@ -1,0 +1,27 @@
+<feed xmlns:bibframe="http://bibframe.org/vocab/" xmlns:simplified="http://librarysimplified.org/terms/" xmlns:app="http://www.w3.org/2007/app" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom">
+  <id>http://content/lookup?urn=https%3A%2F%2Funglue.it%2Fapi%2Fid%2Fwork%2F98398%2F</id>
+  <title>Lookup results</title>
+  <updated>2016-06-29T16:04:36Z</updated>
+  <link href="http://content/lookup?urn=https%3A%2F%2Funglue.it%2Fapi%2Fid%2Fwork%2F98398%2F" rel="self"/>
+  <entry schema:additionalType="http://schema.org/Book">
+    <id>https://unglue.it/api/id/work/98398/</id>
+    <title>Howards End</title>
+    <bibframe:distribution bibframe:ProviderName="unglue.it"/>
+    <author>
+      <name>Edward Morgan Forster</name>
+      <simplified:sort_name>Forster, Edward Morgan.</simplified:sort_name>
+    </author>
+    <updated>2016-06-29T16:04:36Z</updated>
+    <summary type="html">This OPDS entry comes from the content server
+     but it doesn't actually provide any way to get the book.
+    </summary>
+    <simplified:pwid>eba6d8f3-2684-5be6-01db-9476c27a21f1</simplified:pwid>
+    <link href="http://covers/unglue.it/URI/https%3A//unglue.it/api/id/work/98398//books.jpg" type="image/jpeg" rel="http://opds-spec.org/image"/>
+    <link href="http://covers/unglue.it/URI/https%3A//unglue.it/api/id/work/98398//books.jpg" type="image/jpeg" rel="http://opds-spec.org/image/thumbnail"/>
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult"/>
+    <category term="18" scheme="http://schema.org/typicalAgeRange" label="18"/>
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction"/>
+    <dcterms:language>en</dcterms:language>
+    <published>2016-01-22T17:39:23Z</published>
+  </entry>
+</feed>

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -738,6 +738,18 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(t1, i1.thumbnail)
         eq_(None, i2.thumbnail)
 
+    def test_import_book_that_offers_no_license(self):
+        path = os.path.join(self.resource_path, "book_without_license.opds")
+        feed = open(path).read()
+        importer = OPDSImporter(self._db, DataSource.OA_CONTENT_SERVER)
+        imported_editions, imported_pools, imported_works, failures = (
+            importer.import_from_feed(feed)
+        )
+
+        # We got an Edition for this book, but no LicensePool.
+        [edition] = imported_editions
+        eq_("Howards End", edition.title)
+        eq_([], imported_pools)
 
 
 class TestOPDSImporterWithS3Mirror(OPDSImporterTest):

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -746,10 +746,11 @@ class TestOPDSImporter(OPDSImporterTest):
             importer.import_from_feed(feed)
         )
 
-        # We got an Edition for this book, but no LicensePool.
+        # We got an Edition for this book, but no LicensePool and no Work.
         [edition] = imported_editions
         eq_("Howards End", edition.title)
         eq_([], imported_pools)
+        eq_([], imported_works)
 
 
 class TestOPDSImporterWithS3Mirror(OPDSImporterTest):


### PR DESCRIPTION
This branch comes out of my attempts to fix the import of unglue.it books. A more useful circulation branch is also forthcoming; this one's kind of a sideshow.

If we're importing an OPDS feed from a data source that provides LicensePools, but the feed doesn't actually include any links to the book, this branch stops the import process from actually creating a LicensePool. Only an Edition with the metadata will be created.