### PR TITLE
When updating a Contributor from a ContributorData, update VIAF, LC, and Wikipedia name, not just sort and display names.

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1457,6 +1457,12 @@ class Metadata(MetaToModelUtility):
                     contributor.biography = contributor_data.biography
                 if contributor_data.aliases:
                     contributor.aliases = contributor_data.aliases
+                if contributor_data.lc:
+                    contributor.lc = contributor_data.lc
+                if contributor_data.viaf:
+                    contributor.viaf = contributor_data.viaf
+                if contributor_data.wikipedia_name:
+                    contributor.wikipedia_name = contributor_data.wikipedia_name
             else:
                 self.log.info(
                     "Not registering %s because no sort name, LC, or VIAF",

--- a/model.py
+++ b/model.py
@@ -1935,7 +1935,6 @@ class Contributor(Base):
             contributors, new = get_one_or_create(
                 _db, Contributor, create_method_kwargs=create_method_kwargs,
                 **query)
-
         return contributors, new
 
     def merge_into(self, destination):

--- a/threem.py
+++ b/threem.py
@@ -431,7 +431,12 @@ class ThreeMBibliographicCoverageProvider(BibliographicCoverageProvider):
         )
 
     def process_item(self, identifier):
-        metadata = self.api.bibliographic_lookup(identifier)
+        # We don't accept a representation from the cache because
+        # either this is being run for the first time (in which case
+        # there is nothing in the cache) or it's being run to correct
+        # for an earlier failure (in which case the representation
+        # in the cache might be wrong).
+        metadata = self.api.bibliographic_lookup(identifier, max_age=0)
         if not metadata:
             return CoverageFailure(
                 identifier, "3M bibliographic lookup failed.",


### PR DESCRIPTION
I'm not sure why we didn't do this before--probably I didn't write the code because we didn't need it.

This makes an ugly situation a little uglier, as there's no guarantee that the Contributor object we're writing to comes from the same DataSource as the data we're using to modify it. But that's a known issue that we will resolve separately. If you write a ContributorData object to a Contributor it should write _all_ the data.
