### PR TITLE
Bulk search index update

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -218,6 +218,11 @@ class BaseCoverageProvider(object):
         (for transient failures).
         """
 
+        # Batch is a query that may not be ordered, so it may return
+        # different results when executed multiple times. Converting to
+        # a list ensures that all subsequent code will run on the same items.
+        batch = list(batch)
+
         offset_increment = 0
         results = self.process_batch(batch)
         successes = 0
@@ -280,6 +285,7 @@ class BaseCoverageProvider(object):
         # For all purposes outside this method, treat an ignored identifier
         # as a transient failure.
         transient_failures += num_ignored
+        
         return (successes, transient_failures, persistent_failures), records
 
     def process_batch(self, batch):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -51,139 +51,143 @@ class TestExternalSearch(DatabaseTest):
                 print e
 
         if self.search:
+            works = []
+
             self.moby_dick = self._work(title="Moby Dick", authors="Herman Melville", fiction=True)
             self.moby_dick.presentation_edition.subtitle = "Or, the Whale"
             self.moby_dick.presentation_edition.series = "Classics"
             self.moby_dick.summary_text = "Ishmael"
             self.moby_dick.presentation_edition.publisher = "Project Gutenberg"
             self.moby_dick.set_presentation_ready()
-            self.moby_dick.update_external_index(self.search)
+            works.append(self.moby_dick)
 
             self.moby_duck = self._work(title="Moby Duck", authors="Donovan Hohn", fiction=False)
             self.moby_duck.presentation_edition.subtitle = "The True Story of 28,800 Bath Toys Lost at Sea"
             self.moby_duck.summary_text = "A compulsively readable narrative"
             self.moby_duck.presentation_edition.publisher = "Penguin"
             self.moby_duck.set_presentation_ready()
-            self.moby_duck.update_external_index(self.search)
+            works.append(self.moby_duck)
 
             self.title_match = self._work(title="Match")
             self.title_match.set_presentation_ready()
-            self.title_match.update_external_index(self.search)
+            works.append(self.title_match)
 
             self.subtitle_match = self._work()
             self.subtitle_match.presentation_edition.subtitle = "Match"
             self.subtitle_match.set_presentation_ready()
-            self.subtitle_match.update_external_index(self.search)
+            works.append(self.subtitle_match)
 
             self.summary_match = self._work()
             self.summary_match.summary_text = "Match"
             self.summary_match.set_presentation_ready()
-            self.summary_match.update_external_index(self.search)
+            works.append(self.summary_match)
         
             self.publisher_match = self._work()
             self.publisher_match.presentation_edition.publisher = "Match"
             self.publisher_match.set_presentation_ready()
-            self.publisher_match.update_external_index(self.search)
+            works.append(self.publisher_match)
 
             self.tess = self._work(title="Tess of the d'Urbervilles")
             self.tess.set_presentation_ready()
-            self.tess.update_external_index(self.search)
+            works.append(self.tess)
 
             self.tiffany = self._work(title="Breakfast at Tiffany's")
             self.tiffany.set_presentation_ready()
-            self.tiffany.update_external_index(self.search)
+            works.append(self.tiffany)
             
             self.les_mis = self._work()
             self.les_mis.presentation_edition.title = u"Les Mis\u00E9rables"
             self.les_mis.set_presentation_ready()
-            self.les_mis.update_external_index(self.search)
+            works.append(self.les_mis)
 
             self.lincoln = self._work(genre="Biography & Memoir", title="Abraham Lincoln")
             self.lincoln.set_presentation_ready()
-            self.lincoln.update_external_index(self.search)
+            works.append(self.lincoln)
 
             self.washington = self._work(genre="Biography", title="George Washington")
             self.washington.set_presentation_ready()
-            self.washington.update_external_index(self.search)
+            works.append(self.washington)
 
             self.lincoln_vampire = self._work(title="Abraham Lincoln: Vampire Hunter", genre="Fantasy")
             self.lincoln_vampire.set_presentation_ready()
-            self.lincoln_vampire.update_external_index(self.search)
+            works.append(self.lincoln_vampire)
 
             self.children_work = self._work(title="Alice in Wonderland", audience=Classifier.AUDIENCE_CHILDREN)
             self.children_work.set_presentation_ready()
-            self.children_work.update_external_index(self.search)
+            works.append(self.children_work)
 
             self.ya_work = self._work(title="Go Ask Alice", audience=Classifier.AUDIENCE_YOUNG_ADULT)
             self.ya_work.set_presentation_ready()
-            self.ya_work.update_external_index(self.search)
+            works.append(self.ya_work)
 
             self.adult_work = self._work(title="Still Alice", audience=Classifier.AUDIENCE_ADULT)
             self.adult_work.set_presentation_ready()
-            self.adult_work.update_external_index(self.search)
+            works.append(self.adult_work)
 
             self.ya_romance = self._work(audience=Classifier.AUDIENCE_YOUNG_ADULT, genre="Romance")
             self.ya_romance.set_presentation_ready()
-            self.ya_romance.update_external_index(self.search)
+            works.append(self.ya_romance)
 
             self.no_age = self._work()
             self.no_age.summary_text = "President Barack Obama's election in 2008 energized the United States"
             self.no_age.set_presentation_ready()
-            self.no_age.update_external_index(self.search)
+            works.append(self.no_age)
 
             self.age_4_5 = self._work()
             self.age_4_5.target_age = NumericRange(4, 5, '[]')
             self.age_4_5.summary_text = "President Barack Obama's election in 2008 energized the United States"
             self.age_4_5.set_presentation_ready()
-            self.age_4_5.update_external_index(self.search)
+            works.append(self.age_4_5)
 
             self.age_5_6 = self._work(fiction=False)
             self.age_5_6.target_age = NumericRange(5, 6, '[]')
             self.age_5_6.set_presentation_ready()
-            self.age_5_6.update_external_index(self.search)
+            works.append(self.age_5_6)
 
             self.obama = self._work(genre="Biography & Memoir")
             self.obama.target_age = NumericRange(8, 8, '[]')
             self.obama.summary_text = "President Barack Obama's election in 2008 energized the United States"
             self.obama.set_presentation_ready()
-            self.obama.update_external_index(self.search)
+            works.append(self.obama)
 
             self.dodger = self._work()
             self.dodger.target_age = NumericRange(8, 8, '[]')
             self.dodger.summary_text = "Willie finds himself running for student council president"
             self.dodger.set_presentation_ready()
-            self.dodger.update_external_index(self.search)
+            works.append(self.dodger)
 
             self.age_9_10 = self._work()
             self.age_9_10.target_age = NumericRange(9, 10, '[]')
             self.age_9_10.summary_text = "President Barack Obama's election in 2008 energized the United States"
             self.age_9_10.set_presentation_ready()
-            self.age_9_10.update_external_index(self.search)
+            works.append(self.age_9_10)
 
             self.age_2_10 = self._work()
             self.age_2_10.target_age = NumericRange(2, 10, '[]')
             self.age_2_10.set_presentation_ready()
-            self.age_2_10.update_external_index(self.search)
+            works.append(self.age_2_10)
 
             self.pride = self._work(title="Pride and Prejudice")
             self.pride.presentation_edition.medium = Edition.BOOK_MEDIUM
             self.pride.set_presentation_ready()
-            self.pride.update_external_index(self.search)
+            works.append(self.pride)
 
             self.pride_audio = self._work(title="Pride and Prejudice")
             self.pride_audio.presentation_edition.medium = Edition.AUDIO_MEDIUM
             self.pride_audio.set_presentation_ready()
-            self.pride_audio.update_external_index(self.search)
+            works.append(self.pride_audio)
 
             self.sherlock = self._work(title="The Adventures of Sherlock Holmes")
             self.sherlock.presentation_edition.language = "en"
             self.sherlock.set_presentation_ready()
-            self.sherlock.update_external_index(self.search)
+            works.append(self.sherlock)
 
             self.sherlock_spanish = self._work(title="Las Aventuras de Sherlock Holmes")
             self.sherlock_spanish.presentation_edition.language = "es"
             self.sherlock_spanish.set_presentation_ready()
-            self.sherlock_spanish.update_external_index(self.search)
+            works.append(self.sherlock_spanish)
+
+            self.search.bulk_update(works)
 
             time.sleep(1)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2076,6 +2076,125 @@ class TestWork(DatabaseTest):
         )
         eq_(genres[1].name, work.top_genre())
 
+    def test_to_search_document(self):
+        # Set up an edition and work.
+        edition, pool = self._edition(authors=[self._str, self._str], with_license_pool=True)
+        work = self._work(presentation_edition=edition)
+
+        # These are the edition's authors.
+        [contributor1] = [c.contributor for c in edition.contributions if c.role == Contributor.PRIMARY_AUTHOR_ROLE]
+        contributor1.family_name = self._str
+        [contributor2] = [c.contributor for c in edition.contributions if c.role == Contributor.AUTHOR_ROLE]
+
+        data_source = DataSource.lookup(self._db, DataSource.THREEM)
+        
+        # This identifier is strongly equivalent to the edition's.
+        identifier = self._identifier()
+        identifier.equivalent_to(data_source, edition.primary_identifier, 0.9)
+
+        # This identifier is equivalent to the other identifier, but the strength
+        # is too weak for it to be used.
+        identifier2 = self._identifier()
+        identifier.equivalent_to(data_source, identifier, 0.1)
+
+        # Add some classifications.
+
+        # This classification has no subject name, so the search document will use the subject identifier.
+        edition.primary_identifier.classify(data_source, Subject.THREEM, "FICTION/Science Fiction/Time Travel", None, 6)
+
+        # This one has the same subject type and identifier, so their weights will be combined.
+        identifier.classify(data_source, Subject.THREEM, "FICTION/Science Fiction/Time Travel", None, 1)
+
+        # Here's another classification with a different subject type.
+        edition.primary_identifier.classify(data_source, Subject.OVERDRIVE, "Romance", None, 2)
+
+        # This classification has a subject name, so the search document will use that instead of the identifier.
+        identifier.classify(data_source, Subject.FAST, self._str, "Sea Stories", 7)
+
+        # This classification will be left out because its subject type isn't useful for search.
+        identifier.classify(data_source, Subject.DDC, self._str, None)
+
+        # This classification will be left out because its identifier isn't sufficiently equivalent to the edition's.
+        identifier2.classify(data_source, Subject.FAST, self._str, None)
+
+        # Add some genres.
+        genre1, ignore = Genre.lookup(self._db, "Science Fiction")
+        genre2, ignore = Genre.lookup(self._db, "Romance")
+        work.genres = [genre1, genre2]
+        work.work_genres[0].affinity = 1
+
+        # Add the other fields used in the search document.
+        work.target_age = NumericRange(7, 8, '[]')
+        edition.subtitle = self._str
+        edition.series = self._str
+        edition.publisher = self._str
+        edition.imprint = self._str
+        work.fiction = False
+        work.audience = Classifier.AUDIENCE_YOUNG_ADULT
+        work.summary_text = self._str
+        work.rating = 5
+        work.popularity = 4
+
+        # Make sure all of this will show up in a database query.
+        self._db.flush()
+
+
+        search_doc = work.to_search_document()
+        eq_(work.id, search_doc['_id'])
+        eq_(work.title, search_doc['title'])
+        eq_(edition.subtitle, search_doc['subtitle'])
+        eq_(edition.series, search_doc['series'])
+        eq_(edition.language, search_doc['language'])
+        eq_(work.sort_title, search_doc['sort_title'])
+        eq_(work.author, search_doc['author'])
+        eq_(work.sort_author, search_doc['sort_author'])
+        eq_(edition.medium, search_doc['medium'])
+        eq_(edition.publisher, search_doc['publisher'])
+        eq_(edition.imprint, search_doc['imprint'])
+        eq_(edition.permanent_work_id, search_doc['permanent_work_id'])
+        eq_("Nonfiction", search_doc['fiction'])
+        eq_("YoungAdult", search_doc['audience'])
+        eq_(work.summary_text, search_doc['summary'])
+        eq_(work.quality, search_doc['quality'])
+        eq_(work.rating, search_doc['rating'])
+        eq_(work.popularity, search_doc['popularity'])
+
+        contributors = search_doc['contributors']
+        eq_(2, len(contributors))
+        [contributor1_doc] = [c for c in contributors if c['name'] == contributor1.name]
+        [contributor2_doc] = [c for c in contributors if c['name'] == contributor2.name]
+        eq_(contributor1.family_name, contributor1_doc['family_name'])
+        eq_(None, contributor2_doc['family_name'])
+        eq_(Contributor.PRIMARY_AUTHOR_ROLE, contributor1_doc['role'])
+        eq_(Contributor.AUTHOR_ROLE, contributor2_doc['role'])
+
+        classifications = search_doc['classifications']
+        eq_(3, len(classifications))
+        [classification1_doc] = [c for c in classifications if c['scheme'] == Subject.uri_lookup[Subject.THREEM]]
+        [classification2_doc] = [c for c in classifications if c['scheme'] == Subject.uri_lookup[Subject.OVERDRIVE]]
+        [classification3_doc] = [c for c in classifications if c['scheme'] == Subject.uri_lookup[Subject.FAST]]
+        eq_("FICTION Science Fiction Time Travel", classification1_doc['term'])
+        eq_(float(6 + 1)/(6 + 1 + 2 + 7), classification1_doc['weight'])
+        eq_("Romance", classification2_doc['term'])
+        eq_(float(2)/(6 + 1 + 2 + 7), classification2_doc['weight'])
+        eq_("Sea Stories", classification3_doc['term'])
+        eq_(float(7)/(6 + 1 + 2 + 7), classification3_doc['weight'])
+        
+        genres = search_doc['genres']
+        eq_(2, len(genres))
+        [genre1_doc] = [g for g in genres if g['name'] == genre1.name]
+        [genre2_doc] = [g for g in genres if g['name'] == genre2.name]
+        eq_(Subject.SIMPLIFIED_GENRE, genre1_doc['scheme'])
+        eq_(genre1.id, genre1_doc['term'])
+        eq_(1, genre1_doc['weight'])
+        eq_(Subject.SIMPLIFIED_GENRE, genre2_doc['scheme'])
+        eq_(genre2.id, genre2_doc['term'])
+        eq_(0, genre2_doc['weight'])
+
+        target_age_doc = search_doc['target_age']
+        eq_(work.target_age.lower, target_age_doc['lower'])
+        eq_(work.target_age.upper, target_age_doc['upper'])
+
 
 class TestCirculationEvent(DatabaseTest):
 


### PR DESCRIPTION
It's very hard to work on the search index when creating an index takes days, so this branch is my first attempt to speed it up.

Most of the time was spent individually creating a JSON document for each work, so I changed it to create a single SQL query that generates JSON for a batch of works all together. On my laptop this cuts the time for creating 100 documents from about 14 seconds to 0.14 seconds.

I also use elasticsearch's bulk method to upload the batch, which helped a little but not nearly as much as the other change.

With this branch it's taking about 3 seconds to index 500 documents on my laptop, which is much better but could still use improvement. Most of the time is from CoverageProvider itself now.