### PR TITLE
Use labels to remove annoying error from fast_query_count

### DIFF
--- a/util/__init__.py
+++ b/util/__init__.py
@@ -22,8 +22,7 @@ def batch(iterable, size=1):
 
 def fast_query_count(query):
     """Counts the results of a query without using super-slow subquery"""
-
-    statement = query.enable_eagerloads(False).statement
+    statement = query.enable_eagerloads(False).with_labels().statement
     distinct_columns = statement._distinct
     new_columns = [func.count()]
     if isinstance(distinct_columns, list):


### PR DESCRIPTION
I'm tired of annoying SQLAlchemy warnings. 😢  So I removed this one.