### PR TITLE
Support static feeds from lists

### DIFF
--- a/config.py
+++ b/config.py
@@ -73,6 +73,8 @@ class Configuration(object):
     HOLD_POLICY_ALLOW = "allow"
     HOLD_POLICY_HIDE = "hide"
 
+    LANES_POLICY = "lanes"
+
     # Facet policies
     FACET_POLICY = 'facets'
     ENABLED_FACETS_KEY = 'enabled'

--- a/config.py
+++ b/config.py
@@ -15,12 +15,17 @@ class CannotLoadConfiguration(Exception):
 def temp_config(new_config=None, replacement_classes=None):
     old_config = Configuration.instance
     replacement_classes = replacement_classes or [Configuration]
-    if new_config is None:
-        new_config = copy.deepcopy(old_config)
+
+    replacement_config = copy.deepcopy(old_config)
+    if new_config:
+        # Merge the values of top-level keys (e.g. 'links', 'policies',
+        # 'integrations') with values in the proposed config.
+        # TODO: Update lower-level dicts and lists instead of overwriting them.
+        replacement_config.update(new_config)
     try:
         for c in replacement_classes:
-            c.instance = new_config
-        yield new_config
+            c.instance = replacement_config
+        yield replacement_config
     finally:
         for c in replacement_classes:
             c.instance = old_config

--- a/config.py
+++ b/config.py
@@ -15,17 +15,12 @@ class CannotLoadConfiguration(Exception):
 def temp_config(new_config=None, replacement_classes=None):
     old_config = Configuration.instance
     replacement_classes = replacement_classes or [Configuration]
-
-    replacement_config = copy.deepcopy(old_config)
-    if new_config:
-        # Merge the values of top-level keys (e.g. 'links', 'policies',
-        # 'integrations') with values in the proposed config.
-        # TODO: Update lower-level dicts and lists instead of overwriting them.
-        replacement_config.update(new_config)
+    if new_config is None:
+        new_config = copy.deepcopy(old_config)
     try:
         for c in replacement_classes:
-            c.instance = replacement_config
-        yield replacement_config
+            c.instance = new_config
+        yield new_config
     finally:
         for c in replacement_classes:
             c.instance = old_config

--- a/config.py
+++ b/config.py
@@ -338,5 +338,6 @@ class Configuration(object):
 
     @classmethod
     def _load(cls, str):
-        lines = [x for x in str.split("\n") if not x.strip().startswith("#")]
+        lines = [x for x in str.split("\n")
+                 if not (x.strip().startswith("#") or x.strip().startswith("//"))]
         return json.loads("\n".join(lines))

--- a/lane.py
+++ b/lane.py
@@ -600,9 +600,6 @@ class Lane(object):
         set_from_parent(
             'subgenre_behavior', subgenre_behavior, self.IN_SUBLANES)
 
-        if self.searchable and (self.list_data_source_id or self.list_ids):
-            raise UndefinedLane("Lane with list data source cannot be searchable")
-
         self.set_sublanes(
             self._db, sublanes, genres,
             exclude_genres=exclude_genres, fiction=fiction

--- a/lane.py
+++ b/lane.py
@@ -1641,3 +1641,15 @@ class QueryGeneratedLane(Lane):
         :return: query or None
         """
         raise NotImplementedError()
+
+def make_lanes(_db, definitions=None):
+
+    definitions = definitions or Configuration.policy(
+        Configuration.LANES_POLICY
+    )
+    if not definitions:
+        # A lane arrangement is required for lane making.
+        return None
+
+    lanes = [Lane(_db=_db, **definition) for definition in definitions]
+    return LaneList.from_description(_db, None, lanes)

--- a/model.py
+++ b/model.py
@@ -649,7 +649,7 @@ class Annotation(Base):
     def set_inactive(self):
         self.active = False
         self.content = None
-        self.timestamp = datetime.datetime.now()
+        self.timestamp = datetime.datetime.utcnow()
 
 class DataSource(Base):
 
@@ -8069,6 +8069,10 @@ class CustomList(Base):
             entry.license_pool = edition.license_pool
         if featured is not None:
             entry.featured = featured
+
+        if was_new:
+            self.updated = datetime.datetime.utcnow()
+            _db.commit()
         return entry, was_new
 
     def remove_entry(self, edition):
@@ -8080,6 +8084,9 @@ class CustomList(Base):
         existing_entries = self.entries_for_work(edition)
         for entry in existing_entries:
             _db.delete(entry)
+
+        if existing_entries:
+            self.updated = datetime.datetime.utcnow()
         _db.commit()
 
     def entries_for_work(self, work_or_edition):

--- a/model.py
+++ b/model.py
@@ -8072,7 +8072,7 @@ class CustomList(Base):
 
         if was_new:
             self.updated = datetime.datetime.utcnow()
-            _db.commit()
+
         return entry, was_new
 
     def remove_entry(self, edition):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4917,6 +4917,8 @@ class TestCustomList(DatabaseTest):
         eq_(workless_edition, workless_entry.edition)
         eq_(True, workless_entry.first_appearance > now)
         eq_(None, workless_entry.license_pool)
+        # And the CustomList will be seen as updated.
+        eq_(True, custom_list.updated > now)
 
         # An edition with a work can create an entry.
         worked_edition, lp = self._edition(with_license_pool=True)
@@ -4939,10 +4941,13 @@ class TestCustomList(DatabaseTest):
         eq_(now, timed_entry.most_recent_appearance)
 
         # If the entry already exists, the most_recent_appearance is updated.
+        previous_list_update_time = custom_list.updated
         new_timed_entry, is_new = custom_list.add_entry(timed_edition)
         eq_(False, is_new)
         eq_(timed_entry, new_timed_entry)
         eq_(True, timed_entry.most_recent_appearance > now)
+        # But the CustomList update time is not.
+        eq_(previous_list_update_time, custom_list.updated)
 
         # If the entry already exists, the most_recent_appearance can be
         # updated by passing in a later first_appearance.
@@ -4967,6 +4972,8 @@ class TestCustomList(DatabaseTest):
         equivalent_entry, is_new = custom_list.add_entry(equivalent)
         eq_(False, is_new)
         eq_(workless_entry, equivalent_entry)
+        # Or update the CustomList updated time
+        eq_(previous_list_update_time, custom_list.updated)
         # But it will change the edition to the one that's requested.
         eq_(equivalent, workless_entry.edition)
         # And/or add a license_pool if one is newly available.
@@ -4975,25 +4982,32 @@ class TestCustomList(DatabaseTest):
     def test_remove_entry(self):
         custom_list, editions = self._customlist(num_entries=2)
         [first, second] = editions
+        now = datetime.datetime.utcnow()
 
         # An entry is removed if its edition is passed in.
         custom_list.remove_entry(first)
         eq_(1, len(custom_list.entries))
         eq_(second, custom_list.entries[0].edition)
+        # And CustomList.updated is changed.
+        eq_(True, custom_list.updated > now)
 
         # An entry is also removed if any of its equivalent editions
         # are passed in.
+        previous_list_update_time = custom_list.updated
         equivalent = self._edition(with_open_access_download=True)[0]
         second.primary_identifier.equivalent_to(
             equivalent.data_source, equivalent.primary_identifier, 1
         )
         custom_list.remove_entry(second)
         eq_([], custom_list.entries)
+        eq_(True, custom_list.updated > previous_list_update_time)
 
         # An edition that's not on the list doesn't cause any problems.
         custom_list.add_entry(second)
+        previous_list_update_time = custom_list.updated
         custom_list.remove_entry(first)
         eq_(1, len(custom_list.entries))
+        eq_(previous_list_update_time, custom_list.updated)
 
     def test_entries_for_work(self):
         custom_list, editions = self._customlist(num_entries=2)


### PR DESCRIPTION
This branch expands the list of attributes that a sublane will inherit from its parent to include exclude_genres and any `CustomList` information. It supports Lanes that have defined `exclude_genres` without `include_genres` (like "General Fiction"). It also moves `make_lanes` from circulation into core.

Supports NYPL-Simplified/content_server#118.