### PR TITLE
Load Lane.works with all licensepools

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import (
     contains_eager,
     defer,
+    joinedload,
     lazyload,
 )
 
@@ -943,11 +944,11 @@ class Lane(object):
         """
 
         q = self._db.query(Work).join(Work.presentation_edition)
-        q = q.join(Work.license_pools).join(LicensePool.data_source).join(
-            LicensePool.identifier
-        )
+        q = q.join(Work.license_pools).enable_eagerloads(False).\
+            join(LicensePool.data_source).\
+            join(LicensePool.identifier)
         q = q.options(
-            contains_eager(Work.license_pools),
+            joinedload(Work.license_pools),
             contains_eager(Work.presentation_edition),
             contains_eager(Work.license_pools, LicensePool.data_source),
             contains_eager(Work.license_pools, LicensePool.presentation_edition),

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -33,11 +33,12 @@ from config import (
 from model import (
     get_one_or_create,
     DataSource,
-    Genre,
-    Work,
-    LicensePool,
     Edition,
+    Genre,
+    Identifier,
+    LicensePool,
     SessionManager,
+    Work,
     WorkGenre,
 )
 
@@ -1069,6 +1070,33 @@ class TestFilters(DatabaseTest):
             # w7 shows up because we own licenses and copies are available.
             q = Lane.only_show_ready_deliverable_works(orig_q, Work)
             eq_(set([w6, w7]), set(q.all()))
+
+    def test_lane_subclass_queries(self):
+        """Subclasses of Lane can effectively retrieve all of a Work's
+        LicensePools
+        """
+
+        # Create a work with two license_pools.
+        w1 = self._work(with_open_access_download=True)
+        _edition, additional_lp = self._edition(
+            data_source_name=DataSource.OVERDRIVE,
+            identifier_type=Identifier.OVERDRIVE_ID,
+            with_license_pool=True,
+            with_open_access_download=True
+        )
+        additional_lp.work = w1
+        self._db.commit()
+
+        class LaneSubclass(Lane):
+            """A subclass of Lane that filters against a
+            LicensePool-specific criteria
+            """
+            def apply_filters(self, qu, **kwargs):
+                return qu.filter(DataSource.name==DataSource.GUTENBERG)
+
+        subclass = LaneSubclass(self._db, "Lane Subclass")
+        [subclass_work] = subclass.works().all()
+        eq_(2, len(subclass_work.license_pools))
 
 
 class TestPagination(DatabaseTest):


### PR DESCRIPTION
This change fixes a problem not in `Lane` itself, but in its subclasses that apply additional filtering.

Because `contains_eager` applies filtering to joined collections, later filtering on `Identifier` in classes like `StaticFeedBaseLane` (in NYPL-Simplified/content_server:lanes.py) meant that other `LicensePools` on the work were filtered out of the session because their Identifiers weren't specifically requested. Later, when an active `Work.license_pools` was requested, it wasn't available in the session and an error was raised. By using `joinedload` instead, the entire collection is pulled into the db session regardless of later filtering.

See the SQLAlchemy docs for more information: http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#using-contains-eager-to-load-a-custom-filtered-collection-result.

Fixes NYPL-Simplified/content_server#98.