### PR TITLE
Core work for Feedbooks import

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -2678,9 +2678,6 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "legends",
                ),
                Social_Sciences: match_kw(
-                   "social sciences",
-                   "social science",
-                   "human science",
                    Eg("anthropology"),
                    Eg("archaology"),
                    Eg("sociology"),
@@ -2906,6 +2903,13 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
             "thriller.*romance",
         ),
 
+        # Stop from showing up as 'science'
+        Social_Sciences : match_kw(
+            "social sciences",
+            "social science",
+            "human science",
+        ),
+        
         Science_Fiction : match_kw(
             "science fiction",
             "science fiction.*general",

--- a/classifier.py
+++ b/classifier.py
@@ -49,7 +49,7 @@ class Classifier(object):
     BISAC = "BISAC"
     BIC = "BIC"
     TAG = "tag"   # Folksonomic tags.
-
+    
     # Appeal controlled vocabulary developed by NYPL 
     NYPL_APPEAL = "NYPL Appeal"
 

--- a/classifier.py
+++ b/classifier.py
@@ -1757,12 +1757,18 @@ class Eg(object):
 class KeywordBasedClassifier(AgeOrGradeClassifier):
 
     """Classify a book based on keywords."""
+
+    # We have to handle these first because otherwise '\bfiction\b'
+    # will match it.
+    LEVEL_1_NONFICTION_INDICATORS = match_kw(
+        "non-fiction", "non fiction"
+    )
     
-    FICTION_INDICATORS = match_kw(
+    LEVEL_2_FICTION_INDICATORS = match_kw(
         "fiction", Eg("stories"), Eg("tales"), Eg("literature"),
         Eg("bildungsromans"), "fictitious",
     )
-    NONFICTION_INDICATORS = match_kw(
+    LEVEL_2_NONFICTION_INDICATORS = match_kw(
         Eg("history"), Eg("biography"), Eg("histories"), Eg("biographies"), Eg("autobiography"),
         Eg("autobiographies"), "nonfiction", Eg("essays"), Eg("letters"))
     JUVENILE_INDICATORS = match_kw(
@@ -2206,6 +2212,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                Historical_Fiction : match_kw(
                    "historical fiction",
                    "fiction.*historical",
+                   "^historical$",
                ),
                
                Historical_Romance: match_kw(
@@ -2220,11 +2227,14 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                ),
                
                Horror : match_kw(
-                   Eg("ghost stories"),
                    "horror",
+                   Eg("occult"),
+                   Eg("ghost"),
+                   Eg("ghost stories"),
                    Eg("vampires"),
                    Eg("paranormal fiction"),
                    Eg("occult fiction"),
+                   Eg("supernatural"),
                    "scary",
                ),
                
@@ -2648,7 +2658,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                ),
                
                Science_Fiction : match_kw(
-                   "science fiction",
+                   "speculative fiction",
                    Eg("time travel"),
                ),
                
@@ -2672,6 +2682,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                Social_Sciences: match_kw(
                    "social sciences",
                    "social science",
+                   "human science",
                    Eg("anthropology"),
                    Eg("archaology"),
                    Eg("sociology"),
@@ -2898,6 +2909,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
         ),
 
         Science_Fiction : match_kw(
+            "science fiction",
             "science fiction.*general",
         ),
 
@@ -2928,9 +2940,11 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
     def is_fiction(cls, identifier, name, exclude_examples=False):
         if not name:
             return None
-        if (cls.FICTION_INDICATORS["search"](name, exclude_examples)):
+        if (cls.LEVEL_1_NONFICTION_INDICATORS["search"](name, exclude_examples)):
+            return False
+        if (cls.LEVEL_2_FICTION_INDICATORS["search"](name, exclude_examples)):
             return True
-        if (cls.NONFICTION_INDICATORS["search"](name, exclude_examples)):
+        if (cls.LEVEL_2_NONFICTION_INDICATORS["search"](name, exclude_examples)):
             return False
         return None
 
@@ -3023,6 +3037,7 @@ class FASTClassifier(KeywordBasedClassifier):
 
 class TAGClassifier(KeywordBasedClassifier):
     pass
+
 
 class GutenbergBookshelfClassifier(Classifier):
 

--- a/model.py
+++ b/model.py
@@ -812,11 +812,15 @@ class DataSource(Base):
     )
 
     @classmethod
-    def lookup(cls, _db, name):
+    def lookup(cls, _db, name, autocreate=False):
         # Turn a deprecated name (e.g. "3M" into the current name
         # (e.g. "Bibliotheca").
         name = cls.DEPRECATED_NAMES.get(name, name)
-        return get_one(_db, DataSource, name=name)
+        if autocreate:
+            data_source, is_new = get_one_or_create(_db, DataSource, name=name)
+        else:
+            data_source = get_one(_db, DataSource, name=name)
+        return data_source
 
     URI_PREFIX = "http://librarysimplified.org/terms/sources/"
 

--- a/model.py
+++ b/model.py
@@ -704,6 +704,7 @@ class DataSource(Base):
     PROJECT_GITENBERG = "Project GITenberg"
     STANDARD_EBOOKS = "Standard Ebooks"
     UNGLUE_IT = "unglue.it"
+    FEEDBOOKS = "FeedBooks"
     BIBLIOTHECA = "Bibliotheca"
     OCLC = "OCLC Classify"
     OCLC_LINKED_DATA = "OCLC Linked Data"

--- a/model.py
+++ b/model.py
@@ -704,7 +704,6 @@ class DataSource(Base):
     PROJECT_GITENBERG = "Project GITenberg"
     STANDARD_EBOOKS = "Standard Ebooks"
     UNGLUE_IT = "unglue.it"
-    FEEDBOOKS = "FeedBooks"
     BIBLIOTHECA = "Bibliotheca"
     OCLC = "OCLC Classify"
     OCLC_LINKED_DATA = "OCLC Linked Data"

--- a/opds_import.py
+++ b/opds_import.py
@@ -33,7 +33,6 @@ from metadata_layer import (
 )
 from model import (
     get_one,
-    get_one_or_create,
     CoverageRecord,
     DataSource,
     Edition,
@@ -354,8 +353,8 @@ class OPDSImporter(object):
         # This is one of these cases where we want to create a
         # DataSource if it doesn't already exist. This way you don't have
         # to predefine a DataSource for every source of OPDS feeds.
-        data_source, ignore = get_one_or_create(
-            self._db, DataSource, name=self.data_source_name
+        data_source = DataSource.lookup(
+            self._db, name=self.data_source_name, autocreate=True
         )
         fp_metadata, fp_failures = self.extract_data_from_feedparser(feed=feed, data_source=data_source)
         # gets: medium, measurements, links, contributors, etc.

--- a/tests/files/opds/unrecognized_distributor.opds
+++ b/tests/files/opds/unrecognized_distributor.opds
@@ -14,6 +14,7 @@
       <simplified:sort_name>Chambers, Robert W. (Robert William)</simplified:sort_name>
     </author>
     <summary>This is a summary!</summary>
+    <link href="http://www.gutenberg.org/ebooks/10441.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
     <updated>2015-01-02T16:56:40Z</updated>
     <published>2014-01-02T16:56:40Z</published>
     <simplified:pwid>6db4cf90-0129-0eaf-410a-502b20a45e67</simplified:pwid>

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -491,6 +491,19 @@ class TestKeyword(object):
             Keyword.genre(None, "Science Fiction - General")
         )
 
+        # Was General Fiction (!)
+        eq_(classifier.Science_Fiction,
+            Keyword.genre(None, "Science Fiction")
+        )
+        
+        eq_(classifier.Science_Fiction,
+            Keyword.genre(None, "Speculative Fiction")
+        )
+
+        eq_(classifier.Social_Sciences,
+            Keyword.genre(None, "Human Science")
+        )
+        
         # was Military History
         eq_(classifier.Military_SF,
             Keyword.genre(None, "Interstellar Warfare")
@@ -506,6 +519,16 @@ class TestKeyword(object):
             Keyword.genre(None, "TV, Movie, Video game adaptations")
         )
 
+        # Previously only 'nonfiction' was recognized.
+        eq_(False, Keyword.is_fiction(None, "Non-Fiction"))
+        eq_(False, Keyword.is_fiction(None, "Non Fiction"))
+
+        # "Historical" on its own means historical fiction, but a
+        # string containing "Historical" does not mean anything in
+        # particular.
+        eq_(classifier.Historical_Fiction, Keyword.genre(None, "Historical"))
+        eq_(None, Keyword.genre(None, "Historicals"))
+        
 class TestBISAC(object):
 
     def test_is_fiction(self):

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -492,6 +492,14 @@ class TestKeyword(object):
         )
 
         eq_(classifier.Social_Sciences,
+            Keyword.genre(None, "Social Sciences")
+        )
+
+        eq_(classifier.Social_Sciences,
+            Keyword.genre(None, "Social Science")
+        )
+        
+        eq_(classifier.Social_Sciences,
             Keyword.genre(None, "Human Science")
         )
         

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -92,6 +92,7 @@ class TestDataSource(DatabaseTest):
         eq_(DataSource.GUTENBERG, gutenberg.name)
         eq_(True, gutenberg.offers_licenses)
 
+       
     def test_lookup_by_deprecated_name(self):
         threem = DataSource.lookup(self._db, "3M")
         eq_(DataSource.BIBLIOTHECA, threem.name)
@@ -100,6 +101,11 @@ class TestDataSource(DatabaseTest):
     def test_lookup_returns_none_for_nonexistent_source(self):
         eq_(None, DataSource.lookup(
             self._db, "No such data source " + self._str))
+
+    def test_lookup_with_autocreate(self):
+        name = "Brand new data source " + self._str
+        new_source = DataSource.lookup(self._db, name, autocreate=True)
+        eq_(name, new_source.name)
 
     def test_metadata_sources_for(self):
         content_cafe = DataSource.lookup(self._db, DataSource.CONTENT_CAFE)


### PR DESCRIPTION
This branch makes some changes in core in preparation for the ability to import books from FeedBooks. 

Up to this point we have handled a new datasource by defining a new DataSource for the new source of books. I've decided to put a stop to that, by changing opds_import.py so that it automatically creates DataSource objects when it encounters an unrecognized DataSource in an OPDS feed (or as `data_source_name` in the constructor).

So the first time you run a FeedBooks import (or an import of FeedBooks books from the content server), the FeedBooks DataSource will show up in your database.

I also made some improvements to the KeywordClassifier so that it could handle some of the tags specific to FeedBooks, such as "non-fiction" spelled with a dash.