### PR TITLE
Set explicit elasticsearch version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ isbnlib
 tinys3
 textblob
 rdflib
-elasticsearch
+elasticsearch==2.1.0
 python-dateutil
 uwsgi
 loggly-python-handler


### PR DESCRIPTION
The latest version of the elasticsearch python package doesn't work with our code, and is meant to be used with newer versions of elasticsearch.