### PR TITLE
Handle connection timeout errors during bulk search index update.

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -1,7 +1,6 @@
 from nose.tools import set_trace
 from elasticsearch import Elasticsearch
 from elasticsearch.helpers import bulk as elasticsearch_bulk
-from elasticsearch.exceptions import ConnectionTimeout
 from config import Configuration
 from classifier import (
     KeywordBasedClassifier,

--- a/external_search.py
+++ b/external_search.py
@@ -1,6 +1,7 @@
 from nose.tools import set_trace
 from elasticsearch import Elasticsearch
 from elasticsearch.helpers import bulk as elasticsearch_bulk
+from elasticsearch.exceptions import ConnectionTimeout
 from config import Configuration
 from classifier import (
     KeywordBasedClassifier,
@@ -454,7 +455,7 @@ class ExternalSearchIndex(object):
         else:
             return {}
 
-    def bulk_update(self, works):
+    def bulk_update(self, works, retry_on_batch_failure=True):
         """Upload a batch of works to the search index at once."""
 
         from model import Work
@@ -473,6 +474,11 @@ class ExternalSearchIndex(object):
             raise_on_exception=False,
         )
 
+        # If the entire update failed, try it one more time before giving up on the batch.
+        if retry_on_batch_failure and len(errors) == len(docs):
+            self.log.info("Elasticsearch bulk update timed out, trying again.")
+            return self.bulk_update(works, retry_on_batch_failure=False)
+
         time3 = time.time()
         self.log.info("Created %i search documents in %.2f seconds" % (len(docs), time2 - time1))
         self.log.info("Uploaded %i search documents in  %.2f seconds" % (len(docs), time3 - time2))
@@ -482,8 +488,12 @@ class ExternalSearchIndex(object):
         # We weren't able to create search documents for these works, maybe
         # because they don't have presentation editions yet.
         missing_works = [work for work in works if work.id not in doc_ids]
-
-        error_ids = [error['data']["_id"] for error in errors]
+            
+        error_ids = [
+            error.get('data', {}).get("_id", None) or
+            error.get('index', {}).get('_id', None)
+            for error in errors
+        ]
 
         successes = [work for work in works if work.id in doc_ids and work.id not in error_ids]
 
@@ -495,9 +505,18 @@ class ExternalSearchIndex(object):
                 failures.append((work, "Work not indexed"))
 
         for error in errors:
-            work = [work for work in works if work.id == error['data']['_id']][0]
+            error_id = error.get('data', {}).get('_id', None) or error.get('index', {}).get('_id', None)
+
+            work = None
+            works_with_error = [work for work in works if work.id == error_id]
+            if works_with_error:
+                work = works_with_error[0]
+
             exception = error.get('exception', None)
             error_message = error.get('error', None)
+            if not error_message:
+                error_message = error.get('index', {}).get('error', None)
+
             failures.append((work, error_message))
 
         self.log.info("Successfully indexed %i documents, failed to index %i." % (success_count, len(failures)))

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -818,7 +818,7 @@ class TestSearchErrors(DatabaseTest):
         def bulk_with_timeout(docs, raise_on_error=False, raise_on_exception=False):
             attempts.append(docs)
             def error(doc):
-                return dict(index=dict(status='TIMEOUT', 
+                return dict(index=dict(status='TIMEOUT',
                                        exception='ConnectionTimeout',
                                        error='Connection Timeout!',
                                        _id=doc['_id'],
@@ -841,15 +841,16 @@ class TestSearchErrors(DatabaseTest):
         eq_([work.id, work.id],
             [docs[0]['_id'] for docs in attempts])
 
-    def search_single_document_error(self):
+    def test_search_single_document_error(self):
         successful_work = self._work()
         failing_work = self._work()
         
         def bulk_with_error(docs, raise_on_error=False, raise_on_exception=False):
-            failure = ([doc for doc in docs if doc['_id'] == failing_work.id][0], "Error!")
+            failures = [dict(data=dict(_id=failing_work.id),
+                             error="There was an error!",
+                             exception="Exception")]
             success_count = 1
-            return success_count
-
+            return success_count, failures
         search = ExternalSearchIndex()
         search.bulk = bulk_with_error
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -810,3 +810,51 @@ class TestSearchFilterFromLane(DatabaseTest):
         assert 'terms' in exclude_languages_filter['not']
         assert 'language' in exclude_languages_filter['not']['terms']
         eq_(expect_exclude_languages, sorted(exclude_languages_filter['not']['terms']['language']))
+
+class TestSearchErrors(DatabaseTest):
+    def test_search_connection_timeout(self):
+        attempts = []
+
+        def bulk_with_timeout(docs, raise_on_error=False, raise_on_exception=False):
+            attempts.append(docs)
+            def error(doc):
+                return dict(index=dict(status='TIMEOUT', 
+                                       exception='ConnectionTimeout',
+                                       error='Connection Timeout!',
+                                       _id=doc['_id'],
+                                       data=doc))
+
+            errors = map(error, docs)
+            return 0, errors
+
+        search = ExternalSearchIndex()
+        search.bulk = bulk_with_timeout
+        
+        work = self._work()
+        successes, failures = search.bulk_update([work])
+        eq_([], successes)
+        eq_(1, len(failures))
+        eq_(work, failures[0][0])
+        eq_("Connection Timeout!", failures[0][1])
+
+        # When all the documents fail, it tries again once with the same arguments.
+        eq_([work.id, work.id],
+            [docs[0]['_id'] for docs in attempts])
+
+    def search_single_document_error(self):
+        successful_work = self._work()
+        failing_work = self._work()
+        
+        def bulk_with_error(docs, raise_on_error=False, raise_on_exception=False):
+            failure = ([doc for doc in docs if doc['_id'] == failing_work.id][0], "Error!")
+            success_count = 1
+            return success_count
+
+        search = ExternalSearchIndex()
+        search.bulk = bulk_with_error
+
+        successes, failures = search.bulk_update([successful_work, failing_work])
+        eq_([successful_work], successes)
+        eq_(1, len(failures))
+        eq_(failing_work, failures[0][0])
+        eq_("There was an error!", failures[0][1])


### PR DESCRIPTION
I was doing some indexing on the elasticsearch instance Brett set up on AWS, and it would sometimes start timing out. I made it retry the batch when that happens and added code to handle that type of error if it still fails.

It took 26 minutes to index the entire qa db on that instance, but there were a few batches that timed out twice and didn't get indexed. Using the elasticsearch on the same instance as the qa circ manager took 38 minutes (this was via jenkins), but it never timed out. My local elasticsearch took 10 minutes.