### PR TITLE
Patron input script

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -345,9 +345,9 @@ class PatronInputScript(InputScript):
                 )
         return patrons
 
-    def do_run(self):
-        patrons = self.parse_command_line(self._db)
-        for patron in patrons:
+    def do_run(self, *args, **kwargs):
+        parsed = self.parse_command_line(self._db, *args, **kwargs)
+        for patron in parsed.patrons:
             self.process_patron(patron)
 
     def process_patron(self, patron):

--- a/scripts.py
+++ b/scripts.py
@@ -347,7 +347,10 @@ class PatronInputScript(InputScript):
 
     def do_run(self, *args, **kwargs):
         parsed = self.parse_command_line(self._db, *args, **kwargs)
-        for patron in parsed.patrons:
+        self.process_patrons(parsed.patrons)
+
+    def process_patrons(self, patrons):
+        for patron in patrons:
             self.process_patron(patron)
 
     def process_patron(self, patron):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -139,6 +139,26 @@ class TestPatronInputScript(DatabaseTest):
         )
         eq_([], parsed.patrons)
 
+
+    def test_do_run(self):
+        class MockPatronInputScript(PatronInputScript):
+            def process_patron(self, patron):
+                patron.processed = True
+        p1 = self._patron()
+        p2 = self._patron()
+        p3 = self._patron()
+        p3.processed = False
+        p1.authorization_identifier = self._str
+        p2.authorization_identifier = self._str
+        cmd_args = [p1.authorization_identifier, p2.authorization_identifier]
+        stdin = MockStdin(p2.authorization_identifier)
+        script = MockPatronInputScript(self._db)
+        script.do_run(cmd_args=cmd_args)
+        eq_(True, p1.processed)
+        eq_(True, p2.processed)
+        eq_(False, p3.processed)
+        
+        
 class TestRunCoverageProviderScript(DatabaseTest):
 
     def test_parse_command_line(self):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -141,6 +141,9 @@ class TestPatronInputScript(DatabaseTest):
 
 
     def test_do_run(self):
+        """Test that PatronInputScript.do_run() calls process_patron()
+        for every patron designated by the command-line arguments.
+        """
         class MockPatronInputScript(PatronInputScript):
             def process_patron(self, patron):
                 patron.processed = True

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -153,10 +153,10 @@ class TestPatronInputScript(DatabaseTest):
         p3.processed = False
         p1.authorization_identifier = self._str
         p2.authorization_identifier = self._str
-        cmd_args = [p1.authorization_identifier, p2.authorization_identifier]
+        cmd_args = [p1.authorization_identifier]
         stdin = MockStdin(p2.authorization_identifier)
         script = MockPatronInputScript(self._db)
-        script.do_run(cmd_args=cmd_args)
+        script.do_run(cmd_args=cmd_args, stdin=stdin)
         eq_(True, p1.processed)
         eq_(True, p2.processed)
         eq_(False, p3.processed)


### PR DESCRIPTION
This branch creates a `PatronInputScript` abstract class that functions like the `IdentifierInputScript` in that its job is to take certain command-line arguments (patrons in this case), turn them into data model objects, and process them in some undefined way.