### PR TITLE
"Add classification" script

### DIFF
--- a/model.py
+++ b/model.py
@@ -5015,15 +5015,21 @@ class Subject(Base):
         return False
 
     @classmethod
-    def lookup(cls, _db, type, identifier, name):
+    def lookup(cls, _db, type, identifier, name, autocreate=True):
         """Turn a subject type and identifier into a Subject."""
         classifier = Classifier.lookup(type)
-        subject, new = get_one_or_create(
+        if autocreate:
+            m = get_one_or_create
+            kwargs = dict(create_method_kwargs=dict(
+                name=name,
+            ))
+        else:
+            m = get_one
+            kwargs = {}
+        subject, new = m(
             _db, Subject, type=type,
             identifier=identifier,
-            create_method_kwargs=dict(
-                name=name,
-            )
+            **kwargs
         )
         if name and not subject.name:
             # We just discovered the name of a subject that previously

--- a/model.py
+++ b/model.py
@@ -5019,18 +5019,14 @@ class Subject(Base):
         """Turn a subject type and identifier into a Subject."""
         classifier = Classifier.lookup(type)
         if autocreate:
-            m = get_one_or_create
-            kwargs = dict(create_method_kwargs=dict(
-                name=name,
-            ))
+            subject, new = get_one_or_create(
+                _db, Subject, type=type,
+                identifier=identifier,
+                create_method_kwargs=dict(name=name)
+            )
         else:
-            m = get_one
-            kwargs = {}
-        subject, new = m(
-            _db, Subject, type=type,
-            identifier=identifier,
-            **kwargs
-        )
+            new = False
+            subject = get_one(_db, Subject, type=type, identifier=identifier)
         if name and not subject.name:
             # We just discovered the name of a subject that previously
             # had only an ID.

--- a/model.py
+++ b/model.py
@@ -1567,7 +1567,8 @@ class Identifier(Base):
         # Turn the subject type and identifier into a Subject.
         classifications = []
         subject, is_new = Subject.lookup(
-            _db, subject_type, subject_identifier, subject_name)
+            _db, subject_type, subject_identifier, subject_name,
+        )
 
         logging.debug(
             "CLASSIFICATION: %s on %s/%s: %s %s/%s (wt=%d)",

--- a/scripts.py
+++ b/scripts.py
@@ -422,7 +422,7 @@ class BibliographicRefreshScript(RunCoverageProviderScript):
             provider.ensure_coverage(identifier, force=True)
 
 
-class ReclassifyScript(IdentifierInputScript):
+class AddClassificationScript(IdentifierInputScript):
     name = "Add a classification to an identifier"
 
     @classmethod
@@ -449,12 +449,14 @@ class ReclassifyScript(IdentifierInputScript):
         parser.add_argument(
             '--weight', 
             help='The weight to use when classifying.',
+            type=int,
             default=1000
         )     
         return parser
     
-    def __init__(self):
-        args = self.parse_command_line(self._db)
+    def __init__(self, _db=None, cmd_args=None):
+        _db = _db or self._db
+        args = self.parse_command_line(_db, cmd_args=cmd_args)
         self.identifier_type = args.identifier_type
         self.identifiers = args.identifiers
         subject_type = args.subject_type
@@ -464,10 +466,10 @@ class ReclassifyScript(IdentifierInputScript):
             raise ValueError(
                 "Either subject-name or subject-identifier must be provided."
             )
-        self.data_source = DataSource.lookup(self._db, args.data_source)
+        self.data_source = DataSource.lookup(_db, args.data_source)
         self.weight = args.weight
         self.subject, ignore = Subject.lookup(
-            self._db, subject_type, subject_identifier, subject_name
+            _db, subject_type, subject_identifier, subject_name
         )
         
     def run(self):
@@ -487,7 +489,7 @@ class ReclassifyScript(IdentifierInputScript):
                                 self.subject.identifier, self.subject.name,
                                 self.weight)
             pool = identifier.licensed_through
-            if pool.work:
+            if pool and pool.work:
                 pool.work.calculate_presentation(policy=policy)
                     
         

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -517,7 +517,7 @@ class TestSubject(DatabaseTest):
 
         # But you can tell it not to autocreate.
         identifier2 = self._str
-        subject = Subject.lookup(
+        subject, was_new = Subject.lookup(
             self._db, Subject.TAG, identifier2, None, autocreate=False
         )
         eq_(False, was_new)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -506,6 +506,23 @@ class TestIdentifier(DatabaseTest):
 
 class TestSubject(DatabaseTest):
 
+    def test_lookup_autocreate(self):
+        # By default, Subject.lookup creates a Subject that doesn't exist.
+        identifier = self._str
+        subject, was_new = Subject.lookup(
+            self._db, Subject.TAG, identifier, None
+        )
+        eq_(True, was_new)
+        eq_(identifier, subject.identifier)
+
+        # But you can tell it not to autocreate.
+        identifier2 = self._str
+        subject = Subject.lookup(
+            self._db, Subject.TAG, identifier2, None, autocreate=False
+        )
+        eq_(False, was_new)
+        eq_(None, subject)
+        
     def test_assign_to_genre_can_remove_genre(self):
         # Here's a Subject that identifies children's books.
         subject, was_new = Subject.lookup(self._db, Subject.TAG, "Children's books", None)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -11,6 +11,7 @@ from nose.tools import (
 from . import (
     DatabaseTest,
 )
+from classifier import Classifier
 from model import (
     get_one,
     CustomList,
@@ -24,6 +25,7 @@ from scripts import (
     DatabaseMigrationInitializationScript,
     DatabaseMigrationScript,
     IdentifierInputScript,
+    AddClassificationScript,
     RunCoverageProviderScript,
     WorkProcessingScript,
     MockStdin,
@@ -472,3 +474,33 @@ class TestDatabaseMigrationInitializationScript(DatabaseTest):
     def test_error_raised_when_timestamp_exists(self):
         Timestamp.stamp(self._db, self.script.name)
         assert_raises(Exception, self.script.do_run)
+
+
+class TestAddClassificationScript(DatabaseTest):
+
+    def test_end_to_end(self):
+        work = self._work(with_license_pool=True)
+        identifier = work.license_pools[0].identifier
+        eq_(Classifier.AUDIENCE_ADULT, work.audience)
+        
+        cmd_args = [
+            "--identifier-type", identifier.type,
+            "--subject-type", Classifier.FREEFORM_AUDIENCE,
+            "--subject-identifier", Classifier.AUDIENCE_CHILDREN,
+            "--weight", "42",
+            identifier.identifier
+        ]
+        script = AddClassificationScript(self._db, cmd_args)
+        script.run()
+
+        # The identifier has been classified under 'children'.
+        [classification] = identifier.classifications
+        eq_(42, classification.weight)
+        subject = classification.subject
+        eq_(Classifier.FREEFORM_AUDIENCE, subject.type)
+        eq_(Classifier.AUDIENCE_CHILDREN, subject.identifier)
+        
+        # The work has been reclassified and is now known as a
+        # children's book.
+        eq_(Classifier.AUDIENCE_CHILDREN, work.audience)
+

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -487,7 +487,7 @@ class TestAddClassificationScript(DatabaseTest):
             "--identifier-type", identifier.type,
             "--subject-type", Classifier.FREEFORM_AUDIENCE,
             "--subject-identifier", Classifier.AUDIENCE_CHILDREN,
-            "--weight", "42",
+            "--weight", "42", '--create-subject',
             identifier.identifier
         ]
         script = AddClassificationScript(self._db, cmd_args)


### PR DESCRIPTION
This branch introduces a new command-line script that manually classifies an identifier under a certain subject. The main intended purpose is marking as children's books books that came in under a generic "juvenile" heading.