### PR TITLE
Add library and collection scripts

### DIFF
--- a/model.py
+++ b/model.py
@@ -8471,6 +8471,11 @@ class Library(Base):
     # The shared secret to use when signing short client tokens for
     # consumption by the library registry.
     library_registry_shared_secret = Column(Unicode, unique=True)
+
+    def __repr__(cls):
+        return '<Library: name="%s", short name="%s", uuid="%s", library registry short name="%s">' % (
+            self.name, self.short_name, self.uuid, self.library_registry_short_name
+        )
     
     @classmethod
     def instance(cls, _db):
@@ -8481,7 +8486,7 @@ class Library(Base):
             )
         )
         return library
-
+    
     @hybrid_property
     def library_registry_short_name(self):
         """Gets library_registry_short_name from database"""
@@ -8498,6 +8503,34 @@ class Library(Base):
                 )
         self._library_registry_short_name = value
 
+    def explain(self, include_library_registry_shared_secret=False):
+        """Create a series of human-readable strings to explain a library's
+        settings.
+
+        :param include_library_registry_shared_secret: For security reasons,
+           the shared secret is not displayed by default.
+
+        :return: A list of explanatory strings.
+        """
+        lines = []
+        if self.uuid:
+            lines.append('UUID: "%s"' % self.uuid)
+        if self.name:
+            lines.append('Name: "%s"' % self.name)
+        if self.short_name:
+            lines.append('Short name: "%s"' % self.short_name)
+        if self.library_registry_short_name:
+            lines.append(
+                'Short name (for library registry): "%s"' %
+                self.library_registry_short_name
+            )
+        if (self.library_registry_shared_secret and
+            include_library_registry_shared_secret):
+            lines.append(
+                'Shared secret (for library registry): "%s"' %
+                self.library_registry_shared_secret
+            )
+        return lines
 
 class Admin(Base):
 

--- a/model.py
+++ b/model.py
@@ -8567,6 +8567,8 @@ class Collection(Base):
     BIBLIOTHECA = DataSource.BIBLIOTHECA
     AXIS_360 = DataSource.AXIS_360
     ONE_CLICK = DataSource.ONECLICK
+
+    PROTOCOLS = [OPDS_IMPORT, OVERDRIVE, BIBLIOTHECA, AXIS_360, ONE_CLICK]
     
     # How does the provider of this collection distinguish it from
     # other collections it provides? On the other side this is usually

--- a/model.py
+++ b/model.py
@@ -8620,6 +8620,36 @@ class Collection(Base):
         )
         return setting
 
+    def explain(self, include_password=False):
+        """Create a series of human-readable strings to explain a collection's
+        settings.
+
+        :param include_password: For security reasons,
+           the password (if any) is not displayed by default.
+
+        :return: A list of explanatory strings.
+        """
+        lines = []
+        if self.name:
+            lines.append('Name: "%s"' % self.name)
+        if self.protocol:
+            lines.append('Protocol: "%s"' % self.protocol)
+        for library in self.libraries:
+            lines.append('Used by library: "%s"' % (
+                library.short_name or library.name
+            ))
+        if self.external_account_id:
+            lines.append('External account ID: "%s"' % self.external_account_id)
+        if self.url:
+            lines.append('URL: "%s"' % self.url)
+        if self.username:
+            lines.append('Username: "%s"' % self.url)
+        if self.password and include_password:
+            lines.append('Password: "%s"' % self.password)
+        for setting in self.settings:
+            lines.append('Setting "%s": "%s"' % (setting.key, setting.value))
+        return lines
+
 
 class CollectionSetting(Base):
     """An extra piece of information associated with a Collection.

--- a/scripts.py
+++ b/scripts.py
@@ -812,7 +812,7 @@ class ConfigureCollectionScript(Script):
                     )
                 key, value = setting.split('=', 1)
                 collection.setting(key).value = value
-        if args.library:
+        if hasattr(args, 'library'):
             for name in args.library:
                 library = get_one(_db, Library, short_name=name)
                 if not library:

--- a/scripts.py
+++ b/scripts.py
@@ -32,6 +32,7 @@ from model import (
     get_one,
     get_one_or_create,
     production_session,
+    Collection,
     CustomList,
     DataSource,
     Edition,
@@ -685,7 +686,7 @@ class ShowCollectionsScript(Script):
         )
         parser.add_argument(
             '--show-password',
-            help='Print out the password for this collection.',
+            help='Display collection passwords.',
             action='store_true'
         )
         return parser
@@ -693,22 +694,17 @@ class ShowCollectionsScript(Script):
     def do_run(self, _db=None, cmd_args=None, output=sys.stdout):
         _db = _db or self._db
         args = self.parse_command_line(_db, cmd_args=cmd_args)
-        if args.short_name:
-            library = get_one(
-                _db, Library, short_name=args.short_name
-            )
-            libraries = [library]
+        if args.name:
+            collection = get_one(_db, Collection, name=args.name)
+            collections = [collection]
         else:
-            libraries = _db.query(Library).order_by(Library.name).all()
-        if not libraries:
-            output.write("No libraries found.\n")
-        for library in libraries:
+            collections = _db.query(Collection).order_by(Collection.name).all()
+        if not collections:
+            output.write("No collections found.\n")
+        for collection in collections:
             output.write(
                 "\n".join(
-                    library.explain(
-                        include_library_registry_shared_secret=
-                        args.show_registry_shared_secret
-                    )
+                    collection.explain(include_password=args.show_password)
                 )
             )
             output.write("\n")

--- a/scripts.py
+++ b/scripts.py
@@ -627,9 +627,9 @@ class ConfigureLibraryScript(Script):
                 "You can't set the shared secret to a random value and a specific value at the same time."
             )
        
-        if not args.name and not args.short_name:
+        if not args.short_name:
             raise ValueError(
-                "You must specify either the name or the short name of the library."
+                "You must identify the library by its short name."
             )
 
         # Are we talking about an existing library?
@@ -638,6 +638,8 @@ class ConfigureLibraryScript(Script):
         if libraries:
             # Currently there can only be one library, and one already exists.
             [library] = libraries
+            if args.short_name and library.short_name != args.short_name:
+                raise ValueError("Could not locate library '%s'" % args.short_name)
         else:
             # No existing library. Make one.
             library, ignore = get_one_or_create(

--- a/scripts.py
+++ b/scripts.py
@@ -546,9 +546,9 @@ class BibliographicRefreshScript(RunCoverageProviderScript):
 
 
 class ShowLibrariesScript(Script):
-    """Show information about the libraries on a circulation manager."""
+    """Show information about the libraries on a server."""
     
-    name = "List the libraries on this circulation manager."
+    name = "List the libraries on this server."
     @classmethod
     def arg_parser(cls):
         parser = argparse.ArgumentParser()
@@ -670,7 +670,49 @@ class ConfigureLibraryScript(Script):
         output.write("Configuration settings stored.\n")
         output.write("\n".join(library.explain()))
         output.write("\n")
-            
+
+
+class ShowCollectionsScript(Script):
+    """Show information about the collections on a server."""
+    
+    name = "List the collections on this server."
+    @classmethod
+    def arg_parser(cls):
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            '--name',
+            help='Only display information for the collection with the given name',
+        )
+        parser.add_argument(
+            '--show-password',
+            help='Print out the password for this collection.',
+            action='store_true'
+        )
+        return parser
+    
+    def do_run(self, _db=None, cmd_args=None, output=sys.stdout):
+        _db = _db or self._db
+        args = self.parse_command_line(_db, cmd_args=cmd_args)
+        if args.short_name:
+            library = get_one(
+                _db, Library, short_name=args.short_name
+            )
+            libraries = [library]
+        else:
+            libraries = _db.query(Library).order_by(Library.name).all()
+        if not libraries:
+            output.write("No libraries found.\n")
+        for library in libraries:
+            output.write(
+                "\n".join(
+                    library.explain(
+                        include_library_registry_shared_secret=
+                        args.show_registry_shared_secret
+                    )
+                )
+            )
+            output.write("\n")
+
         
 class AddClassificationScript(IdentifierInputScript):
     name = "Add a classification to an identifier"


### PR DESCRIPTION
This branch adds four new scripts. One of them lists the libraries in the database, and one of them creates a new library or reconfigures an existing library.

The other two scripts do the same for collections.

The goal is to provide a simple way of doing initial configuration from the command line, and to provide a stopgap until the administrative interface allows the configuration of library and collection.

These scripts are in core rather than in circulation because I'm pretty sure the content server, at least, is going to use the concept of collection.