### PR TITLE
Feedbooks import

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1307,7 +1307,6 @@ class Metadata(MetaToModelUtility):
         self.log.info(
             "APPLYING METADATA TO EDITION: %s",  self.title
         )
-
         fields = self.BASIC_EDITION_FIELDS+['permanent_work_id']
         for field in fields:
             old_edition_value = getattr(edition, field)

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -465,6 +465,14 @@ class MetaToModelUtility(object):
                 self.log.info("Not mirroring %s: rel=%s", link.href, link_obj.rel)
             return
 
+        if (link.rights_uri
+            and link.rights_uri not in RightsStatus.OPEN_ACCESS):
+            self.log.info(
+                "Not mirroring %s: rights status=%s" % (
+                    link.href, link.rights_uri
+                )
+            )
+        
         mirror = policy.mirror
         http_get = policy.http_get
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -466,13 +466,14 @@ class MetaToModelUtility(object):
             return
 
         if (link.rights_uri
-            and link.rights_uri not in RightsStatus.OPEN_ACCESS):
+            and link.rights_uri == RightsStatus.IN_COPYRIGHT):
             self.log.info(
                 "Not mirroring %s: rights status=%s" % (
                     link.href, link.rights_uri
                 )
             )
-        
+            return
+            
         mirror = policy.mirror
         http_get = policy.http_get
 

--- a/model.py
+++ b/model.py
@@ -811,12 +811,15 @@ class DataSource(Base):
     )
 
     @classmethod
-    def lookup(cls, _db, name, autocreate=False):
+    def lookup(cls, _db, name, autocreate=False, offers_licenses=False):
         # Turn a deprecated name (e.g. "3M" into the current name
         # (e.g. "Bibliotheca").
         name = cls.DEPRECATED_NAMES.get(name, name)
         if autocreate:
-            data_source, is_new = get_one_or_create(_db, DataSource, name=name)
+            data_source, is_new = get_one_or_create(
+                _db, DataSource, name=name,
+                create_method_kwargs=dict(offers_licenses=offers_licenses)
+            )
         else:
             data_source = get_one(_db, DataSource, name=name)
         return data_source
@@ -4590,6 +4593,7 @@ class Hyperlink(Base):
 
     # Some common link relations.
     CANONICAL = u"canonical"
+    GENERIC_OPDS_ACQUISITION = u"http://opds-spec.org/acquisition"
     OPEN_ACCESS_DOWNLOAD = u"http://opds-spec.org/acquisition/open-access"
     IMAGE = u"http://opds-spec.org/image"
     THUMBNAIL_IMAGE = u"http://opds-spec.org/image/thumbnail"

--- a/model.py
+++ b/model.py
@@ -7215,7 +7215,6 @@ class Representation(Base):
         self.fetch_exception = None
         self.update_image_size()
 
-
     def set_as_mirrored(self):
         """Record the fact that the representation has been mirrored
         to its .mirror_url.

--- a/model.py
+++ b/model.py
@@ -6445,6 +6445,9 @@ class RightsStatus(Base):
             return RightsStatus.CC_BY_NC_SA
         elif rights == 'cc by-nc-nd':
             return RightsStatus.CC_BY_NC_ND
+        elif (rights in RightsStatus.OPEN_ACCESS
+              or rights == RightsStatus.IN_COPYRIGHT):
+            return rights
         else:
             return RightsStatus.UNKNOWN
 

--- a/opds_import.py
+++ b/opds_import.py
@@ -818,7 +818,10 @@ class OPDSImporter(object):
 
         if feedparser_data:
             feedparser_detail = feedparser_data.get(identifier)
-        
+        else:
+            set_trace()
+            feedparser_detail={}
+            
         try:
             data = cls._detail_for_elementtree_entry(
                 parser, entry_tag, feed_url, feedparser_detail=feedparser_detail

--- a/opds_import.py
+++ b/opds_import.py
@@ -448,15 +448,27 @@ class OPDSImporter(object):
             return dict(d1)
         new_dict = dict(d1)
         for k, v in d2.items():
-            if k in new_dict:
+            if k not in new_dict:
+                # There is no value from d1. Even if the d2 value
+                # is None, we want to set it.
+                new_dict[k] = v
+            elif v != None:
+                # d1 provided a value, and d2 provided a value other
+                # than None.
                 if isinstance(v, list):
+                    # The values are lists. Merge them.
                     new_dict[k].extend(v)
                 elif isinstance(v, dict):
+                    # The values are dicts. Merge them by with
+                    # a recursive combine() call.
                     new_dict[k] = self.combine(new_dict[k], v)
-                elif new_dict[k] is None:
+                else:
+                    # Overwrite d1's value with d2's value.
                     new_dict[k] = v
-            elif k not in new_dict or v != None:
-                new_dict[k] = v
+            else:
+                # d1 provided a value and d2 provided None.  Do
+                # nothing.
+                pass
         return new_dict
 
 

--- a/opds_import.py
+++ b/opds_import.py
@@ -819,7 +819,6 @@ class OPDSImporter(object):
         if feedparser_data:
             feedparser_detail = feedparser_data.get(identifier)
         else:
-            set_trace()
             feedparser_detail={}
             
         try:
@@ -988,8 +987,6 @@ class OPDSImporter(object):
         """
         attr = link_tag.attrib
         rel = attr.get('rel')
-        print etree.tostring(link_tag)
-        print rel
         media_type = attr.get('type')
         href = attr.get('href')
         if not href or not rel:

--- a/opds_import.py
+++ b/opds_import.py
@@ -199,12 +199,14 @@ class OPDSImporter(object):
         "No existing license pool for this identifier and no way of creating one.")
    
     def __init__(self, _db, data_source_name=DataSource.METADATA_WRANGLER,
-                 identifier_mapping=None, mirror=None, http_get=None):
+                 identifier_mapping=None, mirror=None, http_get=None,
+                 metadata_client=None
+    ):
         self._db = _db
         self.log = logging.getLogger("OPDS Importer")
         self.data_source_name = data_source_name
         self.identifier_mapping = identifier_mapping
-        self.metadata_client = SimplifiedOPDSLookup.from_config()
+        self.metadata_client = metadata_client or SimplifiedOPDSLookup.from_config()
         self.mirror = mirror
         self.http_get = http_get
 
@@ -1210,9 +1212,10 @@ class OPDSImportMonitor(Monitor):
 class OPDSImporterWithS3Mirror(OPDSImporter):
     """OPDS Importer that mirrors content to S3."""
 
-    def __init__(self, _db, default_data_source, **kwargs):
+    def __init__(self, _db, default_data_source, *args, **kwargs):
         kwargs = dict(kwargs)
-        kwargs['mirror'] = S3Uploader()
+        if not 'mirror' in kwargs:
+            kwargs['mirror'] = S3Uploader()
         super(OPDSImporterWithS3Mirror, self).__init__(
-            _db, default_data_source, **kwargs
+            _db, default_data_source, *args, **kwargs
         )

--- a/opds_import.py
+++ b/opds_import.py
@@ -362,7 +362,7 @@ class OPDSImporter(object):
         fp_metadata, fp_failures = self.extract_data_from_feedparser(feed=feed, data_source=data_source)
         # gets: medium, measurements, links, contributors, etc.
         xml_data_meta, xml_failures = self.extract_metadata_from_elementtree(
-            feed, data_source=data_source, feed_url=feed_url,
+            feed, data_source=data_source, feed_url=feed_url
         )
 
         # translate the id in failures to identifier.urn
@@ -702,10 +702,9 @@ class OPDSImporter(object):
 
         :return: A rights URI.
         """
-        for name in ('atom:rights', 'rights'):
-            rights = OPDSXMLParser._xpath1(entry, 'rights')
-            if rights:
-                return cls.rights_uri(rights)
+        rights = OPDSXMLParser._xpath1(entry, 'rights')
+        if rights:
+            return cls.rights_uri(rights)
     
     @classmethod
     def extract_messages(cls, parser, feed_tag):

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -601,8 +601,27 @@ class TestMetaToModelUtility(DatabaseTest):
         eq_(True, pool.suppressed)
         assert representation.mirror_exception in pool.license_exception
 
+    def test_has_open_access_link(self):
+        identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
+        
+        circulationdata = CirculationData(DataSource.GUTENBERG, identifier)
 
+        # No links
+        eq_(False, circulationdata.has_open_access_link)
 
+        linkdata = LinkData(
+            rel=Hyperlink.OPEN_ACCESS_DOWNLOAD,
+            href=self._url,
+        )
+        circulationdata.links = [linkdata]
+        
+        # Open-access link with no explicit rights URI.
+        eq_(True, circulationdata.has_open_access_link)
 
+        # Open-access link with contradictory rights URI.
+        linkdata.rights_uri = RightsStatus.IN_COPYRIGHT
+        eq_(False, circulationdata.has_open_access_link)
 
-
+        # Open-access link with consistent rights URI.
+        linkdata.rights_uri = RightsStatus.GENERIC_OPEN_ACCESS
+        eq_(True, circulationdata.has_open_access_link)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -852,3 +852,31 @@ class TestAssociateWithIdentifiersBasedOnPermanentWorkID(DatabaseTest):
         # with the identifier of the audiobook
         equivalent_identifiers = [x.output for x in identifier.equivalencies]
         eq_([book.primary_identifier], equivalent_identifiers)
+
+
+class TestCirculationData(DatabaseTest):
+    
+    def test_has_open_access_link(self):
+        identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
+        
+        circulationdata = CirculationData(DataSource.GUTENBERG, identifier)
+
+        # No links
+        eq_(False, circulationdata.has_open_access_link)
+
+        linkdata = LinkData(
+            rel=Hyperlink.OPEN_ACCESS_DOWNLOAD,
+            href=self._url,
+        )
+        circulationdata.links = [linkdata]
+        
+        # Open-access link with no explicit rights URI.
+        eq_(True, circulationdata.has_open_access_link)
+
+        # Open-access link with contradictory rights URI.
+        linkdata.rights_uri = RightsStatus.IN_COPYRIGHT
+        eq_(False, circulationdata.has_open_access_link)
+
+        # Open-access link with consistent rights URI.
+        linkdata.rights_uri = RightsStatus.GENERIC_OPEN_ACCESS
+        eq_(True, circulationdata.has_open_access_link)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -34,6 +34,7 @@ from model import (
     DeliveryMechanism,
     Hyperlink, 
     Representation,
+    RightsStatus,
     Subject,
 )
 
@@ -366,6 +367,41 @@ class TestMetadataImporter(DatabaseTest):
         # if fetch failed on getting an Hyperlink.OPEN_ACCESS_DOWNLOAD-type epub.
         eq_(None, pool.license_exception)
 
+    def test_non_open_access_book_not_mirrored(self):        
+        data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)
+        m = Metadata(data_source=data_source)
+
+        mirror = DummyS3Uploader(fail=True)
+        h = DummyHTTPClient()
+
+        policy = ReplacementPolicy(mirror=mirror, http_get=h.do_get)
+
+        content = "foo"
+        link = LinkData(
+            rel=Hyperlink.OPEN_ACCESS_DOWNLOAD,
+            media_type=Representation.EPUB_MEDIA_TYPE,
+            href="http://example.com/",
+            content=content,
+            rights_uri=RightsStatus.IN_COPYRIGHT
+        )
+
+        identifier = self._identifier()
+        link_obj, is_new = identifier.add_link(
+            rel=link.rel, href=link.href, data_source=data_source,
+            media_type=link.media_type, content=link.content,
+        )
+
+        # The Hyperlink object makes it look like an open-access book,
+        # but the context we have from the OPDS feed says that it's
+        # not.
+        m.mirror_link(None, data_source, link, link_obj, policy)
+
+        # No HTTP requests were made.
+        eq_([], h.requests)
+        
+        # Nothing was uploaded.
+        eq_([], mirror.uploaded)
+        
     def test_measurements(self):
         edition = self._edition()
         measurement = MeasurementData(quantity_measured=Measurement.POPULARITY,

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -852,31 +852,4 @@ class TestAssociateWithIdentifiersBasedOnPermanentWorkID(DatabaseTest):
         # with the identifier of the audiobook
         equivalent_identifiers = [x.output for x in identifier.equivalencies]
         eq_([book.primary_identifier], equivalent_identifiers)
-
-
-class TestCirculationData(DatabaseTest):
     
-    def test_has_open_access_link(self):
-        identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
-        
-        circulationdata = CirculationData(DataSource.GUTENBERG, identifier)
-
-        # No links
-        eq_(False, circulationdata.has_open_access_link)
-
-        linkdata = LinkData(
-            rel=Hyperlink.OPEN_ACCESS_DOWNLOAD,
-            href=self._url,
-        )
-        circulationdata.links = [linkdata]
-        
-        # Open-access link with no explicit rights URI.
-        eq_(True, circulationdata.has_open_access_link)
-
-        # Open-access link with contradictory rights URI.
-        linkdata.rights_uri = RightsStatus.IN_COPYRIGHT
-        eq_(False, circulationdata.has_open_access_link)
-
-        # Open-access link with consistent rights URI.
-        linkdata.rights_uri = RightsStatus.GENERIC_OPEN_ACCESS
-        eq_(True, circulationdata.has_open_access_link)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -106,7 +106,14 @@ class TestDataSource(DatabaseTest):
         name = "Brand new data source " + self._str
         new_source = DataSource.lookup(self._db, name, autocreate=True)
         eq_(name, new_source.name)
-
+        eq_(False, new_source.offers_licenses)
+        
+        name = "New data source with licenses" + self._str
+        new_source = DataSource.lookup(
+            self._db, name, autocreate=True, offers_licenses=True
+        )
+        eq_(True, new_source.offers_licenses)
+        
     def test_metadata_sources_for(self):
         content_cafe = DataSource.lookup(self._db, DataSource.CONTENT_CAFE)
         isbn_metadata_sources = DataSource.metadata_sources_for(

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -256,7 +256,7 @@ class TestOPDSImporter(OPDSImporterTest):
         data, failures = OPDSImporter.extract_metadata_from_elementtree(
             self.content_server_feed, data_source
         )
-
+        
         # There are 76 entries in the feed, and we got metadata for
         # every one of them.
         eq_(76, len(data))

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -842,7 +842,37 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_([], imported_pools)
         eq_([], imported_works)
 
+    def test_combine(self):
+        d1 = dict(
+            a_list=[1],
+            a_scalar="old value",
+            a_dict=dict(key1=None, key2=[2], key3="value3")
+        )
 
+        d2 = dict(
+            a_list=[2],
+            a_scalar="new value",
+            a_dict=dict(key1="finally a value", key4="value4", key2=[200])
+        )
+
+        combined = OPDSImporter.combine(d1, d2)
+
+        # Dictionaries get combined recursively.
+        d = combined['a_dict']
+        
+        # Normal scalar values don't get overridden once set.
+        eq_("old value", combined['a_scalar'])
+
+        # Missing values are filled in.
+        eq_('finally a value', d["key1"])
+        eq_('value3', d['key3'])
+        eq_('value4', d['key4'])
+        
+        # Lists get extended.
+        eq_([1, 2], combined['a_list'])
+        eq_([2, 200], d['key2'])
+
+        
 class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
 
     def test_resources_are_mirrored_on_import(self):

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -209,7 +209,6 @@ class TestOPDSImporter(OPDSImporterTest):
         # But a dcterms:rights tag beneath the link can override this.
         rights_attr = "{%s}rights" % AtomFeed.DCTERMS_NS
         link_tag.attrib[rights_attr] = RightsStatus.IN_COPYRIGHT
-        set_trace()
         link = OPDSImporter.extract_link(
             link_tag, entry_rights_uri=entry_rights
         )

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -125,6 +125,24 @@ class OPDSImporterTest(DatabaseTest):
 
 class TestOPDSImporter(OPDSImporterTest):
 
+    def test_data_source_autocreated(self):
+        name = "New data source " + self._str
+        importer = OPDSImporter(self._db, name)
+        source1 = importer.data_source
+        eq_(name, source1.name)
+        
+        # By default, DataSources created through this mechanism do
+        # not offer licenses.
+        eq_(False, source1.offers_licenses)
+
+        # But we can create a DataSource that does offer licenses.
+        name = "New data source " + self._str
+        importer = OPDSImporter(self._db, name,
+                                data_source_offers_licenses=True)
+        source2 = importer.data_source
+        eq_(name, source2.name)
+        eq_(True, source2.offers_licenses)
+        
     def test_extract_next_links(self):
         importer = OPDSImporter(self._db, DataSource.NYT)
         next_links = importer.extract_next_links(


### PR DESCRIPTION
Framework changes necessary to support imports from Feedbooks's idiosyncratic OPDS feed.

* It's possible for an open-access link to have a rights status of "in copyright". (In Feedbooks's case this is a book that is public domain in Europe but not in the US). Links like these do not get mirrored to S3.

* A LicensePool can have a DeliveryMechanism that contains an open-access link with a status of "in copyright" is not treated as an open-access LicensePool. I decided to do things this way (as opposed to changing the link relation or removing the DeliveryMechanism altogether) because it focuses the problem in the rights status. If the rights status ever changes it will be easy to reevaluate and make the LicensePool open-access.

* When creating a new DataSource at runtime it's possible to set its `.offers_licenses`.

* It's possible for the feedparser code to decline to contribute a value it's expected to contribute, with the expectation that the elementtree code will fill it in later. For Feedbooks we do this with the entry's default rights URI.