### PR TITLE
Add a missing import

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import os
 import requests
+import time
 from requests.exceptions import (
     ConnectionError, 
     HTTPError,
@@ -93,6 +94,15 @@ class Script(object):
                 except ValueError, e:
                     continue
         raise ValueError("Could not parse time: %s" % time_string)
+
+    def __init__(self, _db=None):
+        """Basic constructor.
+
+        :_db: A database session to be used instead of
+        creating a new one. Useful in tests.
+        """
+        if _db:
+            self._session = _db
 
     def run(self):
         self.load_configuration()
@@ -293,8 +303,7 @@ class RunCoverageProviderScript(IdentifierInputScript):
         return parsed
 
     def __init__(self, provider, _db=None, cmd_args=None, **provider_arguments):
-        if _db:
-            self._session = _db
+        super(RunCoverageProviderScript, self).__init__(_db)
         args = self.parse_command_line(self._db, cmd_args)
         if callable(provider):
             if args.identifier_type:
@@ -603,7 +612,7 @@ class NYTBestSellerListsScript(Script):
 
 class RefreshMaterializedViewsScript(Script):
     """Refresh all materialized views."""
-    
+
     def do_run(self):
         # Initialize database
         from model import (

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -132,8 +132,3 @@ class TestWorkProcessingScript(DatabaseTest):
             self._db, Identifier.GUTENBERG_ID, [g1.license_pools[0].identifier]
         )
         eq_([g1], one_gutenberg.all())
-
-
-
-
-


### PR DESCRIPTION
This branch adds a missing import of `time` which was stopping the materialized view script from running.

I tried pretty hard to add a test of the materialized view script but it seems impossible. The CONCURRENTLY part of the refresh command only works on certain versions of Postgres, and a failure invalidates the entire database session. Even if the materialised view refresh _succeeds_, it then closes the database session to vacuum the database, ruining every subsequent test.