### PR TITLE
Added migration script.

### DIFF
--- a/migration/20160928-rename-bibliotheca-primary-identifier-type.sql
+++ b/migration/20160928-rename-bibliotheca-primary-identifier-type.sql
@@ -1,0 +1,1 @@
+update datasources set primary_identifier_type='Bibliotheca ID' where name='Bibliotheca';


### PR DESCRIPTION
This branch adds a migration script that updates `datasources` so that the primary identifier type of the Bibliotheca data source is 'Bibliotheca ID', not '3M ID'.

I've run this on the SimplyE QA database and I believe I've verified that it doesn't cause any new problems when borrowing books. I'm going to wait until tomorrow to run it on the production database, so that I have plenty of time to deal with any fallout.