### PR TITLE
Feedbooks books are better than Gutenberg books

### DIFF
--- a/model.py
+++ b/model.py
@@ -729,7 +729,8 @@ class DataSource(Base):
     OA_CONTENT_SERVER = "Library Simplified Open Access Content Server"
     PRESENTATION_EDITION = "Presentation edition generator"
     INTERNAL_PROCESSING = "Library Simplified Internal Process"
-
+    FEEDBOOKS = "FeedBooks"
+    
     DEPRECATED_NAMES = {
         "3M" : BIBLIOTHECA
     }
@@ -746,6 +747,7 @@ class DataSource(Base):
         GUTENBERG_EPUB_GENERATOR,
         PROJECT_GITENBERG,
         ELIB,
+        FEEDBOOKS,
         PLYMPTON,
         STANDARD_EBOOKS,
     ]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1224,6 +1224,16 @@ class TestLicensePool(DatabaseTest):
             with_open_access_download=True
         )
 
+        # Make sure Feedbooks data source exists -- it's not created
+        # by default.
+        feedbooks_data_source = DataSource.lookup(
+            self._db, DataSource.FEEDBOOKS, autocreate=True
+        )
+        feedbooks = self._licensepool(
+            None, open_access=True, data_source_name=DataSource.FEEDBOOKS,
+            with_open_access_download=True
+        )
+        
         overdrive = self._licensepool(
             None, open_access=False, data_source_name=DataSource.OVERDRIVE
         )
@@ -1249,8 +1259,9 @@ class TestLicensePool(DatabaseTest):
         # An open access book from a high-quality source beats one
         # from a low-quality source.
         eq_(True, better(standard_ebooks, gutenberg_1))
+        eq_(True, better(feedbooks, gutenberg_1))
         eq_(False, better(gutenberg_1, standard_ebooks))
-
+        
         # A high Gutenberg number beats a low Gutenberg number.
         eq_(True, better(gutenberg_2, gutenberg_1))
         eq_(False, better(gutenberg_1, gutenberg_2))


### PR DESCRIPTION
I was hoping to avoid the creation of a DataSource.FEEDBOOKS constant, but it seems like the quickest way to get Feedbooks books properly set up in the content server.

A more flexible solution would be to create a `default_quality` field on `DataSource`. When you create a `DataSource` you would be allowed to specify its `default_quality`. We'd be able to get rid of OPEN_ACCESS_SOURCE_PRIORITY and instead calculate priority based on comparisons of `default_quality`.