### PR TITLE
Abstract implementation of the User Profile Management Protocol

### DIFF
--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -8,7 +8,7 @@ from user_profile import (
     DictionaryBasedProfileStore,
 )
 
-class TestProfileManager(object):
+class TestProfileController(object):
 
     def setup(self):
         self.read_only = dict(key="value")

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -1,0 +1,151 @@
+from nose.tools import (
+    eq_,
+    set_trace
+)
+import json
+from user_profile import (
+    ProfileController,
+    DictionaryBasedProfileStore,
+)
+
+class TestProfileManager(object):
+
+    def setup(self):
+        self.read_only = dict(key="value")
+        self.writable = dict(writable_key="old_value")
+        self.store = DictionaryBasedProfileStore(self.read_only, self.writable)
+        self.controller = ProfileController(self.store)
+
+    def test_representation(self):
+        """Test that the default setup becomes a dictionary ready for
+        conversion to JSON.
+        """
+        eq_({'key': 'value', 'settings': {'writable_key': 'old_value'}},
+            self.store.representation)
+        
+    def test_get_success(self):
+        """Test that sending a GET request to the controller results in the
+        expected representation.
+        """
+        status_code, media_type, body = self.controller.get()
+        eq_(200, status_code)
+        eq_(ProfileController.MEDIA_TYPE, media_type)
+        eq_(json.dumps(self.store.representation), body)
+
+    def test_put_success(self):
+        """Test that sending a new dictionary of key-value pairs
+        leads to changes in the writable part of the store, but not in 
+        the read-only part.
+        """
+        headers = {"Content-Type" : ProfileController.MEDIA_TYPE}
+        expected_new_state = dict(writable_key="new value")
+        old_read_only = dict(self.store.read_only)
+        body = json.dumps(dict(settings=expected_new_state))
+        status_code, media_type, body = self.controller.put(headers, body)
+        eq_(200, status_code)
+        eq_(expected_new_state, self.store.writable)
+        eq_(old_read_only, self.store.read_only)
+
+    def test_put_noop(self):
+        """Test that sending an empty dictionary of key-value pairs
+        succeeds but does nothing.
+        """
+        headers = {"Content-Type" : ProfileController.MEDIA_TYPE}
+        expected_new_state = dict(self.store.writable)
+        status_code, media_type, body = self.controller.put(
+            headers, json.dumps({})
+        )
+        eq_(200, status_code)
+        eq_(expected_new_state, self.store.writable)
+        
+    def test_get_exception_during_representation(self):
+        """Test what happens if an exception is raised during the
+        creation of a representation.
+        """
+        
+        class BadStore(DictionaryBasedProfileStore):
+            @property
+            def representation(self):
+                raise Exception("Oh no")
+
+        self.controller.store = BadStore()
+        problem = self.controller.get()
+        eq_(500, problem.status_code)
+        eq_(u"Oh no", problem.debug_message)
+        
+    def test_get_non_dictionary_representation(self):
+        """Test what happens if the representation is not a dictionary.
+        """
+        
+        class BadStore(DictionaryBasedProfileStore):
+            @property
+            def representation(self):
+                return u"Here it is!"
+
+        self.controller.store = BadStore()
+        problem = self.controller.get()
+        eq_(500, problem.status_code)
+        eq_(u"Profile representation is not a JSON object: u'Here it is!'.",
+            problem.debug_message)
+        
+    def test_get_non_dictionary_representation(self):
+        """Test what happens if the representation cannot be converted to JSON.
+        """
+        
+        class BadStore(DictionaryBasedProfileStore):
+            @property
+            def representation(self):
+                return dict(key=object())
+
+        self.controller.store = BadStore()
+        problem = self.controller.get()
+        eq_(500, problem.status_code)
+        assert problem.debug_message.startswith(
+            u"Could not convert profile to JSON: {'key': <object object"
+        )
+
+    def test_put_bad_media_type(self):
+        """You must send the proper media type with your PUT request."""
+        headers = {"Content-Type" : "application/json"}
+        body = json.dumps(dict(settings={}))
+        problem = self.controller.put(headers, body)
+        eq_(415, problem.status_code)
+        eq_('Expected vnd.librarysimplified/user-profile+json',
+            problem.detail)
+
+    def test_put_invalid_json(self):
+        """You can't send any random string that's not JSON."""
+        headers = {"Content-Type" : ProfileController.MEDIA_TYPE}
+        problem = self.controller.put(headers, "blah blah")
+        eq_(400, problem.status_code)
+        eq_(u"Submitted profile document was not valid JSON.", problem.detail)
+
+    def test_put_non_object(self):
+        """You can't send any random JSON string, it has to be an object."""
+        headers = {"Content-Type" : ProfileController.MEDIA_TYPE}
+        problem = self.controller.put(headers, json.dumps("blah blah"))
+        eq_(400, problem.status_code)
+        eq_(u'Submitted profile document was not a JSON object.',
+            problem.detail)
+        
+    def test_attempt_to_set_read_only_setting(self):
+        """You can't change the value of a setting that's not
+        writable.
+        """
+        headers = {"Content-Type" : ProfileController.MEDIA_TYPE}
+        body = json.dumps(dict(settings=dict(key="new value")))
+        problem = self.controller.put(headers, body)
+        eq_(400, problem.status_code)
+        eq_('"key" is not a writable setting.', problem.detail)
+
+    def test_set_raises_exception(self):
+
+        class BadStore(DictionaryBasedProfileStore):
+            def set(self, settable, full):
+                raise Exception("Oh no")
+        self.controller.store = BadStore(self.read_only, self.writable)
+        headers = {"Content-Type" : ProfileController.MEDIA_TYPE}
+        body = json.dumps(dict(settings=dict(writable_key="new value")))
+        problem = self.controller.put(headers, body)
+        eq_(500, problem.status_code)
+        eq_("Oh no", problem.debug_message)

--- a/user_profile.py
+++ b/user_profile.py
@@ -126,7 +126,7 @@ class ProfileStorage(object):
 
         :param profile_document: The full Profile document as provided
             by the client. Should not be necessary, but provided in
-            case it's userful.
+            case it's useful.
 
         :raise Exception: If there's a problem making the user's profile
             look like the provided Profile document.
@@ -145,7 +145,7 @@ class ProfileStorage(object):
         raise NotImplementedError()
 
 
-class MockProfileStorage(object):
+class MockProfileStorage(ProfileStorage):
     """A profile storage object for use in tests.
 
     Keeps information in in-memory dictionaries rather than in a database.

--- a/user_profile.py
+++ b/user_profile.py
@@ -1,0 +1,172 @@
+from nose.tools import set_trace
+import json
+from problem_details import *
+from flask.ext.babel import lazy_gettext as _
+
+class ProfileController(object):
+    """Implement the User Profile Management Protocol.
+
+    https://github.com/NYPL-Simplified/Simplified/wiki/User-Profile-Management-Protocol
+    """
+
+    MEDIA_TYPE = "vnd.librarysimplified/user-profile+json"
+    LINK_RELATION = "http://librarysimplified.org/terms/rel/user-profile"
+    SETTINGS_KEY = 'settings'
+    
+    def __init__(self, store):
+        """Constructor.
+
+        :param store: An instance of ProfileStore.
+        """
+        self.store = store
+
+    def get(self):
+        """Turn the store into a Profile document and send out its JSON-based
+        representation.
+
+        :param return: A ProblemDetail if there is a problem; otherwise,
+            a 3-tuple (response code, media type, entity-body)
+        """
+        representation = None
+        try:
+            representation = self.store.representation
+        except Exception, e:
+            if hasattr(e, 'as_problem_detail_document'):
+                return e.as_problem_detail_document()
+            else:
+                return INTERNAL_SERVER_ERROR.with_debug(e.message)
+        if not isinstance(representation, dict):
+            return INTERNAL_SERVER_ERROR.with_debug(
+                _("Profile representation is not a JSON object: %r.") % (
+                    representation
+                )
+            )
+        try:
+            body = json.dumps(representation)
+        except Exception, e:
+            return INTERNAL_SERVER_ERROR.with_debug(
+                _("Could not convert profile to JSON: %r.") % (
+                    representation
+                )
+            )
+            
+        return 200, self.MEDIA_TYPE, body
+        
+    def put(self, headers, body):
+        """Turn the store into a Profile document and send out its JSON-based
+        representation.
+
+        :param return: A ProblemDetail if there is a problem; otherwise,
+            a 3-tuple (response code, media type, entity-body)
+        """
+        media_type = headers.get('Content-Type')
+        if media_type != self.MEDIA_TYPE:
+            return UNSUPPORTED_MEDIA_TYPE.detailed(
+                _("Expected %s") % self.MEDIA_TYPE
+            )
+        try:
+            full_data = json.loads(body)
+        except Exception, e:
+            return INVALID_INPUT.detailed(
+                _("Submitted profile document was not valid JSON.")
+            )
+        if not isinstance(full_data, dict):
+            return INVALID_INPUT.detailed(
+                _("Submitted profile document was not a JSON object.")
+            )
+        settable = full_data.get(self.SETTINGS_KEY)
+        if settable:
+            # The incoming document is a request to change at least one
+            # setting.
+            allowable = set(self.store.setting_names)
+            for k in settable.keys():
+                if k not in allowable:
+                    return INVALID_INPUT.detailed(
+                        _('"%s" is not a writable setting.' % k)
+                    )
+            try:
+                self.store.set(settable, full_data)
+            except Exception, e:
+                if hasattr(e, 'as_problem_detail_document'):
+                    return e.as_problem_detail_document()
+                else:
+                    return INTERNAL_SERVER_ERROR.with_debug(e.message)
+        return 200, "text/plain", ""
+
+
+class ProfileStore(object):
+    """An abstract store for a user profile."""
+
+    @property
+    def representation(self):
+        """Represent the current state of the store as a dictionary.
+
+        :return: A dictionary that can be converted to a Profile document.
+        """
+        raise NotImplementedError()
+
+
+    @property
+    def setting_names(self):
+        """Return the subset of fields that are considered writable.
+        
+        :return: An iterable.
+        """
+        raise NotImplementedError()
+    
+    def set(self, settable, full):
+        """(Try to) make the local store look like the provided Profile
+        document.
+
+        :param settable: The portion of the Profile document containing
+            settings that the client wants to change.
+
+        :param full: The full Profile document as provided by the client.
+            Should not be necessary but provided in case it's userful.
+        """
+        raise NotImplementedError()
+    
+
+class DictionaryBasedProfileStore(object):
+    """A simple in-memory store based on Python dictionaries."""
+    
+    def __init__(self, read_only=None, writable=None):
+        """Constructor.
+        
+        :param read_only: A dictionary of profile information that cannot
+            be changed.
+        :param writable: A dictionary of settings that can be changed.
+        """
+        self.read_only = read_only or dict()
+        self.writable = writable or dict()
+
+    @property
+    def representation(self):
+        """Represent the current state of the store as a dictionary.
+
+        :return: A dictionary that can be converted to a Profile document.
+        """
+        body = dict(self.read_only)
+        body[ProfileController.SETTINGS_KEY] = dict(self.writable)
+        return body
+
+    @property
+    def setting_names(self):
+        """Return the subset of fields that are considered writable.
+        
+        :return: An iterable.
+        """
+        return self.writable.keys()
+        
+    def set(self, settable, full):
+        """(Try to) make the local store look like the provided Profile
+        document.
+
+        :param settable: The portion of the Profile document containing
+            settings that the client wants to change.
+
+        :param full: The full Profile document as provided by the client.
+            Should not be necessary but provided in case it's userful.
+        """
+        for k, v in settable.items():
+            self.writable[k] = v

--- a/user_profile.py
+++ b/user_profile.py
@@ -13,48 +13,48 @@ class ProfileController(object):
     LINK_RELATION = "http://librarysimplified.org/terms/rel/user-profile"
     SETTINGS_KEY = 'settings'
     
-    def __init__(self, store):
+    def __init__(self, storage):
         """Constructor.
 
-        :param store: An instance of ProfileStore.
+        :param storage: An instance of ProfileStorage.
         """
-        self.store = store
+        self.storage = storage
 
     def get(self):
-        """Turn the store into a Profile document and send out its JSON-based
-        representation.
+        """Turn the storage object into a Profile document and send out its
+        JSON-based representation.
 
         :param return: A ProblemDetail if there is a problem; otherwise,
             a 3-tuple (response code, media type, entity-body)
         """
-        representation = None
+        profile_document = None
         try:
-            representation = self.store.representation
+            profile_document = self.storage.profile_document
         except Exception, e:
             if hasattr(e, 'as_problem_detail_document'):
                 return e.as_problem_detail_document()
             else:
                 return INTERNAL_SERVER_ERROR.with_debug(e.message)
-        if not isinstance(representation, dict):
+        if not isinstance(profile_document, dict):
             return INTERNAL_SERVER_ERROR.with_debug(
-                _("Profile representation is not a JSON object: %r.") % (
-                    representation
+                _("Profile document is not a JSON object: %r.") % (
+                    profile_document
                 )
             )
         try:
-            body = json.dumps(representation)
+            body = json.dumps(profile_document)
         except Exception, e:
             return INTERNAL_SERVER_ERROR.with_debug(
-                _("Could not convert profile to JSON: %r.") % (
-                    representation
+                _("Could not convert profile document to JSON: %r.") % (
+                    profile_document
                 )
             )
             
         return 200, self.MEDIA_TYPE, body
         
     def put(self, headers, body):
-        """Turn the store into a Profile document and send out its JSON-based
-        representation.
+        """Update the profile storage object with new settings
+        from a Profile document sent with a PUT request.
 
         :param return: A ProblemDetail if there is a problem; otherwise,
             a 3-tuple (response code, media type, entity-body)
@@ -65,28 +65,32 @@ class ProfileController(object):
                 _("Expected %s") % self.MEDIA_TYPE
             )
         try:
-            full_data = json.loads(body)
+            profile_document = json.loads(body)
         except Exception, e:
             return INVALID_INPUT.detailed(
                 _("Submitted profile document was not valid JSON.")
             )
-        if not isinstance(full_data, dict):
+        if not isinstance(profile_document, dict):
             return INVALID_INPUT.detailed(
                 _("Submitted profile document was not a JSON object.")
             )
-        settable = full_data.get(self.SETTINGS_KEY)
-        if settable:
+        new_settings = profile_document.get(self.SETTINGS_KEY)
+        if new_settings:
             # The incoming document is a request to change at least one
-            # setting.
-            allowable = set(self.store.setting_names)
-            for k in settable.keys():
-                if k not in allowable:
+            # setting in the profile.
+            writable = set(self.storage.writable_setting_names)
+            for k in new_settings.keys():
+                # A Profile document is invalid if it attempts to
+                # change the value of a read-only profile setting.
+                if k not in writable:
                     return INVALID_INPUT.detailed(
                         _('"%s" is not a writable setting.' % k)
                     )
             try:
-                self.store.set(settable, full_data)
+                # Update the profile storage with the new settings.
+                self.storage.update(new_settings, profile_document)
             except Exception, e:
+                # There was a problem updating the profile storage.
                 if hasattr(e, 'as_problem_detail_document'):
                     return e.as_problem_detail_document()
                 else:
@@ -94,79 +98,85 @@ class ProfileController(object):
         return 200, "text/plain", ""
 
 
-class ProfileStore(object):
-    """An abstract store for a user profile."""
+class ProfileStorage(object):
+    """An abstract class defining a specific user's profile.
+
+    Subclasses should get profile information from somewhere specific,
+    e.g. a database row.
+
+    An instance of this class is responsible for one specific user's profile,
+    not the set of all profiles.
+    """
 
     @property
-    def representation(self):
-        """Represent the current state of the store as a dictionary.
+    def profile_document(self):
+        """Create a Profile document representing the current state of 
+        the user's profile.
 
-        :return: A dictionary that can be converted to a Profile document.
+        :return: A dictionary that can be serialized as JSON.
+        """
+        raise NotImplementedError()
+    
+    def update(self, new_values, profile_document):
+        """(Try to) change the user's profile so it looks like the provided
+        Profile document.
+
+        :param new_values: A dictionary of settings that the
+            client wants to change.
+
+        :param profile_document: The full Profile document as provided
+            by the client. Should not be necessary, but provided in
+            case it's userful.
+
+        :raise Exception: If there's a problem making the user's profile
+            look like the provided Profile document.
         """
         raise NotImplementedError()
 
-
     @property
-    def setting_names(self):
-        """Return the subset of fields that are considered writable.
-        
+    def writable_setting_names(self):
+        """Return the subset of settings that are considered writable.
+    
+        An attempt to modify a setting that's not in this list will fail
+        before update() is called.
+
         :return: An iterable.
         """
         raise NotImplementedError()
+
+
+class MockProfileStorage(object):
+    """A profile storage object for use in tests.
+
+    Keeps information in in-memory dictionaries rather than in a database.
+    """
     
-    def set(self, settable, full):
-        """(Try to) make the local store look like the provided Profile
-        document.
+    def __init__(self, read_only_settings=None, writable_settings=None):
+        """Create a profile for a simulated user.
 
-        :param settable: The portion of the Profile document containing
-            settings that the client wants to change.
+        :param read_only_settings: A dictionary of values that cannot be
+            changed.
 
-        :param full: The full Profile document as provided by the client.
-            Should not be necessary but provided in case it's userful.
+        :param writable_settings: A dictionary of values that can be changed
+            through the User Profile Management Protocol.
         """
-        raise NotImplementedError()
-    
-
-class DictionaryBasedProfileStore(object):
-    """A simple in-memory store based on Python dictionaries."""
-    
-    def __init__(self, read_only=None, writable=None):
-        """Constructor.
-        
-        :param read_only: A dictionary of profile information that cannot
-            be changed.
-        :param writable: A dictionary of settings that can be changed.
-        """
-        self.read_only = read_only or dict()
-        self.writable = writable or dict()
+        self.read_only_settings = read_only_settings or dict()
+        self.writable_settings = writable_settings or dict()
 
     @property
-    def representation(self):
-        """Represent the current state of the store as a dictionary.
-
-        :return: A dictionary that can be converted to a Profile document.
-        """
-        body = dict(self.read_only)
-        body[ProfileController.SETTINGS_KEY] = dict(self.writable)
+    def profile_document(self):
+        body = dict(self.read_only_settings)
+        body[ProfileController.SETTINGS_KEY] = dict(self.writable_settings)
         return body
 
+    def update(self, new_values, profile_document):
+        """(Try to) change the user's profile so it looks like the provided
+        Profile document.
+        """
+        for k, v in new_values.items():
+            self.writable_settings[k] = v
+    
     @property
-    def setting_names(self):
-        """Return the subset of fields that are considered writable.
-        
-        :return: An iterable.
-        """
-        return self.writable.keys()
-        
-    def set(self, settable, full):
-        """(Try to) make the local store look like the provided Profile
-        document.
-
-        :param settable: The portion of the Profile document containing
-            settings that the client wants to change.
-
-        :param full: The full Profile document as provided by the client.
-            Should not be necessary but provided in case it's userful.
-        """
-        for k, v in settable.items():
-            self.writable[k] = v
+    def writable_setting_names(self):
+        """Return the subset of fields that are considered writable."""
+        return self.writable_settings.keys()


### PR DESCRIPTION
This branch implements and tests a simple implementation of https://github.com/NYPL-Simplified/Simplified/wiki/User-Profile-Management-Protocol that uses a swappable data store.

The data store used for testing keeps the read-only items in one dictionary and the writable items in another dictionary.

If there are any discrepancies between this and the spec, it's possible the spec needs to change, but more likely it's a bug in the implementation.