### PR TITLE
Auto convert to svg

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1188,7 +1188,6 @@ class Metadata(MetaToModelUtility):
         """
         _db = Session.object_session(edition)
         made_core_changes = False
-
         if replace is None:
             replace = ReplacementPolicy(
                 identifiers=replace_identifiers,

--- a/model.py
+++ b/model.py
@@ -7026,14 +7026,14 @@ class Representation(Base):
         """
         if not self.is_image or self.clean_media_type != self.SVG_MEDIA_TYPE:
             # Passthrough
-            return self.media_type, self.content_fh()
+            return self.content_fh()
 
         # This representation is an SVG image. We want to mirror it as
         # PNG.
         image = self.as_image()
         output = StringIO()
         image.save(output, format='PNG')
-        return self.PNG_MEDIA_TYPE, StringIO(output.getvalue())
+        return StringIO(output.getvalue())
 
     def content_fh(self):
         """Return an open filehandle to the representation's contents.

--- a/model.py
+++ b/model.py
@@ -7017,7 +7017,7 @@ class Representation(Base):
     def external_media_type(self):
         if self.clean_media_type == self.SVG_MEDIA_TYPE:
             return self.PNG_MEDIA_TYPE
-        return self.SVG_MEDIA_TYPE
+        return self.media_type
 
     def external_content(self):
         """Return a filehandle to the representation's contents, as they

--- a/model.py
+++ b/model.py
@@ -7051,7 +7051,8 @@ class Representation(Base):
         image = self.as_image()
         output = StringIO()
         image.save(output, format='PNG')
-        return StringIO(output.getvalue())
+        output.seek(0)
+        return output
 
     def content_fh(self):
         """Return an open filehandle to the representation's contents.

--- a/s3.py
+++ b/s3.py
@@ -131,7 +131,6 @@ class S3Uploader(MirrorUploader):
         filehandles = []
         requests = []
         representations_by_response_url = dict()
-        
         for representation in representations:
             if not representation.mirror_url:
                 representation.mirror_url = representation.url
@@ -142,9 +141,9 @@ class S3Uploader(MirrorUploader):
             response_url = self.url(bucket, filename)
             representations_by_response_url[response_url] = (
                 representation)
+            media_type, fh = representation.external_content()
             bucket, remote_filename = self.bucket_and_filename(
                 representation.mirror_url)
-            media_type, fh = representation.external_content()
             filehandles.append(fh)
             request = self.pool.upload(
                 remote_filename, fh, bucket=bucket,

--- a/s3.py
+++ b/s3.py
@@ -141,7 +141,8 @@ class S3Uploader(MirrorUploader):
             response_url = self.url(bucket, filename)
             representations_by_response_url[response_url] = (
                 representation)
-            media_type, fh = representation.external_content()
+            media_type = representation.external_media_type
+            fh = representation.external_content()
             bucket, remote_filename = self.bucket_and_filename(
                 representation.mirror_url)
             filehandles.append(fh)

--- a/testing.py
+++ b/testing.py
@@ -381,8 +381,8 @@ class DatabaseTest(object):
         url = url or "http://foo.com/" + self._str
         repr, is_new = get_one_or_create(
             self._db, Representation, url=url)
+        repr.media_type = media_type
         if media_type and content:
-            repr.media_type=media_type
             repr.content = content
             repr.fetched_at = datetime.utcnow()
             if mirrored:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3265,21 +3265,45 @@ class TestRepresentation(DatabaseTest):
         representation.media_type = "text/plain"
         eq_(False, representation.mirrorable_media_type)
 
-    def test_external_media_type(self):
+    def test_external_media_type_and_extension(self):
+        """Test the various transformations that might happen to media type
+        and extension when we mirror a representation.
+        """
+
+        # A text file at /foo
         representation, ignore = self._representation(self._url, "text/plain")
         eq_("text/plain", representation.external_media_type)
-        eq_(None, representation.extension())
+        eq_('', representation.extension())
 
+        # A JPEG at /foo.jpg
+        representation, ignore = self._representation(
+            self._url + ".jpg", "image/jpeg"
+        )
+        eq_("image/jpeg", representation.external_media_type)
+        eq_(".jpg", representation.extension())
+
+        # A JPEG at /foo
         representation, ignore = self._representation(self._url, "image/jpeg")
         eq_("image/jpeg", representation.external_media_type)
         eq_(".jpg", representation.extension())
 
+        # A PNG at /foo
         representation, ignore = self._representation(self._url, "image/png")
         eq_("image/png", representation.external_media_type)
         eq_(".png", representation.extension())
 
+        # An EPUB at /foo.epub.images -- information present in the URL
+        # is preserved.
+        representation, ignore = self._representation(
+            self._url + '.epub.images', Representation.EPUB_MEDIA_TYPE
+        )
+        eq_(Representation.EPUB_MEDIA_TYPE, representation.external_media_type)
+        eq_(".epub.images", representation.extension())
+        
+
         # SVG representations are always converted to PNG on the way out.
-        representation, ignore = self._representation(self._url, "image/svg+xml")
+        # This affects the media type.
+        representation, ignore = self._representation(self._url + ".svg", "image/svg+xml")
         eq_("image/png", representation.external_media_type)
         eq_(".png", representation.extension())
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+from StringIO import StringIO
 import datetime
 import os
 import sys
@@ -3509,7 +3510,9 @@ class TestRepresentation(DatabaseTest):
             Hyperlink.IMAGE, None, source, Representation.SVG_MEDIA_TYPE,
             content=svg)
         representation = hyperlink.resource.representation
+
         eq_(Representation.SVG_MEDIA_TYPE, representation.media_type)
+        eq_(Representation.PNG_MEDIA_TYPE, representation.external_media_type)
 
         # If we get the Representation as a PIL image, it's automatically
         # converted to PNG.
@@ -3519,8 +3522,12 @@ class TestRepresentation(DatabaseTest):
         # When we prepare to mirror the Representation to an external
         # file store, it's automatically converted to PNG.
         external_media_type, external_fh = representation.external_content()
-        eq_(image.tobytes(), external_fh.read())
+        output = StringIO()
+        image.save(output, format='PNG')
+        eq_(output.getvalue(), external_fh.read())
         eq_(Representation.PNG_MEDIA_TYPE, external_media_type)
+        
+        # Verify that the conversion happened correctly.
 
         # Even though the SVG image is smaller than the thumbnail
         # size, thumbnailing it will create a separate PNG-format

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3265,6 +3265,24 @@ class TestRepresentation(DatabaseTest):
         representation.media_type = "text/plain"
         eq_(False, representation.mirrorable_media_type)
 
+    def test_external_media_type(self):
+        representation, ignore = self._representation(self._url, "text/plain")
+        eq_("text/plain", representation.external_media_type)
+        eq_(None, representation.extension())
+
+        representation, ignore = self._representation(self._url, "image/jpeg")
+        eq_("image/jpeg", representation.external_media_type)
+        eq_(".jpg", representation.extension())
+
+        representation, ignore = self._representation(self._url, "image/png")
+        eq_("image/png", representation.external_media_type)
+        eq_(".png", representation.extension())
+
+        # SVG representations are always converted to PNG on the way out.
+        representation, ignore = self._representation(self._url, "image/svg+xml")
+        eq_("image/png", representation.external_media_type)
+        eq_(".png", representation.extension())
+
     def test_set_fetched_content(self):
         representation, ignore = self._representation(self._url, "text/plain")
         representation.set_fetched_content("some text")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3536,14 +3536,14 @@ class TestRepresentation(DatabaseTest):
         # converted to PNG.
         image = representation.as_image()
         eq_("PNG", image.format)
+        expect = StringIO()
+        image.save(expect, format='PNG')
 
         # When we prepare to mirror the Representation to an external
         # file store, it's automatically converted to PNG.
-        external_media_type, external_fh = representation.external_content()
-        output = StringIO()
-        image.save(output, format='PNG')
-        eq_(output.getvalue(), external_fh.read())
-        eq_(Representation.PNG_MEDIA_TYPE, external_media_type)
+        external_fh = representation.external_content()
+        eq_(expect.getvalue(), external_fh.read())
+        eq_(Representation.PNG_MEDIA_TYPE, representation.external_media_type)
         
         # Verify that the conversion happened correctly.
 

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -673,7 +673,7 @@ class TestOPDSImporter(OPDSImporterTest):
         # There's an error message for the work that failed. 
         failure = failures['http://www.gutenberg.org/ebooks/10441']
         assert isinstance(failure, CoverageFailure)
-        eq_(True, failure.transient)
+        eq_(False, failure.transient)
         assert "Utter work failure!" in failure.exception
 
     def test_consolidate_links(self):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,5 +1,7 @@
 import os
 import contextlib
+from PIL import Image
+from StringIO import StringIO
 from nose.tools import (
     set_trace,
     eq_,
@@ -81,5 +83,5 @@ class TestUpload(DatabaseTest):
         # The thing that got uploaded was a PNG, not the original SVG
         # file.
         eq_(Representation.PNG_MEDIA_TYPE, media_type)
+        assert 'PNG' in data
         assert 'svg' not in data
-


### PR DESCRIPTION
This branch fixes https://github.com/NYPL-Simplified/content_server/issues/68 by ensuring that SVG images are converted to PNG when it's time to mirror them to S3. This is as opposed to thumbnail images, which are converted to PNG when the thumbnail is created.

There's also a minor change made to the code that fetches OPDS feds for import purposes, which was necessary to get the Standard Ebooks import to work.