### PR TITLE
Support suppressed covers

### DIFF
--- a/migration/20170104-add-suppressed-to-resources.sql
+++ b/migration/20170104-add-suppressed-to-resources.sql
@@ -1,0 +1,1 @@
+ALTER TABLE resources ADD COLUMN suppressed boolean DEFAULT false;

--- a/migration/20170104-add-suppressed-to-resources.sql
+++ b/migration/20170104-add-suppressed-to-resources.sql
@@ -1,1 +1,0 @@
-ALTER TABLE resources ADD COLUMN suppressed boolean DEFAULT false;

--- a/migration/20170110-set-voted-quality-default-values.sql
+++ b/migration/20170110-set-voted-quality-default-values.sql
@@ -1,0 +1,2 @@
+ALTER TABLE resources ALTER COLUMN voted_quality SET DEFAULT 0.0;
+ALTER TABLE resources ALTER COLUMN votes_for_quality SET DEFAULT 0;

--- a/model.py
+++ b/model.py
@@ -2925,20 +2925,14 @@ class Edition(Base):
                             self.primary_identiifer, 
                             rep.url
                         )
-                if best_cover.suppressed:
-                    # TODO : Currently, this suppresses the cover entirely.
-                    # In the future, it would be nice to look for another
-                    # acceptable cover somewhere in those others returned
-                    # by `best_cover_within_distance()` or possibly at a
-                    # farther distance.
-                    logging.info(
-                        "Best cover for %r has been suppressed.",
-                        self.primary_identifier
-                    )
-                else:
-                    self.set_cover(best_cover)
+                self.set_cover(best_cover)
                 break
-            else:
+        else:
+            # No cover has been found. If the Edition currently references
+            # a cover, it has since been suppressed or otherwise removed.
+            # All cover details need to be removed.
+            cover_info = [self.cover, self.cover_full_url, self.cover_thumbnail_url]
+            if any(cover_info):
                 self.cover = None
                 self.cover_full_url = None
                 self.cover_thumbnail_url = None

--- a/model.py
+++ b/model.py
@@ -2928,7 +2928,7 @@ class Edition(Base):
                 break
         else:
             # No cover has been found. If the Edition currently references
-            # a cover, it has since been suppressed or otherwise removed.
+            # a cover, it has since been rejected or otherwise removed.
             # All cover details need to be removed.
             cover_info = [self.cover, self.cover_full_url, self.cover_thumbnail_url]
             if any(cover_info):
@@ -3498,7 +3498,7 @@ class Work(Base):
         return query
 
     @classmethod
-    def suppress_covers(cls, _db, works_or_identifiers,
+    def reject_covers(cls, _db, works_or_identifiers,
                         search_index_client=None):
         """Suppresses the currently visible covers of a number of Works"""
 
@@ -3556,7 +3556,7 @@ class Work(Base):
             edition.calculate_presentation(policy=policy)
         _db.commit()
 
-    def suppress_cover(self, search_index_client=None):
+    def reject_cover(self, search_index_client=None):
         """Suppresses the current cover of the Work"""
         _db = Session.object_session(self)
         self.suppress_covers(

--- a/model.py
+++ b/model.py
@@ -3515,7 +3515,11 @@ class Work(Base):
             # same class: either Work or Identifier.
             works = cls.from_identifiers(_db, works_or_identifiers).all()
         work_ids = [w.id for w in works]
-        logging.info("Supressing covers for %i Works", len(works))
+
+        if len(works) == 1:
+            logging.info("Suppressing cover for %r", works[0])
+        else:
+            logging.info("Supressing covers for %i Works", len(works))
 
         cover_urls = list()
         for work in works:
@@ -3543,6 +3547,13 @@ class Work(Base):
                 policy=policy, search_index_client=search_index_client
             )
         _db.commit()
+
+    def suppress_cover(self, search_index_client=None):
+        """Suppresses the current cover of the Work"""
+        _db = Session.object_session(self)
+        self.suppress_covers(
+            _db, [self], search_index_client=search_index_client
+        )
 
     def all_editions(self, recursion_level=5):
         """All Editions identified by an Identifier equivalent to 

--- a/model.py
+++ b/model.py
@@ -3526,15 +3526,18 @@ class Work(Base):
                     cover_urls.append(edition.cover_thumbnail_url)
 
         covers = _db.query(Resource).join(Hyperlink.identifier).\
-            join(Identifier.licensed_through).\
-            filter(Resource.url.in_(cover_urls), LicensePool.work_id.in_(work_ids))
+            join(Identifier.licensed_through).filter(
+                Resource.url.in_(cover_urls),
+                LicensePool.work_id.in_(work_ids),
+                Resource.suppressed != True
+            )
 
         editions = list()
         for cover in covers:
             cover.suppressed = True
             if len(cover.cover_editions) > 1:
                 editions += cover.cover_editions
-        _db.commit()
+        _db.flush()
 
         editions = list(set(editions))
         if editions:

--- a/opds.py
+++ b/opds.py
@@ -413,7 +413,7 @@ class AcquisitionFeed(OPDSFeed):
     @classmethod
     def groups(cls, _db, title, url, lane, annotator,
                cache_type=None, force_refresh=False,
-               use_materialized_works=True, suppressed_covers=None):
+               use_materialized_works=True):
         """The acquisition feed for 'featured' items from a given lane's
         sublanes, organized into per-lane groups.
 
@@ -487,10 +487,7 @@ class AcquisitionFeed(OPDSFeed):
             all_works.append(work)
 
         all_works = annotator.sort_works_for_groups_feed(all_works)
-        feed = AcquisitionFeed(
-            _db, title, url, all_works, annotator,
-            suppressed_covers=suppressed_covers
-        )
+        feed = AcquisitionFeed(_db, title, url, all_works, annotator)
 
         # Render a 'start' link and an 'up' link.
         top_level_title = annotator.top_level_title() or "Collection Home"
@@ -517,9 +514,7 @@ class AcquisitionFeed(OPDSFeed):
     @classmethod
     def page(cls, _db, title, url, lane, annotator,
              cache_type=None, facets=None, pagination=None,
-             force_refresh=False, use_materialized_works=True,
-             suppressed_covers=None
-    ):
+             force_refresh=False, use_materialized_works=True):
         """Create a feed representing one page of works from a given lane.
 
         :return: CachedFeed (if use_cache is True) or unicode
@@ -552,10 +547,7 @@ class AcquisitionFeed(OPDSFeed):
             works = []
         else:
             works = works_q.all()
-        feed = cls(
-            _db, title, url, works, annotator,
-            suppressed_covers=suppressed_covers
-        )
+        feed = cls(_db, title, url, works, annotator)
 
         # Add URLs to change faceted views of the collection.
         for args in cls.facet_links(annotator, facets):
@@ -673,7 +665,7 @@ class AcquisitionFeed(OPDSFeed):
             yield link
 
     def __init__(self, _db, title, url, works, annotator=None,
-                 precomposed_entries=[], suppressed_covers=None):
+                 precomposed_entries=[]):
         """Turn a list of works, messages, and precomposed <opds> entries
         into a feed.
         """
@@ -684,14 +676,7 @@ class AcquisitionFeed(OPDSFeed):
         super(AcquisitionFeed, self).__init__(title, url)
 
         for work in works:
-            suppressed_cover = filter(
-                lambda lp: lp.identifier in suppressed_covers,
-                work.license_pools
-            )
-            if suppressed_cover:
-                self.add_entry(work, use_cache=False)
-            else:
-                self.add_entry(work)
+            self.add_entry(work)
 
         # Add the precomposed entries and the messages.
         for entry in precomposed_entries:

--- a/opds.py
+++ b/opds.py
@@ -684,11 +684,11 @@ class AcquisitionFeed(OPDSFeed):
                 entry = entry.tag
             self.feed.append(entry)
 
-    def add_entry(self, work, use_cache=True):
+    def add_entry(self, work):
         """Attempt to create an OPDS <entry>. If successful, append it to
         the feed.
         """
-        entry = self.create_entry(work, use_cache=use_cache)
+        entry = self.create_entry(work)
 
         if entry is not None:
             if isinstance(entry, OPDSMessage):

--- a/testing.py
+++ b/testing.py
@@ -422,7 +422,6 @@ class DatabaseTest(object):
         )
         return complaint
 
-
     def _sample_ecosystem(self):
         """ Creates an ecosystem of some sample work, pool, edition, and author 
         objects that all know each other. 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2077,7 +2077,7 @@ class TestWork(DatabaseTest):
         eq_("Alice Adder, Bob Bitshifter", work.author)
         eq_("Adder, Alice ; Bitshifter, Bob", work.sort_author)
 
-    def test_suppress_covers(self):
+    def test_reject_covers(self):
         edition, lp = self._edition(with_open_access_download=True)
 
         # Create a cover and thumbnail for the edition.
@@ -2143,13 +2143,13 @@ class TestWork(DatabaseTest):
 
         # Suppressing the cover removes the cover from the work.
         index = DummyExternalSearchIndex()
-        Work.suppress_covers(self._db, [work], search_index_client=index)
+        Work.reject_covers(self._db, [work], search_index_client=index)
         assert has_no_cover(work)
         reset_cover()
 
         # It also works with Identifiers.
         identifier = work.license_pools[0].identifier
-        Work.suppress_covers(self._db, [identifier], search_index_client=index)
+        Work.reject_covers(self._db, [identifier], search_index_client=index)
         assert has_no_cover(work)
         reset_cover()
 
@@ -2161,7 +2161,7 @@ class TestWork(DatabaseTest):
         other_work_ed.set_cover(cover_link.resource)
         other_work = self._work(presentation_edition=other_work_ed)
 
-        Work.suppress_covers(self._db, [work], search_index_client=index)
+        Work.reject_covers(self._db, [work], search_index_client=index)
         assert has_no_cover(other_edition)
         assert has_no_cover(other_work)
 


### PR DESCRIPTION
This branch allows us to hide covers that we don't want in the feeds for whatever reason. It will hide the cover on a list of Works and any Works or Editions that use the same cover.

I'm not sold on the design yet--particularly the fact that it's done either by batch or individually by `Work`--but it's an initial fix for NYPL-Simplified/content_server#109.

Right now, it suppresses the cover entirely. In the future, we may want to search for a different cover image if more are available on the same or related Editions.