### PR TITLE
Seriously allow persistent tokens, now that it's a real use case.

### DIFF
--- a/model.py
+++ b/model.py
@@ -6375,12 +6375,12 @@ class Credential(Base):
 
     @classmethod
     def lookup(self, _db, data_source, type, patron, refresher_method,
-               allow_permanent_token=False):
+               allow_persistent_token=False):
         if isinstance(data_source, basestring):
             data_source = DataSource.lookup(_db, data_source)
         credential, is_new = get_one_or_create(
             _db, Credential, data_source=data_source, type=type, patron=patron)
-        if (is_new or (not credential.expires and not allow_permanent_token)
+        if (is_new or (not credential.expires and not allow_persistent_token)
             or (credential.expires 
                 and credential.expires <= datetime.datetime.utcnow())):
             if refresher_method:
@@ -6389,11 +6389,11 @@ class Credential(Base):
 
     @classmethod
     def lookup_by_token(self, _db, data_source, type, token,
-                               allow_permanent_token=False):
+                               allow_persistent_token=False):
         """Look up a unique token.
 
-        Lookup will fail on expired tokens. Unless permanent tokens
-        are specifically allowed, lookup will fail on permanent tokens.
+        Lookup will fail on expired tokens. Unless persistent tokens
+        are specifically allowed, lookup will fail on persistent tokens.
         """
 
         credential = get_one(
@@ -6405,7 +6405,7 @@ class Credential(Base):
             return None
 
         if not credential.expires:
-            if allow_permanent_token:
+            if allow_persistent_token:
                 return credential
             else:
                 # It's an error that this token never expires. It's invalid.
@@ -6436,11 +6436,25 @@ class Credential(Base):
         token_string = str(uuid.uuid1())
         credential, is_new = get_one_or_create(
             _db, Credential, data_source=data_source, type=type, patron=patron)
+        # If there was already a token of this type for this patron,
+        # the new one overwrites the old one.
         credential.credential=token_string
         credential.expires=expires
         return credential, is_new
 
-# Index to make temporary_token_lookup() fast.
+    @classmethod
+    def persistent_token_create(self, _db, data_source, type, patron):
+        """Create a persistent token for the given data_source/type/patron.
+        """
+        token_string = str(uuid.uuid1())
+        credential, is_new = get_one_or_create(
+            _db, Credential, data_source=data_source, type=type, patron=patron)
+        if is_new:
+            credential.credential=token_string
+        credential.expires=None
+        return credential, is_new
+
+# Index to make lookup_by_token() fast.
 Index("ix_credentials_data_source_id_type_token", Credential.data_source_id, Credential.type, Credential.credential, unique=True)
 
 class Timestamp(Base):

--- a/model.py
+++ b/model.py
@@ -6444,13 +6444,14 @@ class Credential(Base):
 
     @classmethod
     def persistent_token_create(self, _db, data_source, type, patron):
-        """Create a persistent token for the given data_source/type/patron.
+        """Create or retrieve a persistent token for the given 
+        data_source/type/patron.
         """
         token_string = str(uuid.uuid1())
         credential, is_new = get_one_or_create(
-            _db, Credential, data_source=data_source, type=type, patron=patron)
-        if is_new:
-            credential.credential=token_string
+            _db, Credential, data_source=data_source, type=type, patron=patron,
+            create_method_kwargs=dict(credential=token_string)
+        )
         credential.expires=None
         return credential, is_new
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4108,7 +4108,7 @@ class TestCredentials(DatabaseTest):
 
     def test_persistent_token(self):
 
-        # Create a persistent token good for one hour.
+        # Create a persistent token.
         data_source = DataSource.lookup(self._db, DataSource.ADOBE)
         patron = self._patron()
         token, is_new = Credential.persistent_token_create(
@@ -4127,7 +4127,8 @@ class TestCredentials(DatabaseTest):
         credential = new_token.credential
 
         # We can keep calling lookup_by_token and getting the same
-        # Credential object with the same .credential.
+        # Credential object with the same .credential -- it doesn't
+        # expire.
         again_token = Credential.lookup_by_token(
             self._db, data_source, token.type, token.credential, 
             allow_persistent_token=True

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4076,15 +4076,18 @@ class TestCredentials(DatabaseTest):
             self._db, data_source, token.type, token.credential)
         eq_(None, new_token)
  
-        # A token with no expiration date is treated as expired.
+        # A token with no expiration date is treated as expired...
         token.expires = None
         self._db.commit()
         no_expiration_token = Credential.lookup_by_token(
             self._db, data_source, token.type, token.credential)
         eq_(None, no_expiration_token)
 
+        # ...unless we specifically say we're looking for a persistent token.
         no_expiration_token = Credential.lookup_by_token(
-            self._db, data_source, token.type, token.credential, True)
+            self._db, data_source, token.type, token.credential, 
+            allow_persistent_token=True
+        )
         eq_(token, no_expiration_token)
 
     def test_temporary_token_overwrites_old_token(self):
@@ -4102,6 +4105,35 @@ class TestCredentials(DatabaseTest):
         eq_(False, is_new)
         eq_(token.id, old_token.id)
         assert old_credential != token.credential
+
+    def test_persistent_token(self):
+
+        # Create a persistent token good for one hour.
+        data_source = DataSource.lookup(self._db, DataSource.ADOBE)
+        patron = self._patron()
+        token, is_new = Credential.persistent_token_create(
+            self._db, data_source, "some random type", patron
+        )
+        eq_(data_source, token.data_source)
+        eq_("some random type", token.type)
+        eq_(patron, token.patron)
+
+        # Now try to look up the credential based solely on the UUID.
+        new_token = Credential.lookup_by_token(
+            self._db, data_source, token.type, token.credential, 
+            allow_persistent_token=True
+        )
+        eq_(new_token, token)
+        credential = new_token.credential
+
+        # We can keep calling lookup_by_token and getting the same
+        # Credential object with the same .credential.
+        again_token = Credential.lookup_by_token(
+            self._db, data_source, token.type, token.credential, 
+            allow_persistent_token=True
+        )
+        eq_(again_token, new_token)
+        eq_(again_token.credential, credential)
 
     def test_cannot_look_up_nonexistent_token(self):
         data_source = DataSource.lookup(self._db, DataSource.ADOBE)


### PR DESCRIPTION
This branch adds a method called `persistent_token_create` which creates a Credential object whose `.credential` does not expire. Previously you could look up persistent tokens but there was no easy way of creating them.

I changed some language that referred to 'permanent' tokens to refer to 'persistent' tokens instead.