### PR TITLE
Given cover images of equal quality, prefer media types that are easier to work with

### DIFF
--- a/model.py
+++ b/model.py
@@ -4787,24 +4787,31 @@ class Resource(Base):
         self.quality = total_quality / float(total_weight)
 
     @classmethod
+    def image_type_priority(cls, media_type):
+        """Where does the given image media type rank on our list of
+        preferences?
+
+        :return: A lower number is better. None means it's not an
+        image type or we don't care about it at all.
+        """
+        if media_type in Representation.IMAGE_MEDIA_TYPES: 
+            return Representation.IMAGE_MEDIA_TYPES.index(media_type)
+        return None
+        
+    @classmethod
     def best_covers_among(cls, resources):
+
         """Choose the best covers from a list of Resources."""
         champions = []
         champion_score = None
         champion_media_type_score = None
-
-        def media_type_priority(representation):
-            media_type = representation.media_type
-            if media_type in Representation.IMAGE_MEDIA_TYPES:
-                return Representation.IMAGE_MEDIA_TYPES.index(media_type)
-            return None
-            
+           
         for r in resources:
             rep = r.representation
             if not rep:
                 # A Resource with no Representation is not usable, period
                 continue
-            media_priority = media_type_priority(rep)
+            media_priority = cls.image_type_priority(rep.media_type)
             quality = r.quality_as_thumbnail_image
             if not quality >= cls.MINIMUM_IMAGE_QUALITY:
                 # A Resource below the minimum quality threshold is not
@@ -4817,7 +4824,7 @@ class Resource(Base):
             elif quality == champion_score:
                 # We have two images with the same score. One might be
                 # in a format we prefer.
-                if (not champion_media_type_priority
+                if (champion_media_type_priority is None
                     or (media_priority is not None
                         and media_priority < champion_media_type_priority)):
                     print "%s beats %s" % (media_priority, champion_media_type_priority)
@@ -4827,7 +4834,6 @@ class Resource(Base):
                 elif media_priority == champion_media_type_priority:
                     # Same score, same format. We have two champions.
                     champions.append(r)
-        set_trace()
         return champions
 
     @property


### PR DESCRIPTION
This branch fixes https://github.com/NYPL-Simplified/content_server/issues/103 by changing `best_covers_among()` to take media type into consideration. If two covers are from the same data source and same quality but different formats, we will prefer PNG over JPEG over GIF over SVG, because PNG and JPEG are the easiest image formats for us to deal with programatically and are less likely to harbor surprises.