### PR TITLE
Circulation event types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ before_install:
   - sleep 10
 
 install:
+  # pycparser is a dependency of cairosvg that currently does not work on travis.
+  # The bug has apparently been fixed (https://github.com/eliben/pycparser/issues/148)
+  # but it still doesn't work with cairocffi: https://github.com/Kozea/cairocffi/issues/91
+  # This is a temporary workaround.
+  - pip install git+https://github.com/eliben/pycparser@release_v2.14
   - pip install -r requirements.txt
   - python -m textblob.download_corpora
   - cp config.json.sample config.json

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -774,7 +774,7 @@ class CirculationData(MetaToModelUtility):
                 # occurence as a separate event.
                 event = get_one_or_create(
                     _db, CirculationEvent,
-                    type=CirculationEvent.TITLE_ADD,
+                    type=CirculationEvent.DISTRIBUTOR_TITLE_ADD,
                     license_pool=license_pool,
                     create_method_kwargs=dict(
                         start=last_checked,

--- a/migration/20161018-rename-distributor-circulation-event-types.sql
+++ b/migration/20161018-rename-distributor-circulation-event-types.sql
@@ -1,0 +1,9 @@
+update circulationevents set type='distributor_check_out' where type='check_out';
+update circulationevents set type='distributor_check_in' where type='check_in';
+update circulationevents set type='distributor_hold_place' where type='hold_place';
+update circulationevents set type='distributor_hold_release' where type='hold_release';
+update circulationevents set type='distributor_license_add' where type='license_add';
+update circulationevents set type='distributor_license_remove' where type='license_remove';
+update circulationevents set type='distributor_availability_notify' where type='availability_notify';
+update circulationevents set type='distributor_title_add' where type='title_add';
+update circulationevents set type='distributor_title_remove' where type='title_remove';

--- a/model.py
+++ b/model.py
@@ -6409,6 +6409,18 @@ class CirculationEvent(Base):
     TYPE = u"event"
 
     # The names of the circulation events we recognize.
+    # They may be sent to third-party analytics services
+    # as well as used locally.
+
+    # Events that happen in a circulation manager.
+    NEW_PATRON = u"circulation_manager_new_patron"
+    CM_CHECKOUT = u"circulation_manager_check_out"
+    CM_CHECKIN = u"circulation_manager_check_in"
+    CM_HOLD_PLACE = u"circulation_manager_hold_place"
+    CM_HOLD_RELEASE = u"circulation_manager_hold_release"
+    CM_FULFILL = u"circulation_manager_fulfill"
+
+    # Events that we hear about from a distributor.
     CHECKOUT = u"check_out"
     CHECKIN = u"check_in"
     HOLD_PLACE = u"hold_place"
@@ -6420,8 +6432,15 @@ class CirculationEvent(Base):
     SERVER_NOTIFICATION = u"server_notification"
     TITLE_ADD = u"title_add"
     TITLE_REMOVE = u"title_remove"
-    OPEN_BOOK = u"open_book"
     UNKNOWN = u"unknown"
+
+    # Events that we hear about from a client app.
+    OPEN_BOOK = u"open_book"
+    
+    CLIENT_EVENTS = [
+        OPEN_BOOK,
+    ]
+
 
     # The time format used when exporting to JSON.
     TIME_FORMAT = "%Y-%m-%dT%H:%M:%S+00:00"

--- a/model.py
+++ b/model.py
@@ -5812,14 +5812,14 @@ class LicensePool(Base):
 
         for old_value, new_value, more_event, fewer_event in (
                 [self.patrons_in_hold_queue,  new_patrons_in_hold_queue,
-                 CirculationEvent.HOLD_PLACE, CirculationEvent.HOLD_RELEASE], 
+                 CirculationEvent.DISTRIBUTOR_HOLD_PLACE, CirculationEvent.DISTRIBUTOR_HOLD_RELEASE],
                 [self.licenses_available, new_licenses_available,
-                 CirculationEvent.CHECKIN, CirculationEvent.CHECKOUT], 
+                 CirculationEvent.DISTRIBUTOR_CHECKIN, CirculationEvent.DISTRIBUTOR_CHECKOUT],
                 [self.licenses_reserved, new_licenses_reserved,
-                 CirculationEvent.AVAILABILITY_NOTIFY, None], 
+                 CirculationEvent.DISTRIBUTOR_AVAILABILITY_NOTIFY, None],
                 [self.licenses_owned, new_licenses_owned,
-                 CirculationEvent.LICENSE_ADD,
-                 CirculationEvent.LICENSE_REMOVE]):
+                 CirculationEvent.DISTRIBUTOR_LICENSE_ADD,
+                 CirculationEvent.DISTRIBUTOR_LICENSE_REMOVE]):
             if new_value is None:
                 continue
             if old_value == new_value:
@@ -6421,15 +6421,15 @@ class CirculationEvent(Base):
     CM_FULFILL = u"circulation_manager_fulfill"
 
     # Events that we hear about from a distributor.
-    CHECKOUT = u"distributor_check_out"
-    CHECKIN = u"distributor_check_in"
-    HOLD_PLACE = u"distributor_hold_place"
-    HOLD_RELEASE = u"distributor_hold_release"
-    LICENSE_ADD = u"distributor_license_add"
-    LICENSE_REMOVE = u"distributor_license_remove"
-    AVAILABILITY_NOTIFY = u"distributor_availability_notify"
-    TITLE_ADD = u"distributor_title_add"
-    TITLE_REMOVE = u"distributor_title_remove"
+    DISTRIBUTOR_CHECKOUT = u"distributor_check_out"
+    DISTRIBUTOR_CHECKIN = u"distributor_check_in"
+    DISTRIBUTOR_HOLD_PLACE = u"distributor_hold_place"
+    DISTRIBUTOR_HOLD_RELEASE = u"distributor_hold_release"
+    DISTRIBUTOR_LICENSE_ADD = u"distributor_license_add"
+    DISTRIBUTOR_LICENSE_REMOVE = u"distributor_license_remove"
+    DISTRIBUTOR_AVAILABILITY_NOTIFY = u"distributor_availability_notify"
+    DISTRIBUTOR_TITLE_ADD = u"distributor_title_add"
+    DISTRIBUTOR_TITLE_REMOVE = u"distributor_title_remove"
 
     # Events that we hear about from a client app.
     OPEN_BOOK = u"open_book"

--- a/model.py
+++ b/model.py
@@ -6421,18 +6421,15 @@ class CirculationEvent(Base):
     CM_FULFILL = u"circulation_manager_fulfill"
 
     # Events that we hear about from a distributor.
-    CHECKOUT = u"check_out"
-    CHECKIN = u"check_in"
-    HOLD_PLACE = u"hold_place"
-    HOLD_RELEASE = u"hold_release"
-    LICENSE_ADD = u"license_add"
-    LICENSE_REMOVE = u"license_remove"
-    AVAILABILITY_NOTIFY = u"availability_notify"
-    CIRCULATION_CHECK = u"circulation_check"
-    SERVER_NOTIFICATION = u"server_notification"
-    TITLE_ADD = u"title_add"
-    TITLE_REMOVE = u"title_remove"
-    UNKNOWN = u"unknown"
+    CHECKOUT = u"distributor_check_out"
+    CHECKIN = u"distributor_check_in"
+    HOLD_PLACE = u"distributor_hold_place"
+    HOLD_RELEASE = u"distributor_hold_release"
+    LICENSE_ADD = u"distributor_license_add"
+    LICENSE_REMOVE = u"distributor_license_remove"
+    AVAILABILITY_NOTIFY = u"distributor_availability_notify"
+    TITLE_ADD = u"distributor_title_add"
+    TITLE_REMOVE = u"distributor_title_remove"
 
     # Events that we hear about from a client app.
     OPEN_BOOK = u"open_book"

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ python-dateutil
 uwsgi
 loggly-python-handler
 cairosvg
+# pycparser is used by cairosvg with no specific version, and version 2.15 doesn't work on travis.
+pycparser==2.14
 mock
 py-bcrypt
 Flask-Babel

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,6 @@ python-dateutil
 uwsgi
 loggly-python-handler
 cairosvg
-# pycparser is used by cairosvg with no specific version, and version 2.15 doesn't work on travis.
-pycparser==2.14
 mock
 py-bcrypt
 Flask-Babel

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -31,7 +31,7 @@ class TestAnalytics(DatabaseTest):
         with temp_config(config) as config:
             work = self._work(title="title", with_license_pool=True)
             [lp] = work.license_pools
-            Analytics.collect_event(self._db, lp, CirculationEvent.CHECKIN, None)
+            Analytics.collect_event(self._db, lp, CirculationEvent.DISTRIBUTOR_CHECKIN, None)
             mock = Analytics.instance().providers[0]
             eq_(1, mock.count)
             

--- a/tests/test_local_analytics_provider.py
+++ b/tests/test_local_analytics_provider.py
@@ -18,13 +18,13 @@ class TestLocalAnalyticsProvider(DatabaseTest):
         [lp] = work.license_pools
         now = datetime.datetime.utcnow()
         la.collect_event(
-            self._db, lp, CirculationEvent.CHECKIN, now,
+            self._db, lp, CirculationEvent.DISTRIBUTOR_CHECKIN, now,
             old_value=None, new_value=None)
         [event] = self._db \
             .query(CirculationEvent) \
-            .filter(CirculationEvent.type == CirculationEvent.CHECKIN) \
+            .filter(CirculationEvent.type == CirculationEvent.DISTRIBUTOR_CHECKIN) \
             .all()
 
         eq_(lp, event.license_pool)
-        eq_(CirculationEvent.CHECKIN, event.type)
+        eq_(CirculationEvent.DISTRIBUTOR_CHECKIN, event.type)
         eq_(now, event.start)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1119,10 +1119,10 @@ class TestLicensePool(DatabaseTest):
             count = provider.count
             pool.update_availability(30, 21, 2, 0)
             eq_(count + 1, provider.count)
-            eq_(CirculationEvent.CHECKIN, provider.event_type)
+            eq_(CirculationEvent.DISTRIBUTOR_CHECKIN, provider.event_type)
             pool.update_availability(30, 21, 2, 1)
             eq_(count + 2, provider.count)
-            eq_(CirculationEvent.HOLD_PLACE, provider.event_type)
+            eq_(CirculationEvent.DISTRIBUTOR_HOLD_PLACE, provider.event_type)
 
     def test_update_availability_does_nothing_if_given_no_data(self):
         """Passing an empty set of data into update_availability is
@@ -2172,7 +2172,7 @@ class TestCirculationEvent(DatabaseTest):
                 ("source", DataSource.OVERDRIVE),
                 ("id_type", Identifier.OVERDRIVE_ID),
                 ("start", datetime.datetime.utcnow()),
-                ("type", CirculationEvent.LICENSE_ADD),
+                ("type", CirculationEvent.DISTRIBUTOR_LICENSE_ADD),
         ):
             kwargs.setdefault(k, default)
         if 'old_value' in kwargs and 'new_value' in kwargs:
@@ -2234,7 +2234,7 @@ class TestCirculationEvent(DatabaseTest):
         data = self._event_data(
             source=DataSource.OVERDRIVE,
             id="{1-2-3}",
-            type=CirculationEvent.LICENSE_ADD,
+            type=CirculationEvent.DISTRIBUTOR_LICENSE_ADD,
             old_value=0,
             delta=2,
             new_value=2,


### PR DESCRIPTION
This branch adds constants for the new circulation event types we're tracking, and organizes them by the source of the event. We can add additional client event types as needed.

Once these are getting sent to google analytics on production, we won't be able to migrate old event labels if we change any of the constants, so we should think about what they should be. I think the distinction between circ manager events and distributor events could be confusing.