### PR TITLE
Avoid a crash by skipping over a LicensePoolDeliveryMechanism that has no rights status.

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -941,7 +941,8 @@ class CirculationData(MetaToModelUtility):
         # open-access status.
         old_open_access = pool.open_access                    
         for lpdm in pool.delivery_mechanisms:
-            if lpdm.rights_status.uri in RightsStatus.OPEN_ACCESS:
+            if (lpdm.rights_status
+                and lpdm.rights_status.uri in RightsStatus.OPEN_ACCESS):
                 pool.open_access = True
                 break
         else:


### PR DESCRIPTION
I'm not sure how this happened, but on Open Ebooks I found a small number of books that had two nearly identical `LicensePoolDeliveryMechanism`s: one with the correct rights status of 'in copyright' and one with no rights status. There are no books like this on NYPL's server so it's probably the result of a one-off maintenance script gone wrong.

This branch changes CirculationData.apply() so that it doesn't crash if it encounters a LicensePoolDeliveryMechanism that has no rights status--it just skips that object, since it's not relevant to determining whether or not there's an open-access edition of the book.

