### PR TITLE
Empty the exception of a previously-unsuccessful CoverageRecord if it becomes successful

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -268,6 +268,7 @@ class BaseCoverageProvider(object):
                 successes += 1
                 record, ignore = self.add_coverage_record_for(item)
                 record.status = BaseCoverageRecord.SUCCESS
+                record.exception = None
             records.append(record)
 
         # Perhaps some records were ignored--they neither succeeded nor

--- a/migration/20161101-remove-exceptions-from-successful-coverage-records.sql
+++ b/migration/20161101-remove-exceptions-from-successful-coverage-records.sql
@@ -1,0 +1,2 @@
+update coveragerecords set exception = null where status = 'success' and exception is not null;
+update workcoveragerecords set exception = null where status = 'success' and exception is not null;

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -198,8 +198,6 @@ class TestCoverageProvider(DatabaseTest):
         record.timestamp = cutoff
         eq_(False, provider.should_update(record))
 
-
-
     def test_ensure_coverage_transient_coverage_failure(self):
 
         provider = TransientFailureCoverageProvider(
@@ -569,6 +567,12 @@ class TestCoverageProvider(DatabaseTest):
         eq_([CoverageRecord.TRANSIENT_FAILURE] * 2,
             [x.status for x in records])
         eq_(["i ignore"] * 2, [x.operation for x in records])
+
+        # If a transient failure becomes a success, the it won't have
+        # an exception anymore.
+        eq_(['Was ignored by CoverageProvider.'] * 2, [x.exception for x in records])
+        records = success_provider.process_batch_and_handle_results(batch)[1]
+        eq_([None, None], [x.exception for x in records])
 
         # Or you can go really bad and have persistent failures.
         persistent_failure_provider = NeverSuccessfulCoverageProvider(


### PR DESCRIPTION
I thought we had 23k+ unresolved identifiers being ignored in the Metadata Wrangler (exception: "No work done yet"). It turns out they're all successfully covered; it's just that their exceptions hadn't been removed.