### PR TITLE
Convert entity-body and headers from Unicode to UTF-8 before going over the wire, to avoid triggering SSL bugs.

### DIFF
--- a/util/http.py
+++ b/util/http.py
@@ -159,6 +159,22 @@ class HTTP(object):
 
         if not 'timeout' in kwargs:
             kwargs['timeout'] = 20
+
+        # Unicode data can't be sent over the wire. Convert it
+        # to UTF-8.
+        if 'data' in kwargs and isinstance(kwargs['data'], unicode):
+            kwargs['data'] = kwargs.get('data').encode("utf8")
+        if 'headers' in kwargs:
+            headers = kwargs['headers']
+            new_headers = {}
+            for k, v in headers.items():
+                if isinstance(k, unicode):
+                    k = k.encode("utf8")
+                if isinstance(v, unicode):
+                    v = v.encode("utf8")
+                new_headers[k] = v
+            kwargs['headers'] = new_headers
+
         try:
             response = m(*args, **kwargs)
         except requests.exceptions.Timeout, e:


### PR DESCRIPTION
This branch fixes https://github.com/NYPL-Simplified/circulation/issues/338.

One thing this doesn't fix is the URL. It's still possible for a Unicode URL to get into the system and cause the error. I couldn't fix this easily because of the weird way the URL becomes part of `*args` within the HTTP wrapper method. I considered iterating over `*args` and converting all the Unicode to bytestrings, and I'm happy to make that change if you think it's smart.