### PR TITLE
DRM Device ID

### DIFF
--- a/model.py
+++ b/model.py
@@ -6676,7 +6676,7 @@ class DelegatedPatronIdentifier(Base):
 
     # One DelegatedPatronIdentifier can keep track of many
     # DRMDeviceIdentifiers.
-    relationship(
+    device_identifiers = relationship(
         "DRMDeviceIdentifier", backref=backref("delegated_patron_identifier",
                                                lazy='joined')
     )
@@ -6722,7 +6722,7 @@ class DelegatedPatronIdentifier(Base):
         _db = Session.object_session(self)
         return get_one_or_create(
             _db, DRMDeviceIdentifier,
-            delegated_patron=self,
+            delegated_patron_identifier=self,
             device_identifier=device_identifier
         )
 
@@ -6730,7 +6730,7 @@ class DelegatedPatronIdentifier(Base):
         _db = Session.object_session(self)
         device_id_obj = get_one(
             _db, DRMDeviceIdentifier,
-            delegated_patron=self,
+            delegated_patron_identifier=self,
             device_identifier=device_identifier
         )
         if device_id_obj:

--- a/model.py
+++ b/model.py
@@ -416,7 +416,7 @@ class Patron(Base):
 
     # One Patron can have many associated Credentials.
     credentials = relationship("Credential", backref="patron")
-
+   
     AUDIENCE_RESTRICTION_POLICY = 'audiences'
     EXTERNAL_TYPE_REGULAR_EXPRESSION = 'external_type_regular_expression'
     
@@ -6558,6 +6558,11 @@ class Credential(Base):
     credential = Column(String)
     expires = Column(DateTime)
 
+    # One Credential can have many associated DRMDeviceIdentifiers.
+    drm_device_identifiers = relationship(
+        "DRMDeviceIdentifier", backref=backref("credential", lazy='joined')
+    )
+    
     __table_args__ = (
         UniqueConstraint('data_source_id', 'patron_id', 'type'),
     )
@@ -6646,6 +6651,26 @@ class Credential(Base):
         credential.expires=None
         return credential, is_new
 
+    # A Credential may have many associated DRMDeviceIdentifiers.
+    def register_drm_device_identifier(self, device_identifier):
+        _db = Session.object_session(self)
+        return get_one_or_create(
+            _db, DRMDeviceIdentifier,
+            credential=self,
+            device_identifier=device_identifier
+        )
+
+    def deregister_drm_device_identifier(self, device_identifier):
+        _db = Session.object_session(self)
+        device_id_obj = get_one(
+            _db, DRMDeviceIdentifier,
+            credential=self,
+            device_identifier=device_identifier
+        )
+        if device_id_obj:
+            _db.delete(device_id_obj)
+
+    
 # Index to make lookup_by_token() fast.
 Index("ix_credentials_data_source_id_type_token", Credential.data_source_id, Credential.type, Credential.credential, unique=True)
 
@@ -6673,13 +6698,6 @@ class DelegatedPatronIdentifier(Base):
     # This is the identifier we made up for the patron. This is what the
     # foreign library is trying to look up.
     delegated_identifier = Column(String)
-
-    # One DelegatedPatronIdentifier can keep track of many
-    # DRMDeviceIdentifiers.
-    device_identifiers = relationship(
-        "DRMDeviceIdentifier", backref=backref("delegated_patron_identifier",
-                                               lazy='joined')
-    )
     
     __table_args__ = (
         UniqueConstraint('type', 'library_uri', 'patron_identifier'),
@@ -6718,35 +6736,19 @@ class DelegatedPatronIdentifier(Base):
             identifier.delegated_identifier = create_function()
         return identifier, is_new
 
-    def register_device(self, device_identifier):
-        _db = Session.object_session(self)
-        return get_one_or_create(
-            _db, DRMDeviceIdentifier,
-            delegated_patron_identifier=self,
-            device_identifier=device_identifier
-        )
-
-    def deregister_device(self, device_identifier):
-        _db = Session.object_session(self)
-        device_id_obj = get_one(
-            _db, DRMDeviceIdentifier,
-            delegated_patron_identifier=self,
-            device_identifier=device_identifier
-        )
-        if device_id_obj:
-            _db.delete(device_id_obj)
-
     
 class DRMDeviceIdentifier(Base):
-    """A device identifier for a particular DRM scheme."""
+    """A device identifier for a particular DRM scheme.
+
+    Associated with a Credential, most commonly a patron's "Identifier
+    for Adobe account ID purposes" Credential.
+    """
     __tablename__ = 'drmdeviceidentifiers'
     id = Column(Integer, primary_key=True)
-    delegated_patron_identifier_id = Column(
-        Integer, ForeignKey('delegatedpatronidentifiers.id'), index=True
-    )
+    credential_id = Column(Integer, ForeignKey('credentials.id'), index=True)
     device_identifier = Column(String(255), index=True)    
 
-
+    
 class Timestamp(Base):
     """A general-purpose timestamp for external services."""
 

--- a/problem_details.py
+++ b/problem_details.py
@@ -2,18 +2,14 @@ from util.problem_detail import ProblemDetail as pd
 from util.http import INTEGRATION_ERROR
 from flask.ext.babel import lazy_gettext as _
 
+# Generic problem detail documents that recapitulate HTTP errors.
+# call detailed() to add more specific information.
+
 INVALID_INPUT = pd(
       "http://librarysimplified.org/terms/problem/invalid-input",
       400,
       _("Invalid input."),
       _("You provided invalid or unrecognized input."),
-)
-
-UNRECOGNIZED_DATA_SOURCE = pd(
-      "http://librarysimplified.org/terms/problem/unrecognized-data-source",
-      400,
-      _("Unrecognized data source."),
-      _("I don't know anything about that data source."),
 )
 
 INVALID_CREDENTIALS = pd(
@@ -23,11 +19,25 @@ INVALID_CREDENTIALS = pd(
       _("Valid credentials are required."),
 )
 
-INVALID_URN = pd(
-      "http://librarysimplified.org/terms/problem/could-not-parse-urn",
-      400,
-      _("Invalid URN"),
-      _("Could not parse identifier."),
+METHOD_NOT_ALLOWED = pd(
+      "http://librarysimplified.org/terms/problem/method-not-allowed",
+      405,
+      _("Method not allowed"),
+      _("The HTTP method you used is not allowed on this resource."),
+)
+
+UNSUPPORTED_MEDIA_TYPE = pd(
+      "http://librarysimplified.org/terms/problem/unsupported-media-type",
+      415,
+      _("Unsupported media type"),
+      _("You submitted an unsupported media type."),
+)
+
+PAYLOAD_TOO_LARGE = pd(
+      "http://librarysimplified.org/terms/problem/unsupported-media-type",
+      413,
+      _("Payload too large"),
+      _("You submitted a document that was too large."),
 )
 
 INTERNAL_SERVER_ERROR = pd(
@@ -35,4 +45,21 @@ INTERNAL_SERVER_ERROR = pd(
       500,
       _("Internal server error."),
       _("Internal server error"),
+)
+
+# Problem detail documents that are specific to the Library Simplified
+# domain.
+
+INVALID_URN = pd(
+      "http://librarysimplified.org/terms/problem/could-not-parse-urn",
+      400,
+      _("Invalid URN"),
+      _("Could not parse identifier."),
+)
+
+UNRECOGNIZED_DATA_SOURCE = pd(
+      "http://librarysimplified.org/terms/problem/unrecognized-data-source",
+      400,
+      _("Unrecognized data source."),
+      _("I don't know anything about that data source."),
 )

--- a/testing.py
+++ b/testing.py
@@ -18,6 +18,7 @@ from model import (
     Complaint,
     Contributor,
     CoverageRecord,
+    Credential,
     CustomList,
     DataSource,
     DeliveryMechanism,
@@ -423,6 +424,16 @@ class DatabaseTest(object):
         )
         return complaint
 
+    def _credential(self, data_source_name=DataSource.GUTENBERG,
+                    type=None, patron=None):
+        data_source = DataSource.lookup(self._db, data_source_name)
+        type = type or self._str
+        patron = patron or self._patron()
+        credential, is_new = Credential.persistent_token_create(
+            self._db, data_source, type, patron
+        )
+        return credential
+    
     def _delegated_patron_identifier(
             self, library_uri=None, patron_identifier=None,
             identifier_type=DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID,

--- a/testing.py
+++ b/testing.py
@@ -422,6 +422,24 @@ class DatabaseTest(object):
         )
         return complaint
 
+    def _delegated_patron_identifier(
+            self, library_uri=None, patron_identifier=None,
+            identifier_type=DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID
+            make_id=None
+    ):
+        """Create a sample DelegatedPatronIdentifier"""
+        library_uri = library_uri or self._url
+        patron_identifier = patron_identifier or self._str
+        def default_make_id():
+            return "id1"
+        if not make_id:
+            make_id = default_make_id
+        patron, is_new = DelegatedPatronIdentifier.get_one_or_create(
+            self._db, library_uri, patron_identifier, identifier_type,
+            make_id
+        )
+        return patron
+
 
     def _sample_ecosystem(self):
         """ Creates an ecosystem of some sample work, pool, edition, and author 

--- a/testing.py
+++ b/testing.py
@@ -21,6 +21,7 @@ from model import (
     CustomList,
     DataSource,
     DeliveryMechanism,
+    DelegatedPatronIdentifier,
     Edition,
     Genre,
     Hyperlink,
@@ -424,16 +425,19 @@ class DatabaseTest(object):
 
     def _delegated_patron_identifier(
             self, library_uri=None, patron_identifier=None,
-            identifier_type=DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID
-            make_id=None
+            identifier_type=DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID,
+            identifier=None
     ):
         """Create a sample DelegatedPatronIdentifier"""
         library_uri = library_uri or self._url
         patron_identifier = patron_identifier or self._str
-        def default_make_id():
-            return "id1"
-        if not make_id:
-            make_id = default_make_id
+        if callable(identifier):
+            make_id = identifier
+        else:
+            if not identifier:
+                identifier = self._str
+            def make_id():
+                return identifier
         patron, is_new = DelegatedPatronIdentifier.get_one_or_create(
             self._db, library_uri, patron_identifier, identifier_type,
             make_id

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4336,20 +4336,8 @@ class TestDelegatedPatronIdentifier(DatabaseTest):
 
 class TestDRMDeviceIdentifier(DatabaseTest):
 
-    def _patron_identifier(self):
-        library_uri = self._url
-        patron_identifier = self._str
-        identifier_type = DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID
-        def make_id():
-            return "id1"
-        patron, is_new = DelegatedPatronIdentifier.get_one_or_create(
-            self._db, library_uri, patron_identifier, identifier_type,
-            make_id
-        )
-        return patron
-    
     def test_devices_for_patron_identifier(self):
-        patron = self._patron_identifier()
+        patron = self._delegated_patron_identifier()
         device_id_1, new = patron.register_device("foo")
         eq_("foo", device_id_1.device_identifier)
         eq_(patron, device_id_1.delegated_patron_identifier)
@@ -4364,7 +4352,7 @@ class TestDRMDeviceIdentifier(DatabaseTest):
         eq_(set([device_id_1, device_id_3]), set(patron.device_identifiers))
 
     def test_deregister(self):
-        patron = self._patron_identifier()
+        patron = self._delegated_patron_identifier()
         device, new = patron.register_device("foo")
         patron.deregister_device("foo")
         eq_([], patron.device_identifiers)


### PR DESCRIPTION
This branch creates a new model class, DRMDeviceID, which will be used to store the information used in the [DRM Device Management Protocol](https://github.com/NYPL-Simplified/Simplified/wiki/DRM-Device-Management).