### PR TITLE
Support facets in static feeds

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -90,7 +90,8 @@ class Facets(FacetConstants):
         """Create a slightly different Facets object from this one."""
         return Facets(collection or self.collection, 
                       availability or self.availability, 
-                      order or self.order) 
+                      order or self.order,
+                      enabled_facets=self.facets_enabled_at_init)
 
     def items(self):
         if self.order:

--- a/lane.py
+++ b/lane.py
@@ -51,8 +51,7 @@ class Facets(FacetConstants):
         )
 
     def __init__(self, collection, availability, order,
-                 order_ascending=None):
-        
+                 order_ascending=None, enabled_facets=None):
         if order_ascending is None:
             if order == self.ORDER_ADDED_TO_COLLECTION:
                 order_ascending = self.ORDER_DESCENDING
@@ -85,6 +84,7 @@ class Facets(FacetConstants):
         elif order_ascending == self.ORDER_DESCENDING:
             order_ascending = False
         self.order_ascending = order_ascending
+        self.facets_enabled_at_init = enabled_facets
 
     def navigate(self, collection=None, availability=None, order=None):
         """Create a slightly different Facets object from this one."""
@@ -105,11 +105,44 @@ class Facets(FacetConstants):
         return "&".join("=".join(x) for x in sorted(self.items()))
 
     @property
+    def enabled_facets(self):
+        """Yield a 3-tuple of lists (order, availability, collection)
+        representing facet values enabled via initialization or Configuration
+        """
+        if self.facets_enabled_at_init:
+            # When this Facets object was initialized, a list of enabled
+            # facets was passed. We'll only work with those facets.
+            facet_types = [
+                self.ORDER_FACET_GROUP_NAME,
+                self.AVAILABILITY_FACET_GROUP_NAME,
+                self.COLLECTION_FACET_GROUP_NAME
+            ]
+            for facet_type in facet_types:
+                yield self.facets_enabled_at_init.get(facet_type, [])
+        else:
+            order_facets = Configuration.enabled_facets(
+                Facets.ORDER_FACET_GROUP_NAME
+            )
+            yield order_facets
+
+            availability_facets = Configuration.enabled_facets(
+                Facets.AVAILABILITY_FACET_GROUP_NAME
+            )
+            yield availability_facets
+
+            collection_facets = Configuration.enabled_facets(
+                Facets.COLLECTION_FACET_GROUP_NAME
+            )
+            yield collection_facets
+
+    @property
     def facet_groups(self):
         """Yield a list of 4-tuples 
         (facet group, facet value, new Facets object, selected)
         for use in building OPDS facets.
         """
+
+        order_facets, availability_facets, collection_facets = self.enabled_facets
 
         def dy(new_value):
             group = self.ORDER_FACET_GROUP_NAME
@@ -118,9 +151,6 @@ class Facets(FacetConstants):
             return (group, new_value, facets, current_value==new_value)
 
         # First, the order facets.
-        order_facets = Configuration.enabled_facets(
-            Facets.ORDER_FACET_GROUP_NAME
-        )
         if len(order_facets) > 1:
             for facet in order_facets:
                 yield dy(facet)
@@ -131,22 +161,18 @@ class Facets(FacetConstants):
             current_value = self.availability
             facets = self.navigate(availability=new_value)
             return (group, new_value, facets, new_value==current_value)
-        availability_facets = Configuration.enabled_facets(
-            Facets.AVAILABILITY_FACET_GROUP_NAME
-        )
+
         if len(availability_facets) > 1:
             for facet in availability_facets:
                 yield dy(facet)
 
         # Next, the collection facets.
-        collection_facets = Configuration.enabled_facets(
-            Facets.COLLECTION_FACET_GROUP_NAME
-        )        
         def dy(new_value):
             group = self.COLLECTION_FACET_GROUP_NAME
             current_value = self.collection
             facets = self.navigate(collection=new_value)
             return (group, new_value, facets, new_value==current_value)
+
         if len(collection_facets) > 1:
             for facet in collection_facets:
                 yield dy(facet)

--- a/opds.py
+++ b/opds.py
@@ -633,7 +633,6 @@ class AcquisitionFeed(OPDSFeed):
                 link['{%s}activeFacet' % AtomFeed.OPDS_NS] = "true"
             yield link
 
-
     def __init__(self, _db, title, url, works, annotator=None,
                  precomposed_entries=[]):
         """Turn a list of works, messages, and precomposed <opds> entries

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -91,6 +91,24 @@ class TestFacets(object):
             expect = [['order', 'title', True], ['order', 'work_id', False]]
             eq_(expect, sorted([list(x[:2]) + [x[-1]] for x in all_groups]))
 
+    def test_facets_can_be_enabled_at_initialization(self):
+        enabled_facets = {
+            Facets.ORDER_FACET_GROUP_NAME : [
+                Facets.ORDER_TITLE, Facets.ORDER_AUTHOR,
+            ],
+            Facets.COLLECTION_FACET_GROUP_NAME : [Facets.COLLECTION_MAIN],
+            Facets.AVAILABILITY_FACET_GROUP_NAME : [Facets.AVAILABLE_OPEN_ACCESS]
+        }
+
+        # Create a new Facets object with these facets enabled,
+        # no matter the Configuration.
+        facets = Facets(
+            Facets.COLLECTION_MAIN, Facets.AVAILABLE_OPEN_ACCESS,
+            Facets.ORDER_TITLE, enabled_facets=enabled_facets
+        )
+        all_groups = list(facets.facet_groups)
+        expect = [['order', 'author', False], ['order', 'title', True]]
+        eq_(expect, sorted([list(x[:2]) + [x[-1]] for x in all_groups]))
 
     def test_order_facet_to_database_field(self):
         from model import (


### PR DESCRIPTION
Tacked on to support Facets in environments without configuration. Like, say, NYPL-Simplified/content_server#86.