### PR TITLE
New OPDS authentication document format

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -429,16 +429,16 @@ class TestOPDSAuthenticationDocument(object):
     def test_bad_documents(self):
         assert_raises(
             ValueError, OPDSAuthenticationDocument.fill_in, 
-            {}, [], "A title", "An id"
+            {}, "Not a list", "A title", "An id"
         )
 
         assert_raises(
-            ValueError, OPDSAuthenticationDocument.fill_in, {}, {},
+            ValueError, OPDSAuthenticationDocument.fill_in, {}, [],
             None, "An id"
         )
 
         assert_raises(
-            ValueError, OPDSAuthenticationDocument.fill_in, {}, {},
+            ValueError, OPDSAuthenticationDocument.fill_in, {}, [],
             "A title", None
         )
 
@@ -447,7 +447,7 @@ class TestOPDSAuthenticationDocument(object):
         doc1 = {"id": "An ID", "name": "A title"}
 
         doc2 = OPDSAuthenticationDocument.fill_in(
-            doc1, {}, "Bla1", "Bla2")
+            doc1, [], "Bla1", "Bla2")
         del doc2['providers']
         eq_(doc2, doc1)
 
@@ -464,7 +464,7 @@ class TestOPDSAuthenticationDocument(object):
         }
 
         doc = OPDSAuthenticationDocument.fill_in(
-            {}, {},
+            {}, [],
             "A title", "An ID", links=links)
 
         eq_(doc['links'], {'complex-link': {'href': 'http://baz', 'type': 'text/html'}, 'double-link': [{'href': 'http://bar1'}, {'href': 'http://bar2'}], 'single-link': {'href': 'http://foo'}, 'complex-links': [{'href': 'http://comp1', 'type': 'text/html'}, {'href': 'http://comp2', 'type': 'text/plain'}]})

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -429,52 +429,27 @@ class TestOPDSAuthenticationDocument(object):
     def test_bad_documents(self):
         assert_raises(
             ValueError, OPDSAuthenticationDocument.fill_in, 
-            {}, OPDSAuthenticationDocument.BASIC_AUTH_FLOW,
-            "A title", "An id"
+            {}, [], "A title", "An id"
         )
 
         assert_raises(
-            ValueError, OPDSAuthenticationDocument.fill_in, {}, [],
-            "A title", "An id"
-        )
-
-        assert_raises(
-            ValueError, OPDSAuthenticationDocument.fill_in, {}, 
-            [OPDSAuthenticationDocument.BASIC_AUTH_FLOW],
+            ValueError, OPDSAuthenticationDocument.fill_in, {}, {},
             None, "An id"
         )
 
         assert_raises(
-            ValueError, OPDSAuthenticationDocument.fill_in, {},
-            [OPDSAuthenticationDocument.BASIC_AUTH_FLOW],
+            ValueError, OPDSAuthenticationDocument.fill_in, {}, {},
             "A title", None
         )
 
     def test_fill_in_does_not_change_already_set_values(self):
 
-        doc1 = {"id": "An ID", "labels": {"login": "Barcode", "password": "PIN"}, "text": "A text description", "title": "A title", "type": ["http://opds-spec.org/auth/basic"]}
+        doc1 = {"id": "An ID", "name": "A title"}
 
         doc2 = OPDSAuthenticationDocument.fill_in(
-            doc1, [], "Bla1", "Bla2", "Bla3", "Bla4", "Bla5")
+            doc1, {}, "Bla1", "Bla2")
+        del doc2['providers']
         eq_(doc2, doc1)
-
-    def test_document_labels(self):
-
-        doc = OPDSAuthenticationDocument.fill_in(
-            {}, [OPDSAuthenticationDocument.BASIC_AUTH_FLOW],
-            "A title", "An ID", "A text description", "Barcode", "PIN")
-        data = json.dumps(doc, sort_keys=True)
-        eq_('{"id": "An ID", "labels": {"login": "Barcode", "password": "PIN"}, "text": "A text description", "title": "A title", "type": ["http://opds-spec.org/auth/basic"]}', 
-            data)
-
-    def test_document_no_labels(self):
-
-        doc = OPDSAuthenticationDocument.fill_in(
-            {}, [OPDSAuthenticationDocument.BASIC_AUTH_FLOW],
-            "A title", "An ID")
-        data = json.dumps(doc, sort_keys=True)
-        eq_('{"id": "An ID", "title": "A title", "type": ["http://opds-spec.org/auth/basic"]}', 
-            data)
 
     def test_document_links(self):
 
@@ -489,7 +464,7 @@ class TestOPDSAuthenticationDocument(object):
         }
 
         doc = OPDSAuthenticationDocument.fill_in(
-            {}, [OPDSAuthenticationDocument.BASIC_AUTH_FLOW],
+            {}, {},
             "A title", "An ID", links=links)
 
         eq_(doc['links'], {'complex-link': {'href': 'http://baz', 'type': 'text/html'}, 'double-link': [{'href': 'http://bar1'}, {'href': 'http://bar2'}], 'single-link': {'href': 'http://foo'}, 'complex-links': [{'href': 'http://comp1', 'type': 'text/html'}, {'href': 'http://comp2', 'type': 'text/plain'}]})

--- a/util/opds_authentication_document.py
+++ b/util/opds_authentication_document.py
@@ -2,11 +2,8 @@ class OPDSAuthenticationDocument(object):
 
     MEDIA_TYPE = "application/vnd.opds.authentication.v1.0+json"
 
-    BASIC_AUTH_FLOW = "http://opds-spec.org/auth/basic"
-
     @classmethod
-    def fill_in(self, document, type=None, title=None, id=None, text=None,
-                login_label=None, password_label=None, links={}):
+    def fill_in(self, document, providers, name=None, id=None, links={}):
         """Fill in any missing fields of an OPDS Authentication Document
         with the given values.
         """
@@ -18,28 +15,16 @@ class OPDSAuthenticationDocument(object):
 
         for key, value in (
                 ('id', id), 
-                ('title', title), 
-                ('type', type)
+                ('name', name), 
         ):
             if value and (not key in data or not data[key]):
                 data[key] = value
             if not key in data or not data[key]:
                 raise ValueError('`%s` must be specified.' % key)
 
-        if not isinstance(data['type'], list):
-            raise ValueError('`type` must be a List.')
-
-        if not 'labels' in data and (password_label or login_label):
-            data['labels'] = {}
-
-        for name, value in (
-                ('password', password_label), ('login', login_label)):
-            if value and (not name in data['labels'] 
-                          or not data['labels'][name]):
-                data['labels'][name] = value
-
-        if text and (not 'text' in data or not data['text']):
-            data['text'] = text
+        if not isinstance(providers, dict):
+            raise ValueError('`providers` must be a dictionary.')
+        data['providers'] = providers
 
         if links:
             data['links'] = {}

--- a/util/opds_authentication_document.py
+++ b/util/opds_authentication_document.py
@@ -22,9 +22,12 @@ class OPDSAuthenticationDocument(object):
             if not key in data or not data[key]:
                 raise ValueError('`%s` must be specified.' % key)
 
-        if not isinstance(providers, dict):
-            raise ValueError('`providers` must be a dictionary.')
-        data['providers'] = providers
+        if not isinstance(providers, list):
+            raise ValueError('`providers` must be a list.')
+        provider_docs = {}
+        for provider in providers:
+            provider_docs[provider.URI] = provider.create_authentication_provider_document()
+        data['providers'] = provider_docs
 
         if links:
             data['links'] = {}


### PR DESCRIPTION
This connects to https://github.com/NYPL-Simplified/circulation/issues/274

We've been discussing a new OPDS authentication format, and this branch changes the fill_in method to organize the document by provider as we decided to do for Open eBooks. 

It's not clear yet what we'll do for NYPL, which only has one default authentication method. Current clients use the auth headers and don't look at the document at all, so putting in providers for NYPL too won't break anything.