### PR TITLE
Minor opds import cleanup

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -466,6 +466,13 @@ class MetaToModelUtility(object):
             )
             return
 
+        if representation.status_code / 100 not in (2,3):
+            self.log.info(
+                "Representation %s gave %s status code, not mirroring.",
+                representation.url, representation.status_code
+            )
+            return
+
         # The metadata may have some idea about the media type for this
         # LinkObject, but the media type we actually just saw takes 
         # precedence.

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -388,7 +388,10 @@ class MetaToModelUtility(object):
 
         if link_obj.rel not in Hyperlink.MIRRORED:
             # we only host locally open-source epubs and cover images
-            self.log.info("Not mirroring %s: rel=%s", link.href, link_obj.rel)
+            if link.href:
+                # The log message only makes sense if the resource is
+                # hosted elsewhere.
+                self.log.info("Not mirroring %s: rel=%s", link.href, link_obj.rel)
             return
 
         mirror = policy.mirror

--- a/opds.py
+++ b/opds.py
@@ -54,6 +54,15 @@ from util.opds_writer import (
 )
 from util.cdn import cdnify
 
+class UnfulfillableWork(Exception):
+    """Raise this exception when it turns out a Work currently cannot be
+    fulfilled through any means, *and* this is a problem sufficient to
+    cancel the creation of an <entry> for the Work.
+
+    For commercial works, this might be because the collection
+    contains no licenses. For open-access works, it might be because
+    none of the delivery mechanisms could be mirrored.
+    """
 
 
 class Annotator(object):
@@ -630,6 +639,12 @@ class AcquisitionFeed(OPDSFeed):
             yield entry
 
     @classmethod
+    def error_message(cls, identifier, error_status, error_message):
+        """Create a minimal OPDS entry for an error message."""
+        message = { identifier.urn : (error_status, error_message)}
+        return list(cls.render_messages(message))[0]
+
+    @classmethod
     def facet_links(self, annotator, facets):
         for group, value, new_facets, selected, in facets.facet_groups:
             url = annotator.facet_url(new_facets)
@@ -680,6 +695,7 @@ class AcquisitionFeed(OPDSFeed):
     def create_entry(self, work, lane_link, even_if_no_license_pool=False,
                      force_create=False, use_cache=True):
         """Turn a work into an entry for an acquisition feed."""
+        identifier = None
         if isinstance(work, Edition):
             active_edition = work
             identifier = active_edition.primary_identifier
@@ -703,22 +719,40 @@ class AcquisitionFeed(OPDSFeed):
                 identifier = active_edition.primary_identifier
 
         # There's no reason to present a book that has no active license pool.
-        if not active_license_pool and not even_if_no_license_pool:
-            logging.warn("NO ACTIVE LICENSE POOL FOR %r", work)
-            return None
-
-        if not active_edition and not isinstance(work, BaseMaterializedWork):
-            logging.warn("NO ACTIVE EDITION FOR %r", active_license_pool)
-            return None
-
         if not identifier:
             logging.warn("%r HAS NO IDENTIFIER", work)
             return None
+
+        if not active_license_pool and not even_if_no_license_pool:
+            logging.warn("NO ACTIVE LICENSE POOL FOR %r", work)
+            return self.error_message(
+                identifier,
+                403,
+                "I've heard about this work but have no active licenses for it."
+            )
+
+        if not active_edition and not isinstance(work, BaseMaterializedWork):
+            logging.warn("NO ACTIVE EDITION FOR %r", active_license_pool)
+            return self.error_message(
+                identifier,
+                403,
+                "I've heard about this work but have no metadata for it."
+            )
 
         try:
             return self._create_entry(work, active_license_pool, active_edition,
                                       identifier, lane_link, force_create, 
                                       use_cache)
+        except UnfulfillableWork, e:
+            logging.info(
+                "Work %r is not fulfillable, refusing to create an <entry>.",
+                work,
+            )
+            return self.error_message(
+                identifier, 
+                403,
+                "I know about this work but can offer no way of fulfilling it."
+            )
         except Exception, e:
             logging.error(
                 "Exception generating OPDS entry for %r", work,
@@ -1150,14 +1184,25 @@ class LookupAcquisitionFeed(AcquisitionFeed):
             error_message = 'I tried to generate an OPDS entry for the identifier "%s" using a Work not associated with that identifier.' % identifier.urn
            
         if error_status:
-            message = { identifier.urn : (error_status, error_message)}
-            return list(self.render_messages(message))[0]
+            return self.error_message(error_status, error_message)
 
         if active_licensepool:
             edition = active_licensepool.presentation_edition
         else:
             edition = work.presentation_edition
-        return self._create_entry(
-            work, active_licensepool, edition, identifier, lane_link,
-            use_cache=use_cache
-        )
+        try:
+            self._create_entry(
+                work, active_licensepool, edition, identifier, lane_link,
+                use_cache=use_cache
+            )
+        except UnfulfillableWork, e:
+            logging.info(
+                "Work %r is not fulfillable, refusing to create an <entry>.",
+                work
+            )
+            return self.error_message(
+                identifier,
+                403,
+                "I know about this work but can offer no way of fulfilling it."
+            )
+

--- a/opds.py
+++ b/opds.py
@@ -1184,14 +1184,14 @@ class LookupAcquisitionFeed(AcquisitionFeed):
             error_message = 'I tried to generate an OPDS entry for the identifier "%s" using a Work not associated with that identifier.' % identifier.urn
            
         if error_status:
-            return self.error_message(error_status, error_message)
+            return self.error_message(identifier, error_status, error_message)
 
         if active_licensepool:
             edition = active_licensepool.presentation_edition
         else:
             edition = work.presentation_edition
         try:
-            self._create_entry(
+            return self._create_entry(
                 work, active_licensepool, edition, identifier, lane_link,
                 use_cache=use_cache
             )

--- a/opds_import.py
+++ b/opds_import.py
@@ -825,6 +825,10 @@ class OPDSImporter(object):
         rel = attr.get('rel')
         media_type = attr.get('type')
         href = attr.get('href')
+        if not href or not rel:
+            # The link exists but has no destination, or no specified
+            # relationship to the entry.
+            return None
         rights = attr.get('{%s}rights' % OPDSXMLParser.NAMESPACES["dcterms"])
         if rights:
             rights_uri = RightsStatus.rights_uri_from_string(rights)
@@ -834,6 +838,7 @@ class OPDSImporter(object):
             # This link is relative, so we need to get the absolute url
             href = urljoin(feed_url, href)
         return LinkData(rel=rel, href=href, media_type=media_type, rights_uri=rights_uri)
+        return foo
 
     @classmethod
     def consolidate_links(cls, links):
@@ -844,7 +849,8 @@ class OPDSImporter(object):
 
         Similarly if link n is a thumbnail and link n+1 is an image.
         """
-        new_links = list(links)
+        new_links = [x for x in links if x]
+        links = list(new_links)
         next_link_already_handled = False
         for i, link in enumerate(links):
 
@@ -966,6 +972,10 @@ class OPDSImportMonitor(Monitor):
             # feed has changed.
             if record and record.status == CoverageRecord.TRANSIENT_FAILURE:
                 new_data = True
+                self.log.info(
+                    "Counting %s as new because previous attempt resulted in transient failure: %s", 
+                    record.identifier, record.exception
+                )
                 break
 
             # If our last attempt was a success or a persistent
@@ -980,18 +990,30 @@ class OPDSImportMonitor(Monitor):
                     # The remote isn't telling us whether the entry
                     # has been updated. Import it again to be safe.
                     new_data = True
+                    self.log.info(
+                        "Counting %s as new because remote has no information about when it was updated.", 
+                        record.identifier
+                    )
                     break
 
                 if remote_updated >= record.timestamp:
                     # This book has been updated.
+                    self.log.info(
+                        "Counting %s as new because its coverage date is %s and remote has %s.", 
+                        record.identifier, record.timestamp, remote_updated
+                    )
+
                     new_data = True
                     break
 
             else:
                 # There's no record of an attempt to import this book.
+                self.log.info(
+                    "Counting %s as new because it has no CoverageRecord.", 
+                    record.identifier
+                )
                 new_data = True
                 break
-
         return new_data
 
     def follow_one_link(self, link, do_get=None):

--- a/opds_import.py
+++ b/opds_import.py
@@ -266,7 +266,7 @@ class OPDSImporter(object):
             except Exception, e:
                 identifier, ignore = Identifier.parse_urn(self._db, key)
                 data_source = DataSource.lookup(self._db, self.data_source_name)
-                failure = CoverageFailure(identifier, traceback.format_exc(), data_source=data_source, transient=False)
+                failure = CoverageFailure(identifier, traceback.format_exc(), data_source=data_source, transient=True)
                 failures[key] = failure
 
         return imported_editions.values(), pools.values(), works.values(), failures
@@ -1010,7 +1010,7 @@ class OPDSImportMonitor(Monitor):
                 # There's no record of an attempt to import this book.
                 self.log.info(
                     "Counting %s as new because it has no CoverageRecord.", 
-                    record.identifier
+                    identifier
                 )
                 new_data = True
                 break

--- a/opds_import.py
+++ b/opds_import.py
@@ -838,7 +838,6 @@ class OPDSImporter(object):
             # This link is relative, so we need to get the absolute url
             href = urljoin(feed_url, href)
         return LinkData(rel=rel, href=href, media_type=media_type, rights_uri=rights_uri)
-        return foo
 
     @classmethod
     def consolidate_links(cls, links):

--- a/opds_import.py
+++ b/opds_import.py
@@ -848,8 +848,15 @@ class OPDSImporter(object):
 
         Similarly if link n is a thumbnail and link n+1 is an image.
         """
+        # Strip out any links that didn't get turned into LinkData objects
+        # due to missing `href` or whatever.
         new_links = [x for x in links if x]
+
+        # Make a new list of links from that list, to iterate over --
+        # we'll be modifying new_links in place so we can't iterate
+        # over it.
         links = list(new_links)
+
         next_link_already_handled = False
         for i, link in enumerate(links):
 

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -673,7 +673,7 @@ class TestOPDSImporter(OPDSImporterTest):
         # There's an error message for the work that failed. 
         failure = failures['http://www.gutenberg.org/ebooks/10441']
         assert isinstance(failure, CoverageFailure)
-        eq_(False, failure.transient)
+        eq_(True, failure.transient)
         assert "Utter work failure!" in failure.exception
 
     def test_consolidate_links(self):


### PR DESCRIPTION
This branch fixes a number of edge cases that showed up while importing OPDS feeds from unglue.it.

1. If the HTTP request to download a resource before mirroring it results in an HTTP error code, we no longer act as though we successfully downloaded something.
2. An Annotator is allowed (but not required) to raise `UnfulfillableWork` if it's asked to annotate an OPDS entry but it turns out there's no way to acquire that work. If this happens, the `<entry>` tag for the Work will contain only an explanatory error message.
3. In some cases where we go in expecting to generate an `<entry>` for a Work but it turns out we can't, we will now return an explanatory error message instead of None.