### PR TITLE
Added option to ReplacementPolicy to modify Representation content before mirroring.

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -57,6 +57,7 @@ class ReplacementPolicy(object):
             rights=False,
             link_content=False,
             mirror=None,
+            content_modifier=None,
             http_get=None,
             even_if_not_apparently_updated=False,
             presentation_calculation_policy=None
@@ -70,6 +71,7 @@ class ReplacementPolicy(object):
         self.link_content = link_content
         self.even_if_not_apparently_updated = even_if_not_apparently_updated
         self.mirror = mirror
+        self.content_modifier = content_modifier
         self.http_get = http_get
         self.presentation_calculation_policy = (
             presentation_calculation_policy or
@@ -552,6 +554,9 @@ class MetaToModelUtility(object):
                 representation.url, representation.status_code
             )
             return
+
+        if policy.content_modifier:
+            policy.content_modifier(representation)
 
         # The metadata may have some idea about the media type for this
         # LinkObject, but the media type we actually just saw takes 

--- a/opds_import.py
+++ b/opds_import.py
@@ -201,7 +201,8 @@ class OPDSImporter(object):
    
     def __init__(self, _db, data_source_name=DataSource.METADATA_WRANGLER,
                  identifier_mapping=None, mirror=None, http_get=None,
-                 metadata_client=None, data_source_offers_licenses=False
+                 metadata_client=None, data_source_offers_licenses=False,
+                 content_modifier=None,
     ):
         """
         :param data_source_name: Name of the source of this OPDS feed.
@@ -219,6 +220,7 @@ class OPDSImporter(object):
         self.identifier_mapping = identifier_mapping
         self.metadata_client = metadata_client or SimplifiedOPDSLookup.from_config()
         self.mirror = mirror
+        self.content_modifier = content_modifier
         self.http_get = http_get
 
     @property
@@ -311,6 +313,7 @@ class OPDSImporter(object):
             link_content=True,
             even_if_not_apparently_updated=True,
             mirror=self.mirror,
+            content_modifier=self.content_modifier,
             http_get=self.http_get,
         )
         metadata.apply(


### PR DESCRIPTION
This supports a forthcoming content server pr that will replace css in imported epub files.