### PR TITLE
Change the base URL to the Cloud Library API.

### DIFF
--- a/threem.py
+++ b/threem.py
@@ -60,7 +60,7 @@ class ThreeMAPI(object):
 
     log = logging.getLogger("3M API")
 
-    def __init__(self, _db, base_url = "https://cloudlibraryapi.3m.com/",
+    def __init__(self, _db, base_url = "https://partner.yourcloudlibrary.com/",
                  version="2.0", testing=False):
         self._db = _db
         self.version = version


### PR DESCRIPTION
Bibliotheca bought 3M and changed the URL. The old URL still works but let's start using the new one just to be safe.
