### PR TITLE
Add the drm: namespace to cached entries.

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -758,6 +758,18 @@ class AcquisitionFeed(OPDSFeed):
         self.annotator.annotate_work_entry(
             work, license_pool, edition, identifier, self, xml)
 
+        # Make sure that potentially old XML includes new namespace
+        # declarations.
+        if not 'drm' in xml.nsmap:
+            # This workaround (creating a brand new tag) is necessary
+            # because the nsmap attribute is immutable. See
+            # https://bugs.launchpad.net/lxml/+bug/555602
+            nsmap = xml.nsmap
+            nsmap['drm'] = AtomFeed.DRM_NS
+            new_root = etree.Element(xml.tag, nsmap=nsmap)
+            new_root[:] = xml[:]
+            xml = new_root
+            
         group_uri, group_title = self.annotator.group_uri(
             work, license_pool, identifier)
         if group_uri:

--- a/opds.py
+++ b/opds.py
@@ -615,7 +615,7 @@ class AcquisitionFeed(OPDSFeed):
         # document it's essential that it include an up-to-date nsmap,
         # even if it was generated from an old cached <entry> tag that
         # had an older nsmap.
-        if not 'drm' in entry.nsmap:
+        if isinstance(entry, etree._Element) and not 'drm' in entry.nsmap:
             # This workaround (creating a brand new tag) is necessary
             # because the nsmap attribute is immutable. See
             # https://bugs.launchpad.net/lxml/+bug/555602

--- a/opds_import.py
+++ b/opds_import.py
@@ -831,10 +831,8 @@ class OPDSImporter(object):
                 ratings.append(v)
         data['measurements'] = ratings
 
-        entry_rights = parser._xpath(entry_tag, 'rights')
-        
         data['links'] = cls.consolidate_links([
-            cls.extract_link(link_tag, feed_url, entry_rights)
+            cls.extract_link(link_tag, feed_url)
             for link_tag in parser._xpath(entry_tag, 'atom:link')
         ])
         return data
@@ -929,17 +927,7 @@ class OPDSImporter(object):
         )
 
     @classmethod
-    def extract_link(cls, link_tag, feed_url=None, entry_rights_uri=None):
-        """Convert a <link> tag into a LinkData object.
-
-        :param feed_url: The URL to the enclosing feed, for use in resolving
-        relative links.
-
-        :param entry_rights_uri: A URI describing the rights advertised
-        in the entry. Unless this specific link says otherwise, we
-        will assume that the representation on the other end of the link
-        if made available on these terms.
-        """
+    def extract_link(cls, link_tag, feed_url=None):
         attr = link_tag.attrib
         rel = attr.get('rel')
         media_type = attr.get('type')
@@ -952,8 +940,7 @@ class OPDSImporter(object):
         if rights:
             rights_uri = RightsStatus.rights_uri_from_string(rights)
         else:
-            rights_uri = entry_rights_uri
-        set_trace()
+            rights_uri = None
         if feed_url and not urlparse(href).netloc:
             # This link is relative, so we need to get the absolute url
             href = urljoin(feed_url, href)


### PR DESCRIPTION
This branch fixes https://github.com/NYPL-Simplified/circulation/issues/408

We could do without this branch by regenerating the OPDS cache for every entry in our collections. I think it's less work to make sure the drm: namespace is present whenever an <entry> tag is about to be used as the root tag of an XML document.

Also, this probably isn't the only time this will happen, and it's good to have a precedent in the code base.