### PR TITLE
Reject a Bibliotheca ID that contains a slash.

### DIFF
--- a/model.py
+++ b/model.py
@@ -875,7 +875,7 @@ class DataSource(Base):
                 (cls.GUTENBERG, True, False, Identifier.GUTENBERG_ID, None),
                 (cls.ONECLICK, True, True, Identifier.ONECLICK_ID, None),
                 (cls.OVERDRIVE, True, False, Identifier.OVERDRIVE_ID, 0),
-                (cls.THREEM, True, False, Identifier.THREEM_ID, 60*60*6),
+                (cls.THREEM, True, False, Identifier.BIBLIOTHECA_ID, 60*60*6),
                 (cls.AXIS_360, True, False, Identifier.AXIS_360_ID, 0),
                 (cls.OCLC, False, False, None, None),
                 (cls.OCLC_LINKED_DATA, False, False, None, None),
@@ -1225,7 +1225,7 @@ class Identifier(Base):
     THREEM_ID = BIBLIOTHECA_ID
 
     LICENSE_PROVIDING_IDENTIFIER_TYPES = [
-        THREEM_ID, OVERDRIVE_ID, AXIS_360_ID,
+        BIBLIOTHECA_ID, OVERDRIVE_ID, AXIS_360_ID,
         GUTENBERG_ID, ELIB_ID
     ]
 
@@ -1339,8 +1339,13 @@ class Identifier(Base):
         )
         
         if foreign_identifier_type in (
-                Identifier.OVERDRIVE_ID, Identifier.THREEM_ID):
+                Identifier.OVERDRIVE_ID, Identifier.BIBLIOTHECA_ID):
             foreign_id = foreign_id.lower()
+        if (foreign_identifier_type == Identifier.BIBLIOTHECA_ID
+            and '/' in foreign_id):
+            raise ValueError(
+                '"%s" is not a valid Bibliotheca ID.' % (foreign_id)
+            )
         if autocreate:
             m = get_one_or_create
         else:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -175,7 +175,17 @@ class TestIdentifier(DatabaseTest):
             Identifier.for_foreign_id,
             self._db, Identifier.BIBLIOTHECA_ID, "foo/bar"
         )
-        
+
+    def test_valid_as_foreign_identifier(self):
+        m = Identifier.valid_as_foreign_identifier
+
+        eq_(True, m(Identifier.BIBLIOTHECA_ID, "bhhot389"))
+        eq_(False, m(Identifier.BIBLIOTHECA_ID, "bhhot389/open_book"))
+        eq_(False, m(Identifier.BIBLIOTHECA_ID, "bhhot389,bhhot389"))
+
+        eq_(True, m(Identifier.BIBLIOTHECA_ID, "0015142259"))
+        eq_(False, m(Identifier.BIBLIOTHECA_ID, "0015142259,0015187940"))
+            
     def test_for_foreign_id_without_autocreate(self):
         identifier_type = Identifier.ISBN
         isbn = self._str

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -167,6 +167,14 @@ class TestIdentifier(DatabaseTest):
         )
         eq_(Identifier.BIBLIOTHECA_ID, threem_id.type)
         assert Identifier.BIBLIOTHECA_ID != "3M ID"
+
+    def test_for_foreign_id_rejects_invalid_identifiers(self):
+        assert_raises_regexp(
+            ValueError,
+            '"foo/bar" is not a valid Bibliotheca ID.',
+            Identifier.for_foreign_id,
+            self._db, Identifier.BIBLIOTHECA_ID, "foo/bar"
+        )
         
     def test_for_foreign_id_without_autocreate(self):
         identifier_type = Identifier.ISBN


### PR DESCRIPTION
This fixes https://github.com/NYPL-Simplified/server_core/issues/430.

I also started using Identifier.BIBLIOTHECA_ID instead of (the identical) Identifier.THREEM_ID constant within model.py.