### PR TITLE
Patron fines are numeric

### DIFF
--- a/migration/20161024-numeric-patron-fines.sql
+++ b/migration/20161024-numeric-patron-fines.sql
@@ -1,0 +1,4 @@
+alter table patrons add column fines2 numeric;
+update patrons set fines2=to_number(substr(fines, 2, 100), '9999.99');
+alter patrons drop column fines;
+alter table patrons rename column fines2 to fines;

--- a/model.py
+++ b/model.py
@@ -6580,7 +6580,7 @@ class Credential(Base):
             return None
 
     @classmethod
-    def lookup_by_temporary_token(cls, _db, data_source, type, token):
+    def lookup_and_expire_temporary_token(cls, _db, data_source, type, token):
         """Look up a temporary token and expire it immediately."""
         credential = cls.lookup_by_token(_db, data_source, type, token)
         if not credential:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ cairosvg
 mock
 py-bcrypt
 Flask-Babel
+money

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4075,9 +4075,9 @@ class TestCredentials(DatabaseTest):
             self._db, data_source, token.type, token.credential)
         eq_(new_token, token)
 
-        # When we call lookup_by_temporary_token, the token is automatically
+        # When we call lookup_and_expire_temporary_token, the token is automatically
         # expired and we cannot use it anymore.
-        new_token = Credential.lookup_by_temporary_token(
+        new_token = Credential.lookup_and_expire_temporary_token(
             self._db, data_source, token.type, token.credential)
         eq_(new_token, token)        
         assert new_token.expires < now
@@ -4086,7 +4086,7 @@ class TestCredentials(DatabaseTest):
             self._db, data_source, token.type, token.credential)
         eq_(None, new_token)
 
-        new_token = Credential.lookup_by_temporary_token(
+        new_token = Credential.lookup_and_expire_temporary_token(
             self._db, data_source, token.type, token.credential)
         eq_(None, new_token)
  

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 from collections import defaultdict
 import json
+from money import Money
 from nose.tools import (
     assert_raises,
     assert_raises_regexp,
@@ -20,6 +21,7 @@ from util import (
     english_bigrams,
     LanguageCodes,
     MetadataSimilarity,
+    MoneyUtility,
     TitleProcessor,
     fast_query_count,
 )
@@ -533,3 +535,13 @@ class TestFastQueryCount(DatabaseTest):
         # the query will return three editions.
         qu3 = qu.distinct(Edition.title, Edition.author)
         eq_(qu3.count(), fast_query_count(qu3))
+
+
+class TestMoneyUtility(object):
+
+    def test_parse(self):
+        p = MoneyUtility.parse
+        eq_(Money("4.00", "USD"), p("4"))
+        eq_(Money("-4.00", "USD"), p("-4"))
+        eq_(Money("4.40", "USD"), p("4.40"))
+        eq_(Money("4.40", "USD"), p("$4.40"))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -541,6 +541,7 @@ class TestMoneyUtility(object):
 
     def test_parse(self):
         p = MoneyUtility.parse
+        eq_(Money("0", "USD"), p(None))
         eq_(Money("4.00", "USD"), p("4"))
         eq_(Money("-4.00", "USD"), p("-4"))
         eq_(Money("4.40", "USD"), p("4.40"))

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 "Miscellaneous utilities"
+from money import Money
 from nose.tools import set_trace
 from collections import (
     Counter,
@@ -1091,3 +1092,17 @@ english_bigram_frequencies = {
 english_bigrams = Bigrams(Counter())
 english_bigrams.proportional = Counter(english_bigram_frequencies)
 
+
+class MoneyUtility(object):
+
+    DEFAULT_CURRENCY = 'USD'
+
+    @classmethod
+    def parse(cls, amount):
+        """Attempt to turn a string into a Money object."""
+        currency = cls.DEFAULT_CURRENCY
+        if amount[0] == '$':
+            currency = 'USD'
+            amount = amount[1:]
+        return Money(amount, currency)
+        

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -1101,6 +1101,8 @@ class MoneyUtility(object):
     def parse(cls, amount):
         """Attempt to turn a string into a Money object."""
         currency = cls.DEFAULT_CURRENCY
+        if not amount:
+            amount = '0'
         if amount[0] == '$':
             currency = 'USD'
             amount = amount[1:]


### PR DESCRIPTION
This branch changes `Patron.fines` from a string field to a numeric field. Patron fines are always sent to us as a string, but parsing that string is the job of the authentication plugin. By the time the data is stored in the database it needs to be a number that can be easily compared against other numbers.
