### PR TITLE
Fix OPDS import edge cases

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -388,6 +388,7 @@ class MetaToModelUtility(object):
 
         if link_obj.rel not in Hyperlink.MIRRORED:
             # we only host locally open-source epubs and cover images
+            self.log.info("Not mirroring %s: rel=%s", link.href, link_obj.rel)
             return
 
         mirror = policy.mirror
@@ -396,7 +397,7 @@ class MetaToModelUtility(object):
         _db = Session.object_session(link_obj)
         original_url = link.href
 
-        self.log.debug("About to mirror %s" % original_url)
+        self.log.info("About to mirror %s" % original_url)
         pool = None
         edition = None
         title = None
@@ -450,12 +451,16 @@ class MetaToModelUtility(object):
             if pool and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
                 pool.suppressed = True
                 pool.license_exception = "Fetch exception: %s" % representation.fetch_exception
+                self.log.error(pool.license_exception)
             return
 
         # If we fetched the representation and it hasn't changed,
         # the previously mirrored version is fine. Don't mirror it
         # again.
         if representation.status_code == 304 and representation.mirror_url:
+            self.log.info(
+                "Representation has not changed, assuming mirror at %s is up to date.", representation.mirror_url
+            )
             return
 
         # The metadata may have some idea about the media type for this
@@ -493,6 +498,7 @@ class MetaToModelUtility(object):
             if pool and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
                 pool.suppressed = True
                 pool.license_exception = "Mirror exception: %s" % representation.mirror_exception
+                self.log.error(pool.license_exception)
 
         if link_obj.rel == Hyperlink.IMAGE:
             # Create and mirror a thumbnail.

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -470,8 +470,8 @@ class MetaToModelUtility(object):
             link.media_type = representation.media_type
 
         if not representation.mirrorable_media_type:
-            log.info("Not mirroring %s: unsupported media type %s",
-                     representation.url, representation.media_type)
+            self.log.info("Not mirroring %s: unsupported media type %s",
+                          representation.url, representation.media_type)
             return
 
         # Determine the best URL to use when mirroring this

--- a/model.py
+++ b/model.py
@@ -2246,6 +2246,19 @@ class Edition(Base):
     def author_contributors(self):
         """All distinct 'author'-type contributors, with the primary author
         first, other authors sorted by sort name.
+
+        Basically, we're trying to figure out what would go on the
+        book cover. The primary author should go first, and be
+        followed by non-primary authors in alphabetical order. People
+        whose role does not rise to the level of "authorship"
+        (e.g. author of afterword) do not show up.
+
+        The list as a whole should contain no duplicates. This might
+        happen because someone is erroneously listed twice in the same
+        role, someone is listed as both primary author and regular
+        author, someone is listed as both author and translator,
+        etc. However it happens, your name only shows up once on the
+        front of the book.
         """
         seen_authors = set()
         primary_author = None
@@ -6245,6 +6258,7 @@ class Representation(Base):
     GIF_MEDIA_TYPE = u"image/gif"
     SVG_MEDIA_TYPE = u"image/svg+xml"
     MP3_MEDIA_TYPE = u"audio/mpeg"
+    OCTET_STREAM_MEDIA_TYPE = u"application/octet-stream"
     TEXT_PLAIN = u"text/plain"
 
     BOOK_MEDIA_TYPES = [
@@ -6264,6 +6278,14 @@ class Representation(Base):
     SUPPORTED_BOOK_MEDIA_TYPES = [
         EPUB_MEDIA_TYPE
     ]
+
+    # Most of the time, if you believe a resource to be media type A,
+    # but then you make a request and get media type B, then the
+    # actual media type (B) takes precedence over what you thought it
+    # was (A). These media types are the exceptions: they are so
+    # generic that they don't tell you anything, so it's more useful
+    # to stick with A.
+    GENERIC_MEDIA_TYPES = [OCTET_STREAM_MEDIA_TYPE]
 
     FILE_EXTENSIONS = {
         EPUB_MEDIA_TYPE: "epub",
@@ -6508,10 +6530,7 @@ class Representation(Base):
                 # post response isn't worth caching.
                 response_reviewer((status_code, headers, content))
             exception = None
-            if 'content-type' in headers:
-                media_type = headers['content-type'].lower()
-            else:
-                media_type = presumed_media_type
+            media_type = cls._best_media_type(headers, presumed_media_type)
             if isinstance(content, unicode):
                 content = content.encode("utf8")
         except Exception, fetch_exception:
@@ -6593,6 +6612,24 @@ class Representation(Base):
         representation.headers = cls.headers_to_string(headers)
         representation.content = content
         return representation, False
+
+    @classmethod
+    def _best_media_type(cls, headers, default):
+        """Determine the most likely media type for the given HTTP headers.
+
+        Almost all the time, this is the value of the content-type
+        header, if present. However, if the content-type header has a
+        really generic value like "application/octet-stream" (as often
+        happens with binary files hosted on Github), we'll privilege
+        the default value.
+        """
+        if not headers or not 'content-type' in headers:
+            return default
+        headers_type = headers['content-type'].lower()
+        clean = cls._clean_media_type(headers_type)
+        if clean in Representation.GENERIC_MEDIA_TYPES and default:
+            return default
+        return headers_type
 
     @classmethod
     def reraise_exception(cls, representation, exception, traceback):

--- a/testing.py
+++ b/testing.py
@@ -736,7 +736,9 @@ class DummyHTTPClient(object):
 
     def queue_response(self, response_code, media_type="text/html",
                        other_headers=None, content=''):
-        headers = {"content-type": media_type}
+        headers = {}
+        if media_type:
+            headers["content-type"] = media_type
         if other_headers:
             for k, v in other_headers.items():
                 headers[k.lower()] = v

--- a/tests/files/opds/content_server_mini.opds
+++ b/tests/files/opds/content_server_mini.opds
@@ -45,6 +45,7 @@
     <updated>2015-01-02T16:56:40Z</updated>
     <published>2014-01-02T16:56:40Z</published>
     <simplified:pwid>9acabf17-cea8-c7dd-8440-f12dfa75caa9</simplified:pwid>
+    <link href="/full-cover-image.png" rel="http://opds-spec.org/image"/>
     <category term="Animals -- Juvenile poetry" scheme="http://purl.org/dc/terms/LCSH"/>
     <category term="Nursery rhymes" scheme="http://purl.org/dc/terms/LCSH"/>
     <category term="PZ" label="Juvenile Fiction" scheme="http://purl.org/dc/terms/LCC"/>

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -727,6 +727,9 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
 </svg>"""
 
         http = DummyHTTPClient()
+        # The request to http://root/full-cover-image.png
+        # will result in a 404 error, and the image will not be mirrored.
+        http.queue_response(404, media_type="text/plain")
         http.queue_response(
             200, content='I am 10557.epub.images',
             media_type=Representation.EPUB_MEDIA_TYPE,
@@ -747,7 +750,8 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
         )
 
         imported_editions, pools, works, failures = (
-            importer.import_from_feed(self.content_server_mini_feed)
+            importer.import_from_feed(self.content_server_mini_feed, 
+                                      feed_url='http://root')
         )
         e1 = imported_editions[0]
         e2 = imported_editions[1]
@@ -760,15 +764,18 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
             'http://www.gutenberg.org/ebooks/10441.epub.images',
             'https://s3.amazonaws.com/book-covers.nypl.org/Gutenberg-Illustrated/10441/cover_10441_9.png', 
             'http://www.gutenberg.org/ebooks/10557.epub.images',
+            'http://root/full-cover-image.png',
         ])
 
         [e1_oa_link, e1_image_link, e1_description_link] = sorted(
             e1.primary_identifier.links, key=lambda x: x.rel
         )
-        [e2_oa_link] = e2.primary_identifier.links
+        [e2_image_link, e2_oa_link] = e2.primary_identifier.links
 
         # The two open-access links were mirrored to S3, as was the
-        # original SVG image and its PNG thumbnail.
+        # original SVG image and its PNG thumbnail. The PNG image was
+        # not mirrored because our attempt to download it resulted in
+        # a 404 error.
         imported_representations = [
             e1_oa_link.resource.representation,
             e1_image_link.resource.representation,
@@ -776,7 +783,6 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
             e2_oa_link.resource.representation,
         ]
         eq_(imported_representations, s3.uploaded)
-
 
         eq_(4, len(s3.uploaded))
         eq_("I am 10441.epub.images", s3.content[0])
@@ -1040,7 +1046,7 @@ class TestOPDSImportMonitor(OPDSImporterTest):
             def follow_one_link(self, link, cutoff_date=None, do_get=None):
                 return self.responses.pop()
 
-            def import_one_feed(self, feed):
+            def import_one_feed(self, feed, feed_url):
                 self.imports.append(feed)
 
         monitor = MockOPDSImportMonitor(self._db, "http://url", DataSource.OA_CONTENT_SERVER, OPDSImporter)


### PR DESCRIPTION
This branch fixes some problems I discovered while trying to import books from unglue.it.

1. Some ebooks are hosted at Github, which serves them as `application/octet-stream`. Previous to this branch we had a blanket policy of replacing the `type` of a link in an OPDS feed with the `Content-Type` we got once we followed the link. This branch makes sure that doesn't happen for `application/octet-stream`. 

2. Some OPDS entries (such as https://unglue.it/api/opds/all/?work=158143) include relative URLs. We had code to handle relative URLs but it requires a `self` link to start with, and unlike with Standard Ebooks there's no `self` link here. I changed it so that the original feed URL is passed all the way down into the code that parses the relative URLs, and we use the original feed URL to qualify relative URLs into absolute URLs.

I don't know what the 'right' thing to do is in #2. RFC 4287 says that the `<xml:base>` tag can be used to quality relative URLs, but nobody uses that. I definitely think using the feed URL is better than using the `self` link but I'm torn on whether it's worth getting rid of the code that checks the `self` link--it's definitely not right, but it seems like it will work pretty often, but it's not necessary if you just pass in the feed URL.