### PR TITLE
Move complex URNLookupController code into metadata

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -255,13 +255,13 @@ class URNLookupController(object):
         self.precomposed_entries = []
         self.unresolved_identifiers = []
 
-    def work_lookup(self, annotator, route_name='lookup'):
+    def work_lookup(self, annotator, route_name='lookup', urns=[]):
         """Generate an OPDS feed describing works identified by identifier."""
         urns = flask.request.args.getlist('urn')
 
         this_url = cdn_url_for(route_name, _external=True, urn=urns)
         for urn in urns:
-            self.handle_result(self.process_urn(urn))
+            self.process_urn(urn)
         self.post_lookup_hook()
 
         opds_feed = LookupAcquisitionFeed(
@@ -274,11 +274,15 @@ class URNLookupController(object):
     def permalink(self, urn, annotator, route_name='work'):
         """Look up a single identifier and generate an OPDS feed."""
         this_url = cdn_url_for(route_name, _external=True, urn=urn)
-        self.handle_result(self.process_urn(urn))
+        self.process_urn(urn)
         self.post_lookup_hook()
 
+        # A LookupAcquisitionFeed's .works is a list of (identifier,
+        # work) tuples, but an AcquisitionFeed's .works is just a
+        # list of works.
+        works = [work for (identifier, work) in self.works]
         opds_feed = AcquisitionFeed(
-            self._db, urn, this_url, self.works, annotator,
+            self._db, urn, this_url, works, annotator,
             messages_by_urn=self.messages_by_urn
         )
 

--- a/app_server.py
+++ b/app_server.py
@@ -288,11 +288,14 @@ class URNLookupController(object):
         """Turn a URN into a Work suitable for use in an OPDS feed.
 
         """
-        identifier, is_new = Identifier.parse_urn(_db, urn)
+        try:
+            identifier, is_new = Identifier.parse_urn(self._db, urn)
+        except ValueError, e:
+            identifier = None
 
         if not identifier:
-            # URN is probably invalid.
-            return self.add_message(urn, 400, self.UNRESOLVABLE_URN)
+            # Not a well-formed URN.
+            return self.add_message(urn, 400, INVALID_URN.detail)
 
         if not identifier.licensed_through:
             # The default URNLookupController cannot look up an

--- a/app_server.py
+++ b/app_server.py
@@ -239,218 +239,99 @@ class HeartbeatController(object):
 
 
 class URNLookupController(object):
+    """A generic controller that takes URNs as input and looks up their
+    OPDS entries.
+    """
 
-    UNRECOGNIZED_IDENTIFIER = "I've never heard of this work."
+    UNRECOGNIZED_IDENTIFIER = "This work is not in the collection."
     UNRESOLVABLE_URN = "I don't know how to get metadata for this kind of identifier."
     WORK_NOT_PRESENTATION_READY = "Work created but not yet presentation-ready."
     WORK_NOT_CREATED = "Identifier resolved but work not yet created."
-    IDENTIFIER_REGISTERED = "You're the first one to ask about this identifier. I'll try to find out about it."
-    WORKING_TO_RESOLVE_IDENTIFIER = "I'm working to locate a source for this identifier."
 
-    def __init__(self, _db, can_resolve_identifiers=False):
+    def __init__(self, _db):
         self._db = _db
         self.works = []
         self.messages_by_urn = dict()
         self.precomposed_entries = []
         self.unresolved_identifiers = []
-        self.can_resolve_identifiers = can_resolve_identifiers
-        self.content_cafe = DataSource.lookup(self._db, DataSource.CONTENT_CAFE)
 
-    @classmethod
-    def parse_urn(self, _db, urn, must_support_metadata=True):
-
-        try:
-            identifier, is_new = Identifier.parse_urn(
-                _db, urn)
-        except ValueError, e:
-            return (INVALID_URN.status_code, INVALID_URN.detail)
-
-        if not must_support_metadata:
-            return identifier
-
-        # We support any identifier that can support a metadata
-        # lookup.
-        if DataSource.metadata_sources_for(_db, identifier):
-            return identifier
-
-        # Failing that, we support any identifier that can support a
-        # license pool.
-        source = DataSource.license_sources_for(_db, identifier)
-        if source.count() > 0:
-            return identifier
-
-        return (400, self.UNRESOLVABLE_URN)
-
-    def process_urn(self, urn, collection=None):
-        """Turn a URN into a Work suitable for use in an OPDS feed.
-
-        :return: If a Work is found, the return value is None.
-        Otherwise a 2-tuple (status, message) is returned explaining why
-        no work was found.
-        """
-        identifier = self.parse_urn(self._db, urn, True)
-        if not isinstance(identifier, Identifier):
-            # Error.
-            self.messages_by_urn[urn] = identifier
-            return
-
-        if collection:
-            collection.catalog_identifier(self._db, identifier)
-
-        if identifier.licensed_through:
-            # There is a LicensePool for this identifier!
-            work = identifier.licensed_through.work
-            if work:
-                # And there's a Work! Is it presentation ready?
-                if work.presentation_ready:
-                    # It's ready for use in an OPDS feed!
-                    self.works.append((identifier, work))
-                    return
-                else:
-                    self.messages_by_urn[urn] = (202, self.WORK_NOT_PRESENTATION_READY)
-                    return
-            else:
-                # There is a LicensePool but no Work. 
-                self.messages_by_urn[urn] = (202, self.WORK_NOT_CREATED)
-                return
-
-        # This identifier has yet to be resolved into a LicensePool. Or maybe
-        # the best we can do is metadata lookups.
-        if not self.can_resolve_identifiers:
-            # This app can't resolve identifiers, so the best thing to
-            # do is to treat this identifier as a 404 error.
-            #
-            # TODO: We should delete the original Identifier object as it
-            # is not properly part of the dataset and never will be.
-            self.messages_by_urn[urn] = (404, self.UNRECOGNIZED_IDENTIFIER)
-            return
-
-        license_sources = DataSource.license_sources_for(
-            self._db, identifier)
-        if identifier.type != Identifier.ISBN and license_sources.count():
-            self.messages_by_urn[urn] = self.register_identifier_as_unresolved(identifier)
-            return
-        else:
-            entry = self.make_opds_entry_from_metadata_lookups(identifier)
-            if isinstance(entry, tuple):
-                # Alleged 'entry' is actually a message
-                self.messages_by_urn[urn] = entry
-                return
-            else:
-                self.precomposed_entries.append(entry)
-                return
-
-    def register_identifier_as_unresolved(self, identifier):
-        # This identifier could have a LicensePool associated with
-        # it. If this application is capable of resolving identifiers,
-        # then create or retrieve an UnresolvedIdentifier object for
-        # it.
-        unresolved_identifier, is_new = UnresolvedIdentifier.register(
-            self._db, identifier)
-        self.unresolved_identifiers.append(unresolved_identifier)
-        if is_new:
-            # We just found out about this identifier, or rather,
-            # we just found out that someone expects it to be associated
-            # with a LicensePool.
-            return (201, self.IDENTIFIER_REGISTERED)
-        else:
-            # There is a pending attempt to resolve this identifier.
-            message = (unresolved_identifier.exception 
-                           or self.WORKING_TO_RESOLVE_IDENTIFIER)
-            return (unresolved_identifier.status, message)
-
-    def make_opds_entry_from_metadata_lookups(self, identifier):
-        """This identifier cannot be resolved into a LicensePool,
-        but maybe we can make an OPDS entry based on metadata
-        lookups.
-        """
-
-        # We can only create an OPDS entry if all the lookups have
-        # in fact been done.
-        metadata_sources = DataSource.metadata_sources_for(
-            self._db, identifier)
-        q = self._db.query(
-            CoverageRecord).filter(
-                CoverageRecord.identifier==identifier).filter(
-                    CoverageRecord.data_source_id.in_(
-                        [x.id for x in metadata_sources]))
-        coverage_records = q.all()
-        unaccounted_for = set(metadata_sources)
-        for r in coverage_records:
-            if r.data_source in unaccounted_for:
-                unaccounted_for.remove(r.data_source)
-
-        if unaccounted_for:
-            # At least one metadata lookup has not successfully
-            # completed.
-            names = [x.name for x in unaccounted_for]
-            logging.info(
-                "Cannot build metadata-based OPDS feed for %r: missing coverage records for %s",
-                identifier,
-                ", ".join(names)
-            )
-            unresolved_identifier, is_new = UnresolvedIdentifier.register(
-                self._db, identifier)
-            if is_new:
-                # We just found out about this identifier, or rather,
-                # we just found out that someone expects it to be associated
-                # with a LicensePool.
-                return (201, self.IDENTIFIER_REGISTERED)
-            else:
-                # There is a pending attempt to resolve this identifier.
-                message = (unresolved_identifier.exception 
-                           or self.WORKING_TO_RESOLVE_IDENTIFIER)
-                return (unresolved_identifier.status, message)
-        else:
-            # All metadata lookups have completed. Create that OPDS
-            # entry!
-            entry = identifier.opds_entry()
-
-        if entry is None:
-            # This app can't do lookups on an identifier of this
-            # type, so the best thing to do is to treat this
-            # identifier as a 404 error.
-            return (404, self.UNRECOGNIZED_IDENTIFIER)
-
-        # We made it!
-        return entry
-
-    def work_lookup(self, annotator, route_name='lookup',
-                    require_active_licensepool=True, collection=None):
+    def work_lookup(self, annotator, route_name='lookup'):
         """Generate an OPDS feed describing works identified by identifier."""
         urns = flask.request.args.getlist('urn')
 
         this_url = cdn_url_for(route_name, _external=True, urn=urns)
         for urn in urns:
-            self.process_urn(urn, collection=collection)
-
-        # The commit is necessary because we may have registered new
-        # Identifier or UnresolvedIdentifier objects.
-        self._db.commit()
+            self.handle_result(self.process_urn(urn))
+        self.post_lookup_hook()
 
         opds_feed = LookupAcquisitionFeed(
             self._db, "Lookup results", this_url, self.works, annotator,
             messages_by_urn=self.messages_by_urn, 
             precomposed_entries=self.precomposed_entries,
-            require_active_licensepool=require_active_licensepool
         )
         return feed_response(opds_feed)
 
-    def permalink(self, urn, annotator):
-        """Generate an OPDS feed for looking up a single work by identifier."""
-        this_url = cdn_url_for('work', _external=True, urn=urn)
-        self.process_urn(urn)
-
-        # The commit is necessary because we may have registered new
-        # Identifier or UnresolvedIdentifier objects.
-        self._db.commit()
+    def permalink(self, urn, annotator, route_name='work'):
+        """Look up a single identifier and generate an OPDS feed."""
+        this_url = cdn_url_for(route_name, _external=True, urn=urn)
+        self.handle_result(self.process_urn(urn))
+        self.post_lookup_hook()
 
         opds_feed = AcquisitionFeed(
             self._db, urn, this_url, self.works, annotator,
-            messages_by_urn=self.messages_by_urn)
+            messages_by_urn=self.messages_by_urn
+        )
 
         return feed_response(opds_feed)
+    
+    def process_urn(self, urn):
+        """Turn a URN into a Work suitable for use in an OPDS feed.
 
+        """
+        identifier, is_new = Identifier.parse_urn(_db, urn)
+
+        if not identifier:
+            # URN is probably invalid.
+            return self.add_message(urn, 400, self.UNRESOLVABLE_URN)
+
+        if not identifier.licensed_through:
+            # The default URNLookupController cannot look up an
+            # Identifier that has no associated LicensePool.
+            return self.add_message(urn, 404, self.UNRECOGNIZED_IDENTIFIER)
+            
+        # If we get to this point, there is a LicensePool for this
+        # identifier.
+        work = identifier.licensed_through.work
+        if not work:
+            # There is a LicensePool but no Work. 
+            return self.add_message(urn, 202, self.WORK_NOT_CREATED)
+            
+        if not work.presentation_ready:
+            # There is a work but it's not presentation ready.
+            return self.add_message(urn, 202, self.WORK_NOT_PRESENTATION_READY)
+
+        # The work is ready for use in an OPDS feed!
+        return self.add_work(identifier, work)
+
+    def add_work(self, identifier, work):
+        """An identifier lookup succeeded in finding a Work."""
+        self.works.append((identifier, work))
+        
+    def add_entry(self, entry):
+        """An identifier lookup succeeded in creating an OPDS entry."""
+        self.precomposed_entries.append(entry)
+    
+    def add_message(self, urn, status_code, message):
+        """An identifier lookup resulted in the creation of a message."""
+        self.messages_by_urn[urn] = (status_code, message)
+        
+    def post_lookup_hook(self):
+        """Run after looking up a number of Identifiers.
+
+        By default, does nothing.
+        """
+        pass
+            
 
 class ComplaintController(object):
     """A controller to register complaints against objects."""

--- a/app_server.py
+++ b/app_server.py
@@ -244,7 +244,6 @@ class URNLookupController(object):
     """
 
     UNRECOGNIZED_IDENTIFIER = "This work is not in the collection."
-    UNRESOLVABLE_URN = "I don't know how to get metadata for this kind of identifier."
     WORK_NOT_PRESENTATION_READY = "Work created but not yet presentation-ready."
     WORK_NOT_CREATED = "Identifier resolved but work not yet created."
 
@@ -255,14 +254,14 @@ class URNLookupController(object):
         self.precomposed_entries = []
         self.unresolved_identifiers = []
 
-    def work_lookup(self, annotator, route_name='lookup', collection=None,
-                    urns=[]):
+    def work_lookup(self, annotator, route_name='lookup',
+                    urns=[], **process_urn_kwargs):
         """Generate an OPDS feed describing works identified by identifier."""
         urns = flask.request.args.getlist('urn')
 
         this_url = cdn_url_for(route_name, _external=True, urn=urns)
         for urn in urns:
-            self.process_urn(urn, collection)
+            self.process_urn(urn, **process_urn_kwargs)
         self.post_lookup_hook()
 
         opds_feed = LookupAcquisitionFeed(
@@ -289,10 +288,8 @@ class URNLookupController(object):
 
         return feed_response(opds_feed)
     
-    def process_urn(self, urn, collection=None):
+    def process_urn(self, urn, **kwargs):
         """Turn a URN into a Work suitable for use in an OPDS feed.
-
-        :param collection: Not used in this base class.
         """
         try:
             identifier, is_new = Identifier.parse_urn(self._db, urn)

--- a/app_server.py
+++ b/app_server.py
@@ -255,13 +255,14 @@ class URNLookupController(object):
         self.precomposed_entries = []
         self.unresolved_identifiers = []
 
-    def work_lookup(self, annotator, route_name='lookup', urns=[]):
+    def work_lookup(self, annotator, route_name='lookup', collection=None,
+                    urns=[]):
         """Generate an OPDS feed describing works identified by identifier."""
         urns = flask.request.args.getlist('urn')
 
         this_url = cdn_url_for(route_name, _external=True, urn=urns)
         for urn in urns:
-            self.process_urn(urn)
+            self.process_urn(urn, collection)
         self.post_lookup_hook()
 
         opds_feed = LookupAcquisitionFeed(
@@ -288,9 +289,10 @@ class URNLookupController(object):
 
         return feed_response(opds_feed)
     
-    def process_urn(self, urn):
+    def process_urn(self, urn, collection=None):
         """Turn a URN into a Work suitable for use in an OPDS feed.
 
+        :param collection: Not used in this base class.
         """
         try:
             identifier, is_new = Identifier.parse_urn(self._db, urn)

--- a/opds.py
+++ b/opds.py
@@ -1182,3 +1182,93 @@ class LookupAcquisitionFeed(AcquisitionFeed):
                 "I know about this work but can offer no way of fulfilling it."
             )
 
+# Mock annotators for use in unit tests.
+
+class TestAnnotator(Annotator):
+
+    @classmethod
+    def lane_url(cls, lane):
+        if lane and lane.has_visible_sublane():
+            return cls.groups_url(lane)
+        elif lane:
+            return cls.feed_url(lane)
+        else:
+            return ""
+
+    @classmethod
+    def feed_url(cls, lane, facets=None, pagination=None):
+        base = "http://%s/" % lane.url_name
+        sep = '?'
+        if facets:
+            base += sep + facets.query_string
+            sep = '&'
+        if pagination:
+            base += sep + pagination.query_string
+        return base
+
+    @classmethod
+    def search_url(cls, lane, query, pagination):
+        base = "http://search/%s/" % lane.url_name
+        sep = '?'
+        if pagination:
+            base += sep + pagination.query_string
+        return base
+
+    @classmethod
+    def groups_url(cls, lane):
+        if lane:
+            name = lane.name
+        else:
+            name = ""
+        return "http://groups/%s" % name
+
+    @classmethod
+    def default_lane_url(cls):
+        return cls.groups_url(None)
+
+    @classmethod
+    def facet_url(cls, facets):
+        return "http://facet/" + "&".join(
+            ["%s=%s" % (k, v) for k, v in sorted(facets.items())]
+        )
+
+    @classmethod
+    def top_level_title(cls):
+        return "Test Top Level Title"
+
+
+class TestAnnotatorWithGroup(TestAnnotator):
+
+    def __init__(self):
+        self.lanes_by_work = defaultdict(list)
+
+    def group_uri(self, work, license_pool, identifier):
+        lanes = self.lanes_by_work.get(work, None)
+
+        if lanes:
+            lane_name = lanes[0]['lane'].display_name
+            additional_lanes = lanes[1:]
+            if additional_lanes:
+                self.lanes_by_work[work] = additional_lanes
+        else:
+            lane_name = str(work.id)
+        return ("http://group/%s" % lane_name,
+                "Group Title for %s!" % lane_name)
+
+    def group_uri_for_lane(self, lane):
+        if lane:
+            return ("http://groups/%s" % lane.display_name, 
+                    "Groups of %s" % lane.display_name)
+        else:
+            return "http://groups/", "Top-level groups"
+
+    def top_level_title(self):
+        return "Test Top Level Title"
+
+
+class TestUnfulfillableAnnotator(TestAnnotator):
+    """Raise an UnfulfillableWork exception when asked to annotate an entry."""
+
+    @classmethod
+    def annotate_work_entry(self, *args, **kwargs):
+        raise UnfulfillableWork()

--- a/opds.py
+++ b/opds.py
@@ -1154,6 +1154,10 @@ class LookupAcquisitionFeed(AcquisitionFeed):
         use_cache = (active_licensepool == default_licensepool)
 
         error_status = error_message = None
+        if not active_licensepool:
+            error_status = 404
+            error_message = "Identifier not found in collection"
+            
         if (identifier.licensed_through and 
             identifier.licensed_through.work != work):
             error_status = 500

--- a/opds.py
+++ b/opds.py
@@ -64,7 +64,6 @@ class UnfulfillableWork(Exception):
     none of the delivery mechanisms could be mirrored.
     """
 
-
 class Annotator(object):
     """The Annotator knows how to present an OPDS feed in a specific
     application context.
@@ -1136,15 +1135,6 @@ class LookupAcquisitionFeed(AcquisitionFeed):
     which may be different from the identifier used by the Work's
     default LicensePool.
     """
-    def __init__(self, _db, title, url, works, annotator=None,
-                 messages_by_urn={}, precomposed_entries=[],
-                 require_active_licensepool=True):
-        self.require_active_licensepool=require_active_licensepool
-
-        super(LookupAcquisitionFeed, self).__init__(
-            _db, title, url, works, annotator,
-            messages_by_urn, precomposed_entries
-        )
 
     def create_entry(self, work, lane_link):
         """Turn an Identifier and a Work into an entry for an acquisition
@@ -1164,10 +1154,6 @@ class LookupAcquisitionFeed(AcquisitionFeed):
         use_cache = (active_licensepool == default_licensepool)
 
         error_status = error_message = None
-        if self.require_active_licensepool and not active_licensepool:
-            error_status = 404
-            error_message = "Identifier not found in collection"
-        
         if (identifier.licensed_through and 
             identifier.licensed_through.work != work):
             error_status = 500

--- a/testing.py
+++ b/testing.py
@@ -44,6 +44,7 @@ from coverage import (
     CoverageFailure,
     WorkCoverageProvider,
 )
+
 from external_search import DummyExternalSearchIndex
 import mock
 import model

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -15,6 +15,8 @@ from . import (
     DatabaseTest,
 )
 
+from opds import TestAnnotator
+
 from model import (
     Identifier,
     UnresolvedIdentifier,
@@ -38,20 +40,30 @@ from problem_details import (
     INVALID_URN,
 )
 
+from util.opds_writer import OPDSFeed
+
+
 class TestURNLookupController(DatabaseTest):
 
     def setup(self):
         super(TestURNLookupController, self).setup()
         self.controller = URNLookupController(self._db)
 
+    def assert_one_message(self, urn, code, message):
+        """Assert that the given message is the only one in
+        messages_by_urn.
+        """
+        [(u, (c, m))] = self.controller.messages_by_urn.items()
+        eq_(u, urn)
+        eq_(c, code)
+        eq_(m, message)
+        eq_([], self.controller.works)
+        eq_([], self.controller.precomposed_entries)
+        
     def test_process_urn_invalid_urn(self):
         urn = "not even a URN"
         self.controller.process_urn(urn)
-
-        key, (code, message) = self.controller.messages_by_urn.items()
-        eq_(urn, key)
-        eq_(400, code)
-        eq_(INVALID_URN.detail, message)
+        self.assert_one_message(urn, 400, INVALID_URN.detail)
 
     def test_process_urn_unrecognized_identifier(self):
         # Give the controller a URN that, although valid, doesn't
@@ -60,10 +72,9 @@ class TestURNLookupController(DatabaseTest):
         self.controller.process_urn(urn)
 
         # The result is a 404 message.
-        key, (code, message) = self.controller.messages_by_urn.items()
-        eq_(urn, key)
-        eq_(404, code)
-        eq_(self.controller.UNRECOGNIZED_IDENTIFIER, message)
+        self.assert_one_message(
+            urn, 404, self.controller.UNRECOGNIZED_IDENTIFIER
+        )
 
     def test_process_urn_no_license_pool(self):
         # Give the controller a URN that corresponds to an Identifier
@@ -73,40 +84,78 @@ class TestURNLookupController(DatabaseTest):
         self.controller.process_urn(urn)
 
         # The result is a 404 message.
-        key, (code, message) = self.controller.messages_by_urn.items()
-        eq_(urn, key)
-        eq_(404, code)
-        eq_(self.controller.UNRECOGNIZED_IDENTIFIER, message)
+        self.assert_one_message(
+            urn, 404, self.controller.UNRECOGNIZED_IDENTIFIER
+        )
+
+    def test_process_urn_license_pool_but_no_work(self):
+        edition, pool = self._edition(with_license_pool=True)
+        identifier = edition.primary_identifier
+        self.controller.process_urn(identifier.urn)
+        self.assert_one_message(
+            identifier.urn, 202, self.controller.WORK_NOT_CREATED
+        )
+
+    def test_process_urn_work_not_presentation_ready(self):
+        work = self._work(with_license_pool=True)
+        work.presentation_ready = False
+        identifier = work.license_pools[0].identifier
+        self.controller.process_urn(identifier.urn)
+
+        self.assert_one_message(
+            identifier.urn, 202, self.controller.WORK_NOT_PRESENTATION_READY
+        )
         
     def test_process_urn_work_is_presentation_ready(self):
         work = self._work(with_license_pool=True)
         identifier = work.license_pools[0].identifier
         self.controller.process_urn(identifier.urn)
-        eq_(0, len(self.controller.messages_by_urn.keys()))
-        eq_([(work.presentation_edition.primary_identifier, work)], self.controller.works)
+        eq_(0, len(self.controller.messages_by_urn))
+        eq_([(work.presentation_edition.primary_identifier, work)],
+            self.controller.works
+        )
 
-    def test_process_urn_work_is_not_presentation_ready(self):
+    # Set up a mock Flask app for testing the controller methods.
+    app = Flask(__name__)
+    @app.route('/lookup')
+    def lookup(self, urn):
+        pass
+    @app.route('/work')
+    def work(self, urn):
+        pass
+    
+    def test_work_lookup(self):
         work = self._work(with_license_pool=True)
-        work.presentation_ready = False
         identifier = work.license_pools[0].identifier
-        self.controller.process_urn(identifier.urn)
-        eq_(1, len(self.controller.messages_by_urn.keys()))
-        code, message = self.controller.messages_by_urn[identifier.urn]
-        eq_(202, code)
-        eq_(self.controller.WORK_NOT_PRESENTATION_READY, message)
-        eq_([], self.controller.works)
+        annotator = TestAnnotator()
+        with self.app.test_request_context("/?urn=%s" % identifier.urn):
+            response = self.controller.work_lookup(
+                annotator=annotator
+            )
 
-    def test_process_urn_work_not_created_yet(self):
-        edition, pool = self._edition(with_license_pool=True)
-        identifier = edition.primary_identifier
-        self.controller.process_urn(identifier.urn)
-        eq_(1, len(self.controller.messages_by_urn.keys()))
-        code, message = self.controller.messages_by_urn[identifier.urn]
-        eq_(202, code)
-        eq_(self.controller.WORK_NOT_CREATED, message)
-        eq_([], self.controller.works)        
+            # We got an OPDS feed that includes an entry for the work.
+            eq_(200, response.status_code)
+            eq_(OPDSFeed.ACQUISITION_FEED_TYPE,
+                response.headers['Content-Type'])
+            assert identifier.urn in response.data
+            assert work.title in response.data
 
+    def test_permalink(self):
+        work = self._work(with_license_pool=True)
+        work.license_pools[0].open_access = False
+        identifier = work.license_pools[0].identifier
+        annotator = TestAnnotator()
+        with self.app.test_request_context("/?urn=%s" % identifier.urn):
+            response = self.controller.permalink(identifier.urn, annotator)
 
+            # We got an OPDS feed that includes an entry for the work.
+            eq_(200, response.status_code)
+            eq_(OPDSFeed.ACQUISITION_FEED_TYPE,
+                response.headers['Content-Type'])
+            assert identifier.urn in response.data
+            assert work.title in response.data
+        
+        
 class TestComplaintController(DatabaseTest):
     
     def setup(self):

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -42,7 +42,7 @@ class TestURNLookupController(DatabaseTest):
 
     def setup(self):
         super(TestURNLookupController, self).setup()
-        self.controller = URNLookupController(self._db, True)
+        self.controller = URNLookupController(self._db)
 
     def test_process_urn_invalid_urn(self):
         urn = "not even a URN"
@@ -51,37 +51,6 @@ class TestURNLookupController(DatabaseTest):
         code, message = self.controller.messages_by_urn[urn]
         eq_(400, code)
         eq_(INVALID_URN.detail, message)
-
-    def test_process_urn_initial_registration(self):
-        identifier = self._identifier(Identifier.GUTENBERG_ID)
-        self.controller.process_urn(identifier.urn)
-        eq_(1, len(self.controller.messages_by_urn.keys()))
-        code, message = self.controller.messages_by_urn[identifier.urn]
-        eq_(201, code)
-        eq_(URNLookupController.IDENTIFIER_REGISTERED, message)
-        [unresolved] = self.controller.unresolved_identifiers
-        eq_(identifier, unresolved.identifier)
-        eq_(202, unresolved.status)
-
-    def test_process_urn_pending_resolve_attempt(self):
-        identifier = self._identifier(Identifier.GUTENBERG_ID)
-        unresolved, is_new = UnresolvedIdentifier.register(self._db, identifier)
-        self.controller.process_urn(identifier.urn)
-        eq_(1, len(self.controller.messages_by_urn.keys()))
-        code, message = self.controller.messages_by_urn[identifier.urn]
-        eq_(202, code)
-        eq_(URNLookupController.WORKING_TO_RESOLVE_IDENTIFIER, message)
-
-    def test_process_urn_exception_during_resolve_attempt(self):
-        identifier = self._identifier(Identifier.GUTENBERG_ID)
-        unresolved, is_new = UnresolvedIdentifier.register(self._db, identifier)
-        unresolved.status = 500
-        unresolved.exception = "foo"
-        self.controller.process_urn(identifier.urn)
-        eq_(1, len(self.controller.messages_by_urn.keys()))
-        code, message = self.controller.messages_by_urn[identifier.urn]
-        eq_(500, code)
-        eq_("foo", message)
 
     def test_process_urn_work_is_presentation_ready(self):
         work = self._work(with_license_pool=True)
@@ -112,39 +81,16 @@ class TestURNLookupController(DatabaseTest):
         eq_([], self.controller.works)        
 
     def test_process_urn_unrecognized_identifier(self):
-        # Create a controller that just doesn't resolve identifiers.
-        controller = URNLookupController(self._db, False)
-
-        # Give it an identifier it doesn't recognize.
+        # Give the controller a URN that, although valid, doesn't
+        # correspond to any Identifier in the database.
         urn = Identifier.URN_SCHEME_PREFIX + 'Gutenberg%20ID/30000000'
-        controller.process_urn(urn)
+        self.controller.process_urn(urn)
         eq_(1, len(controller.messages_by_urn.keys()))
+
+        # The result is a 404 message.
         code, message = controller.messages_by_urn[urn]
-
-        # Instead of creating a resolution task, it simply rejects the
-        # input.
         eq_(404, code)
-        eq_(controller.UNRECOGNIZED_IDENTIFIER, message)
-
-    def test_process_urn_with_collection(self):
-        collection = self._collection()
-        i1 = self._identifier()
-        i2 = self._identifier()
-
-        eq_([], collection.catalog)
-        self.controller.process_urn(i1.urn, collection=collection)
-        eq_(1, len(collection.catalog))
-        eq_([i1], collection.catalog)
-
-        # Adds new identifiers to an existing catalog
-        self.controller.process_urn(i2.urn, collection=collection)
-        eq_(2, len(collection.catalog))
-        eq_([i1, i2], collection.catalog)
-
-        # Does not duplicate identifiers in the catalog
-        self.controller.process_urn(i1.urn, collection=collection)
-        eq_(2, len(collection.catalog))
-        eq_([i1, i2], collection.catalog)
+        eq_(self.controller.UNRECOGNIZED_IDENTIFIER, message)
 
 
 class TestComplaintController(DatabaseTest):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1219,18 +1219,8 @@ class TestLookupAcquisitionFeed(DatabaseTest):
 
         # By default, a work is treated as 'not in the collection' if
         # there is no LicensePool for it.
-        eq_(True, feed.require_active_licensepool)
         assert "Identifier not found in collection" in entry
         assert work.title not in entry
-
-        # But if the LookupAcquisitionFeed is set up to allow a lookup
-        # even in the absense of a LicensePool (as might happen in the
-        # metadata wrangler), the same lookup succeeds.
-        feed, entry = self.entry(
-            identifier, work, require_active_licensepool = False
-        )
-        assert 'simplified:status_code' not in entry
-        assert work.title in entry
 
     def test_unfilfullable_work(self):
         work = self._work(with_open_access_download=True)


### PR DESCRIPTION
This branch removes a lot of the complex code in URNLookupController, leaving only a controller that can create an OPDS entry based on an Identifier if it can associate that Identifier with a presentation-ready Work. This is the lookup code used by circulation and content. All the complicated code is specific to the metadata wrangler, and I've created a separate class for the metadata wrangler's URNLookupController, which will go in a metadata branch.