### PR TITLE
Handle missing data when gathering the availability link list, so long as the missing data is something relatively unimportant like the book's title.

### DIFF
--- a/overdrive.py
+++ b/overdrive.py
@@ -391,7 +391,7 @@ class OverdriveRepresentationExtractor(object):
     log = logging.getLogger("Overdrive representation extractor")
 
     @classmethod
-    def availability_link_list(self, book_list):
+    def availability_link_list(cls, book_list):
         """:return: A list of dictionaries with keys `id`, `title`,
         `availability_link`.
         """
@@ -401,8 +401,12 @@ class OverdriveRepresentationExtractor(object):
 
         products = book_list['products']
         for product in products:
-            data = dict(id=product['id'],
-                        title=product['title'],
+            if not 'id' in product:
+                cls.log.warn("No ID found in %r", product)
+                continue
+            book_id = product['id']
+            data = dict(id=book_id,
+                        title=product.get('title'),
                         author_name=None)
             
             if 'primaryCreator' in product:

--- a/tests/files/overdrive/overdrive_book_list_missing_data.json
+++ b/tests/files/overdrive/overdrive_book_list_missing_data.json
@@ -1,0 +1,27 @@
+{
+    "id": "v1L1BCgAAAA2C",
+    "limit": 300,
+    "links": {
+        "first": {
+            "href": "http://api.overdrive.com/v1/collections/collection-id/products?limit=300&offset=0&lastupdatetime=2014-04-28%2009:25:09&sort=popularity:desc&formats=ebook-epub-open,ebook-epub-adobe,ebook-pdf-adobe,ebook-pdf-open",
+            "type": "application/vnd.overdrive.api+json"
+        },
+        "last": {
+            "href": "http://api.overdrive.com/v1/collections/collection-id/products?limit=300&offset=0&lastupdatetime=2014-04-28%2009:25:09&sort=popularity:desc&formats=ebook-epub-open,ebook-epub-adobe,ebook-pdf-adobe,ebook-pdf-open",
+            "type": "application/vnd.overdrive.api+json"
+        },
+        "self": {
+            "href": "http://api.overdrive.com/v1/collections/collection-id/products?limit=300&offset=0&lastupdatetime=2014-04-28%2009:25:09&sort=popularity:desc&formats=ebook-epub-open,ebook-epub-adobe,ebook-pdf-adobe,ebook-pdf-open",
+            "type": "application/vnd.overdrive.api+json"
+        }
+    },
+    "offset": 0,
+    "products": [
+        {
+	    "title": "id is missing"
+        },
+        {
+	    "id": "title is missing"
+        }
+    ]
+}

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -169,6 +169,18 @@ class TestOverdriveRepresentationExtractor(OverdriveTest):
             for key in 'availability_link', 'id', 'title':
                 assert key in item
 
+    def test_availability_info_missing_data(self):
+        data, raw = self.sample_json("overdrive_book_list_missing_data.json")
+        [item] = OverdriveRepresentationExtractor.availability_link_list(
+            raw)
+
+        # We got a data structure for the item that has an ID but no title.
+        # We did not get a data structure for the item that has a title
+        # but no ID.
+        eq_('title is missing', item['id'])
+        eq_(None, item['title'])
+
+                
     def test_link(self):
         data, raw = self.sample_json("overdrive_book_list.json")
         expect = OverdriveAPI.make_link_safe("http://api.overdrive.com/v1/collections/collection-id/products?limit=300&offset=0&lastupdatetime=2014-04-28%2009:25:09&sort=popularity:desc&formats=ebook-epub-open,ebook-epub-adobe,ebook-pdf-adobe,ebook-pdf-open")


### PR DESCRIPTION
This branch fixes part of https://github.com/NYPL-Simplified/circulation/issues/350