### PR TITLE
Don't let default_fiction crash if the classifier hasn't heard of a genre

### DIFF
--- a/model.py
+++ b/model.py
@@ -5209,6 +5209,8 @@ class Genre(Base):
 
     @property
     def default_fiction(self):
+        if self.name not in classifier.genres:
+            return None
         return classifier.genres[self.name].is_fiction
 
 class Subject(Base):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -582,6 +582,23 @@ class TestIdentifier(DatabaseTest):
         )
 
 
+class TestGenre(DatabaseTest):
+
+    def test_default_fiction(self):
+        sf, ignore = Genre.lookup(self._db, "Science Fiction")
+        nonfiction, ignore = Genre.lookup(self._db, "History")
+        eq_(True, sf.default_fiction)
+        eq_(False, nonfiction.default_fiction)
+
+        # Create a previously unknown genre.
+        genre, ignore = Genre.lookup(
+            self._db, "Some Weird Genre", autocreate=True
+        )
+
+        # We don't know its default fiction status.
+        eq_(None, genre.default_fiction)
+
+        
 class TestSubject(DatabaseTest):
 
     def test_lookup_autocreate(self):


### PR DESCRIPTION
This branch adds some resilience to the `Genre.default_fiction` method. If the classifier hasn't heard of a Genre, we don't know whether it's fiction or nonfiction, so `default_fiction` returns None instead of crashing.

There aren't supposed to be any Genres that the classifier doesn't know about, but sometimes they stick around. NYPL's production and QA circulation managers have some really old ones. This only became a problem recently with Courteney's changes to how genres are excluded from lanes.

It doesn't hurt to delete the unused genres, but it's better to make sure that they don't cause problems if they do creep into the database.