### PR TITLE
Dont put opds message in entry

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -33,6 +33,15 @@ class CoverageFailure(object):
         self.exception = exception
         self.transient = transient
 
+    def __repr__(self):
+        if self.data_source:
+            data_source = self.data_source.name
+        else:
+            data_source = None
+        return "<CoverageFailure: obj=%r data_source=%r transient=%r exception=%r>" % (
+            self.obj, data_source, self.transient, self.exception
+        )
+
     def to_coverage_record(self, operation=None):
         """Convert this failure into a CoverageRecord."""
         if not self.data_source:

--- a/model.py
+++ b/model.py
@@ -1264,6 +1264,8 @@ class Identifier(Base):
                        autocreate=True):
         """Turn a foreign ID into an Identifier."""
 
+        if not foreign_identifier_type or not foreign_id:
+            return None
         if foreign_identifier_type in (
                 Identifier.OVERDRIVE_ID, Identifier.THREEM_ID):
             foreign_id = foreign_id.lower()
@@ -1301,7 +1303,7 @@ class Identifier(Base):
     @classmethod
     def type_and_identifier_for_urn(cls, identifier_string):
         if not identifier_string:
-            return None
+            return None, None
         m = cls.GUTENBERG_URN_SCHEME_RE.match(identifier_string)
         if m:
             type = Identifier.GUTENBERG_ID

--- a/opds.py
+++ b/opds.py
@@ -633,7 +633,7 @@ class AcquisitionFeed(OPDSFeed):
 
 
     def __init__(self, _db, title, url, works, annotator=None,
-                 messages=[], precomposed_entries=[]):
+                 precomposed_entries=[]):
         """Turn a list of works, messages, and precomposed <opds> entries
         into a feed.
         """
@@ -643,16 +643,14 @@ class AcquisitionFeed(OPDSFeed):
 
         super(AcquisitionFeed, self).__init__(title, url)
 
-        # Add minimal entries for the messages.
-        for message in messages:
-            self.feed.append(message.tag)
-
         lane_link = dict(rel="collection", href=url)
         for work in works:
             self.add_entry(work, lane_link)
 
-        # Add the precomposed entries.
+        # Add the precomposed entries and the messages.
         for entry in precomposed_entries:
+            if isinstance(entry, OPDSMessage):
+                entry = entry.tag
             self.feed.append(entry)
 
     def add_entry(self, work, lane_link):

--- a/opds.py
+++ b/opds.py
@@ -51,7 +51,7 @@ from lane import (
 from util.opds_writer import (
     AtomFeed,
     OPDSFeed, 
-    SimplifiedMessage,
+    OPDSMessage,
 )
 from util.cdn import cdnify
 
@@ -614,7 +614,7 @@ class AcquisitionFeed(OPDSFeed):
     @classmethod
     def error_message(cls, identifier, error_status, error_message):
         """Create a minimal OPDS entry for an error message."""
-        return SimplifiedMessage(identifier.urn, error_status, error_message)
+        return OPDSMessage(identifier.urn, error_status, error_message)
 
     @classmethod
     def facet_links(self, annotator, facets):
@@ -661,7 +661,7 @@ class AcquisitionFeed(OPDSFeed):
         """
         entry = self.create_entry(work, lane_link)
         if entry is not None:
-            if isinstance(entry, SimplifiedMessage):
+            if isinstance(entry, OPDSMessage):
                 entry = entry.tag
             self.feed.append(entry)
         return entry

--- a/opds.py
+++ b/opds.py
@@ -613,7 +613,9 @@ class AcquisitionFeed(OPDSFeed):
 
     @classmethod
     def error_message(cls, identifier, error_status, error_message):
-        """Create a minimal OPDS entry for an error message."""
+        """Turn an error result into an OPDSMessage suitable for
+        adding to a feed.
+        """
         return OPDSMessage(identifier.urn, error_status, error_message)
 
     @classmethod

--- a/tests/files/opds/content_server_mini.opds
+++ b/tests/files/opds/content_server_mini.opds
@@ -54,11 +54,11 @@
     <link href="http://www.gutenberg.org/ebooks/10557.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
 
-  <entry>
+  <simplified:message>
    <id>http://www.gutenberg.org/ebooks/1984</id>
    <simplified:status_code>202</simplified:status_code>
-   <simplified:message>I'm working to locate a source for this identifier.</simplified:message>
-  </entry>
+   <schema:description>I'm working to locate a source for this identifier.</schema:description>
+  </simplified:message>
 
   <link href="http://localhost:5000/?after=327&amp;size=100" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="next"/>
 </feed>

--- a/tests/files/opds/unrecognized_identifier.opds
+++ b/tests/files/opds/unrecognized_identifier.opds
@@ -1,12 +1,12 @@
-<feed xmlns:simplified="http://library-simplified.com/terms/" xmlns:app="http://www.w3.org/2007/app" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom">
+<feed xmlns:simplified="http://librarysimplified.org/terms/" xmlns:app="http://www.w3.org/2007/app" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom">
   <id>http://localhost:5000/lookup?urn=urn%3Alibrarysimplified.org%2Fterms%2Fid%2FGutenberg+ID%2F100</id>
   <title>Lookup results</title>
   <updated>2015-01-08T14:55:59Z</updated>
   <link href="http://localhost:5000/lookup?urn=urn%3Alibrarysimplified.org%2Fterms%2Fid%2FGutenberg+ID%2F100"/>
   <link href="http://localhost:5000/lookup?urn=urn%3Alibrarysimplified.org%2Fterms%2Fid%2FGutenberg+ID%2F100" rel="self"/>
-  <entry>
+  <simplified:message>
     <id>urn:librarysimplified.org/terms/id/Gutenberg ID/100</id>
     <simplified:status_code>404</simplified:status_code>
-    <simplified:message>I've never heard of this work.</simplified:message>
-  </entry>
+    <schema:description>I've never heard of this work.</schema:description>
+  </simplified:message>
 </feed>

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -137,6 +137,9 @@ class TestIdentifier(DatabaseTest):
         eq_(identifier, identifier2)
         eq_(False, was_new)
 
+        # If we pass in no data we get nothing back.
+        eq_(None, Identifier.for_foreign_id(self._db, None, None))
+        
     def test_for_foreign_id_without_autocreate(self):
         identifier_type = Identifier.ISBN
         isbn = self._str
@@ -232,6 +235,9 @@ class TestIdentifier(DatabaseTest):
         # An invalid ISBN raises an exception.
         assert_raises(ValueError, Identifier.parse_urn, self._db, "urn:isbn:notanisbn")
 
+        # Pass in None and you get None.
+        eq_(None, Identifier.parse_urn(self._db, None))
+        
     def parse_urn_must_support_license_pools(self):
         # We have no way of associating ISBNs with license pools.
         # If we try to parse an ISBN URN in a context that only accepts

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1089,6 +1089,11 @@ class TestAcquisitionFeed(DatabaseTest):
         entry = feed.create_entry(work, self._url)
         eq_(None, entry)
 
+    def test_render_messages(self):
+        by_urn = { "urn1" : (201, "message1")}
+        [m1] = list(AcquisitionFeed.render_messages(by_urn))
+        eq_("", etree.tostring(m1))
+        
     def test_cache_usage(self):
         work = self._work(with_open_access_download=True)
         feed = AcquisitionFeed(

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -52,8 +52,9 @@ from opds import (
 )
 
 from util.opds_writer import (    
-     AtomFeed,
-     OPDSFeed,
+    AtomFeed,
+    OPDSFeed,
+    SimplifiedMessage,
 )
 
 from classifier import (
@@ -700,17 +701,19 @@ class TestOPDS(DatabaseTest):
         # the non-open-access book--and two error messages--the book with
         # no license pool and the book but with no download.
         works = self._db.query(Work)
-        by_title = AcquisitionFeed(self._db, "test", "url", works)
-        by_title = feedparser.parse(unicode(by_title))
+        by_title_feed = AcquisitionFeed(self._db, "test", "url", works)
+        by_title_raw = unicode(by_title_feed)
+        by_title = feedparser.parse(by_title_raw)
 
-        eq_(4, len(by_title['entries']))
+        # We have two entries...
+        eq_(2, len(by_title['entries']))
         eq_(["not open access", "open access"], sorted(
-            [x['title'] for x in by_title['entries'] if 'title' in x]))
+            [x['title'] for x in by_title['entries']]))
 
-        errors = [x['simplified_message'] for x in by_title['entries']
-                  if 'title' not in x]
-        expect = [u"I've heard about this work but have no active licenses for it."] * 2
-        eq_(expect, errors)
+        # ...and two messages.
+        eq_(2,
+            by_title_raw.count("I've heard about this work but have no active licenses for it.")
+        )
 
     def test_acquisition_feed_includes_image_links(self):
         lane=self.lanes.by_languages['']['Fantasy']
@@ -747,19 +750,17 @@ class TestOPDS(DatabaseTest):
         """Test the ability to include messages (with HTTP-style status code)
         for a given URI in lieu of a proper ODPS entry.
         """
-        messages = { "urn:foo" : (400, _("msg1")),
-                     "urn:bar" : (500, _("msg2"))}
+        messages = [
+            SimplifiedMessage("urn:foo", 400, _("msg1")),
+            SimplifiedMessage("urn:bar", 500, _("msg2")),
+        ]
         feed = AcquisitionFeed(self._db, "test", "http://the-url.com/",
-                               [], messages_by_urn=messages)
-        parsed = feedparser.parse(unicode(feed))
-        bar, foo = sorted(parsed['entries'], key = lambda x: x['id'])
-        eq_("urn:foo", foo['id'])
-        eq_("msg1", foo['simplified_message'])
-        eq_("400", foo['simplified_status_code'])
-
-        eq_("urn:bar", bar['id'])
-        eq_("msg2", bar['simplified_message'])
-        eq_("500", bar['simplified_status_code'])
+                               [], messages=messages)
+        feed = unicode(feed)
+        for m in messages:
+            assert m.urn in feed
+            assert str(m.status_code) in feed
+            assert str(m.message) in feed
 
 
     def test_page_feed(self):
@@ -1074,7 +1075,7 @@ class TestAcquisitionFeed(DatabaseTest):
             403,
             "I've heard about this work but have no active licenses for it.",
         )
-        eq_(etree.tostring(expect), etree.tostring(entry))
+        eq_(expect, entry)
 
     def test_error_when_work_has_no_presentation_edition(self):
         """We cannot create an OPDS entry (or even an error message) for a
@@ -1088,11 +1089,6 @@ class TestAcquisitionFeed(DatabaseTest):
         )
         entry = feed.create_entry(work, self._url)
         eq_(None, entry)
-
-    def test_render_messages(self):
-        by_urn = { "urn1" : (201, "message1")}
-        [m1] = list(AcquisitionFeed.render_messages(by_urn))
-        eq_("", etree.tostring(m1))
         
     def test_cache_usage(self):
         work = self._work(with_open_access_download=True)
@@ -1148,7 +1144,7 @@ class TestAcquisitionFeed(DatabaseTest):
             pool.identifier, 403, 
             "I know about this work but can offer no way of fulfilling it."
         )
-        assert etree.tostring(expect) in etree.tostring(entry)
+        eq_(expect, entry)
 
     def test_format_types(self):
         epub_no_drm, ignore = DeliveryMechanism.lookup(
@@ -1175,6 +1171,8 @@ class TestLookupAcquisitionFeed(DatabaseTest):
             annotator=annotator, **kwargs
         )
         entry = feed.create_entry((identifier, work), u"http://lane/")
+        if isinstance(entry, SimplifiedMessage):
+            return feed, entry
         if entry:
             entry = etree.tostring(entry)
         return feed, entry
@@ -1215,21 +1213,24 @@ class TestLookupAcquisitionFeed(DatabaseTest):
         feed, entry = self.entry(identifier, work)
 
         # We were not successful at creating an <entry> for this
-        # lookup.
-        expect_status = '<simplified:status_code>404'
-        expect_message = '<simplified:message>Identifier not found in collection'
-        assert expect_status in entry
-        assert expect_message in entry
+        # lookup. We got a SimplifiedMessage instead of an entry
+        eq_(entry,
+            SimplifiedMessage(identifier.urn, 404,
+                              "Identifier not found in collection")
+        )
 
         # We also get an error if we use an Identifier that is
         # associated with a LicensePool, but that LicensePool is not
         # associated with the Work.
         edition, lp = self._edition(with_license_pool=True)
-        feed, entry = self.entry(lp.identifier, work)
-        expect_status = '<simplified:status_code>500'
-        expect_message = '<simplified:message>I tried to generate an OPDS entry for the identifier "%s" using a Work not associated with that identifier.'
-        assert expect_status in entry
-        assert (expect_message % lp.identifier.urn) in entry
+        identifier = lp.identifier
+        feed, entry = self.entry(identifier, work)
+        eq_(entry,
+            SimplifiedMessage(
+                identifier.urn, 500,
+                'I tried to generate an OPDS entry for the identifier "%s" using a Work not associated with that identifier.' % identifier.urn
+            )
+        )
 
     def test_error_when_work_has_no_licensepool(self):
         """Under most circumstances, a Work must have at least one
@@ -1243,8 +1244,9 @@ class TestLookupAcquisitionFeed(DatabaseTest):
 
         # By default, a work is treated as 'not in the collection' if
         # there is no LicensePool for it.
-        assert "Identifier not found in collection" in entry
-        assert work.title not in entry
+        isinstance(entry, SimplifiedMessage)
+        eq_(404, entry.status_code)
+        eq_("Identifier not found in collection", entry.message)
 
     def test_unfilfullable_work(self):
         work = self._work(with_open_access_download=True)
@@ -1255,4 +1257,19 @@ class TestLookupAcquisitionFeed(DatabaseTest):
             pool.identifier, 403, 
             "I know about this work but can offer no way of fulfilling it."
         )
-        assert etree.tostring(expect) in entry
+        eq_(expect, entry)
+
+
+class TestSimplifiedMessage(object):
+
+    def test_xml_rendering(self):
+        """Test that a SimplifiedMessage renders to a reasonable
+        XML representation.
+        """
+        message = SimplifiedMessage("urn:foo", 404, "Not found")
+        tag = message.tag
+        xml = etree.tostring(tag)
+        assert tag.tag.endswith('message')
+        assert '<simplified:identifier>urn:foo</simplified:identifier>' in xml
+        assert '<simplified:status_code>404</simplified:status_code>' in xml
+        assert '<schema:description>Not found</schema:description>' in xml

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -948,17 +948,8 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
 
 class TestOPDSImportMonitor(OPDSImporterTest):
 
-    def setup(self):
-        super(TestOPDSImportMonitor, self).setup()
-        feed = self.content_server_mini_feed
-        # Remove the last entry, since it's a message and will always be new.
-        last_entry_start = feed.rfind('<entry>')
-        last_entry_end = feed.rfind('</entry>') + len('</entry>')
-        self.content_server_mini_feed_without_message = feed[0:last_entry_start] + feed[last_entry_end:]
-
-
     def test_check_for_new_data(self):
-        feed = self.content_server_mini_feed_without_message
+        feed = self.content_server_mini_feed
 
         class MockOPDSImportMonitor(OPDSImportMonitor):
             def _get(self, url, headers):
@@ -1029,7 +1020,7 @@ class TestOPDSImportMonitor(OPDSImporterTest):
 
     def test_follow_one_link(self):
         monitor = OPDSImportMonitor(self._db, "http://url", DataSource.OA_CONTENT_SERVER, OPDSImporter)
-        feed = self.content_server_mini_feed_without_message
+        feed = self.content_server_mini_feed
 
         # If there's new data, follow_one_link extracts the next links.
 

--- a/tests/test_util_opds_writer.py
+++ b/tests/test_util_opds_writer.py
@@ -37,8 +37,7 @@ class TestOPDSMessage(object):
         assert 'xmlns:simplified="http://librarysimplified.org/terms/"' in text
 
         # Verify that the tags we want are in place.
-        assert '<simplified:identifier>urn</simplified:identifier>' in text
-        
+        assert '<id>urn</id>' in text
         assert '<simplified:status_code>200</simplified:status_code>' in text
         assert '<schema:description>message</schema:description>' in text
         assert text.endswith('</simplified:message>')

--- a/tests/test_util_opds_writer.py
+++ b/tests/test_util_opds_writer.py
@@ -1,0 +1,44 @@
+import re
+from nose.tools import (
+    eq_,
+    set_trace
+)
+from lxml import etree
+from util.opds_writer import (
+    OPDSMessage
+)
+
+
+class TestOPDSMessage(object):
+
+    def test_equality(self):
+        
+        a = OPDSMessage("urn", 200, "message")
+        eq_(a,a)
+        assert a != None
+        assert a != "message"
+
+        eq_(a, OPDSMessage("urn", 200, "message"))
+        assert a != OPDSMessage("urn2", 200, "message")
+        assert a != OPDSMessage("urn", 201, "message")
+        assert a != OPDSMessage("urn", 200, "message2")
+
+    def test_tag(self):
+        """Verify that an OPDSMessage becomes a reasonable XML tag."""
+        a = OPDSMessage("urn", 200, "message")
+        text = etree.tostring(a.tag)
+        eq_(text, str(a))
+        
+        # Verify that we start with a simplified:message tag.
+        assert text.startswith('<simplified:message')
+
+        # Verify that the namespaces we need are in place.
+        assert 'xmlns:schema="http://schema.org/"' in text
+        assert 'xmlns:simplified="http://librarysimplified.org/terms/"' in text
+
+        # Verify that the tags we want are in place.
+        assert '<simplified:identifier>urn</simplified:identifier>' in text
+        
+        assert '<simplified:status_code>200</simplified:status_code>' in text
+        assert '<schema:description>message</schema:description>' in text
+        assert text.endswith('</simplified:message>')

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -162,8 +162,8 @@ class OPDSFeed(AtomFeed):
         super(OPDSFeed, self).__init__(title, url)
 
 
-class SimplifiedMessage(object):
-    """An indication that an <entry> could not be created for an 
+class OPDSMessage(object):
+    """An indication that an <entry> could not be created for an
     identifier.
 
     Inserted into an OPDS feed as an extension tag.
@@ -184,7 +184,7 @@ class SimplifiedMessage(object):
         if self is other:
             return True
 
-        if not isinstance(other, SimplifiedMessage):
+        if not isinstance(other, OPDSMessage):
             return False
 
         if (self.urn != other.urn or self.status_code != other.status_code

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -194,7 +194,6 @@ class OPDSMessage(object):
         
     @property
     def tag(self):
-        ns = AtomFeed.SIMPLIFIED_NS
         message_tag = AtomFeed.SIMPLIFIED.message()
         identifier_tag = AtomFeed.E.id()
         identifier_tag.text = self.urn

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -161,6 +161,9 @@ class OPDSFeed(AtomFeed):
         super(OPDSFeed, self).__init__(title, url)
 
 
+class SimplifiedStatusMessage(object):
+    """An indicator that an <entry> could not be created for an 
+    identifier.
+    """
 
-
-
+    def __init__(self, identifier, status_code, message):

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -196,7 +196,7 @@ class OPDSMessage(object):
     def tag(self):
         ns = AtomFeed.SIMPLIFIED_NS
         message_tag = AtomFeed.SIMPLIFIED.message()
-        identifier_tag = AtomFeed.SIMPLIFIED.identifier()
+        identifier_tag = AtomFeed.E.id()
         identifier_tag.text = self.urn
         message_tag.append(identifier_tag)
 

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -171,6 +171,8 @@ class OPDSMessage(object):
 
     def __init__(self, urn, status_code, message):
         self.urn = urn
+        if status_code:
+            status_code = int(status_code)
         self.status_code = status_code
         self.message = message
 


### PR DESCRIPTION
This branch fixes https://github.com/NYPL-Simplified/server_core/issues/371

This branch stops overloading the OPDS `<entry>` tag to convey error statuses. Instead we use a new tag, `<simplified:message>`. The only current purpose of these messages is in OPDS import processes to convey error conditions; I changed opds_import.py to manage this.