### PR TITLE
Licensepool with no pwid gets kicked out of work

### DIFF
--- a/migration/20160721-kick-out-licensepools-without-pwid.py
+++ b/migration/20160721-kick-out-licensepools-without-pwid.py
@@ -13,6 +13,10 @@ bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 
+from sqlalchemy.orm import (
+    aliased,
+)
+
 from nose.tools import set_trace
 from core.model import (
     production_session,
@@ -25,9 +29,14 @@ _db = production_session()
 
 
 def fix(_db, description, qu):
+    a = 0
     print "%s: %s" % (description, qu.count())
     for lp in qu:
         lp.calculate_work()
+        a += 1
+        if not a % 10:
+            print "Committing"
+            _db.commit()
 
 no_presentation_edition = _db.query(LicensePool).outerjoin(
     LicensePool.presentation_edition).filter(Edition.id==None).filter(
@@ -41,8 +50,24 @@ no_permanent_work_id = _db.query(LicensePool).join(
         LicensePool.work_id != None
     )
 
+no_title = _db.query(LicensePool).join(
+    LicensePool.presentation_edition).filter(
+        Edition.title==None
+    ).filter(
+        LicensePool.work_id != None
+    )
+
+licensepools_in_same_work_as_another_licensepool_with_different_pwid = _db.execute("select lp1.id from licensepools lp1 join works w on lp1.work_id=w.id join editions e1 on lp1.presentation_edition_id=e1.id join licensepools lp2 on lp2.work_id=w.id join editions e2 on e2.id=lp2.presentation_edition_id and e2.permanent_work_id != e1.permanent_work_id;")
+ids = [x[0] for x in licensepools_in_same_work_as_another_licensepool_with_different_pwid]
+in_same_work = _db.query(LicensePool).filter(LicensePool.id.in_(ids))
+
+fix(_db, "Pools in the same work as another pool with a different pwid", in_same_work)
+_db.commit()
 fix(_db, "Pools with work but no presentation edition", no_presentation_edition)
+_db.commit()
 fix(_db, "Pools with work but no permanent work ID", no_permanent_work_id)
+_db.commit()
+fix(_db, "Pools with work but no title", no_title)
 _db.commit()
 
 qu = _db.query(Work).filter(~Work.license_pools.any())

--- a/migration/20160721-kick-out-licensepools-without-pwid.py
+++ b/migration/20160721-kick-out-licensepools-without-pwid.py
@@ -13,10 +13,6 @@ bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 
-from sqlalchemy.orm import (
-    aliased,
-)
-
 from nose.tools import set_trace
 from core.model import (
     production_session,


### PR DESCRIPTION
This branch improves the previously committed migration script so that it also investigates a LicensePool with PWID "A" that is grouped together in a Work with another LicensePool with PWID "B". Those LPs should always be in separate works.

Also a LicensePool whose presentation edition has no title, which shouldn't have a work either.