### PR TITLE
RightsStatus.uri is unique.

### DIFF
--- a/migration/20161215-rightsstatus-uri-is-unique.sql
+++ b/migration/20161215-rightsstatus-uri-is-unique.sql
@@ -1,0 +1,1 @@
+alter table rightsstatus add constraint rightsstatus_uri_key UNIQUE (uri);

--- a/model.py
+++ b/model.py
@@ -6376,7 +6376,7 @@ class RightsStatus(Base):
 
     # A URI unique to the license. This may be a URL (e.g. Creative
     # Commons)
-    uri = Column(String, index=True)
+    uri = Column(String, index=True, unique=True)
 
     # Human-readable name of the license.
     name = Column(String, index=True)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -17,6 +17,10 @@ from nose.tools import (
 
 from psycopg2.extras import NumericRange
 
+from sqlalchemy.exc import (
+    IntegrityError,
+)
+
 from sqlalchemy.orm.exc import (
     NoResultFound,
 )
@@ -4141,6 +4145,17 @@ class TestRightsStatus(DatabaseTest):
         status = RightsStatus.lookup(self._db, "not a known rights uri")
         eq_(RightsStatus.UNKNOWN, status.uri)
         eq_(RightsStatus.NAMES.get(RightsStatus.UNKNOWN), status.name)
+
+    def test_unique_uri_constraint(self):
+        # We already have this RightsStatus.
+        status = RightsStatus.lookup(self._db, RightsStatus.IN_COPYRIGHT)
+
+        # Let's try to create another one with the same URI.
+        dupe = RightsStatus(uri=RightsStatus.IN_COPYRIGHT)
+        self._db.add(dupe)
+
+        # Nope.
+        assert_raises(IntegrityError, self._db.commit)
 
 
 class TestCredentials(DatabaseTest):


### PR DESCRIPTION
We have code that assumes RightsStatus.uri is unique, and it should in fact be unique, but it wasn't actually required to be unique in the database. This branch adds a unique constraint on that field.

This can cause a problem when two scripts run at the same time and find a license pool with the same RightsStatus. We just saw this on BPL when a Bibliotheca script ran at the same time as an Overdrive script and we ended up with two copies of IN_COPYRIGHT.