### PR TITLE
Support sorted static feed lanes

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -367,12 +367,16 @@ class Pagination(object):
 
     @property
     def has_next_page(self):
-        """Returns boolean reporting whether pagination is done for a query"""
+        """Returns boolean reporting whether pagination is done for a query
+
+        This method only returns valid information _after_ self.apply
+        has been run on a query.
+        """
         if self.query_size is None:
             return True
         if self.query_size==0:
             return False
-        return (self.offset+1) * self.size < self.query_size
+        return self.offset + self.size < self.query_size
 
     def apply(self, q):
         """Modify the given query with OFFSET and LIMIT."""

--- a/opds.py
+++ b/opds.py
@@ -302,6 +302,9 @@ class Annotator(object):
                 active_license_pool = p
         return active_license_pool
 
+    def sort_works_for_groups_feed(self, works, **kwargs):
+        return works
+
 
 class VerboseAnnotator(Annotator):
     """The default Annotator for machine-to-machine integration.
@@ -477,6 +480,7 @@ class AcquisitionFeed(OPDSFeed):
             annotator.lanes_by_work[work].append(v)
             all_works.append(work)
 
+        all_works = annotator.sort_works_for_groups_feed(all_works)
         feed = AcquisitionFeed(
             _db, title, url, all_works, annotator,
         )
@@ -751,13 +755,11 @@ class AcquisitionFeed(OPDSFeed):
     def _create_entry(self, work, license_pool, edition, identifier,
                       force_create=False, use_cache=True):
         xml = None
-        cache_hit = False
         field = self.annotator.opds_cache_field
         if field and work and not force_create and use_cache:
             xml = getattr(work, field)
 
         if xml:
-            cache_hit = True
             xml = etree.fromstring(xml)
         else:
             if isinstance(work, BaseMaterializedWork):

--- a/opds.py
+++ b/opds.py
@@ -408,16 +408,19 @@ class AcquisitionFeed(OPDSFeed):
 
     FACET_REL = "http://opds-spec.org/facet"
     FEED_CACHE_TIME = int(Configuration.get('default_feed_cache_time', 600))
+    NO_CACHE = object()
 
     @classmethod
-    def groups(cls, _db, title, url, lane, annotator, use_cache=True,
-               cache_type=None, force_refresh=False, use_materialized_works=True):
+    def groups(cls, _db, title, url, lane, annotator,
+               cache_type=None, force_refresh=False,
+               use_materialized_works=True):
         """The acquisition feed for 'featured' items from a given lane's
         sublanes, organized into per-lane groups.
 
         :return: CachedFeed (if use_cache is True) or unicode
         """
         cached = None
+        use_cache = not cache_type == cls.NO_CACHE
         if use_cache:
             cache_type = cache_type or CachedFeed.GROUPS_TYPE
             cached, usable = CachedFeed.fetch(
@@ -451,8 +454,7 @@ class AcquisitionFeed(OPDSFeed):
                 _db, title, url, lane, annotator,
                 cache_type=cache_type,
                 force_refresh=force_refresh,
-                use_materialized_works=use_materialized_works,
-                use_cache=use_cache
+                use_materialized_works=use_materialized_works
             )
             return cached
 
@@ -512,7 +514,7 @@ class AcquisitionFeed(OPDSFeed):
         return content
 
     @classmethod
-    def page(cls, _db, title, url, lane, annotator, use_cache=True,
+    def page(cls, _db, title, url, lane, annotator,
              cache_type=None, facets=None, pagination=None,
              force_refresh=False, use_materialized_works=True
     ):
@@ -524,6 +526,7 @@ class AcquisitionFeed(OPDSFeed):
         pagination = pagination or Pagination.default()
 
         cached = None
+        use_cache = not cache_type == cls.NO_CACHE
         if use_cache:
             cache_type = cache_type or CachedFeed.PAGE_TYPE
             cached, usable = CachedFeed.fetch(

--- a/opds.py
+++ b/opds.py
@@ -414,6 +414,8 @@ class AcquisitionFeed(OPDSFeed):
                cache_type=None, force_refresh=False, use_materialized_works=True):
         """The acquisition feed for 'featured' items from a given lane's
         sublanes, organized into per-lane groups.
+
+        :return: CachedFeed (if use_cache is True) or unicode
         """
         cached = None
         if use_cache:
@@ -514,7 +516,10 @@ class AcquisitionFeed(OPDSFeed):
              cache_type=None, facets=None, pagination=None,
              force_refresh=False, use_materialized_works=True
     ):
-        """Create a feed representing one page of works from a given lane."""
+        """Create a feed representing one page of works from a given lane.
+
+        :return: CachedFeed (if use_cache is True) or unicode
+        """
         facets = facets or Facets.default()
         pagination = pagination or Pagination.default()
 

--- a/s3.py
+++ b/s3.py
@@ -187,6 +187,7 @@ class S3Uploader(MirrorUploader):
         for fh in filehandles:
             fh.close()
 
+
 class DummyS3Uploader(S3Uploader):
     """A dummy uploader for use in tests."""
     def __init__(self, fail=False, *args, **kwargs):

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1099,5 +1099,5 @@ class TestPagination(DatabaseTest):
         eq_(True, pagination.has_next_page)
 
         # Even when the query ends at the same size as a page, all is well.
-        pagination.offset = 2
+        pagination.offset = 4
         eq_(False, pagination.has_next_page)


### PR DESCRIPTION
This branch fixes a couple of issues around static feeds (and probably feeds in general).

- It fixes some bad math in Pagination.has_next_page which may be the reason why the clients can only scroll down 100 books. It also fixes some bad math in the tests of this method. 😢 
- It makes using CachedFeeds optional in AcquisitionFeed.groups and AcquisitionFeed.pages, to avoid overwriting of similarly named feeds when creating Static feed options.

Supports NYPL-Simplified/content_server#104.