### PR TITLE
Pull API configuration from Collection objects

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -49,6 +49,12 @@ class Axis360API(object):
 
     PRODUCTION_BASE_URL = "https://axis360api.baker-taylor.com/Services/VendorAPI/"
     QA_BASE_URL = "http://axis360apiqa.baker-taylor.com/Services/VendorAPI/"
+
+    # Map simple nicknames to server URLs.
+    SERVER_NICKNAMES = {
+        "production" : PRODUCTION_BASE_URL,
+        "qa" : QA_BASE_URL,
+    }
     
     DATE_FORMAT = "%m-%d-%Y %H:%M:%S"
 
@@ -65,12 +71,10 @@ class Axis360API(object):
         self.password = collection.password
 
         # Convert the nickname for a server into an actual URL.
-        if base_url == 'qa':
-            self.base_url = self.QA_BASE_URL
-        elif base_url == 'production' or not base_url:
-            self.base_url = self.PRODUCTION_BASE_URL
-        else:
-            self.base_url = base_url
+        base_url = collection.url
+        if base_url in self.SERVER_NICKNAMES:
+            base_url = self.SERVER_NICKNAMES[base_url]
+        self.base_url = base_url
 
         if (not self.library_id or not self.username
             or not self.password):
@@ -207,7 +211,7 @@ class MockAxis360API(Axis360API):
             )
         )
         library.collections.append(collection)
-        super(MockAxis360API, self).__init__(_db, *args, **kwargs)
+        super(MockAxis360API, self).__init__(_db, collection, *args, **kwargs)
         if with_token:
             self.token = "mock token"
         self.responses = []

--- a/axis.py
+++ b/axis.py
@@ -64,6 +64,12 @@ class Axis360API(object):
     log = logging.getLogger("Axis 360 API")
 
     def __init__(self, _db, collection):
+        if collection.protocol != collection.AXIS_360:
+            raise ValueError(
+                "Collection protocol is %s, but passed into Axis360API!" %
+                collection.protocol
+            )
+
         self._db = _db
 
         self.library_id = collection.external_account_id

--- a/axis.py
+++ b/axis.py
@@ -91,8 +91,8 @@ class Axis360API(object):
         """
         library = Library.instance(_db)
         collections = [x for x in library.collections
-                      if x.protocol == collection.AXIS_360]
-        if len(collections == 0):
+                      if x.protocol == Collection.AXIS_360]
+        if len(collections) == 0:
             # There are no Axis 360 collections configured.
             return None
 
@@ -246,7 +246,6 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
         :param input_identifiers: Passed in by RunCoverageProviderScript, specific identifiers to get coverage for.
         """
         self.parser = BibliographicParser()
-        axis_360_api = axis_360_api or Axis360API(_db)
         super(Axis360BibliographicCoverageProvider, self).__init__(
             _db, axis_360_api, DataSource.AXIS_360,
             batch_size=25, 

--- a/axis.py
+++ b/axis.py
@@ -77,7 +77,7 @@ class Axis360API(object):
         self.password = collection.password
 
         # Convert the nickname for a server into an actual URL.
-        base_url = collection.url
+        base_url = collection.url or self.PRODUCTION_BASE_URL
         if base_url in self.SERVER_NICKNAMES:
             base_url = self.SERVER_NICKNAMES[base_url]
         self.base_url = base_url

--- a/axis.py
+++ b/axis.py
@@ -20,12 +20,15 @@ from util.http import (
 )
 from coverage import CoverageFailure
 from model import (
+    get_one_or_create,
+    Collection,
     Contributor,
     DataSource,
     DeliveryMechanism,
     LicensePool,
     Edition,
     Identifier,
+    Library,
     Representation,
     Subject,
 )
@@ -54,50 +57,52 @@ class Axis360API(object):
 
     log = logging.getLogger("Axis 360 API")
 
-    def __init__(self, _db, username=None, library_id=None, password=None,
-                 base_url=None):
+    def __init__(self, _db, collection):
         self._db = _db
-        (env_library_id, env_username, 
-         env_password, env_base_url) = self.environment_values()
-            
-        self.library_id = library_id or env_library_id
-        self.username = username or env_username
-        self.password = password or env_password
-        self.base_url = base_url or env_base_url
-        if self.base_url == 'qa':
+
+        self.library_id = collection.external_account_id
+        self.username = collection.username
+        self.password = collection.password
+
+        # Convert the nickname for a server into an actual URL.
+        if base_url == 'qa':
             self.base_url = self.QA_BASE_URL
-        elif self.base_url == 'production':
+        elif base_url == 'production' or not base_url:
             self.base_url = self.PRODUCTION_BASE_URL
+        else:
+            self.base_url = base_url
+
+        if (not self.library_id or not self.username
+            or not self.password):
+            raise CannotLoadConfiguration(
+                "Axis 360 configuration is incomplete."
+            )
+            
         self.token = None
 
     @classmethod
-    def environment_values(cls):
-        config = Configuration.integration('Axis 360')
-        values = []
-        for name in [
-                'library_id',
-                'username',
-                'password',
-                'server',
-        ]:
-            value = config.get(name)
-            if value:
-                value = value.encode("utf8")
-            values.append(value)
-        return values
-
-    @classmethod
     def from_environment(cls, _db):
-        # Make sure all environment values are present. If any are missing,
-        # return None
-        values = cls.environment_values()
-        if len([x for x in values if not x]):
-            cls.log.info(
-                "No Axis 360 client configured."
-            )
+        """Load an Axis360API instance for the 'default' Axis 360
+        collection.
+        """
+        library = Library.instance(_db)
+        collections = [x for x in library.collections
+                      if x.protocol == collection.AXIS_360]
+        if len(collections == 0):
+            # There are no Axis 360 collections configured.
             return None
-        return cls(_db)
 
+        if len(collections) > 1:
+            raise ValueError(
+                "Multiple Axis 360 collections found for one library. This is not yet supported."
+            )
+        [collection] = collections 
+
+        try:
+            return cls(_db, collection)
+        except CannotLoadConfiguration, e:
+            return None
+        
     @property
     def source(self):
         return DataSource.lookup(self._db, DataSource.AXIS_360)
@@ -192,14 +197,17 @@ class Axis360API(object):
 class MockAxis360API(Axis360API):
 
     def __init__(self, _db, with_token=True, *args, **kwargs):
-        with temp_config() as config:
-            config[Configuration.INTEGRATIONS]['Axis 360'] = {
-                'library_id' : 'a',
-                'username' : 'b',
-                'password' : 'c',
-                'server' : 'http://axis.test/',
-            }
-            super(MockAxis360API, self).__init__(_db, *args, **kwargs)
+        library = Library.instance(_db)
+        collection, ignore = get_one_or_create(
+            _db, Collection,
+            name="Test Axis 360 Collection",
+            protocol=Collection.AXIS_360, create_method_kwargs=dict(
+                username='a', password='b', external_account_id='c',
+                url="http://axis.test/"
+            )
+        )
+        library.collections.append(collection)
+        super(MockAxis360API, self).__init__(_db, *args, **kwargs)
         if with_token:
             self.token = "mock token"
         self.responses = []

--- a/model.py
+++ b/model.py
@@ -8566,7 +8566,7 @@ class Collection(Base):
 
     def set_setting(self, key, value):
         """Create or update a key-value setting for this Collection."""
-        setting, ignore = self.setting(key)
+        setting = self.setting(key)
         setting.value = value
         return setting
     
@@ -8574,12 +8574,13 @@ class Collection(Base):
         """Find or create a CollectionSetting on this Collection.
 
         :param key: Name of the setting.
-        :return: 2-tuple (CollectionSetting, is_new)
+        :return: A CollectionSetting
         """
         _db = Session.object_session(self)
-        return get_one_or_create(
+        setting, is_new = get_one_or_create(
             _db, CollectionSetting, collection=self, key=key
         )
+        return setting
 
 
 class CollectionSetting(Base):

--- a/overdrive.py
+++ b/overdrive.py
@@ -132,8 +132,8 @@ class OverdriveAPI(object):
         """
         library = Library.instance(_db)
         collections = [x for x in library.collections
-                      if x.protocol == collection.OVERDRIVE]
-        if len(collections == 0):
+                      if x.protocol == Collection.OVERDRIVE]
+        if len(collections) == 0:
             # There are no Overdrive collections configured.
             return None
 

--- a/overdrive.py
+++ b/overdrive.py
@@ -127,18 +127,21 @@ class OverdriveAPI(object):
 
     @classmethod
     def from_environment(cls, _db):
+        """Load an OverdriveAPI instance for the 'default' Overdrive
+        collection.
+        """
         library = Library.instance(_db)
-        collection = [x for x in library.collections
+        collections = [x for x in library.collections
                       if x.protocol == collection.OVERDRIVE]
-        if len(collection == 0):
+        if len(collections == 0):
             # There are no Overdrive collections configured.
             return None
 
-        if len(collection) > 1:
+        if len(collections) > 1:
             raise ValueError(
-                "Multiple Overdrive collections found for one library. This is not yet supprted."
+                "Multiple Overdrive collections found for one library. This is not yet supported."
             )
-        [collection] = collection 
+        [collection] = collections 
 
         try:
             return cls(_db, collection)

--- a/testing.py
+++ b/testing.py
@@ -784,8 +784,13 @@ class MockRequestsResponse(object):
         self.url = url or "http://url/"
 
     def json(self):
-        return json.loads(self.content)
-
+        content = self.content
+        # The queued content might be a JSON string or it might
+        # just be the object you'd get from loading a JSON string.
+        if isinstance(content, basestring):
+            content = json.loads(self.content)
+        return content
+        
     @property
     def text(self):
         return self.content.decode("utf8")

--- a/tests/test_3m.py
+++ b/tests/test_3m.py
@@ -52,9 +52,9 @@ class TestThreeMAPI(DatabaseTest, BaseThreeMTest):
 
     def test_full_url(self):
         id = self.api.library_id
-        eq_("http://3m.test/cirrus/library/%s/foo" % id,
+        eq_("http://bibliotheca.test/cirrus/library/%s/foo" % id,
             self.api.full_url("foo"))
-        eq_("http://3m.test/cirrus/library/%s/foo" % id, 
+        eq_("http://bibliotheca.test/cirrus/library/%s/foo" % id, 
             self.api.full_url("/foo"))
 
     def test_request_signing(self):
@@ -67,7 +67,7 @@ class TestThreeMAPI(DatabaseTest, BaseThreeMTest):
         headers = request[-1]['headers']
         eq_('Fri, 01 Jan 2016 00:00:00 GMT', headers['3mcl-Datetime'])
         eq_('2.0', headers['3mcl-Version'])
-        expect = '3MCLAUTH b:ppuKJ2nf8OO3vCYhH3mJE8c7mjB6mGxzcPO3KOz4FTE='
+        expect = '3MCLAUTH a:HZHNGfn6WVceakGrwXaJQ9zIY0Ai5opGct38j9/bHrE='
         eq_(expect, headers['3mcl-Authorization'])
         
         # Tweak one of the variables that go into the signature, and

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5289,7 +5289,7 @@ class TestCollection(DatabaseTest):
         eq_(setting, setting2)
         eq_("id2", setting2.value)
 
-        eq_((setting2, False), collection.setting("website_id"))
+        eq_(setting2, collection.setting("website_id"))
 
 
 class TestCatalog(DatabaseTest):

--- a/threem.py
+++ b/threem.py
@@ -90,8 +90,8 @@ class ThreeMAPI(object):
         """
         library = Library.instance(_db)
         collections = [x for x in library.collections
-                      if x.protocol == collection.BIBLIOTHECA]
-        if len(collections == 0):
+                      if x.protocol == Collection.BIBLIOTHECA]
+        if len(collections) == 0:
             # There are no Bibliotheca collections configured.
             return None
 

--- a/threem.py
+++ b/threem.py
@@ -67,6 +67,12 @@ class ThreeMAPI(object):
     DEFAULT_BASE_URL = "https://partner.yourcloudlibrary.com/"
     
     def __init__(self, _db, collection):
+        if collection.protocol != collection.BIBLIOTHECA:
+            raise ValueError(
+                "Collection protocol is %s, but passed into BibliothecaAPI!" %
+                collection.protocol
+            )
+
         self._db = _db
         self.version = (
             collection.setting('version').value or self.DEFAULT_VERSION


### PR DESCRIPTION
This branch changes the constructors for API objects (ThreeMAPI, OverdriveAPI, etc) so that rather than taking individual bits of configuration information, they take a `Collection` object with the configuration information. The idea is that you instantiate an API object for a specific API account. There's no longer an implication that every piece of the circulation manager always authenticates against the Overdrive API with the exact same credentials.

However, that assumption is still present in class methods called `from_environment` (which originally pulled API configuration from environment variables, and then from JSON files), which assume there is a single `Library` object with (at most) a single associated `Collection` of the appropriate type. Once these assumptions go away, the `from_environment` methods will also have to go away.