### PR TITLE
Support FeedBooks short stories genre

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -2726,11 +2726,6 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    Eg("african-american studies"),
                    Eg("customs & traditions"),
                    Eg("criminology"),
-
-                   # Stop from showing up as 'science'
-                   "social sciences",
-                   "social science",
-                   "human science",
                ),               
                
                Sports: match_kw(
@@ -2944,6 +2939,13 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
             "thriller.*romance",
         ),
         
+        # Stop from showing up as 'science'
+        Social_Sciences : match_kw(
+            "social sciences",
+            "social science",
+            "human science",
+        ),
+
         Science_Fiction : match_kw(
             "science fiction",
             "science fiction.*general",

--- a/classifier.py
+++ b/classifier.py
@@ -3579,7 +3579,10 @@ class WorkClassifier(object):
         """
         self.weigh_metadata()
 
-        explicitly_indicated_audiences = (Classifier.AUDIENCE_CHILDREN, Classifier.AUDIENCE_YOUNG_ADULT, Classifier.AUDIENCE_ADULTS_ONLY)
+        explicitly_indicated_audiences = (
+            Classifier.AUDIENCE_CHILDREN,
+            Classifier.AUDIENCE_YOUNG_ADULT,
+            Classifier.AUDIENCE_ADULTS_ONLY)
         audiences_from_license_source = set(
             [classification.subject.audience
              for classification in self.direct_from_license_source]

--- a/classifier.py
+++ b/classifier.py
@@ -1767,8 +1767,10 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
         Eg("bildungsromans"), "fictitious",
     )
     LEVEL_2_NONFICTION_INDICATORS = match_kw(
-        Eg("history"), Eg("biography"), Eg("histories"), Eg("biographies"), Eg("autobiography"),
-        Eg("autobiographies"), "nonfiction", Eg("essays"), Eg("letters"))
+        Eg("history"), Eg("biography"), Eg("histories"),
+        Eg("biographies"), Eg("autobiography"), Eg("autobiographies"),
+        "nonfiction", Eg("essays"), Eg("letters"), Eg("biographical"),
+        Eg("true story"), Eg("personal memoirs"))
     JUVENILE_INDICATORS = match_kw(
         "for children", "children's", "juvenile",
         Eg("nursery rhymes"), Eg("9-12"))
@@ -1843,6 +1845,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                
         Art: match_kw(
             "art",
+            "arts",
             "artist",
             "artists",
             "artistic",
@@ -1879,6 +1882,8 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "autobiography",
                    "biographies",
                    "biography",
+                   "biographical",
+                   "personal memoirs",
                ),
                
                Body_Mind_Spirit: match_kw(
@@ -1907,6 +1912,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                
                Christianity : match_kw(
                    Eg("schema:creativework:bible"),
+                   Eg("baptist"),
                    Eg("bible"),
                    Eg("sermons"),
                    Eg("devotional"),
@@ -1920,11 +1926,13 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    Eg("catholicism"),
                    Eg("protestantism"),
                    Eg("church"),
+                   Eg("christmas & advent"),
                ),
                
                Civil_War_History: match_kw(
                    "american civil war",
                    "1861-1865",
+                   "civil war period",
                ),
                
                Classics: match_kw(
@@ -2104,6 +2112,8 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "family & relationships",                   
                    "relationships",
                    "family relationships",
+                   "human sexuality",
+                   "sexuality",
                ),
                
                Fantasy : match_kw(
@@ -2222,6 +2232,9 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                History : match_kw(
                    "histories",
                    "history",
+                   "historiography",
+                   "historical period",
+                   Eg("pre-confederation"),
                ),
                
                Horror : match_kw(
@@ -2366,6 +2379,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "medical",
                    "medicine", 
                    Eg("neuroscience"),
+                   Eg("ophthalmology"),
                    Eg("physiology"),
                    Eg("vaccines"),
                    Eg("virus"),
@@ -2479,6 +2493,8 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "theatrical",
                    "performing arts",
                    "entertainers",
+                   Eg("farce"),
+                   Eg("tragicomedy"),
                ),
                
                Periodicals : match_kw(
@@ -2505,6 +2521,8 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "philosophical",
                    "philosopher",
                    "philosophers",
+                   Eg("epistemology"),
+                   Eg("metaphysics"),
                ),
                
                Photography: match_kw(
@@ -2540,7 +2558,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    Eg("corrupt practices"),
                    Eg("democracy"),
                    Eg("geopolitics"),
-                   "goverment",
+                   "government",
                    Eg("human rights"),
                    Eg("international relations"),
                    Eg("political economy"),
@@ -2550,6 +2568,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    Eg("public affairs"),
                    Eg("public policy"),
                    "politics",
+                   "political",
                    Eg("current events"),
                ),
                
@@ -2558,6 +2577,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    Eg("psychiatry"),
                    "psychological aspects",
                    Eg("psychiatric"),
+                   Eg("psychoanalysis"),
                ),
                
                Real_Estate: match_kw(
@@ -2568,6 +2588,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    Eg("catalogs"),
                    Eg("handbooks"),
                    Eg("manuals"),
+                   Eg("reference"),
 
                    # Formerly in 'Encyclopedias'
                    Eg("encyclopaedias"),
@@ -2604,6 +2625,9 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                Religion_Spirituality : match_kw(
                    "religion",
                    "religious",
+                   Eg("taoism"),
+                   Eg("taoist"),
+                   Eg("confucianism"),
                ),
                
                Renaissance_Early_Modern_History: match_kw(
@@ -2630,6 +2654,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    Eg("biochemistry"), 
                    Eg("botany"),
                    Eg("chemistry"),
+                   Eg("earth sciences"),
                    Eg("ecology"),
                    Eg("entomology"),
                    Eg("evolution"),
@@ -2677,11 +2702,17 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "myth",
                    "legends",
                ),
+
+                Short_Stories: match_kw(
+                    "short stories",
+                ),
+
                Social_Sciences: match_kw(
                    Eg("anthropology"),
-                   Eg("archaology"),
+                   Eg("archaeology"),
                    Eg("sociology"),
                    Eg("ethnic studies"),
+                   Eg("feminism & feminist theory"),
                    Eg("gender studies"),
                    Eg("media studies"),
                    Eg("minority studies"),
@@ -2693,6 +2724,13 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    Eg('gay studies'),
                    Eg("black studies"),
                    Eg("african-american studies"),
+                   Eg("customs & traditions"),
+                   Eg("criminology"),
+
+                   # Stop from showing up as 'science'
+                   "social sciences",
+                   "social science",
+                   "human science",
                ),               
                
                Sports: match_kw(
@@ -2746,6 +2784,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "technology",
                    Eg("engineering"),
                    Eg("bioengineering"),
+                   Eg("mechanics"),
 
                    # Formerly in 'Transportation'
                    Eg("transportation"),
@@ -2788,6 +2827,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "u.s. history",
                    Eg("american revolution"),
                    Eg("1775-1783"),
+                   Eg("revolutionary period"),
                ),
                
                Urban_Fantasy: match_kw(
@@ -2892,6 +2932,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
             Eg("fiction.*christian"),
             "religious fiction",
             "fiction.*religious",
+            Eg("Oriental religions and wisdom")
         ),
 
         Romantic_Suspense : match_kw(
@@ -2901,13 +2942,6 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
             "romantic.*thriller",
             "romance.*thriller",
             "thriller.*romance",
-        ),
-
-        # Stop from showing up as 'science'
-        Social_Sciences : match_kw(
-            "social sciences",
-            "social science",
-            "human science",
         ),
         
         Science_Fiction : match_kw(

--- a/lane.py
+++ b/lane.py
@@ -456,7 +456,11 @@ class Lane(object):
         return depth
     
     def __repr__(self):
-        template = "<Lane name=%(full_name)s, display=%(display_name)s, media=%(media)s, genre=%(genres)s, fiction=%(fiction)s, audience=%(audiences)s, age_range=%(age_range)r, language=%(language)s, sublanes=%(sublanes)d>"
+        template = (
+            "<Lane name=%(full_name)s, display=%(display_name)s, "
+            "media=%(media)s, genre=%(genres)s, fiction=%(fiction)s, "
+            "audience=%(audiences)s, age_range=%(age_range)r, "
+            "language=%(language)s, sublanes=%(sublanes)d>")
 
         sublanes = getattr(self, 'sublanes', None)
         if sublanes:
@@ -669,7 +673,7 @@ class Lane(object):
         """
         # However the genres came in, turn them into database Genre
         # objects and the corresponding GenreData objects.
-        genres, genredata = self.load_genres(self._db, genres)
+        genres = self.load_genres(self._db, genres)[0]
 
         # Create a complete list of genres to exclude.
         full_exclude_genres = set()

--- a/model.py
+++ b/model.py
@@ -4021,7 +4021,7 @@ class Work(Base):
             self, operation=WorkCoverageRecord.QUALITY_OPERATION
         )
 
-    def assign_genres(self, identifier_ids, cutoff=0.15):
+    def assign_genres(self, identifier_ids):
         """Set classification information for this work based on the
         subquery to get equivalent identifiers.
 

--- a/model.py
+++ b/model.py
@@ -893,6 +893,7 @@ class DataSource(Base):
                 (cls.NOVELIST, False, True, Identifier.NOVELIST_ID, None),
                 (cls.PRESENTATION_EDITION, False, False, None, None),
                 (cls.INTERNAL_PROCESSING, True, False, None, None),
+                (cls.FEEDBOOKS, True, False, Identifier.URI, None)
         ):
 
             extra = dict()

--- a/scripts.py
+++ b/scripts.py
@@ -236,7 +236,7 @@ class IdentifierInputScript(InputScript):
         )
         parser.add_argument(
             '--identifier-data-source',
-            help='Process identifiers with this LicensePool.data_source'
+            help='Process only identifiers which have a LicensePool associated with this DataSource'
         )
         parser.add_argument(
             'identifier_strings',

--- a/scripts.py
+++ b/scripts.py
@@ -628,7 +628,10 @@ class WorkProcessingScript(IdentifierInputScript):
 
     name = "Work processing script"
 
-    def __init__(self, force=False, batch_size=10):
+    def __init__(self, force=False, batch_size=10, _db=None):
+        if _db:
+            self._session = _db
+
         args = self.parse_command_line(self._db)
         self.identifier_type = args.identifier_type
         self.identifiers = args.identifiers
@@ -880,7 +883,11 @@ class OPDSImportScript(Script):
         return parser
 
     def __init__(self, feed_url, opds_data_source, importer_class, 
-                 immediately_presentation_ready=False, cmd_args=None):
+                 immediately_presentation_ready=False, cmd_args=None,
+                 _db=None):
+        if _db:
+            self._session = _db
+
         args = self.parse_command_line(cmd_args)
         self.force_reimport = args.force
         self.feed_url = args.url or feed_url

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -502,6 +502,11 @@ class TestKeyword(object):
         eq_(classifier.Social_Sciences,
             Keyword.genre(None, "Human Science")
         )
+
+        # was genreless
+        eq_(classifier.Short_Stories,
+            Keyword.genre(None, "Short Stories")
+        )
         
         # was Military History
         eq_(classifier.Military_SF,


### PR DESCRIPTION
Supports the work done in NYPL-Simplified/content_server#116, including:
 - allowing URI-type identifiers to be differentiated by DataSource,
 - creating the FeedBooks DataSource at initialization,
 - passing bypass database sessions, and
 - trimming some long lines and unused variables.