### PR TITLE
Change search labels to match the lane that's actually searched

### DIFF
--- a/opensearch.py
+++ b/opensearch.py
@@ -15,9 +15,9 @@ class OpenSearchDocument(object):
         d = dict(name="Search")
         tags = []
         
-        if lane is not None:
-            tags.append(lane.name.lower().replace(" ", "-").replace("&", "&amp;"))
-            description = "Search %s" % lane.name.replace("&", "&amp;")
+        if lane is not None and lane.search_target is not None:
+            tags.append(lane.search_target.name.lower().replace(" ", "-").replace("&", "&amp;"))
+            description = "Search %s" % lane.search_target.name.replace("&", "&amp;")
         else:
             description = "Search"
         d['description'] = description

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -1,0 +1,58 @@
+from nose.tools import (
+    set_trace,
+    eq_,
+)
+
+from opensearch import OpenSearchDocument
+from lane import Lane
+from . import DatabaseTest
+
+class TestOpenSearchDocument(DatabaseTest):
+
+    def test_search_info(self):
+        sublane = Lane(self._db, "Sublane")
+
+        lane = Lane(self._db, "Lane", sublanes=[sublane])
+
+        # Neither lane is searchable yet.
+
+        info = OpenSearchDocument.search_info(lane)
+        eq_("Search", info['name'])
+        eq_("Search", info['description'])
+        eq_("", info['tags'])
+
+        info = OpenSearchDocument.search_info(sublane)
+        eq_("Search", info['name'])
+        eq_("Search", info['description'])
+        eq_("", info['tags'])
+
+        # Make the parent lane searchable.
+
+        lane.searchable = True
+
+        info = OpenSearchDocument.search_info(lane)
+        eq_("Search", info['name'])
+        eq_("Search Lane", info['description'])
+        eq_("lane", info['tags'])
+
+        info = OpenSearchDocument.search_info(sublane)
+        eq_("Search", info['name'])
+        eq_("Search Lane", info['description'])
+        eq_("lane", info['tags'])
+
+        # Make the sublane searchable.
+
+        sublane.searchable = True
+
+        info = OpenSearchDocument.search_info(lane)
+        eq_("Search", info['name'])
+        eq_("Search Lane", info['description'])
+        eq_("lane", info['tags'])
+
+        info = OpenSearchDocument.search_info(sublane)
+        eq_("Search", info['name'])
+        eq_("Search Sublane", info['description'])
+        eq_("sublane", info['tags'])
+
+
+    


### PR DESCRIPTION
This is the easy part of https://github.com/NYPL-Simplified/circulation/issues/318

Changing the language lane names in circulation will be tricky because of localization.