### PR TITLE
Delegated patron identifiers

### DIFF
--- a/model.py
+++ b/model.py
@@ -4,7 +4,6 @@ from collections import (
     Counter,
     defaultdict,
 )
-import contextlib
 from lxml import etree
 from nose.tools import set_trace
 import cairosvg
@@ -329,7 +328,6 @@ def get_one(db, model, on_multiple='error', **kwargs):
 
 def get_one_or_create(db, model, create_method='',
                       create_method_kwargs=None,
-                      create_method_kwargs_methods=None,
                       **kwargs):
     one = get_one(db, model, **kwargs)
     if one:

--- a/model.py
+++ b/model.py
@@ -4,6 +4,7 @@ from collections import (
     Counter,
     defaultdict,
 )
+import contextlib
 from lxml import etree
 from nose.tools import set_trace
 import cairosvg
@@ -6650,8 +6651,14 @@ class DelegatedPatronIdentifier(Base):
     id = Column(Integer, primary_key=True)
     type = Column(String(255), index=True)
     library_uri = Column(String(255), index=True)
+
+    # This is the ID the foreign library gives us when referring to
+    # this patron.
     patron_identifier = Column(String(255), index=True)
-    identifier = Column(String)
+
+    # This is the identifier we made up for the patron. This is what the
+    # foreign library is trying to look up.
+    delegated_identifier = Column(String)
 
     __table_args__ = (
         UniqueConstraint('type', 'library_uri', 'patron_identifier'),
@@ -6678,7 +6685,7 @@ class DelegatedPatronIdentifier(Base):
         :param create_function: If this patron does not have a
          DelegatedPatronIdentifier, one will be created, and this
          function will be called to determine the value of
-         DelegatedPatronIdentifier.identifier. 
+         DelegatedPatronIdentifier.delegated_identifier. 
 
         :return: A 2-tuple (DelegatedPatronIdentifier, is_new)
         """
@@ -6687,7 +6694,7 @@ class DelegatedPatronIdentifier(Base):
             patron_identifier=patron_identifier, type=identifier_type
         )
         if is_new:
-            identifier.identifier = create_function()
+            identifier.delegated_identifier = create_function()
         return identifier, is_new
         
 

--- a/model.py
+++ b/model.py
@@ -6643,7 +6643,7 @@ class DelegatedPatronIdentifier(Base):
 
     Those identifiers are stored here.
     """
-    ADOBE_ID = 'Adobe ID'
+    ADOBE_ACCOUNT_ID = 'Adobe Account ID'
     
     __tablename__ = 'delegatedpatronidentifiers'
     id = Column(Integer, primary_key=True)
@@ -6678,7 +6678,7 @@ class DelegatedPatronIdentifier(Base):
          patron with _this_ library, and not (e.g.) the patron's barcode.
 
         :param identifier_type: The type of the delegated identifier
-         to look up. (probably ADOBE_ID)
+         to look up. (probably ADOBE_ACCOUNT_ID)
 
         :param create_function: If this patron does not have a
          DelegatedPatronIdentifier, one will be created, and this

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4192,7 +4192,7 @@ class TestDelegatedPatronIdentifier(DatabaseTest):
     def test_get_one_or_create(self):
         library_uri = self._url
         patron_identifier = self._str
-        identifier_type = DelegatedPatronIdentifier.ADOBE_ID
+        identifier_type = DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID
         def make_id():
             return "id1"
         identifier, is_new = DelegatedPatronIdentifier.get_one_or_create(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4203,7 +4203,7 @@ class TestDelegatedPatronIdentifier(DatabaseTest):
         eq_(library_uri, identifier.library_uri)
         eq_(patron_identifier, identifier.patron_identifier)
         # id_1() was called.
-        eq_("id1", identifier.identifier)
+        eq_("id1", identifier.delegated_identifier)
 
         # Try the same thing again but provide a different create_function
         # that raises an exception if called.
@@ -4216,7 +4216,7 @@ class TestDelegatedPatronIdentifier(DatabaseTest):
         eq_(False, is_new)
         eq_(identifier2.id, identifier.id)
         # id_2() was not called.
-        eq_("id1", identifier2.identifier)
+        eq_("id1", identifier2.delegated_identifier)
         
         
 class TestPatron(DatabaseTest):


### PR DESCRIPTION
This branch introduces the DelegatedPatronIdentifier model class: a place for library A to map a patron identifier from library B onto some other identifier (for which library A is the naming authority). Currently the only use case for this is Adobe IDs.