### PR TITLE
Initialize database with date

### DIFF
--- a/model.py
+++ b/model.py
@@ -6950,6 +6950,12 @@ class Timestamp(Base):
     timestamp = Column(DateTime)
     counter = Column(Integer)
 
+    def __repr__(self):
+        timestamp = self.timestamp.strftime('%b %d, %Y at %H:%M')
+        if self.counter:
+            timestamp += (' %d' % self.counter)
+        return (u"<Timestamp %s: %s>" % (self.service, timestamp)).encode("utf8")
+
     @classmethod
     def stamp(self, _db, service):
         now = datetime.datetime.utcnow()

--- a/scripts.py
+++ b/scripts.py
@@ -1240,6 +1240,7 @@ class DatabaseMigrationScript(Script):
         # additional number is added. This number is held in the 'counter'
         # column of Timestamp.
         # (It's not ideal, but it avoids creating a new database table.)
+        timestamp.counter = None
         match = self.MIGRATION_WITH_COUNTER.search(migration_file)
         if match:
             timestamp.counter = int(match.groups()[0])
@@ -1308,12 +1309,11 @@ class Explain(IdentifierInputScript):
         editions = self._db.query(Edition).filter(
             Edition.primary_identifier_id.in_(identifier_ids)
         )
-        #policy = PresentationCalculationPolicy.recalculate_everything()
+
         policy = None
         for edition in editions:
             self.explain(self._db, edition, policy)
             print "-" * 80
-        #self._db.commit()
 
     @classmethod
     def explain(cls, _db, edition, presentation_calculation_policy=None):

--- a/scripts.py
+++ b/scripts.py
@@ -1283,7 +1283,7 @@ class DatabaseMigrationInitializationScript(DatabaseMigrationScript):
                     self.name, existing_timestamp)
             else:
                 raise RuntimeError(
-                    "%s timestamp already exists: %r" %
+                    "%s timestamp already exists: %r. Use --force to update." %
                     (self.name, existing_timestamp))
 
         timestamp = existing_timestamp or Timestamp.stamp(self._db, self.name)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -499,6 +499,12 @@ class TestDatabaseMigrationScript(DatabaseTest):
         eq_(self.timestamp.timestamp.strftime('%Y%m%d'), migration[0:8])
         eq_(str(self.timestamp.counter), migration[9])
 
+        # And removes those counter digits when the timestamp is updated.
+        migration = '20260101-what-it-do.sql'
+        self.script.update_timestamp(self.timestamp, migration)
+        eq_(self.timestamp.timestamp.strftime('%Y%m%d'), migration[0:8])
+        eq_(self.timestamp.counter, None)
+
     def test_running_a_migration_updates_the_timestamp(self):
         future_time = datetime.datetime.strptime('20261030', '%Y%m%d')
         self.timestamp.timestamp = future_time


### PR DESCRIPTION
Previously, the database initialization script was basically a toggle that would only create a **new** `"Database Migration"` timestamp for the **most recent** migration file. With this branch, an existing timestamp can be overwritten as needed, and the timestamp (new or existing) can be set to a date passed in via the command line. This provides some flexibility that should make working with the `DatabaseMigrationInitializationScript` more bearable in development without impacting production.

There was also a dumb bug in the `DatabaseMigrationScript` where the timestamp counter wasn't being reset to `None`. That's fixed here.

Fixes #441.