### PR TITLE
Superceded licensepool cannot be active in opds feed

### DIFF
--- a/model.py
+++ b/model.py
@@ -3629,6 +3629,33 @@ class Work(Base):
                      audience=self.audience, target_age=target_age)))
         l.append(" " + ", ".join(repr(wg) for wg in self.work_genres))
 
+        if self.cover_full_url:
+            l.append(" Full cover: %s" % self.cover_full_url)
+        else:
+            l.append(" No full cover.")
+
+        if self.cover_thumbnail_url:
+            l.append(" Cover thumbnail: %s" % self.cover_full_url)
+        else:
+            l.append(" No thumbnail cover.")
+
+        downloads = []
+        expect_downloads = False
+        for pool in self.license_pools:
+            if pool.superceded:
+                continue
+            if pool.open_access:
+                expect_downloads = True
+            for lpdm in pool.delivery_mechanisms:
+                if lpdm.resource and lpdm.resource.final_url:
+                    downloads.append(lpdm.resource)
+
+        if downloads:
+            l.append(" Open-access downloads:")
+            for r in downloads:
+                l.append("  " + r.final_url)
+        elif expect_downloads:
+            l.append(" Expected open-access downloads but found none.")
         def _ensure(s):
             if not s:
                 return ""

--- a/opds.py
+++ b/opds.py
@@ -274,7 +274,6 @@ class Annotator(object):
         """Which license pool would be/has been used to issue a license for
         this work?
         """
-        open_access_license_pool = None
         active_license_pool = None
 
         if not work:
@@ -295,12 +294,12 @@ class Annotator(object):
                 # Make sure there's a usable link--it might be
                 # audio-only or something.
                 if edition and edition.open_access_download_url:
-                    open_access_license_pool = p
+                    active_license_pool = p
+                    # We have an unlimited source for this book.
+                    # There's no need to keep looking.
+                    break
             elif edition and edition.title and p.licenses_owned > 0:
                 active_license_pool = p
-                break
-        if not active_license_pool:
-            active_license_pool = open_access_license_pool
         return active_license_pool
 
 

--- a/opds.py
+++ b/opds.py
@@ -284,30 +284,21 @@ class Annotator(object):
             # Active license pool is preloaded from database.
             return work.license_pool
             
-        if work.has_open_access_license:
-            # All licenses are issued from the license pool associated with
-            # the work's presentation edition.
-            edition = work.presentation_edition
-
-            if (edition and edition.license_pool and
-                edition.open_access_download_url and edition.title):
-                # Looks good.
-                open_access_license_pool = edition.license_pool
-
-        if not open_access_license_pool:
-            # The active license pool is the one that *would* be
-            # associated with a loan, were a loan to be issued right
-            # now.
-            for p in work.license_pools:
-                edition = p.presentation_edition
-                if p.open_access:
-                    # Make sure there's a usable link--it might be
-                    # audio-only or something.
-                    if edition and edition.open_access_download_url:
-                        open_access_license_pool = p
-                elif edition and edition.title and p.licenses_owned > 0:
-                    active_license_pool = p
-                    break
+        # The active license pool is the one that *would* be
+        # associated with a loan, were a loan to be issued right
+        # now.
+        for p in work.license_pools:
+            if p.superceded:
+                continue
+            edition = p.presentation_edition
+            if p.open_access:
+                # Make sure there's a usable link--it might be
+                # audio-only or something.
+                if edition and edition.open_access_download_url:
+                    open_access_license_pool = p
+            elif edition and edition.title and p.licenses_owned > 0:
+                active_license_pool = p
+                break
         if not active_license_pool:
             active_license_pool = open_access_license_pool
         return active_license_pool

--- a/scripts.py
+++ b/scripts.py
@@ -678,8 +678,10 @@ class Explain(IdentifierInputScript):
         editions = self._db.query(Edition).filter(
             Edition.primary_identifier_id.in_(identifier_ids)
         )
+        #policy = PresentationCalculationPolicy.recalculate_everything()
+        policy = None
         for edition in editions:
-            self.explain(self._db, edition)
+            self.explain(self._db, edition, policy)
             print "-" * 80
         #self._db.commit()
 
@@ -687,7 +689,7 @@ class Explain(IdentifierInputScript):
     def explain(cls, _db, edition, presentation_calculation_policy=None):
         if edition.medium != 'Book':
             return
-        output = "%s (%s, %s)" % (edition.title, edition.author, edition.medium)
+        output = "%s (%s, %s) according to %s" % (edition.title, edition.author, edition.medium, edition.data_source.name)
         print output.encode("utf8")
         work = edition.work
         lp = edition.license_pool
@@ -757,7 +759,7 @@ class Explain(IdentifierInputScript):
                     fulfillable = "Fulfillable"
                 else:
                     fulfillable = "Unfulfillable"
-                    print "  %s %s/%s" % (fulfillable, dm.content_type, dm.drm_scheme)
+                print "  %s %s/%s" % (fulfillable, dm.content_type, dm.drm_scheme)
         else:
             print " No delivery mechanisms."
         print " %s owned, %d available, %d holds, %d reserves" % (
@@ -773,7 +775,12 @@ class Explain(IdentifierInputScript):
         print " %s genres." % (len(work.genres))
         for genre in work.genres:
             print " ", genre
-
+        print " License pools:"
+        for pool in work.license_pools:
+            active = "SUPERCEDED"
+            if not pool.superceded:
+                active = "ACTIVE"
+            print "  %s: %r" % (active, pool.identifier)
 
 
 class SubjectAssignmentScript(SubjectInputScript):

--- a/scripts.py
+++ b/scripts.py
@@ -691,6 +691,7 @@ class Explain(IdentifierInputScript):
             return
         output = "%s (%s, %s) according to %s" % (edition.title, edition.author, edition.medium, edition.data_source.name)
         print output.encode("utf8")
+        print " Permanent work ID: %s" % edition.permanent_work_id
         work = edition.work
         lp = edition.license_pool
         print " Metadata URL: http://metadata.alpha.librarysimplified.org/lookup?urn=%s" % edition.primary_identifier.urn

--- a/scripts.py
+++ b/scripts.py
@@ -770,6 +770,10 @@ class Explain(IdentifierInputScript):
     @classmethod
     def explain_work(cls, work):
         print "Work info:"
+        if work.presentation_edition:
+            print " Identifier of presentation edition: %r" % work.presentation_edition.primary_identifier
+        else:
+            print " No presentation edition."
         print " Fiction: %s" % work.fiction
         print " Audience: %s" % work.audience
         print " Target age: %r" % work.target_age

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -181,7 +181,7 @@ class TestBaseAnnotator(DatabaseTest):
         eq_(pool2, Annotator.active_licensepool_for(work))
 
         # pool2 is superceded and pool1 is not. The active licensepool
-        # is pool2.
+        # is pool1.
         pool1.superceded = False
         pool2.superceded = True
         eq_(pool1, Annotator.active_licensepool_for(work))

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -152,6 +152,73 @@ class UnfulfillableAnnotator(TestAnnotator):
         raise UnfulfillableWork()
 
 
+class TestBaseAnnotator(DatabaseTest):
+
+    def test_active_licensepool_for_ignores_superceded_licensepools(self):
+        work = self._work(with_license_pool=True, 
+                          with_open_access_download=True)
+        [pool1] = work.license_pools
+        edition, pool2 = self._edition(with_license_pool=True)
+        work.license_pools.append(pool2)
+
+        # Start off with neither LicensePool being open-access. pool1
+        # will become open-access later on, which is why we created an
+        # open-access download for it.
+        pool1.open_access = False
+        pool1.licenses_owned = 1
+
+        pool2.open_access = False
+        pool2.licenses_owned = 1
+
+        # If there are multiple non-superceded non-open-access license
+        # pools for a work, the active license pool is one of them,
+        # though we don't really know or care which one.
+        assert Annotator.active_licensepool_for(work) is not None
+
+        # Neither license pool is open-access, and pool1 is superceded.
+        # The active license pool is pool2.
+        pool1.superceded = True
+        eq_(pool2, Annotator.active_licensepool_for(work))
+
+        # pool2 is superceded and pool1 is not. The active licensepool
+        # is pool2.
+        pool1.superceded = False
+        pool2.superceded = True
+        eq_(pool1, Annotator.active_licensepool_for(work))
+
+        # If both license pools are superceded, there is no active license
+        # pool for the book.
+        pool1.superceded = True
+        eq_(None, Annotator.active_licensepool_for(work))
+        pool1.superceded = False
+        pool2.superceded = False
+
+        # If one license pool is open-access and the other is not, the
+        # open-access pool wins.
+        pool1.open_access = True
+        eq_(pool1, Annotator.active_licensepool_for(work))
+        pool1.open_access = False
+        
+        # pool2 is open-access but has no usable download. The other
+        # pool wins.
+        pool2.open_access = True
+        eq_(pool1, Annotator.active_licensepool_for(work))
+        pool2.open_access = False
+
+        # If one license pool has no owned licenses and the other has
+        # owned licenses, the one with licenses wins.
+        pool1.licenses_owned = 0
+        pool2.licenses_owned = 1
+        eq_(pool2, Annotator.active_licensepool_for(work))
+        pool1.licenses_owned = 1
+
+        # If one license pool has a presentation edition that's missing
+        # a title, and the other pool has a presentation edition with a title,
+        # the one with a title wins.
+        pool2.presentation_edition.title = None
+        eq_(pool1, Annotator.active_licensepool_for(work))
+
+
 class TestAnnotators(DatabaseTest):
 
     def test_all_subjects(self):

--- a/threem.py
+++ b/threem.py
@@ -179,11 +179,15 @@ class ThreeMAPI(object):
                 results[identifier] = (edition, metadata)
         return results
 
-    def bibliographic_lookup(self, identifier, max_age=None):
-        data = self.request(
+    def bibliographic_lookup_request(self, identifier, max_age=None):
+        return self.request(
             "/items/%s" % identifier.identifier,
             max_age=max_age or self.MAX_METADATA_AGE
         )
+
+
+    def bibliographic_lookup(self, identifier, max_age=None):
+        data = self.bibliographic_lookup_request(identifier, max_age)
         response = list(self.item_list_parser.parse(data))
         if not response:
             return None


### PR DESCRIPTION
This branch changes the rules for which LicensePool can be the 'active' pool when generating a work's OPDS entry. In particular, a superceded pool can no longer be the active pool. This solves an issue where a better version of a public domain book was coming in, but the circulation manager was still using the old version.

Note that fixing this completely requires updating the materialized view, since the view will still contain a cached version of the entry's old OPDS entry.

I added a number of tests for the previously untested `active_licensepool_for` method. I also added verbosity to the `Work.detailed_representation` and the `Explain` script, which were useful in debugging this issue.