### PR TITLE
Rename Collection to Catalog, and create a new Collection data model class

### DIFF
--- a/migration/20170224-rename-collections-to-catalogs.sql
+++ b/migration/20170224-rename-collections-to-catalogs.sql
@@ -1,4 +1,4 @@
-# Since these tables are not yet used for anything, it's simpler
-# to drop them and recreate them than to rename the fields.
-drop table collections;
+-- Since these tables are not yet used for anything, it's simpler
+-- to drop them and recreate them than to rename the fields.
 drop table collectionsidentifiers;
+drop table collections;

--- a/migration/20170224-rename-collections-to-catalogs.sql
+++ b/migration/20170224-rename-collections-to-catalogs.sql
@@ -1,0 +1,4 @@
+# Since these tables are not yet used for anything, it's simpler
+# to drop them and recreate them than to rename the fields.
+drop table collections;
+drop table collectionsidentifiers;

--- a/migration/20170301-rename-collections-to-catalogs.sql
+++ b/migration/20170301-rename-collections-to-catalogs.sql
@@ -1,2 +1,0 @@
-drop table collections;
-drop table collectionsidentifiers;

--- a/migration/20170301-rename-collections-to-catalogs.sql
+++ b/migration/20170301-rename-collections-to-catalogs.sql
@@ -1,0 +1,2 @@
+drop table collections;
+drop table collectionsidentifiers;

--- a/model.py
+++ b/model.py
@@ -8345,13 +8345,7 @@ class Library(Base):
     
     # A URN that uniquely identifies the library, used to serve the
     # library's Authentication for OPDS document.
-    urn = Column(Unicode, index=True)
-    
-    # A short name and secret for this library, shared with a library
-    # registry, used to create short client tokens that a patron can
-    # use to get an Adobe Account ID.
-    adobe_short_name = Column(Unicode, index=True)
-    adobe_shared_secret = Column(Unicode)
+    urn = Column(Unicode)
 
     __table_args__ = (
         UniqueConstraint('urn'),
@@ -8367,6 +8361,14 @@ class Library(Base):
             )
         return value.upper()    
 
+    @classmethod
+    def instance(cls, _db):
+        """Find the one and only library."""
+        return get_one(
+            _db, Library, create_method_kwargs=dict(
+                uuid=uuid.uuid4()
+            )
+        )
 
 class Admin(Base):
 

--- a/model.py
+++ b/model.py
@@ -8515,11 +8515,11 @@ class Collection(Base):
     # authenticate. If there's a secret but no key, it's stored in
     # 'password'.
     username = Column(Unicode, nullable=True)
-    password = Column(Unicode, nulalble=True)
+    password = Column(Unicode, nullable=True)
 
     # Any additional configuration information goes into the
     # collectionsettings table.
-    settings = Relationship(
+    settings = relationship(
         "CollectionSetting", backref="collection"
     )
     

--- a/model.py
+++ b/model.py
@@ -8459,7 +8459,9 @@ class Library(Base):
     # The name of this library to use when signing short client tokens
     # for consumption by the library registry. e.g. "NYNYPL" for NYPL.
     # This name must be unique across the library registry.
-    library_registry_short_name = Column(Unicode, unique=True)
+    _library_registry_short_name = Column(
+        Unicode, unique=True, name='library_registry_short_name'
+    )
 
     # The shared secret to use when signing short client tokens for
     # consumption by the library registry.
@@ -8474,6 +8476,22 @@ class Library(Base):
             )
         )
         return library
+
+    @hybrid_property
+    def library_registry_short_name(self):
+        """Gets library_registry_shared_secret from database"""
+        return self._library_registry_short_name
+
+    @library_registry_short_name.setter
+    def _set_library_registry_short_name(self, value):
+        """Uppercase the library registry short name on the way in."""
+        if value:
+            value = value.upper()
+            if '|' in value:
+                raise ValueError(
+                    "Library registry short name cannot contain the pipe character."
+                )
+        self._library_registry_short_name = value
 
 
 class Admin(Base):

--- a/model.py
+++ b/model.py
@@ -8450,13 +8450,22 @@ class Library(Base):
     name = Column(Unicode, unique=True)
 
     # A short name of this library, to use when identifying it in
-    # scripts.
+    # scripts. e.g. "NYPL" for NYPL.
     short_name = Column(Unicode, unique=True)
     
     # A UUID that uniquely identifies the library among all libraries
     # in the world. This is used to serve the library's Authentication
     # for OPDS document, and it also goes to the library registry.
     uuid = Column(Unicode, unique=True)
+
+    # The name of this library to use when signing short client tokens
+    # for consumption by the library registry. e.g. "NYNYPL" for NYPL.
+    # This name must be unique across the library registry.
+    library_registry_short_name = Column(Unicode, unique=True)
+
+    # The shared secret to use when signing short client tokens for
+    # consumption by the library registry.
+    library_registry_shared_secret = Column(Unicode, unique=True)
     
     @classmethod
     def instance(cls, _db):

--- a/model.py
+++ b/model.py
@@ -8654,7 +8654,7 @@ class Catalog(Base):
         catalog, ignore = get_one_or_create(
             _db, cls, name=name, client_id=unicode(client_id),
             client_secret=unicode(plaintext_client_secret),
-            data_source=collection_data_source
+            data_source=catalog_data_source
         )
 
         _db.commit()

--- a/model.py
+++ b/model.py
@@ -8342,33 +8342,30 @@ class Library(Base):
     __tablename__ = 'libraries'
 
     id = Column(Integer, primary_key=True)
-    
-    # A URN that uniquely identifies the library, used to serve the
-    # library's Authentication for OPDS document.
-    urn = Column(Unicode)
 
-    __table_args__ = (
-        UniqueConstraint('urn'),
-    )
-    
-    @validates('adobe_short_name')
-    def validate_adobe_short_name(self, key, value):
-        if not value:
-            return value
-        if '|' in value:
-            raise ValueError(
-                'Adobe short name cannot contain the pipe character.'
-            )
-        return value.upper()    
+    # The human-readable name of this library. Used in the library's
+    # Authentication for OPDS document.
+    name = Column(Unicode, unique=True)
 
+    # A short name of this library, to use when identifying it in
+    # scripts.
+    short_name = Column(Unicode, unique=True)
+    
+    # A UUID that uniquely identifies the library among all libraries
+    # in the world. This is used to serve the library's Authentication
+    # for OPDS document, and it also goes to the library registry.
+    uuid = Column(Unicode, unique=True)
+    
     @classmethod
     def instance(cls, _db):
         """Find the one and only library."""
-        return get_one(
+        library, is_new = get_one_or_create(
             _db, Library, create_method_kwargs=dict(
-                uuid=uuid.uuid4()
+                uuid=str(uuid.uuid4())
             )
         )
+        return library
+
 
 class Admin(Base):
 

--- a/model.py
+++ b/model.py
@@ -852,6 +852,9 @@ class DataSource(Base):
     # One DataSource can generate many CustomLists.
     custom_lists = relationship("CustomList", backref="data_source")
 
+    # One DataSource can have many Catalogs.
+    catalogs = relationship("Catalog", backref="data_source")
+    
     @classmethod
     def lookup(cls, _db, name, autocreate=False, offers_licenses=False):
         # Turn a deprecated name (e.g. "3M" into the current name

--- a/model.py
+++ b/model.py
@@ -8332,6 +8332,42 @@ class Complaint(Base):
         return self.resolved
 
 
+class Library(Base):
+    """A library that uses this circulation manager to authenticate
+    its patrons and manage access to its content.
+
+    Currently, a circulation manager serves only one library,
+    but that will change.
+    """
+    __tablename__ = 'libraries'
+
+    id = Column(Integer, primary_key=True)
+    
+    # A URN that uniquely identifies the library, used to serve the
+    # library's Authentication for OPDS document.
+    urn = Column(Unicode, index=True)
+    
+    # A short name and secret for this library, shared with a library
+    # registry, used to create short client tokens that a patron can
+    # use to get an Adobe Account ID.
+    adobe_short_name = Column(Unicode, index=True)
+    adobe_shared_secret = Column(Unicode)
+
+    __table_args__ = (
+        UniqueConstraint('urn'),
+    )
+    
+    @validates('adobe_short_name')
+    def validate_adobe_short_name(self, key, value):
+        if not value:
+            return value
+        if '|' in value:
+            raise ValueError(
+                'Adobe short name cannot contain the pipe character.'
+            )
+        return value.upper()    
+
+
 class Admin(Base):
 
     __tablename__ = 'admins'
@@ -8345,7 +8381,6 @@ class Admin(Base):
         self.access_token = access_token
         self.credential = credential
         _db.commit()
-
 
 class Collection(Base):
 

--- a/model.py
+++ b/model.py
@@ -8479,7 +8479,7 @@ class Library(Base):
 
     @hybrid_property
     def library_registry_short_name(self):
-        """Gets library_registry_shared_secret from database"""
+        """Gets library_registry_short_name from database"""
         return self._library_registry_short_name
 
     @library_registry_short_name.setter

--- a/testing.py
+++ b/testing.py
@@ -13,8 +13,8 @@ from config import Configuration
 os.environ['TESTING'] = 'true'
 from model import (
     Base,
+    Catalog,
     Classification,
-    Collection,
     Complaint,
     Contributor,
     CoverageRecord,
@@ -637,10 +637,10 @@ class DatabaseTest(object):
         return
 
 
-    def _collection(self, name=u"Faketown Public Library"):
+    def _catalog(self, name=u"Faketown Public Library"):
         source, ignore = get_one_or_create(self._db, DataSource, name=name)
         return get_one_or_create(
-            self._db, Collection, name=name, data_source=source,
+            self._db, Catalog, name=name, data_source=source,
             client_id=u"abc", client_secret=u"def"
         )[0]
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5250,6 +5250,22 @@ class TestLibrary(DatabaseTest):
         instance2 = Library.instance(self._db)
         eq_(instance, instance2)
 
+    def test_library_registry_short_name(self):
+        library = Library.instance(self._db)
+
+        # Short name is always uppercased.
+        library.library_registry_short_name = "foo"
+        eq_("FOO", library.library_registry_short_name)
+
+        # Short name cannot contain a pipe character.
+        def set_to_pipe():
+            library.library_registry_short_name = "foo|bar"
+        assert_raises(ValueError, set_to_pipe)
+
+        # You can set the short name to None. This isn't
+        # recommended, but it's not an error.
+        library.library_registry_short_name = None
+        
 
 class TestCollection(DatabaseTest):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -36,6 +36,7 @@ from config import (
 from model import (
     Annotation,
     BaseCoverageRecord,
+    Catalog,
     CirculationEvent,
     Classification,
     Collection,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -52,6 +52,7 @@ from model import (
     Genre,
     Hold,
     Hyperlink,
+    Library,
     LicensePool,
     Measurement,
     Patron,
@@ -5127,6 +5128,19 @@ class TestCustomListEntry(DatabaseTest):
         eq_(longwinded_entry.most_recent_appearance, entry.most_recent_appearance)
 
 
+class TestLibrary(DatabaseTest):
+
+    def test_instance(self):
+
+        # There are no Library objects until we call instance().
+        eq_(0, self._db.query(Library).count())
+
+        # In the current release there will only ever be one library.
+        instance = Library.instance(self._db)
+        instance2 = Library.instance(self._db)
+        eq_(instance, instance2)
+
+        
 class TestCollection(DatabaseTest):
 
     def setup(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5250,50 +5250,50 @@ class TestLibrary(DatabaseTest):
         eq_(instance, instance2)
 
         
-class TestCollection(DatabaseTest):
+class TestCatalog(DatabaseTest):
 
     def setup(self):
-        super(TestCollection, self).setup()
-        self.collection = self._collection()
+        super(TestCatalog, self).setup()
+        self.catalog = self._catalog()
 
     def test_encrypts_client_secret(self):
-        collection, new = get_one_or_create(
-            self._db, Collection, name=u"Test Collection", client_id=u"test",
+        catalog, new = get_one_or_create(
+            self._db, Catalog, name=u"Test Catalog", client_id=u"test",
             client_secret=u"megatest"
         )
-        assert collection.client_secret != u"megatest"
-        eq_(True, collection.client_secret.startswith("$2a$"))
+        assert catalog.client_secret != u"megatest"
+        eq_(True, catalog.client_secret.startswith("$2a$"))
 
     def test_register(self):
-        collection, plaintext_secret = Collection.register(
+        catalog, plaintext_secret = Catalog.register(
             self._db, u"A Library"
         )
 
-        # It creates client details and a DataSource for the collection
-        assert collection.client_id and collection.client_secret
-        assert get_one(self._db, DataSource, name=collection.name)
+        # It creates client details and a DataSource for the catalog
+        assert catalog.client_id and catalog.client_secret
+        assert get_one(self._db, DataSource, name=catalog.name)
 
         # It returns nothing if the name is already taken.
-        assert_raises(ValueError, Collection.register, self._db, u"A Library")
+        assert_raises(ValueError, Catalog.register, self._db, u"A Library")
 
     def test_authenticate(self):
 
-        result = Collection.authenticate(self._db, u"abc", u"def")
-        eq_(self.collection, result)
+        result = Catalog.authenticate(self._db, u"abc", u"def")
+        eq_(self.catalog, result)
 
-        result = Collection.authenticate(self._db, u"abc", u"bad_secret")
+        result = Catalog.authenticate(self._db, u"abc", u"bad_secret")
         eq_(None, result)
 
-        result = Collection.authenticate(self._db, u"bad_id", u"def")
+        result = Catalog.authenticate(self._db, u"bad_id", u"def")
         eq_(None, result)
 
     def test_catalog_identifier(self):
-        """#catalog_identifier associates an identifier with the collection"""
+        """#catalog_identifier associates an identifier with the catalog"""
 
         identifier = self._identifier()
-        self.collection.catalog_identifier(self._db, identifier)
-        eq_(1, len(self.collection.catalog))
-        eq_(identifier, self.collection.catalog[0])
+        self.catalog.catalog_identifier(self._db, identifier)
+        eq_(1, len(self.catalog.catalog))
+        eq_(identifier, self.catalog.catalog[0])
 
     def test_works_updated_since(self):
 
@@ -5301,13 +5301,13 @@ class TestCollection(DatabaseTest):
         w2 = self._work(with_license_pool=True)
         w3 = self._work(with_license_pool=True)
         timestamp = datetime.datetime.utcnow()
-        # A collection with no catalog returns nothing.
-        eq_([], self.collection.works_updated_since(self._db, timestamp).all())
+        # An empty catalog returns nothing.
+        eq_([], self.catalog.works_updated_since(self._db, timestamp).all())
 
         # When no timestamp is passed, all works in the catalog are returned.
-        self.collection.catalog_identifier(self._db, w1.license_pools[0].identifier)
-        self.collection.catalog_identifier(self._db, w2.license_pools[0].identifier)
-        updated_works = self.collection.works_updated_since(self._db, None).all()
+        self.catalog.catalog_identifier(self._db, w1.license_pools[0].identifier)
+        self.catalog.catalog_identifier(self._db, w2.license_pools[0].identifier)
+        updated_works = self.catalog.works_updated_since(self._db, None).all()
 
         eq_(2, len(updated_works))
         assert w1 in updated_works and w2 in updated_works
@@ -5316,7 +5316,7 @@ class TestCollection(DatabaseTest):
         # When a timestamp is passed, only works that have been updated
         # since then will be returned
         w1.coverage_records[0].timestamp = datetime.datetime.utcnow()
-        eq_([w1], self.collection.works_updated_since(self._db, timestamp).all())
+        eq_([w1], self.catalog.works_updated_since(self._db, timestamp).all())
 
 
 class TestMaterializedViews(DatabaseTest):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5250,7 +5250,32 @@ class TestLibrary(DatabaseTest):
         instance2 = Library.instance(self._db)
         eq_(instance, instance2)
 
-        
+
+class TestCollection(DatabaseTest):
+
+    def test_set_key_value_pair(self):
+        """Test the ability to associate extra key-value pairs with
+        a Collection.
+        """
+        collection, ignore = get_one_or_create(
+            self._db, Collection, name="test collection",
+            protocol=Collection.OVERDRIVE
+        )
+        eq_([], collection.settings)
+
+        setting = collection.set_setting("website_id", "id1")
+        eq_("website_id", setting.key)
+        eq_("id1", setting.value)
+
+        # Calling set() again updates the key-value pair.
+        eq_([setting], collection.settings)
+        setting2 = collection.set_setting("website_id", "id2")
+        eq_(setting, setting2)
+        eq_("id2", setting2.value)
+
+        eq_((setting2, False), collection.setting("website_id"))
+
+
 class TestCatalog(DatabaseTest):
 
     def setup(self):


### PR DESCRIPTION
This finishes the implementation of https://github.com/NYPL-Simplified/circulation/issues/451, and implements https://github.com/NYPL-Simplified/circulation/issues/452.

This branch creates a `Collection` data model class, which represents the set of `LicensePool`s which were obtained from a distributor with a certain set of credentials. The `Collection` is not tied to `DataSource`; rather, the `Collection` is tied to a protocol (a piece of code you run to get `LicensePool`s) and a set of credentials (username, password, library ID, source URL). Most protocols are closely tied to a `DataSource` (the "Overdrive" protocol only gives you Overdrive books), but it's not necessarily so.

The goal of `Collection` is to replace the `"integrations"` JSON configuration for Overdrive, Bibliotheca, Axis 360, OneClickdigital, the Library Simplified content server, and any future ODL or OPDS-based integrations. Instead of being stored in JSON, this information will be stored in the database, where it can be edited.

The schema of `Collection` is designed to hold the basic information associated with collection credentials. The `CollectionSetting` data model class keeps any extra configuration information which doesn't fit the schema. Right now I think the only example is Overdrive's "library ID".

This is a good time to critique the design of the `Collection` data model. It's closely based on https://github.com/NYPL-Simplified/Simplified/wiki/MultipleCollections, except I took out the tie between `Collection` and `DataSource` because I don't think it's necessary.

There already is a `Collection` class, which is a collection of `Identifier`s. That class is intended to be used in the metadata wrangler to keep track of which books a given library wants to track metadata updates for. There is controller code for this class but it's not used in production yet, so I've simply renamed `Collection` to `Catalog` and written a migration script which drops the old tables (they'll be automatically recreated under the new names). The difference between `Collection` and `Catalog` is the difference between a bookshelf and a card catalog.

This branch also follows up on PR #458 by adding two fields to `Library`: `library_registry_short_name` and `library_registry_shared_secret`. This lets us move a couple fields out of JSON configuration and into the database. (The actual work of doing this happens in https://github.com/NYPL-Simplified/circulation/pull/455.)