### PR TITLE
Support instance initialization

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -117,7 +117,7 @@ class ExternalSearchIndex(object):
         the works_index directly for search queries.
         """
 
-        base_works_index = self._base_works_index(self.works_index)
+        base_works_index = self.base_index_name(self.works_index)
         alias_name = base_works_index+self.CURRENT_ALIAS_SUFFIX
         exists = self.indices.exists_alias(name=alias_name)
 
@@ -170,8 +170,17 @@ class ExternalSearchIndex(object):
             raise ValueError(
                 "Index '%s' does not exist on this client." % new_index)
 
+        current_base_name = self.base_index_name(self.works_index)
+        new_base_name = self.base_index_name(new_index)
+
+        if new_base_name != current_base_name:
+            raise ValueError(
+                ("Index '%s' is not in series with current index '%s'. "
+                 "Confirm the base name (without version number) of both indices"
+                 "is the same.") % (new_index, self.works_index))
+
         self.works_index = self.__client.works_index = new_index
-        alias_name = self._base_works_index(new_index)+self.CURRENT_ALIAS_SUFFIX
+        alias_name = self.base_index_name(new_index)+self.CURRENT_ALIAS_SUFFIX
 
         exists = self.indices.exists_alias(name=alias_name)
         if not exists:
@@ -191,7 +200,7 @@ class ExternalSearchIndex(object):
 
         self.works_alias = self.__client.works_alias = alias_name
 
-    def _base_works_index(self, index_or_alias):
+    def base_index_name(self, index_or_alias):
         """Removes version or current suffix from base index name"""
 
         current_re = re.compile(self.CURRENT_ALIAS_SUFFIX+'$')

--- a/external_search.py
+++ b/external_search.py
@@ -15,9 +15,19 @@ import time
 class ExternalSearchIndex(object):
     
     work_document_type = 'work-type'
+    __client = None
+
     CURRENT_ALIAS_SUFFIX = '-current'
     VERSION_RE = re.compile('-v([0-9]+)$')
-    __client = None
+
+    @classmethod
+    def reset(cls):
+        """Resets the __client object to None so a new configuration
+        can be applied during object initialization.
+
+        This method is only intended for use in testing.
+        """
+        cls.__client = None
 
     def __init__(self, url=None, works_index=None):
     

--- a/external_search.py
+++ b/external_search.py
@@ -78,7 +78,9 @@ class ExternalSearchIndex(object):
         self.bulk = bulk
 
     def set_works_index_and_alias(self, current_alias):
-        """Finds or creates the index based on provided configuration"""
+        """Finds or creates the works_index and works_alias based on
+        provided configuration.
+        """
         index_details = self.indices.get_alias(name=current_alias, ignore=[404])
         found = not (index_details.get('status')==404 or 'error' in index_details)
 
@@ -106,7 +108,14 @@ class ExternalSearchIndex(object):
         self.setup_current_alias()
 
     def setup_current_alias(self):
-        """Put an alias ending with '-current' on the existing works_index."""
+        """Finds or creates a works_alias based on the base works_index
+        name and ending in the expected CURRENT_ALIAS_SUFFIX.
+
+        If the resulting alias exists and is affixed to a different
+        index or if it can't be generated for any reason, the alias will
+        not be created or moved. Instead, the search client will use the
+        the works_index directly for search queries.
+        """
 
         base_works_index = self._base_works_index(self.works_index)
         alias_name = base_works_index+self.CURRENT_ALIAS_SUFFIX

--- a/external_search.py
+++ b/external_search.py
@@ -98,19 +98,7 @@ class ExternalSearchIndex(object):
                 # found. Find or create an appropriate index.
                 base_index_name = self.base_index_name(current_alias)
                 new_index = base_index_name+'-'+ExternalSearchIndexVersions.latest()
-                exists = self.indices.exists(index=new_index)
-                created = None
-
-                if not exists:
-                    created = ExternalSearchIndexVersions.create_new_version(
-                        self, base_index_name)
-                if exists or created:
-                    _set_works_index(new_index)
-                else:
-                    raise ValueError(
-                        ("Requested external search alias '%s' not found"
-                         " and new index '%s' could not be found or created.")
-                        % (current_alias, new_index))
+                _set_works_index(new_index)
             else:
                 # Without the CURRENT_ALIAS_SUFFIX, assume the index string
                 # from config is the index itself and needs to be swapped.

--- a/external_search.py
+++ b/external_search.py
@@ -147,7 +147,8 @@ class ExternalSearchIndex(object):
     def setup_current_alias(self):
         """Put an alias ending with '-current' on the existing works_index."""
         if self.works_index.endswith(self.CURRENT_ALIAS_SUFFIX):
-            # The alias has already been created.
+            # The alias has already been created and the works_index
+            # appropriately set.
             return
 
         alias_details = self.indices.get_alias(index=self.works_index)

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -225,9 +225,13 @@ class TestExternalSearch(ExternalSearchTest):
         eq_(False, self.search.indices.exists_alias('the_other_index', alias))
 
     def test_set_works_index_and_alias(self):
+        # If -current alias is given but doesn't exist, the appropriate
+        # index and alias will be created.
+        self.search.set_works_index_and_alias('banana-current')
 
-        # If -current alias is given but doesn't exist, an error will be raised.
-        assert_raises(ValueError, self.search.set_works_index_and_alias, 'banana-current')
+        expected_index = 'banana-' + ExternalSearchIndexVersions.latest()
+        eq_(expected_index, self.search.works_index)
+        eq_('banana-current', self.search.works_alias)
 
     def test_setup_current_alias(self):
         if not self.search:

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -194,6 +194,7 @@ class TestExternalSearch(DatabaseTest):
     def teardown(self):
         if self.search:
             self.search.indices.delete(self.search.works_index)
+            self.search.indices.delete('test_index-v2', ignore=[404])
             ExternalSearchIndex.__client = None
         super(TestExternalSearch, self).teardown()
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -270,30 +270,37 @@ class TestExternalSearch(ExternalSearchTest):
 
         # If the -current alias doesn't exist, it's created
         # and everything is updated accordingly.
-        self.search.setup_index(new_index='the_other_index')
-        self.search.transfer_current_alias('the_other_index')
-        eq_('the_other_index', self.search.works_index)
-        eq_('the_other_index-current', self.search.works_alias)
-
-        # If the -current alias already exists on the index,
-        # it's used without a problem.
-        self.search.transfer_current_alias(original_index)
-        eq_(original_index, self.search.works_index)
-        eq_('test_index-current', self.search.works_alias)
-
-        # If the -current alias is being used on a different version of the
-        # index, it's deleted from that index and placed on the new one.
-        self.search.setup_index('test_index-v100')
+        self.search.indices.delete_alias(
+            index=original_index, name='test_index-current'
+        )
+        self.search.setup_index(new_index='test_index-v100')
         self.search.transfer_current_alias('test_index-v100')
         eq_('test_index-v100', self.search.works_index)
         eq_('test_index-current', self.search.works_alias)
 
+        # If the -current alias already exists on the index,
+        # it's used without a problem.
+        self.search.transfer_current_alias('test_index-v100')
+        eq_('test_index-v100', self.search.works_index)
+        eq_('test_index-current', self.search.works_alias)
+
+        # If the -current alias is being used on a different version of the
+        # index, it's deleted from that index and placed on the new one.
+        self.search.setup_index(original_index)
+        self.search.transfer_current_alias(original_index)
+        eq_(original_index, self.search.works_index)
+        eq_('test_index-current', self.search.works_alias)
+
         # It has been removed from other index.
         eq_(False, self.search.indices.exists_alias(
-            index=original_index, name='test_index-current'))
+            index='test_index-v100', name='test_index-current'))
         # And only exists on the new index.
         alias_indices = self.search.indices.get_alias(name='test_index-current').keys()
-        eq_(['test_index-v100'], alias_indices)
+        eq_(['test_index-v0'], alias_indices)
+
+        # If the index doesn't have the same base name, an error is raised.
+        assert_raises(
+            ValueError, self.search.transfer_current_alias, 'banana-v10')
 
     def test_query_works(self):
         """

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -44,7 +44,7 @@ class TestExternalSearch(DatabaseTest):
                 ExternalSearchIndex.__client = None
                 self.search = ExternalSearchIndex()
                 # Start with an empty index
-                self.search.setup_index()
+                self.search.setup_index(current_alias=True)
             except Exception as e:
                 self.search = None
                 print "Unable to set up elasticsearch index, search tests will be skipped."

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -42,10 +42,7 @@ class TestExternalSearch(DatabaseTest):
             config[Configuration.INTEGRATIONS][Configuration.ELASTICSEARCH_INTEGRATION][Configuration.ELASTICSEARCH_INDEX_KEY] = "test_index-current"
 
             try:
-                ExternalSearchIndex.__client = None
                 self.search = ExternalSearchIndex()
-                # Start with an empty index
-                self.search.setup_index(current_alias=True)
             except Exception as e:
                 self.search = None
                 print "Unable to set up elasticsearch index, search tests will be skipped."
@@ -195,8 +192,8 @@ class TestExternalSearch(DatabaseTest):
     def teardown(self):
         if self.search:
             self.search.indices.delete(self.search.works_index)
-            self.search.indices.delete('test_index-v2', ignore=[404])
-            ExternalSearchIndex.__client = None
+            self.search.indices.delete('the_other_index', ignore=[404])
+            ExternalSearchIndex.reset()
         super(TestExternalSearch, self).teardown()
 
     def test_setup_index_creates_new_index(self):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -40,7 +40,7 @@ class TestExternalSearch(DatabaseTest):
         with temp_config() as config:
             config[Configuration.INTEGRATIONS][Configuration.ELASTICSEARCH_INTEGRATION] = {}
             config[Configuration.INTEGRATIONS][Configuration.ELASTICSEARCH_INTEGRATION][Configuration.URL] = "http://localhost:9200"
-            config[Configuration.INTEGRATIONS][Configuration.ELASTICSEARCH_INTEGRATION][Configuration.ELASTICSEARCH_INDEX_KEY] = "test_index-current"
+            config[Configuration.INTEGRATIONS][Configuration.ELASTICSEARCH_INTEGRATION][Configuration.ELASTICSEARCH_INDEX_KEY] = "test_index-v0"
 
             try:
                 self.search = ExternalSearchIndex()
@@ -218,12 +218,17 @@ class TestExternalSearch(DatabaseTest):
         eq_(True, self.search.indices.exists_alias(current_index, alias))
         eq_(False, self.search.indices.exists_alias('the_other_index', alias))
 
+    def test_set_works_index_and_alias(self):
+
+        # If -current alias is given but doesn't exist, an error will be raised.
+        assert_raises(ValueError, self.search.set_works_index_and_alias, 'banana-current')
+
     def test_setup_current_alias(self):
         if not self.search:
             return
 
-        # The index was generated from the alias in configuration.
-        index_name = 'test_index-' + ExternalSearchIndexVersions.latest()
+        # The index was generated from the string in configuration.
+        index_name = 'test_index-v0'
         eq_(index_name, self.search.works_index)
         eq_(True, self.search.indices.exists(index_name))
 


### PR DESCRIPTION
This branch uses an alias to access the configured Elasticsearch works_index. It then searching against that alias to improve the process of creating new indices.

It also adds a small change to allow the programmatic creation of a new index without an alias.

Fixes NYPL-Simplified/operations#49.