### PR TITLE
If a string can be parsed as both UTF-8 and Windows-1252, prefer UTF-8 -- it's almost always the right answer.

### DIFF
--- a/migration/20160719-fix-incorrectly-encoded-work-descriptions.py
+++ b/migration/20160719-fix-incorrectly-encoded-work-descriptions.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""Fix work descriptions that were originally UTF-8 but were incorrectly
+encoded as Windows-1252.
+"""
+import os
+import sys
+import logging
+from pdb import set_trace
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+
+import time
+from nose.tools import set_trace
+from sqlalchemy.orm import (
+    aliased,
+)
+from sqlalchemy.sql.expression import (
+    and_,
+    or_
+)
+from core.external_search import ExternalSearchIndex
+from core.model import (
+    production_session,
+    Work,
+)
+
+_db = production_session()
+client = ExternalSearchIndex()
+base = _db.query(Work).filter(Work.summary_text != None).order_by(Work.id)
+results = True
+offset = 0
+print "Looking at %d works." % base.count()
+while results:
+    fixed = 0
+    qu = base.offset(offset).limit(1000)
+    results = qu.all()
+    for work in results:
+        possibly_bad = work.summary_text
+        try:
+            windows_1252_from_unicode = work.summary_text.encode("windows-1252")
+            # If we get to this point, the Unicode summary can be
+            # encoded as Windows-1252.
+            try:
+                final = windows_1252_from_unicode.decode("utf8")
+                # If we get to this point, it's UTF-8 that was incorrectly
+                # encoded as Windows-1252.
+            except UnicodeDecodeError, e:
+                # It was Windows-1252 all along.
+                final = windows_1252_from_unicode.decode("windows-1252")
+        except UnicodeEncodeError, e:
+            # This description can't be encoded as Windows-1252, an
+            # indication that it was originally UTF-8 and is not
+            # subject to this problem.
+            final = possibly_bad
+
+        if possibly_bad != final:
+            work.summary_text = final
+            print "%s\n =>\n %s" % (possibly_bad.encode("utf8"), final.encode("utf8"))
+            work.calculate_opds_entries()
+            work.update_external_index(client)
+            print
+            fixed += 1
+        pass
+    offset += 1000
+    print "Fixed %s/1000" % fixed
+    print offset
+    _db.commit()

--- a/migration/20160719-fix-incorrectly-encoded-work-descriptions.py
+++ b/migration/20160719-fix-incorrectly-encoded-work-descriptions.py
@@ -12,13 +12,6 @@ sys.path.append(os.path.abspath(package_dir))
 
 import time
 from nose.tools import set_trace
-from sqlalchemy.orm import (
-    aliased,
-)
-from sqlalchemy.sql.expression import (
-    and_,
-    or_
-)
 from core.external_search import ExternalSearchIndex
 from core.model import (
     production_session,
@@ -63,6 +56,5 @@ while results:
             fixed += 1
         pass
     offset += 1000
-    print "Fixed %s/1000" % fixed
-    print offset
+    print "At %s, %s/%s needed fixing." % (offset, fixed, len(results))
     _db.commit()

--- a/model.py
+++ b/model.py
@@ -6855,6 +6855,7 @@ class Representation(Base):
         for encoding in ('utf-8', 'windows-1252'):
             try:
                 content = self.content.decode(encoding)
+                break
             except UnicodeDecodeError, e:
                 pass
         return content

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3323,12 +3323,21 @@ class TestRepresentation(DatabaseTest):
         eq_("some text", fh.read())
 
     def test_unicode_content_utf8_default(self):
-        unicode_content = u"A “love” story"
+        unicode_content = u"It’s complicated."
+
         utf8_content = unicode_content.encode("utf8")
+
+        # This bytestring can be decoded as Windows-1252, but that
+        # would be the wrong answer.
+        bad_windows_1252 = utf8_content.decode("windows-1252")
+        eq_(u"Itâ€™s complicated.", bad_windows_1252)
 
         representation, ignore = self._representation(self._url, "text/plain")
         representation.set_fetched_content(unicode_content, None)
         eq_(utf8_content, representation.content)
+
+        # By trying to interpret the content as UTF-8 before falling back to 
+        # Windows-1252, we get the right answer.
         eq_(unicode_content, representation.unicode_content)
 
     def test_unicode_content_windows_1252(self):


### PR DESCRIPTION
This is what was _supposed_ to happen before but a missing `break` statement ensured that if a string could be interpreted as either UTF-8 or Windows-1252, we always chose Windows-1252. Now it's a big problem that needs a migration script and everything.

I've tested the migration script on the OA content server and it seems to work fine.