### PR TITLE
Rename 3M to Bibliotheca in the database.

### DIFF
--- a/migration/20160907-rename-3m-to-bibliotheca.sql
+++ b/migration/20160907-rename-3m-to-bibliotheca.sql
@@ -1,0 +1,2 @@
+update datasources set name='Bibliotheca' where name='3M';
+update identifiers set name='Bibliotheca ID' where name='3M ID';

--- a/model.py
+++ b/model.py
@@ -625,7 +625,7 @@ class DataSource(Base):
     PROJECT_GITENBERG = "Project GITenberg"
     STANDARD_EBOOKS = "Standard Ebooks"
     UNGLUE_IT = "unglue.it"
-    THREEM = "3M"
+    BIBLIOTECHA = "Bibliotecha"
     OCLC = "OCLC Classify"
     OCLC_LINKED_DATA = "OCLC Linked Data"
     AMAZON = "Amazon"
@@ -649,6 +649,11 @@ class DataSource(Base):
     PRESENTATION_EDITION = "Presentation edition generator"
     INTERNAL_PROCESSING = "Library Simplified Internal Process"
 
+    DEPRECATED_NAMES = {
+        "3M" : BIBLIOTECHA
+    }
+    THREEM = BIBLIOTECHA
+    
     # Some sources of open-access ebooks are better than others. This
     # list shows which sources we prefer, in ascending order of
     # priority. unglue.it is lowest priority because it tends to
@@ -725,6 +730,9 @@ class DataSource(Base):
 
     @classmethod
     def lookup(cls, _db, name):
+        # Turn a deprecated name (e.g. "3M" into the current name
+        # (e.g. "Bibliotheca").
+        name = cls.DEPRECATED_NAMES.get(name, name)
         return get_one(_db, DataSource, name=name)
 
     URI_PREFIX = "http://librarysimplified.org/terms/sources/"
@@ -1153,7 +1161,7 @@ class Identifier(Base):
     
     # Common types of identifiers.
     OVERDRIVE_ID = "Overdrive ID"
-    THREEM_ID = "3M ID"
+    BIBLIOTHECA_ID = "Bibliotheca ID"
     GUTENBERG_ID = "Gutenberg ID"
     AXIS_360_ID = "Axis 360 ID"
     ASIN = "ASIN"
@@ -1166,6 +1174,11 @@ class Identifier(Base):
     URI = "URI"
     DOI = "DOI"
     UPC = "UPC"
+
+    DEPRECATED_NAMES = {
+        "3M ID" : BIBLIOTHECA_ID
+    }
+    THREEM_ID = BIBLIOTHECA_ID
 
     LICENSE_PROVIDING_IDENTIFIER_TYPES = [
         THREEM_ID, OVERDRIVE_ID, AXIS_360_ID,
@@ -1269,6 +1282,13 @@ class Identifier(Base):
 
         if not foreign_identifier_type or not foreign_id:
             return None
+
+        # Turn a deprecated identifier type (e.g. "3M ID" into the
+        # current type (e.g. "Bibliotheca ID").
+        foreign_identifier_type = cls.DEPRECATED_NAMES.get(
+            foreign_identifier_type, foreign_identifier_type
+        )
+        
         if foreign_identifier_type in (
                 Identifier.OVERDRIVE_ID, Identifier.THREEM_ID):
             foreign_id = foreign_id.lower()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -88,6 +88,11 @@ class TestDataSource(DatabaseTest):
         eq_(DataSource.GUTENBERG, gutenberg.name)
         eq_(True, gutenberg.offers_licenses)
 
+    def test_lookup_by_deprecated_name(self):
+        threem = DataSource.lookup(self._db, "3M")
+        eq_(DataSource.BIBLIOTECHA, threem.name)
+        assert DataSource.BIBLIOTECHA != "3M"
+        
     def test_lookup_returns_none_for_nonexistent_source(self):
         eq_(None, DataSource.lookup(
             self._db, "No such data source " + self._str))
@@ -138,6 +143,13 @@ class TestIdentifier(DatabaseTest):
 
         # If we pass in no data we get nothing back.
         eq_(None, Identifier.for_foreign_id(self._db, None, None))
+
+    def test_for_foreign_id_by_deprecated_type(self):
+        threem_id, is_new = Identifier.for_foreign_id(
+            self._db, "3M ID", self._str
+        )
+        eq_(Identifier.BIBLIOTHECA_ID, threem_id.type)
+        assert Identifier.BIBLIOTHECA_ID != "3M ID"
         
     def test_for_foreign_id_without_autocreate(self):
         identifier_type = Identifier.ISBN


### PR DESCRIPTION
This is a minimal branch to fix https://github.com/NYPL-Simplified/circulation/issues/304

I change the database to rename 3M to its new owner, Bibliotheca. I change the DataSource and Identifier lookups so that "3M" and "3M ID" can still be used. This means old URLs should continue working. 

It's also important for me because I always misspell "Bibliotheca" (see the branch name), and because "bibliotheca" is Latin for "library", which I find very confusing.

Leonard