### PR TITLE
Remove 'biographical' from nonfiction (i.e. biographical fiction)

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -1769,8 +1769,8 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
     LEVEL_2_NONFICTION_INDICATORS = match_kw(
         Eg("history"), Eg("biography"), Eg("histories"),
         Eg("biographies"), Eg("autobiography"), Eg("autobiographies"),
-        "nonfiction", Eg("essays"), Eg("letters"), Eg("biographical"),
-        Eg("true story"), Eg("personal memoirs"))
+        "nonfiction", Eg("essays"), Eg("letters"), Eg("true story"),
+        Eg("personal memoirs"))
     JUVENILE_INDICATORS = match_kw(
         "for children", "children's", "juvenile",
         Eg("nursery rhymes"), Eg("9-12"))

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -132,9 +132,19 @@ class ReplacementPolicy(object):
 class SubjectData(object):
     def __init__(self, type, identifier, name=None, weight=1):
         self.type = type
+
+        # Because subjects are sometimes evaluated according to keyword
+        # matching, it's important that any leading or trailing white
+        # space is removed during import.
         self.identifier = identifier
+        if identifier:
+            self.identifier = identifier.strip()
+
         self.name = name
-        self.weight=weight
+        if name:
+            self.name = name.strip()
+
+        self.weight = weight
 
     @property
     def key(self):


### PR DESCRIPTION
When I ran this against QA, it turns out this subject is for fiction and the keyword is generally used to describe fiction.