### PR TITLE
Support custom list static feeds

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -581,8 +581,15 @@ class Lane(object):
 
         # The lane may be restricted to books that are on a list
         # from a given data source.
-        self.list_data_source_id, self.list_ids = self.custom_lists_for_identifier(
+        custom_list_details = self.custom_lists_for_identifier(
             list_data_source, list_identifier)
+        (self.list_data_source_id,
+         self.list_ids,
+         self.list_featured_works_query) = custom_list_details
+        if not self.list_featured_works_query:
+            # The parent may have featured works from the list that
+            # could be included here.
+            set_from_parent('list_featured_works_query', None)
         set_from_parent(
             'list_seen_in_previous_days', list_seen_in_previous_days)
 
@@ -800,11 +807,34 @@ class Lane(object):
             list_data_source_id = list_data_source.id
         else:
             list_data_source_id = None
+
+        list_featured_works_query = None
         if lists:
             list_ids = [x.id for x in lists]
+            list_featured_works_query = self.extract_list_featured_works_query(lists)
         else:
             list_ids = None
-        return list_data_source_id, list_ids
+        return list_data_source_id, list_ids, list_featured_works_query
+
+    def extract_list_featured_works_query(self, lists):
+        if not lists:
+            return None
+        if isinstance(lists[0], int):
+            # We have CustomList ids instead of CustomList objects.
+            lists = self._db.query(CustomList).filter(CustomList.id.in_(lists))
+            lists = lists.all()
+
+        lists = [custom_list for custom_list in lists if custom_list.featured_works]
+        if not lists:
+            return None
+
+        work_ids = list()
+        for custom_list in lists:
+            work_ids += [work.id for work in custom_list.featured_works]
+
+        works_query = self._db.query(Work).with_labels().\
+            filter(Work.id.in_(work_ids))
+        return works_query
 
     @classmethod
     def from_description(cls, _db, parent, description):
@@ -1295,6 +1325,21 @@ class Lane(object):
         objects.
         """
         books = []
+        featured_subquery = None
+        target_size = Configuration.featured_lane_size()
+
+        # If this lane (or its ancestors) is a CustomList, look for any
+        # featured works that were set on the list itself.
+        list_books, work_id_column = self.list_featured_works(
+            use_materialized_works=use_materialized_works
+        )
+        if list_books:
+            target_size = target_size - len(list_books)
+            if target_size <= 0:
+                # We've found all the books we need from the
+                # human-generated selections on the CustomList.
+                return list_books
+
         # Prefer to feature available books in the featured
         # collection, but if that fails, gradually degrade to
         # featuring all books, no matter what the availability.
@@ -1315,22 +1360,58 @@ class Lane(object):
                 # apply_filters may return None in subclasses of Lane
                 continue
 
+            if list_books:
+                # Remove any already-featured books, set by the
+                # CustomList(s), from the database results.
+                list_book_ids = [getattr(w, work_id_column.key) for w in list_books]
+                query = query.filter(work_id_column.notin_(list_book_ids))
+
             # This is the end of the line, so we're desperate
             # to fill the lane, even if it's a little short.
             use_min_size = (collection==Facets.COLLECTION_FULL and
                             availability==Facets.AVAILABLE_ALL)
 
             # Get a random sample of books to be featured.
-            books = self.randomized_sample_works(query, use_min_size=use_min_size)
+            books += self.randomized_sample_works(
+                query, target_size=target_size, use_min_size=use_min_size)
             if books:
                 break
+
+        if list_books and books:
+            # Combine any books from the CustomList with those that were
+            # randomly generated.
+            return list_books+books
         return books
 
-    def randomized_sample_works(self, query, use_min_size=False):
-        """Find a random sample of works for a feed"""
+    def list_featured_works(self, target_size=None, use_materialized_works=True):
+        """Returns the featured books for a lane descended from CustomList(s)"""
+        books = list()
+        work_id_column = None
+        target_size = target_size or Configuration.featured_lane_size()
 
+        if self.list_featured_works_query:
+            subquery = self.list_featured_works_query.with_labels().subquery()
+
+            if use_materialized_works:
+                query = self.materialized_works()
+
+                # Extract the MaterializedView model from the query
+                [work_model] = query._entities[0].entities
+                work_id_column = work_model.works_id
+            else:
+                query = self.works()
+                work_id_column = Work.id
+
+            query = query.join(subquery, work_id_column==subquery.c.works_id)
+            books += self.randomized_sample_works(
+                query, target_size=target_size, use_min_size=True
+            )
+
+        return books, work_id_column
+
+    def randomized_sample_works(self, query, target_size=None, use_min_size=False):
+        """Find a random sample of works for a feed"""
         offset = 0
-        target_size = Configuration.featured_lane_size()
         smallest_sample_size = target_size
 
         if use_min_size:

--- a/lane.py
+++ b/lane.py
@@ -1416,7 +1416,7 @@ class Lane(object):
 
         if use_min_size:
             smallest_sample_size = self.MINIMUM_SAMPLE_SIZE or (target_size-5)
-        total_size = query.count()
+        total_size = fast_query_count(query)
 
         if total_size < smallest_sample_size:
             # There aren't enough works here. Ignore the lane.
@@ -1586,7 +1586,10 @@ class QueryGeneratedLane(Lane):
         if not query:
             return []
 
-        return self.randomized_sample_works(query, use_min_size=True)
+        target_size = Configuration.featured_lane_size()
+        return self.randomized_sample_works(
+            query, target_size=target_size, use_min_size=True
+        )
 
     def lane_query_hook(self, qu, work_model=Work):
         """Create the query specific to a subclass of  QueryGeneratedLane

--- a/migration/20170111-make-customlists-foreign-identifier-unique.sql
+++ b/migration/20170111-make-customlists-foreign-identifier-unique.sql
@@ -1,3 +1,3 @@
-ALTER TABLE customlists ADD CONSTRAINT customlists_foreign_identifier_key UNIQUE (foreign_identifier);
-ALTER TABLE customlists ADD CONSTRAINT customlists_name_key UNIQUE (name);
 CREATE INDEX ix_customlists_name ON customlists(name);
+ALTER TABLE customlists ADD CONSTRAINT customlists_foreign_identifier_data_source_id_key UNIQUE (foreign_identifier, data_source_id);
+ALTER TABLE customlists ADD CONSTRAINT customlists_name_data_source_id_key UNIQUE (name, data_source_id);

--- a/migration/20170111-make-customlists-foreign-identifier-unique.sql
+++ b/migration/20170111-make-customlists-foreign-identifier-unique.sql
@@ -1,0 +1,1 @@
+ALTER TABLE customlists ADD CONSTRAINT customlists_foreign_identifier_key UNIQUE (foreign_identifier);

--- a/migration/20170111-make-customlists-foreign-identifier-unique.sql
+++ b/migration/20170111-make-customlists-foreign-identifier-unique.sql
@@ -1,1 +1,3 @@
 ALTER TABLE customlists ADD CONSTRAINT customlists_foreign_identifier_key UNIQUE (foreign_identifier);
+ALTER TABLE customlists ADD CONSTRAINT customlists_name_key UNIQUE (name);
+CREATE INDEX ix_customlists_name ON customlists(name);

--- a/migration/20170117-add-featured-to-customlistentries.sql
+++ b/migration/20170117-add-featured-to-customlistentries.sql
@@ -1,0 +1,4 @@
+ALTER TABLE customlistentries ADD COLUMN featured boolean;
+UPDATE customlistentries SET featured = 'f';
+ALTER TABLE customlistentries ALTER COLUMN featured SET NOT NULL;
+ALTER TABLE customlistentries ALTER COLUMN featured SET DEFAULT FALSE;

--- a/model.py
+++ b/model.py
@@ -8004,7 +8004,7 @@ class CustomList(Base):
             was_new = False
             entry = existing[0]
             if len(existing) > 1:
-                entry.update(entries=existing[1:])
+                entry.update(_db, equivalent_entries=existing[1:])
             entry.edition = edition
             _db.commit()
         else:
@@ -8013,6 +8013,7 @@ class CustomList(Base):
                 customlist=self, edition=edition,
                 create_method_kwargs=dict(first_appearance=first_appearance)
             )
+
         if (not entry.most_recent_appearance 
             or entry.most_recent_appearance < first_appearance):
             entry.most_recent_appearance = first_appearance
@@ -8138,7 +8139,7 @@ class CustomListEntry(Base):
         # Confirm that all the entries are from the same CustomList.
         list_ids = set([e.list_id for e in equivalent_entries])
         if not len(list_ids)==1:
-            raise ValueError("Cannot combine entries on different lists.")
+            raise ValueError("Cannot combine entries on different CustomLists.")
 
         # Confirm that all the entries are equivalent.
         error = "Cannot combine entries that represent different Works."
@@ -8171,11 +8172,11 @@ class CustomListEntry(Base):
         annotations = [unicode(e.annotation) for e in equivalent_entries
                        if e.annotation]
         if annotations:
-            if len(annotations)==1:
-                self.annotation = annotations[0]
             if len(annotations) > 1:
                 # Just pick the longest one?
                 self.annotation = max(annotations, key=lambda a: len(a))
+            else:
+                self.annotation = annotations[0]
 
         # Reset the entry's edition to be the Work's presentation edition.
         best_edition = work.presentation_edition
@@ -8187,7 +8188,7 @@ class CustomListEntry(Base):
                 "Changing edition for list entry %r to %r from %r",
                 self, best_edition, self.edition
             )
-            self.edition = best_edition or self
+            self.edition = best_edition
 
         self.set_license_pool()
 

--- a/model.py
+++ b/model.py
@@ -7954,7 +7954,7 @@ class CustomList(Base):
     primary_language = Column(Unicode, index=True)
     data_source_id = Column(Integer, ForeignKey('datasources.id'), index=True)
     foreign_identifier = Column(Unicode, index=True, unique=True)
-    name = Column(Unicode)
+    name = Column(Unicode, index=True, unique=True)
     description = Column(Unicode)
     created = Column(DateTime, index=True)
     updated = Column(DateTime, index=True)
@@ -7980,20 +7980,20 @@ class CustomList(Base):
         return _db.query(CustomList).filter(CustomList.data_source_id.in_(ids))
 
     @classmethod
-    def find(cls, _db, foreign_identifier, name=None):
-        """Finds a foreign list in the database by its `foreign_identifier`
-        and/or its name.
+    def find(cls, _db, foreign_identifier_or_name):
+        """Finds a foreign list in the database by its foreign_identifier
+        or its name.
         """
-        foreign_identifier = unicode(foreign_identifier)
+        foreign_identifier = unicode(foreign_identifier_or_name)
 
-        qu = _db.query(cls)
-        if name:
-            name = unicode(name)
-            return qu.filter(or_(
-                CustomList.name==name,
-                CustomList.foreign_identifier==foreign_identifier
-            ))
-        return qu.filter(CustomList.foreign_identifier==foreign_identifier)
+        custom_lists = _db.query(cls).filter(or_(
+            CustomList.foreign_identifier==foreign_identifier,
+            CustomList.name==foreign_identifier
+        )).all()
+
+        if not custom_lists:
+            return None
+        return custom_lists[0]
 
     def add_entry(self, edition, annotation=None, first_appearance=None):
         first_appearance = first_appearance or datetime.datetime.utcnow()

--- a/model.py
+++ b/model.py
@@ -8061,6 +8061,7 @@ class CustomListEntry(Base):
     list_id = Column(Integer, ForeignKey('customlists.id'), index=True)
     edition_id = Column(Integer, ForeignKey('editions.id'), index=True)
     license_pool_id = Column(Integer, ForeignKey('licensepools.id'), index=True)
+    featured = Column(Boolean, nullable=False, default=False)
     annotation = Column(Unicode)
 
     # These two fields are for best-seller lists. Even after a book

--- a/model.py
+++ b/model.py
@@ -8014,7 +8014,7 @@ class CustomList(Base):
         return Work.from_identifiers(_db, identifiers)
 
     def add_entry(self, edition, annotation=None, first_appearance=None,
-                  featured=False):
+                  featured=None):
         first_appearance = first_appearance or datetime.datetime.utcnow()
         _db = Session.object_session(self)
 
@@ -8040,8 +8040,8 @@ class CustomList(Base):
             entry.annotation = unicode(annotation)
         if edition.license_pool and not entry.license_pool:
             entry.license_pool = edition.license_pool
-        if featured:
-            entry.featured = True
+        if featured is not None:
+            entry.featured = featured
         return entry, was_new
 
     def remove_entry(self, edition):

--- a/model.py
+++ b/model.py
@@ -7953,7 +7953,7 @@ class CustomList(Base):
     id = Column(Integer, primary_key=True)
     primary_language = Column(Unicode, index=True)
     data_source_id = Column(Integer, ForeignKey('datasources.id'), index=True)
-    foreign_identifier = Column(Unicode, index=True)
+    foreign_identifier = Column(Unicode, index=True, unique=True)
     name = Column(Unicode)
     description = Column(Unicode)
     created = Column(DateTime, index=True)
@@ -7978,6 +7978,22 @@ class CustomList(Base):
                 ds = DataSource.lookup(_db, ds)
             ids.append(ds.id)
         return _db.query(CustomList).filter(CustomList.data_source_id.in_(ids))
+
+    @classmethod
+    def find(cls, _db, foreign_identifier, name=None):
+        """Finds a foreign list in the database by its `foreign_identifier`
+        and/or its name.
+        """
+        foreign_identifier = unicode(foreign_identifier)
+
+        qu = _db.query(cls)
+        if name:
+            name = unicode(name)
+            return qu.filter(or_(
+                CustomList.name==name,
+                CustomList.foreign_identifier==foreign_identifier
+            ))
+        return qu.filter(CustomList.foreign_identifier==foreign_identifier)
 
     def add_entry(self, edition, annotation=None, first_appearance=None):
         first_appearance = first_appearance or datetime.datetime.utcnow()

--- a/model.py
+++ b/model.py
@@ -8003,7 +8003,18 @@ class CustomList(Base):
             return None
         return custom_lists[0]
 
-    def add_entry(self, edition, annotation=None, first_appearance=None):
+    @property
+    def featured_works(self):
+        _db = Session.object_session(self)
+        editions = [e.edition for e in self.entries if e.featured]
+        if not editions:
+            return None
+
+        identifiers = [ed.primary_identifier for ed in editions]
+        return Work.from_identifiers(_db, identifiers)
+
+    def add_entry(self, edition, annotation=None, first_appearance=None,
+                  featured=False):
         first_appearance = first_appearance or datetime.datetime.utcnow()
         _db = Session.object_session(self)
 
@@ -8029,6 +8040,8 @@ class CustomList(Base):
             entry.annotation = unicode(annotation)
         if edition.license_pool and not entry.license_pool:
             entry.license_pool = edition.license_pool
+        if featured:
+            entry.featured = True
         return entry, was_new
 
     def remove_entry(self, edition):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4851,19 +4851,20 @@ class TestDeliveryMechanism(DatabaseTest):
 class TestCustomList(DatabaseTest):
 
     def test_find(self):
+        source = DataSource.lookup(self._db, DataSource.NYT)
         # When there's no CustomList to find, nothing is returned.
-        result = CustomList.find(self._db, 'my-list')
+        result = CustomList.find(self._db, source, 'my-list')
         eq_(None, result)
 
         custom_list = self._customlist(
             foreign_identifier='a-list', name='My List', num_entries=0
         )[0]
         # A CustomList can be found by its foreign_identifier.
-        result = CustomList.find(self._db, 'a-list')
+        result = CustomList.find(self._db, source, 'a-list')
         eq_(custom_list, result)
 
         # Or its name.
-        result = CustomList.find(self._db, 'My List')
+        result = CustomList.find(self._db, source.name, 'My List')
         eq_(custom_list, result)
 
     def test_add_entry(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4913,7 +4913,7 @@ class TestCustomList(DatabaseTest):
         eq_(now, new_timed_entry.first_appearance)
         eq_(later, new_timed_entry.most_recent_appearance)
 
-        # For existing entries, arlier first_appearance datetimes are ignored.
+        # For existing entries, earlier first_appearance datetimes are ignored.
         entry = custom_list.add_entry(annotated_edition, first_appearance=now)[0]
         eq_(True, entry.first_appearance != now)
         eq_(True, entry.first_appearance >= now)
@@ -4951,9 +4951,10 @@ class TestCustomList(DatabaseTest):
         custom_list.remove_entry(second)
         eq_([], custom_list.entries)
 
-        # An edition that's not into the list doesn't cause any problems.
+        # An edition that's not on the list doesn't cause any problems.
+        custom_list.add_entry(second)
         custom_list.remove_entry(first)
-        eq_([], custom_list.entries)
+        eq_(1, len(custom_list.entries))
 
     def test_entries_for_work(self):
         custom_list, editions = self._customlist(num_entries=2)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -40,6 +40,7 @@ from model import (
     Contributor,
     CoverageRecord,
     Credential,
+    CustomList,
     CustomListEntry,
     DataSource,
     DelegatedPatronIdentifier,
@@ -4845,6 +4846,26 @@ class TestDeliveryMechanism(DatabaseTest):
         eq_(Representation.EPUB_MEDIA_TYPE, self.epub_adobe_drm.content_type_media_type)
         eq_(Representation.TEXT_HTML_MEDIA_TYPE + DeliveryMechanism.STREAMING_PROFILE,
             self.overdrive_streaming_text.content_type_media_type)
+
+
+class TestCustomList(DatabaseTest):
+
+    def test_find(self):
+        # When there's no CustomList to find, nothing is returned.
+        result = CustomList.find(self._db, 'my-list')
+        eq_(None, result)
+
+        custom_list = self._customlist(
+            foreign_identifier='a-list', name='My List', num_entries=0
+        )[0]
+        # A CustomList can be found by its foreign_identifier.
+        result = CustomList.find(self._db, 'a-list')
+        eq_(custom_list, result)
+
+        # Or its name.
+        result = CustomList.find(self._db, 'My List')
+        eq_(custom_list, result)
+
 
 class TestCustomListEntry(DatabaseTest):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4866,6 +4866,127 @@ class TestCustomList(DatabaseTest):
         result = CustomList.find(self._db, 'My List')
         eq_(custom_list, result)
 
+    def test_add_entry(self):
+        custom_list = self._customlist(num_entries=0)[0]
+        now = datetime.datetime.utcnow()
+
+        # An edition without a work can create an entry.
+        workless_edition = self._edition()
+        workless_entry, is_new = custom_list.add_entry(workless_edition)
+        eq_(True, is_new)
+        eq_(True, isinstance(workless_entry, CustomListEntry))
+        eq_(workless_edition, workless_entry.edition)
+        eq_(True, workless_entry.first_appearance > now)
+        eq_(None, workless_entry.license_pool)
+
+        # An edition with a work can create an entry.
+        worked_edition, lp = self._edition(with_license_pool=True)
+        worked_entry, is_new = custom_list.add_entry(worked_edition)
+        eq_(True, is_new)
+        eq_(worked_edition, worked_entry.edition)
+        eq_(True, worked_entry.first_appearance > now)
+
+        # Annotations can be passed to the entry.
+        annotated_edition = self._edition()
+        annotated_entry = custom_list.add_entry(
+            annotated_edition, annotation="Sure, this is a good book."
+        )[0]
+        eq_(u"Sure, this is a good book.", annotated_entry.annotation)
+
+        # A first_appearance time can be passed to an entry.
+        timed_edition = self._edition()
+        timed_entry = custom_list.add_entry(timed_edition, first_appearance=now)[0]
+        eq_(now, timed_entry.first_appearance)
+        eq_(now, timed_entry.most_recent_appearance)
+
+        # If the entry already exists, the most_recent_appearance is updated.
+        new_timed_entry, is_new = custom_list.add_entry(timed_edition)
+        eq_(False, is_new)
+        eq_(timed_entry, new_timed_entry)
+        eq_(True, timed_entry.most_recent_appearance > now)
+
+        # If the entry already exists, the most_recent_appearance can be
+        # updated by passing in a later first_appearance.
+        later = datetime.datetime.utcnow()
+        new_timed_entry = custom_list.add_entry(timed_edition, first_appearance=later)[0]
+        eq_(timed_entry, new_timed_entry)
+        eq_(now, new_timed_entry.first_appearance)
+        eq_(later, new_timed_entry.most_recent_appearance)
+
+        # For existing entries, arlier first_appearance datetimes are ignored.
+        entry = custom_list.add_entry(annotated_edition, first_appearance=now)[0]
+        eq_(True, entry.first_appearance != now)
+        eq_(True, entry.first_appearance >= now)
+        eq_(True, entry.most_recent_appearance != now)
+        eq_(True, entry.most_recent_appearance >= now)
+
+        # Adding an equivalent edition will not create multiple entries.
+        equivalent, lp = self._edition(with_open_access_download=True)
+        workless_edition.primary_identifier.equivalent_to(
+            equivalent.data_source, equivalent.primary_identifier, 1
+        )
+        equivalent_entry, is_new = custom_list.add_entry(equivalent)
+        eq_(False, is_new)
+        eq_(workless_entry, equivalent_entry)
+        # But it will change the edition to the one that's requested.
+        eq_(equivalent, workless_entry.edition)
+        # And/or add a license_pool if one is newly available.
+        eq_(lp, equivalent_entry.license_pool)
+
+    def test_remove_entry(self):
+        custom_list, editions = self._customlist(num_entries=2)
+        [first, second] = editions
+
+        # An entry is removed if its edition is passed in.
+        custom_list.remove_entry(first)
+        eq_(1, len(custom_list.entries))
+        eq_(second, custom_list.entries[0].edition)
+
+        # An entry is also removed if any of its equivalent editions
+        # are passed in.
+        equivalent = self._edition(with_open_access_download=True)[0]
+        second.primary_identifier.equivalent_to(
+            equivalent.data_source, equivalent.primary_identifier, 1
+        )
+        custom_list.remove_entry(second)
+        eq_([], custom_list.entries)
+
+        # An edition that's not into the list doesn't cause any problems.
+        custom_list.remove_entry(first)
+        eq_([], custom_list.entries)
+
+    def test_entries_for_work(self):
+        custom_list, editions = self._customlist(num_entries=2)
+        edition = editions[0]
+        [entry] = [e for e in custom_list.entries if e.edition==edition]
+
+        # The entry is returned when you search by Edition.
+        eq_([entry], custom_list.entries_for_work(edition))
+
+        # It's also returned when you search by Work.
+        eq_([entry], custom_list.entries_for_work(edition.work))
+
+        # Or when you search with an equivalent Edition
+        equivalent = self._edition()
+        edition.primary_identifier.equivalent_to(
+            equivalent.data_source, equivalent.primary_identifier, 1
+        )
+        eq_([entry], custom_list.entries_for_work(equivalent))
+
+        # Multiple equivalent entries may be returned, too, if they
+        # were added manually or before the editions were set as
+        # equivalent.
+        not_yet_equivalent = self._edition()
+        other_entry = custom_list.add_entry(not_yet_equivalent)[0]
+        edition.primary_identifier.equivalent_to(
+            not_yet_equivalent.data_source,
+            not_yet_equivalent.primary_identifier, 1
+        )
+        eq_(
+            sorted([entry, other_entry]),
+            sorted(custom_list.entries_for_work(not_yet_equivalent))
+        )
+
 
 class TestCustomListEntry(DatabaseTest):
 
@@ -4897,6 +5018,73 @@ class TestCustomListEntry(DatabaseTest):
         entry.set_license_pool()
 
         eq_(lp, entry.license_pool)
+
+    def test_update(self):
+        custom_list, [edition] = self._customlist(entries_exist_as_works=False)
+        identifier = edition.primary_identifier
+        [entry] = custom_list.entries
+        entry_attributes = vars(entry).values()
+        created = entry.first_appearance
+
+        # Running update without entries or forcing doesn't change the entry.
+        entry.update(self._db)
+        eq_(entry_attributes, vars(entry).values())
+
+        # Trying to update an entry with entries from a different
+        # CustomList is a no-go.
+        other_custom_list = self._customlist()[0]
+        [external_entry] = other_custom_list.entries
+        assert_raises(
+            ValueError, entry.update, self._db,
+            equivalent_entries=[external_entry]
+        )
+
+        # So is attempting to update an entry with other entries that
+        # don't represent the same work.
+        external_work = self._work(with_license_pool=True)
+        external_work_edition = external_work.presentation_edition
+        external_work_entry = custom_list.add_entry(external_work_edition)[0]
+        assert_raises(
+            ValueError, entry.update, self._db,
+            equivalent_entries=[external_work_entry]
+        )
+
+        # Okay, but with an actual equivalent entry...
+        work = self._work(with_open_access_download=True)
+        equivalent = work.presentation_edition
+        equivalent_entry = custom_list.add_entry(
+            equivalent, annotation="Whoo, go books!"
+        )[0]
+        identifier.equivalent_to(
+            equivalent.data_source, equivalent.primary_identifier, 1
+        )
+
+        # ...updating changes the original entry as expected.
+        entry.update(self._db, equivalent_entries=[equivalent_entry])
+        # The first_appearance hasn't changed because the entry was created first.
+        eq_(created, entry.first_appearance)
+        # But the most recent appearance is of the entry created last.
+        eq_(equivalent_entry.most_recent_appearance, entry.most_recent_appearance)
+        # Annotations are shared.
+        eq_(u"Whoo, go books!", entry.annotation)
+        # The Edition and LicensePool are updated to have a Work.
+        eq_(entry.edition, work.presentation_edition)
+        eq_(entry.license_pool, equivalent.license_pool)
+        # The equivalent entry has been deleted.
+        eq_([], self._db.query(CustomListEntry).\
+                filter(CustomListEntry.id==equivalent_entry.id).all())
+
+        # The entry with the longest annotation wins the annotation awards.
+        long_annotation = "Wow books are so great especially when they're annotated."
+        longwinded = self._edition()
+        longwinded_entry = custom_list.add_entry(
+            longwinded, annotation=long_annotation)[0]
+
+        identifier.equivalent_to(
+            longwinded.data_source, longwinded.primary_identifier, 1)
+        entry.update(self._db, equivalent_entries=[longwinded_entry])
+        eq_(long_annotation, entry.annotation)
+        eq_(longwinded_entry.most_recent_appearance, entry.most_recent_appearance)
 
 
 class TestCollection(DatabaseTest):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -24,6 +24,7 @@ from util import (
     MoneyUtility,
     TitleProcessor,
     fast_query_count,
+    slugify
 )
 from util.opds_authentication_document import OPDSAuthenticationDocument
 from util.median import median
@@ -548,6 +549,24 @@ class TestFastQueryCount(DatabaseTest):
 
         qu3 = qu.limit(6)
         eq_(qu3.count(), fast_query_count(qu3))
+
+
+class TestSlugify(object):
+
+    def test_slugify(self):
+
+        # text are slugified.
+        eq_('hey-im-a-feed', slugify("Hey! I'm a feed!!"))
+        eq_('you-and-me-n-every_feed', slugify("You & Me n Every_Feed"))
+        eq_('money-honey', slugify("Money $$$       Honey"))
+        eq_('some-title-somewhere', slugify('Some (???) Title Somewhere'))
+        eq_('sly-and-the-family-stone', slugify('sly & the family stone'))
+
+        # The results can be pared down according to length restrictions.
+        eq_('happ', slugify('Happy birthday', length_limit=4))
+
+        # Slugified text isn't altered
+        eq_('already-slugified', slugify('already-slugified'))
 
 
 class TestMoneyUtility(object):

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -42,6 +42,29 @@ def fast_query_count(query):
 
     return count
 
+def slugify(text, length_limit=None):
+    """Takes a string and turns it into a slug.
+
+    :Example:
+
+    >>> slugify('Some (???) Title Somewhere')
+    some-title-somewhere
+    >>> slugify('Sly & the Family Stone')
+    sly-and-the-family-stone
+    >>> slugify('Happy birthday!', length_limit=4)
+    happ
+    """
+    slug = re.sub('[.!@#\'$,?\(\)]', '', text.lower())
+    slug = re.sub('&', ' and ', slug)
+    slug = re.sub(' {2,}', ' ', slug)
+
+    slug = '-'.join(slug.split(' '))
+    while '--' in slug:
+        slug = re.sub('--', '-', slug)
+
+    if length_limit:
+        slug = slug[:length_limit]
+    return unicode(slug)
 
 class LanguageCodes(object):
     """Convert between ISO-639-2 and ISO-693-1 language codes.


### PR DESCRIPTION
A lot of this code aims to minimize duplicates in the CustomList (and duplicates _of_ the CustomList). There's also a `CustomList.remove_entry` method to allow other types of list updates from the upload script in the content_server (NYPL-Simplified/content_server#114).