### PR TITLE
Commit the database session after processing every batch.

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -165,7 +165,6 @@ class BaseCoverageProvider(object):
             transient_failures += t
             persistent_failures += p
             records += r
-            self._db.commit()
             index += self.batch_size
         return (successes, transient_failures, persistent_failures), records
 
@@ -321,9 +320,10 @@ class BaseCoverageProvider(object):
         """Do whatever is necessary to complete this batch before moving on to
         the next one.
         
-        e.g. uploading a bunch of assets to S3.
+        e.g. committing the database session or uploading a bunch of
+        assets to S3.
         """
-        pass
+        self._db.commit()
 
     #
     # Subclasses must implement these virtual methods.

--- a/model.py
+++ b/model.py
@@ -3594,12 +3594,13 @@ class Work(Base):
 
         if changed or policy.regenerate_opds_entries:
             self.calculate_opds_entries()
+            changed = True
 
         if changed or policy.update_search_index:
             # Ensure new changes are reflected in database queries
             _db = Session.object_session(self)
             _db.flush()
-
+            changed = True
             self.update_external_index(search_index_client)
 
         # Now that everything's calculated, print it out.

--- a/model.py
+++ b/model.py
@@ -3594,13 +3594,11 @@ class Work(Base):
 
         if changed or policy.regenerate_opds_entries:
             self.calculate_opds_entries()
-            changed = True
 
         if changed or policy.update_search_index:
             # Ensure new changes are reflected in database queries
             _db = Session.object_session(self)
             _db.flush()
-            changed = True
             self.update_external_index(search_index_client)
 
         # Now that everything's calculated, print it out.


### PR DESCRIPTION
This branch creates a default implementation of `CoverageProvider.finalize_batch` that commits the database session. Without this, a script that needs to create a lot of coverage records will tie up big chunks of the database, potentially causing deadlocks, and if it crashes it will have to start from scratch.

Only one CoverageProvider in our code subclasses `finalize_batch`: `MetadataWranglerCollectionReaper` in circulation. I'll be putting up a circulation branch that makes it call the superclass implementation.

I wasn't able to add a test for this because the difference between the uncommitted session and the actual state of the database are only visible from a second database session. 