### PR TITLE
Licensepool with no pwid gets kicked out of work

### DIFF
--- a/migration/20160721-kick-out-licensepools-without-pwid.py
+++ b/migration/20160721-kick-out-licensepools-without-pwid.py
@@ -28,7 +28,6 @@ def fix(_db, description, qu):
     print "%s: %s" % (description, qu.count())
     for lp in qu:
         lp.calculate_work()
-        break
 
 no_presentation_edition = _db.query(LicensePool).outerjoin(
     LicensePool.presentation_edition).filter(Edition.id==None).filter(

--- a/migration/20160721-kick-out-licensepools-without-pwid.py
+++ b/migration/20160721-kick-out-licensepools-without-pwid.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""Find LicensePools that have a work but no permanent work ID and
+call calculate_work() on them. This will fix the problem, either by
+calculating the appropriate permanent work ID or kicking them out of
+their Works.
+"""
+
+import os
+import sys
+import logging
+from pdb import set_trace
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from nose.tools import set_trace
+from core.model import (
+    production_session,
+    Edition,
+    LicensePool,
+    Work,
+)
+
+_db = production_session()
+
+
+def fix(_db, description, qu):
+    print "%s: %s" % (description, qu.count())
+    for lp in qu:
+        lp.calculate_work()
+        break
+
+no_presentation_edition = _db.query(LicensePool).outerjoin(
+    LicensePool.presentation_edition).filter(Edition.id==None).filter(
+        LicensePool.work_id != None
+    )
+
+no_permanent_work_id = _db.query(LicensePool).join(
+    LicensePool.presentation_edition).filter(
+        Edition.permanent_work_id==None
+    ).filter(
+        LicensePool.work_id != None
+    )
+
+fix(_db, "Pools with work but no presentation edition", no_presentation_edition)
+fix(_db, "Pools with work but no permanent work ID", no_permanent_work_id)
+_db.commit()
+
+qu = _db.query(Work).filter(~Work.license_pools.any())
+print "Deleting %d works with no license pools." % qu.count()

--- a/model.py
+++ b/model.py
@@ -5920,15 +5920,12 @@ class LicensePool(Base):
         if not presentation_edition.title:
             if presentation_edition.work:
                 logging.warn(
-                    "Edition %r has no title but has a Work assigned. This is troubling.", presentation_edition
+                    "Edition %r has no title but has a Work assigned. This will not stand.", presentation_edition
                 )
-                return presentation_edition.work, False
             else:
                 logging.info("Edition %r has no title and it will not get a Work.", presentation_edition)
-                # If there was a work associated with this LicensePool,
-                # it was by mistake. Remove it.
-                self.work = None
-                return None, False
+            self.work = None
+            return None, False
 
         if (not presentation_edition.work
             and presentation_edition.author in (None, Edition.UNKNOWN_AUTHOR)

--- a/model.py
+++ b/model.py
@@ -5925,6 +5925,7 @@ class LicensePool(Base):
             else:
                 logging.info("Edition %r has no title and it will not get a Work.", presentation_edition)
             self.work = None
+            self.work_id = None
             return None, False
 
         if (not presentation_edition.work
@@ -5938,6 +5939,7 @@ class LicensePool(Base):
             # If there was a work associated with this LicensePool,
             # it was by mistake. Remove it.
             self.work = None
+            self.work_id = None
             return None, False
 
         presentation_edition.calculate_permanent_work_id()

--- a/model.py
+++ b/model.py
@@ -3188,15 +3188,13 @@ class Work(Base):
         has the given PWID and medium. Any non-open-access
         LicensePool, and any LicensePool with a different PWID or a
         different medium, is kicked out and assigned to a different
-        Work. LicensePools with no presentation edition and no PWID
-        are left alone. (TODO: although maybe they should be kicked
-        out.)
+        Work. LicensePools with no presentation edition or no PWID
+        are kicked out.
 
         In most cases this Work will be the _only_ work for this PWID,
         but inside open_access_for_permanent_work_id this is called as
         a preparatory step for merging two Works, and after the call
         (but before the merge) there may be two Works for a given PWID.
-
         """
         _db = Session.object_session(self)
         for pool in list(self.license_pools):
@@ -3208,11 +3206,25 @@ class Work(Base):
                 pool.presentation_edition.work = None
                 other_work, is_new = pool.calculate_work()
             elif not pool.presentation_edition:
-                continue
+                # A LicensePool with no presentation edition
+                # cannot have an associated Work.
+                logging.warn(
+                    "LicensePool %r has no presentation edition, setting .work to None.",
+                    pool
+                )
+                pool.work = None
             else:
                 e = pool.presentation_edition
                 this_pwid = e.permanent_work_id
                 if not this_pwid:
+                    # A LicensePool with no permanent work ID
+                    # cannot have an associated Work.
+                    logging.warn(
+                        "Presentation edition for LicensePool %r has no PWID, setting .work to None.",
+                        pool
+                    )
+                    e.work = None
+                    pool.work = None
                     continue
                 if this_pwid != pwid or e.medium != medium:
                     # This LicensePool should not belong to this Work.
@@ -5892,6 +5904,10 @@ class LicensePool(Base):
             # associated with this LicensePool, so we can't create a work.
             logging.warn("NO EDITION for %s, cowardly refusing to create work.",
                      self.identifier)            
+
+            # If there was a work associated with this LicensePool,
+            # it was by mistake. Remove it.
+            self.work = None
             return None, False
 
         if presentation_edition.is_presentation_for != self:
@@ -5908,7 +5924,10 @@ class LicensePool(Base):
                 )
                 return presentation_edition.work, False
             else:
-                logging.info("Edition %r has no title, will not assign it a Work.", presentation_edition)
+                logging.info("Edition %r has no title and it will not get a Work.", presentation_edition)
+                # If there was a work associated with this LicensePool,
+                # it was by mistake. Remove it.
+                self.work = None
                 return None, False
 
         if (not presentation_edition.work
@@ -5919,6 +5938,9 @@ class LicensePool(Base):
                 "Edition %r has no author, not assigning Work to Edition.", 
                 presentation_edition
             )
+            # If there was a work associated with this LicensePool,
+            # it was by mistake. Remove it.
+            self.work = None
             return None, False
 
         presentation_edition.calculate_permanent_work_id()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2679,6 +2679,47 @@ class TestWorkConsolidation(DatabaseTest):
         )
         eq_(expect_audiobook_work, audiobook.work)
 
+    def test_calculate_work_detaches_work_with_no_pwid(self):
+        # Here's a Work with an open-access edition of "abcd".
+        work = self._work(with_license_pool=True)
+        [book] = work.license_pools
+        book.presentation_edition.permanent_work_id = "abcd"
+
+        # Due to a earlier error, the Work also contains an edition
+        # with no title or author, and thus no permanent work ID.
+        edition, no_title = self._edition(with_license_pool=True)
+
+        no_title.presentation_edition.title=None
+        no_title.presentation_edition.author=None
+        no_title.presentation_edition.permanent_work_id = None
+        work.license_pools.append(no_title)
+
+        # Calling calculate_work() on the functional LicensePool will
+        # split off the bad one.
+        work_after, is_new = book.calculate_work()
+        eq_([book], work.license_pools)
+        eq_(None, no_title.work)
+        eq_(None, no_title.presentation_edition.work)
+
+        # calculate_work() on the bad LicensePool will split it off from
+        # the good one.
+        work.license_pools.append(no_title)
+        work_after_2, is_new = no_title.calculate_work()
+        eq_(None, work_after_2)
+        eq_([book], work.license_pools)
+
+        # The same thing happens if the bad LicensePool has no
+        # presentation edition at all.
+        work.license_pools.append(no_title)
+        no_title.presentation_edition = None
+        work_after, is_new = book.calculate_work()
+        eq_([book], work.license_pools)
+
+        work.license_pools.append(no_title)
+        work_after, is_new = no_title.calculate_work()
+        eq_([book], work.license_pools)
+
+
     def test_pwids(self):
         """Test the property that finds all permanent work IDs
         associated with a Work.
@@ -2822,6 +2863,39 @@ class TestWorkConsolidation(DatabaseTest):
 
         # A third work has been created for the commercial edition of "abcd".
         assert abcd_commercial.work not in (work1, work2)
+
+    def test_make_exclusive_open_access_for_null_permanent_work_id(self):
+        # Here's a LicensePool that, due to a previous error, has
+        # a null PWID in its presentation edition.
+        work = self._work(with_license_pool=True, 
+                          with_open_access_download=True)
+        [null1] = work.license_pools
+        null1.presentation_edition.title = None
+        null1.presentation_edition.sort_author = None
+        null1.presentation_edition.permanent_work_id = None
+        
+        # Here's another LicensePool associated with the same work and
+        # with the same problem.
+        edition, null2 = self._edition(
+            with_license_pool=True, with_open_access_download=True
+        )
+        work.license_pools.append(null2)
+
+        for pool in work.license_pools:
+            pool.presentation_edition.title = None
+            pool.presentation_edition.sort_author = None
+            pool.presentation_edition.permanent_work_id = None
+
+        work.make_exclusive_open_access_for_permanent_work_id(
+            None, Edition.BOOK_MEDIUM
+        )
+
+        # Since a LicensePool with no PWID cannot have an associated Work,
+        # this Work now have no LicensePools at all.
+        eq_([], work.license_pools)
+
+        eq_(None, null1.work)
+        eq_(None, null2.work)
 
     def test_merge_into_success(self):
         # Here's a work with an open-access LicensePool.
@@ -3035,9 +3109,26 @@ class TestWorkConsolidation(DatabaseTest):
         )
 
     def test_licensepool_without_identifier_gets_no_work(self):
-        edition, lp = self._edition(with_license_pool=True)
+        work = self._work(with_license_pool=True)
+        [lp] = work.license_pools
         lp.identifier = None
+
+        # Even if the LicensePool had a work before, it gets removed.
         eq_((None, False), lp.calculate_work())
+        eq_(None, lp.work)
+
+    def test_licensepool_without_presentation_edition_gets_no_work(self):
+        work = self._work(with_license_pool=True)
+        [lp] = work.license_pools
+
+        # This LicensePool has no presentation edition and no way of 
+        # getting one.
+        lp.presentation_edition = None
+        lp.identifier.primarily_identifies = []
+
+        # Even if the LicensePool had a work before, it gets removed.
+        eq_((None, False), lp.calculate_work())
+        eq_(None, lp.work)
 
 class TestLoans(DatabaseTest):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2679,7 +2679,24 @@ class TestWorkConsolidation(DatabaseTest):
         )
         eq_(expect_audiobook_work, audiobook.work)
 
-    def test_calculate_work_detaches_work_with_no_pwid(self):
+    def test_calculate_work_detaches_licensepool_with_no_title(self):
+        # Here's a Work with an open-access edition of "abcd".
+        work = self._work(with_license_pool=True)
+        [book] = work.license_pools
+        book.presentation_edition.permanent_work_id = "abcd"
+
+        # But the LicensePool's presentation edition has lost its
+        # title.
+        book.presentation_edition.title = None
+
+        # Calling calculate_work() on the LicensePool will detach the
+        # book from its work, since a book with no title cannot have
+        # an associated Work.
+        work_after, is_new = book.calculate_work()
+        eq_(None, work_after)
+        eq_([], work.license_pools)
+
+    def test_calculate_work_detaches_licensepool_with_no_pwid(self):
         # Here's a Work with an open-access edition of "abcd".
         work = self._work(with_license_pool=True)
         [book] = work.license_pools


### PR DESCRIPTION
A previous comment I wrote in Work.make_exclusive_open_access_for_permanent_work_id():

"LicensePools with no presentation edition and no PWID are left alone. (TODO: although maybe they should be kicked out.)"

Yes, they should be kicked out. There's no reason for a LicensePool that lacks a presentation edition, or whose presentation edition lacks a PWID, to belong to a Work. Our SimplyE production server has some LicensePools like this and they're blocking access to books that do have metadata and that people want to read.