### PR TITLE
Add query generated lane

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -1,9 +1,10 @@
 from collections import defaultdict
 from nose.tools import set_trace
 import datetime
+import logging
 import random
 import time
-import logging
+import urllib
 
 from psycopg2.extras import NumericRange
 
@@ -1467,11 +1468,12 @@ class QueryGeneratedLane(Lane):
 
         # Add lane-specific details to query and return the result.
         qu = self.lane_query_hook(qu, work_model=work_model)
+        if not qu:
+            # The hook may return None.
+            return None
 
         if facets:
-            qu = facets.apply(
-                self._db, qu, work_model, edition_model, distinct=True
-            )
+            qu = facets.apply(self._db, qu, work_model, edition_model)
 
         if pagination:
             qu = pagination.apply(qu)

--- a/lane.py
+++ b/lane.py
@@ -1467,6 +1467,15 @@ class QueryGeneratedLane(Lane):
 
         # Add lane-specific details to query and return the result.
         qu = self.lane_query_hook(qu, work_model=work_model)
+
+        if facets:
+            qu = facets.apply(
+                self._db, qu, work_model, edition_model, distinct=True
+            )
+
+        if pagination:
+            qu = pagination.apply(qu)
+
         return qu
 
     def featured_works(self, use_materialized_works=True):

--- a/lane.py
+++ b/lane.py
@@ -1397,3 +1397,72 @@ class LaneList(object):
                 )
             )
         this_language[lane.name] = lane
+
+
+class QueryGeneratedLane(Lane):
+    """A lane dependent on a particular query, instead of a genre or search"""
+
+    MAX_CACHE_AGE = 14*24*60*60      # two weeks
+    # Inside of groups feeds, we want to return a sample
+    # even if there's only a single result.
+    MINIMUM_SAMPLE_SIZE = 1
+
+    @property
+    def audience_key(self):
+        """Translates audiences list into url-safe string"""
+        key = ''
+        if (self.audiences and
+            Classifier.AUDIENCES.difference(self.audiences)):
+            # There are audiences and they're not the default
+            # "any audience", so add them to the URL.
+            audiences = [urllib.quote_plus(a) for a in sorted(self.audiences)]
+            key += ','.join(audiences)
+        return key
+
+    def apply_filters(self, qu, facets=None, pagination=None, work_model=Work,
+                      edition_model=Edition):
+        """Incorporates general filters that help determine which works can be
+        usefully presented to users with lane-specific queries that select
+        the works specific to the QueryGeneratedLane
+
+        :return: query or None
+        """
+        # Only show works that can be borrowed or reserved.
+        qu = self.only_show_ready_deliverable_works(qu, work_model)
+
+        # Only show works for the proper audiences.
+        if self.audiences:
+            qu = qu.filter(work_model.audience.in_(self.audiences))
+
+        # Only show works in the source language.
+        if self.languages:
+            qu = qu.filter(edition_model.language.in_(self.languages))
+
+        # Add lane-specific details to query and return the result.
+        qu = self.lane_query_hook(qu, work_model=work_model)
+        return qu
+
+    def featured_works(self, use_materialized_works=True):
+        """Find a random sample of books for the feed"""
+
+        # Lane.featured_works searches for books along a variety of facets.
+        # Because LicensePoolBasedLanes are created for individual works as
+        # needed (instead of at app start), we need to avoid the relative
+        # slowness of those queries.
+        #
+        # We'll just ignore facets and return whatever we find.
+        if not use_materialized_works:
+            query = self.works()
+        else:
+            query = self.materialized_works()
+        if not query:
+            return []
+
+        return self.randomized_sample_works(query, use_min_size=True)
+
+    def lane_query_hook(self, qu, work_model=Work):
+        """Create the query specific to a subclass of  QueryGeneratedLane
+
+        :return: query or None
+        """
+        raise NotImplementedError()

--- a/opds.py
+++ b/opds.py
@@ -539,7 +539,7 @@ class AcquisitionFeed(OPDSFeed):
         for args in cls.facet_links(annotator, facets):
             OPDSFeed.add_link_to_feed(feed=feed.feed, **args)
 
-        if len(works) > 0:
+        if len(works) > 0 and pagination.has_next_page:
             # There are works in this list. Add a 'next' link.
             OPDSFeed.add_link_to_feed(feed=feed.feed, rel="next", href=annotator.feed_url(lane, facets, pagination.next_page))
 

--- a/s3.py
+++ b/s3.py
@@ -112,7 +112,7 @@ class S3Uploader(MirrorUploader):
 
     @classmethod
     def feed_url(cls, filename, extension='.opds', open_access=True):
-        """The path to the hosted OPDS file for the given CustomList"""
+        """The path to the hosted file for an OPDS feed with the given filename"""
         root = cls.content_root(open_access)
         if not extension.startswith('.'):
             extension = '.' + extension


### PR DESCRIPTION
Moving QueryGeneratedLane from `circulation/api/lanes.py`, so I can use it in the content server. This supports NYPL-Simplified/content_server#89.

The only changes from circulation are noted in comments below.

Helps resolve NYPL-Simplified/content_server#87.