### PR TITLE
Made it possible to initialize an ExternalSearchIndex with arguments and no configuration.

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -25,17 +25,21 @@ class ExternalSearchIndex(object):
         self.works_index = None
 
         if not ExternalSearchIndex.__client:
-            integration = Configuration.integration(
-                Configuration.ELASTICSEARCH_INTEGRATION, 
-            )
-            works_index = works_index or integration.get(
-                Configuration.ELASTICSEARCH_INDEX_KEY
-            ) or None
+            if not url or not works_index:
+                integration = Configuration.integration(
+                    Configuration.ELASTICSEARCH_INTEGRATION, 
+                )
 
-            if not integration:
-                return
+                if not works_index:
+                    works_index = integration.get(
+                        Configuration.ELASTICSEARCH_INDEX_KEY
+                    ) or None
 
-            url = integration[Configuration.URL]
+                if not url:
+                    if not integration:
+                        return
+                    url = integration[Configuration.URL]
+
             use_ssl = url and url.startswith('https://')
             self.log.info(
                 "Connecting to index %s in Elasticsearch cluster at %s", 


### PR DESCRIPTION
This is a small branch to support the open access search lambda. It can't have environment variables, so I'm initializing the search index by passing in a url and index name instead of having it read the config file. The arguments were already there, but url wasn't being used. 

I might come up with a better way to handle configuration for the lambda, but this seems like a good change anyway. 