### PR TITLE
Remove duplicate contributions

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -943,7 +943,7 @@ class Metadata(MetaToModelUtility):
         for contribution in edition.contributions:
             contributor = ContributorData.from_contribution(contribution)
             contributors.append(contributor)
-        else:
+        if not edition.contributions:
             # This should only happen for low-quality data sources such as
             # the NYT best-seller API.
             if edition.sort_author:

--- a/model.py
+++ b/model.py
@@ -2276,7 +2276,7 @@ class Edition(Base):
 
         def dedupe(l):
             """If an item shows up multiple times in a list, 
-            keep only the first occurance.
+            keep only the first occurence.
             """
             seen = set()
             deduped = []

--- a/model.py
+++ b/model.py
@@ -5406,7 +5406,9 @@ class LicensePool(Base):
         # Note: We can do a cleaner solution, if we refactor to not use metadata's 
         # methods to update editions.  For now, we're choosing to go with the below approach.
         from metadata_layer import (
-            Metadata, IdentifierData, 
+            Metadata, 
+            IdentifierData, 
+            ReplacementPolicy,
         )
 
         if len(all_editions) == 1:
@@ -5429,7 +5431,10 @@ class LicensePool(Base):
             metadata.license_data_source_obj = None
             edition, is_new = metadata.edition(_db)
 
-            self.presentation_edition, edition_core_changed = metadata.apply(edition)
+            policy = ReplacementPolicy.from_metadata_source()
+            self.presentation_edition, edition_core_changed = metadata.apply(
+                edition, replace=policy
+            )
 
         changed = changed or self.presentation_edition.calculate_presentation()
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -719,6 +719,32 @@ class TestContributor(DatabaseTest):
 
 class TestEdition(DatabaseTest):
 
+    def test_author_contributors(self):
+        data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)
+        id = self._str
+        type = Identifier.GUTENBERG_ID
+
+        edition, was_new = Edition.for_foreign_id(
+            self._db, data_source, type, id
+        )
+
+        # We've listed the same person as primary author and author.
+        [alice], ignore = Contributor.lookup(self._db, "Adder, Alice")
+        edition.add_contributor(
+            alice, [Contributor.AUTHOR_ROLE, Contributor.PRIMARY_AUTHOR_ROLE]
+        )
+
+        # We've listed a different person as illustrator.
+        [bob], ignore = Contributor.lookup(self._db, "Bitshifter, Bob")
+        edition.add_contributor(bob, [Contributor.ILLUSTRATOR_ROLE])
+
+        # Both contributors show up in .contributors.
+        eq_(set([alice, bob]), edition.contributors)
+
+        # Only the author shows up in .author_contributors, and she
+        # only shows up once.
+        eq_([alice], edition.author_contributors)
+
     def test_for_foreign_id(self):
         """Verify we can get a data source's view of a foreign id."""
         data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1457,7 +1457,7 @@ class TestLicensePool(DatabaseTest):
 
         # The old contributor has been removed from the composite
         # edition, and the new contributor added.
-        eq_([jane], edition_composite.contributors)
+        eq_(set([jane]), edition_composite.contributors)
 
     def test_circulation_changelog(self):
         


### PR DESCRIPTION
This branch does several different things to fix a problem where Editions are listed as having the same author twice. Example: https://circulation.librarysimplified.org/works/Gutenberg/Gutenberg%20ID/35536

This doesn't do the one thing which would really solve the problem: change the model to prevent someone from being listed as both the PRIMARY_AUTHOR and an AUTHOR of a given book. I didn't change this because we're going to be redoing the contributor system pretty soon and that whole thing might change anyway.