### PR TITLE
Implement the User Profile Management Protocol for Patron objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Library Simplified Server Core
+[![Build Status](https://travis-ci.org/NYPL-Simplified/server_core.svg?branch=master)](https://travis-ci.org/NYPL-Simplified/server_core)
 
 This is the Server Core for [Library Simplified](http://www.librarysimplified.org/). The server core contains functionality common between various LS servers, including database models and essential class constants, OPDS parsers, and certain configuration details.
 

--- a/migration/20170220-patron-sync-reading.sql
+++ b/migration/20170220-patron-sync-reading.sql
@@ -1,0 +1,1 @@
+ALTER TABLE patrons ADD COLUMN synchronize_annotations boolean default null;

--- a/model.py
+++ b/model.py
@@ -431,7 +431,10 @@ class Patron(Base):
 
     # One Patron can have many associated Credentials.
     credentials = relationship("Credential", backref="patron")
-   
+
+    # One Patron can have many associated PatronSettings.
+    settings = relationship("PatronSetting", backref="patron")
+    
     AUDIENCE_RESTRICTION_POLICY = 'audiences'
     EXTERNAL_TYPE_REGULAR_EXPRESSION = 'external_type_regular_expression'
     
@@ -480,6 +483,23 @@ class Patron(Base):
         if work.audience in allowed:
             return True
         return False
+
+
+class PatronSetting(object):
+    """An extra piece of information associated with a patron."""
+    __tablename__ = 'patronsettings'
+    id = Column(Integer, primary_key=True)
+    patron_id = Column(Integer, ForeignKey('patrons.id'), index=True)
+    key = Column(Unicode, index=True)
+    value = Column(Unicode)
+
+    # Constants to use when setting boolean values of PatronSetting.VALUE
+    TRUE = "True"
+    FALSE = "False"
+    
+    __table_args__ = (
+        UniqueConstraint('patron_id', 'key'),
+    )
 
 
 class LoanAndHoldMixin(object):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4637,15 +4637,16 @@ class TestPatronProfileStorage(DatabaseTest):
         self.patron = self._patron()
         self.store = PatronProfileStorage(self.patron)
         
-    def test_setting_names(self):
-        """Only one item is currently settable."""
-        eq_(set([self.store.SYNCHRONIZE_ANNOTATIONS]), self.store.setting_names)
+    def test_writable_setting_names(self):
+        """Only one setting is currently writable."""
+        eq_(set([self.store.SYNCHRONIZE_ANNOTATIONS]),
+            self.store.writable_setting_names)
 
-    def test_representation(self):
+    def test_profile_document(self):
         # synchronize_annotations always shows up as settable, even if
         # the current value is None.
         eq_(None, self.patron.synchronize_annotations)
-        rep = self.store.representation
+        rep = self.store.profile_document
         eq_({'settings': {'simplified:synchronize_annotations': None}},
             rep)
 
@@ -4653,19 +4654,19 @@ class TestPatronProfileStorage(DatabaseTest):
         self.patron.authorization_expires = datetime.datetime(
             2016, 1, 1, 10, 20, 30
         )
-        rep = self.store.representation
+        rep = self.store.profile_document
         eq_({'simplified:authorization_expires': '2016-01-01T10:20:30Z',
              'settings': {'simplified:synchronize_annotations': True}},
             rep
         )
 
-    def test_set(self):
+    def test_update(self):
         # This is a no-op.
-        self.store.set({}, {})
+        self.store.update({}, {})
         eq_(None, self.patron.synchronize_annotations)
 
         # This is not.
-        self.store.set({self.store.SYNCHRONIZE_ANNOTATIONS : True}, {})
+        self.store.update({self.store.SYNCHRONIZE_ANNOTATIONS : True}, {})
         eq_(True, self.patron.synchronize_annotations)
 
         

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -27,9 +27,9 @@ class TestProfileController(object):
         """Test that sending a GET request to the controller results in the
         expected profile_document.
         """
-        status_code, media_type, body = self.controller.get()
+        body, status_code, headers = self.controller.get()
         eq_(200, status_code)
-        eq_(ProfileController.MEDIA_TYPE, media_type)
+        eq_(ProfileController.MEDIA_TYPE, headers['Content-Type'])
         eq_(json.dumps(self.storage.profile_document), body)
 
     def test_put_success(self):
@@ -41,7 +41,7 @@ class TestProfileController(object):
         expected_new_state = dict(writable_key="new value")
         old_read_only = dict(self.storage.read_only_settings)
         body = json.dumps(dict(settings=expected_new_state))
-        status_code, media_type, body = self.controller.put(headers, body)
+        body, status_code, headers = self.controller.put(headers, body)
         eq_(200, status_code)
         eq_(expected_new_state, self.storage.writable_settings)
         eq_(old_read_only, self.storage.read_only_settings)
@@ -52,7 +52,7 @@ class TestProfileController(object):
         """
         headers = {"Content-Type" : ProfileController.MEDIA_TYPE}
         expected_new_state = dict(self.storage.writable_settings)
-        status_code, media_type, body = self.controller.put(
+        body, status_code, headers = self.controller.put(
             headers, json.dumps({})
         )
         eq_(200, status_code)

--- a/user_profile.py
+++ b/user_profile.py
@@ -24,7 +24,7 @@ class ProfileController(object):
         JSON-based representation.
 
         :param return: A ProblemDetail if there is a problem; otherwise,
-            a 3-tuple (response code, media type, entity-body)
+            a 3-tuple (entity-body, response code, headers)
         """
         profile_document = None
         try:
@@ -49,7 +49,7 @@ class ProfileController(object):
                 )
             )
             
-        return 200, self.MEDIA_TYPE, body
+        return body, 200, {"Content-Type": self.MEDIA_TYPE}
         
     def put(self, headers, body):
         """Update the profile storage object with new settings
@@ -94,7 +94,7 @@ class ProfileController(object):
                     return e.as_problem_detail_document()
                 else:
                     return INTERNAL_SERVER_ERROR.with_debug(e.message)
-        return 200, "text/plain", ""
+        return body, 200, {"Content-Type": "text/plain"}
 
 
 class ProfileStorage(object):

--- a/user_profile.py
+++ b/user_profile.py
@@ -11,7 +11,6 @@ class ProfileController(object):
 
     MEDIA_TYPE = "vnd.librarysimplified/user-profile+json"
     LINK_RELATION = "http://librarysimplified.org/terms/rel/user-profile"
-    SETTINGS_KEY = 'settings'
     
     def __init__(self, store):
         """Constructor.
@@ -74,7 +73,7 @@ class ProfileController(object):
             return INVALID_INPUT.detailed(
                 _("Submitted profile document was not a JSON object.")
             )
-        settable = full_data.get(self.SETTINGS_KEY)
+        settable = full_data.get(ProfileStore.SETTINGS_KEY)
         if settable:
             # The incoming document is a request to change at least one
             # setting.
@@ -97,6 +96,12 @@ class ProfileController(object):
 class ProfileStore(object):
     """An abstract store for a user profile."""
 
+    NS = 'simplified:'
+    FINES = NS + 'fines'
+    AUTHORIZATION_EXPIRES = NS + "authorization_expires"
+    SYNCHRONIZE_ANNOTATIONS = NS + 'synchronize_annotations'
+    SETTINGS_KEY = 'settings'
+    
     @property
     def representation(self):
         """Represent the current state of the store as a dictionary.
@@ -147,7 +152,7 @@ class DictionaryBasedProfileStore(object):
         :return: A dictionary that can be converted to a Profile document.
         """
         body = dict(self.read_only)
-        body[ProfileController.SETTINGS_KEY] = dict(self.writable)
+        body[ProfileStore.SETTINGS_KEY] = dict(self.writable)
         return body
 
     @property


### PR DESCRIPTION
This branch introduces `PatronProfileStorage`, an implementation of `ProfileStorage` which uses a `Patron` object as its backing store. I create a new database field to store a patron's annotation synchronization settings, and make it a writable setting that can be manipulated through the UPMP.

The date on which the patron's card expires is also available through UPMP, though it's a profile item, not a writable setting.

I'm not bothering with fines at this point--it's more work and the client won't use it.

The `Patron.synchronize_annotations` field has two implemented effects. First, whenever it is set to false, all of the patron's annotations are deleted. Second, when it is set to false, an attempt to create a new annotation for the patron will raise a ValueError.