### PR TITLE
Fix cached feed content #449

### DIFF
--- a/model.py
+++ b/model.py
@@ -5603,6 +5603,7 @@ class CachedFeed(Base):
             facets=facets_key,
             pagination=pagination_key,
             )
+
         if force_refresh is True:
             # No matter what, we've been directed to treat this
             # cached feed as stale.
@@ -5641,9 +5642,10 @@ class CachedFeed(Base):
         # Either there is no cached feed or it's time to update it.
         return feed, False
 
-    def update(self, content):
+    def update(self, _db, content):
         self.content = content
         self.timestamp = datetime.datetime.utcnow()
+        _db.commit()
 
     def __repr__(self):
         if self.content:

--- a/model.py
+++ b/model.py
@@ -5571,7 +5571,7 @@ class CachedFeed(Base):
 
         license_pool = None
         if lane:
-            lane_name = lane.name
+            lane_name = unicode(lane.name)
             if hasattr(lane, 'license_pool'):
                 license_pool = lane.license_pool
         else:

--- a/model.py
+++ b/model.py
@@ -346,9 +346,6 @@ def get_one_or_create(db, model, create_method='',
             for key in get_one_keys:
                 if key in kwargs:
                     del kwargs[key]
-            # if 'on_multiple' in kwargs:
-            #     del kwargs['on_multiple']
-            # if 'filter_constraints'
             obj = create(db, model, create_method, create_method_kwargs, **kwargs)
             __transaction.commit()
             return obj

--- a/model.py
+++ b/model.py
@@ -5662,7 +5662,7 @@ class CachedFeed(Base):
     def update(self, _db, content):
         self.content = content
         self.timestamp = datetime.datetime.utcnow()
-        _db.commit()
+        _db.flush()
 
     def __repr__(self):
         if self.content:

--- a/opds.py
+++ b/opds.py
@@ -420,7 +420,7 @@ class AcquisitionFeed(OPDSFeed):
         :return: CachedFeed (if use_cache is True) or unicode
         """
         cached = None
-        use_cache = not cache_type == cls.NO_CACHE
+        use_cache = cache_type != cls.NO_CACHE
         if use_cache:
             cache_type = cache_type or CachedFeed.GROUPS_TYPE
             cached, usable = CachedFeed.fetch(
@@ -523,7 +523,7 @@ class AcquisitionFeed(OPDSFeed):
         pagination = pagination or Pagination.default()
 
         cached = None
-        use_cache = not cache_type == cls.NO_CACHE
+        use_cache = cache_type != cls.NO_CACHE
         if use_cache:
             cache_type = cache_type or CachedFeed.PAGE_TYPE
             cached, usable = CachedFeed.fetch(

--- a/opds.py
+++ b/opds.py
@@ -507,7 +507,7 @@ class AcquisitionFeed(OPDSFeed):
 
         content = unicode(feed)
         if cached and use_cache:
-            cached.update(content)
+            cached.update(_db, content)
             return cached
         return content
 
@@ -582,7 +582,7 @@ class AcquisitionFeed(OPDSFeed):
 
         content = unicode(feed)
         if cached and use_cache:
-            cached.update(content)
+            cached.update(_db, content)
             return cached
         return content
 

--- a/tests/test_cachedfeed.py
+++ b/tests/test_cachedfeed.py
@@ -27,6 +27,35 @@ from . import (
 
 class TestCachedFeed(DatabaseTest):
 
+    def test_get_feed_or_create(self):
+        lane = Lane(self._db, u'Fantasy', languages=['eng'])
+        kwargs = dict(
+            lane_name=u'Fantasy',
+            languages=u'eng',
+            facets=u'',
+            pagination=u'',
+            type=CachedFeed.PAGE_TYPE)
+
+        result, is_new = CachedFeed.get_feed_or_create(self._db, **kwargs)
+        eq_(True, isinstance(result, CachedFeed))
+        eq_(True, is_new)
+
+        # If a CachedFeed exists, but it hasn't been updated,
+        # a new CachedFeed is returned.
+        old_result = result
+        new_result, is_new = CachedFeed.get_feed_or_create(self._db, **kwargs)
+        eq_(True, old_result != new_result)
+        eq_(True, is_new)
+        # And the unusable CachedFeed is deleted from the db.
+        eq_(True, old_result not in self._db)
+
+        # But if we give the CachedFeed content, we'll get it back.
+        new_result.update(self._db, u"l'elephante")
+        old_result = new_result
+        new_result, is_new = CachedFeed.get_feed_or_create(self._db, **kwargs)
+        eq_(old_result, new_result)
+        eq_(False, is_new)
+
     def test_lifecycle(self):
         facets = Facets.default()
         pagination = Pagination.default()

--- a/tests/test_cachedfeed.py
+++ b/tests/test_cachedfeed.py
@@ -45,7 +45,7 @@ class TestCachedFeed(DatabaseTest):
         eq_('eng,chi', feed.languages)
 
         # Update the content
-        feed.update("The content")
+        feed.update(self._db, u"The content")
         self._db.commit()
 
         # Fetch it again.
@@ -85,7 +85,7 @@ class TestCachedFeed(DatabaseTest):
         feed, fresh = CachedFeed.fetch(
             *args, force_refresh=True, max_age=Configuration.CACHE_FOREVER
         )
-        feed.update("Cache this forever!")
+        feed.update(self._db, "Cache this forever!")
 
         # Once the feed has content associated with it, we can ask for
         # it in cached-forever mode and no longer get the exception.

--- a/tests/test_cachedfeed.py
+++ b/tests/test_cachedfeed.py
@@ -30,7 +30,7 @@ class TestCachedFeed(DatabaseTest):
     def test_lifecycle(self):
         facets = Facets.default()
         pagination = Pagination.default()
-        lane = Lane(self._db, "My Lane", languages=['eng', 'chi'])
+        lane = Lane(self._db, u"My Lane", languages=['eng', 'chi'])
 
         # Fetch a cached feed from the database--it's empty.
         args = (self._db, lane, CachedFeed.PAGE_TYPE, facets, pagination, None)
@@ -64,7 +64,7 @@ class TestCachedFeed(DatabaseTest):
         
         facets = Facets.default()
         pagination = Pagination.default()
-        lane = Lane(self._db, "My Lane", languages=['eng', 'chi'])
+        lane = Lane(self._db, u"My Lane", languages=['eng', 'chi'])
 
         args = (self._db, lane, CachedFeed.PAGE_TYPE, facets, 
                      pagination, None)


### PR DESCRIPTION
There are a few stray feeds without content or timestamp in the database, which makes them completely unusable to the controllers.

There wasn't a place in the code base where `CachedFeed.fetch` was being called without `CachedFeed#update`, but `CachedFeed#update` wasn't committing its changes to the database immediately. This may have caused problems if scripts or startups erred or stopped unexpectedly.

In accordance with the issue, I also added a CachedFeed-specific "get_one_or_create"-style method that deletes any found instances of CachedFeed that lack required information.

Fixes #449.