### PR TITLE
Begin support for Overdrive Advantage

### DIFF
--- a/model.py
+++ b/model.py
@@ -8556,6 +8556,20 @@ class Collection(Base):
     settings = relationship(
         "CollectionSetting", backref="collection"
     )
+
+    # A Collection may reuse the credentials from some other
+    # Collection. For instance, an Overdrive Advantage collection is a
+    # specialization of an ordinary Overdrive collection. It uses the
+    # same access key and secret as the Overdrive collection, but it
+    # has a distinct external_account_id.
+    parent_id = Column(Integer, ForeignKey('collections.id'), index=True)
+
+    # A collection may have many child collections. For example,
+    # An Overdrive collection may have many children corresponding
+    # to Overdrive Advantage collections.
+    children = relationship(
+        "Collection", backref="parent", remote_side = [id]
+    )
     
     # A Collection can provide books to many Libraries.
     libraries = relationship(

--- a/model.py
+++ b/model.py
@@ -8603,7 +8603,8 @@ class Collection(Base):
     # An Overdrive collection may have many children corresponding
     # to Overdrive Advantage collections.
     children = relationship(
-        "Collection", backref="parent", remote_side = [id]
+        "Collection", backref=backref("parent", remote_side = [id]),
+        uselist=False
     )
     
     # A Collection can provide books to many Libraries.
@@ -8648,6 +8649,8 @@ class Collection(Base):
         lines = []
         if self.name:
             lines.append('Name: "%s"' % self.name)
+        if self.parent:
+            lines.append('Parent: %s' % self.parent.name)
         if self.protocol:
             lines.append('Protocol: "%s"' % self.protocol)
         for library in self.libraries:

--- a/model.py
+++ b/model.py
@@ -8659,7 +8659,7 @@ class Collection(Base):
         if self.url:
             lines.append('URL: "%s"' % self.url)
         if self.username:
-            lines.append('Username: "%s"' % self.url)
+            lines.append('Username: "%s"' % self.username)
         if self.password and include_password:
             lines.append('Password: "%s"' % self.password)
         for setting in self.settings:

--- a/model.py
+++ b/model.py
@@ -8592,11 +8592,11 @@ class Collection(Base):
         "CollectionSetting", backref="collection"
     )
 
-    # A Collection may reuse the credentials from some other
-    # Collection. For instance, an Overdrive Advantage collection is a
-    # specialization of an ordinary Overdrive collection. It uses the
-    # same access key and secret as the Overdrive collection, but it
-    # has a distinct external_account_id.
+    # A Collection may specialize some other Collection. For instance,
+    # an Overdrive Advantage collection is a specialization of an
+    # ordinary Overdrive collection. It uses the same access key and
+    # secret as the Overdrive collection, but it has a distinct
+    # external_account_id.
     parent_id = Column(Integer, ForeignKey('collections.id'), index=True)
 
     # A collection may have many child collections. For example,

--- a/overdrive.py
+++ b/overdrive.py
@@ -409,7 +409,7 @@ class MockOverdriveAPI(OverdriveAPI):
         self.responses = []
 
         if not collection:
-            # OverdriveAPI needs a Collection, but not was provided.
+            # OverdriveAPI needs a Collection, but none was provided.
             # Just create a basic one.
             library = Library.instance(_db)
             collection, ignore = get_one_or_create(
@@ -440,7 +440,7 @@ class MockOverdriveAPI(OverdriveAPI):
         because only the first MockOverdriveAPI instantiation in a
         given test actually makes this call. By mocking the response
         to this method separately we remove the need to figure out
-        whether to queue a response.
+        whether to queue a response in a given test.
         """
         response = self.access_token_response
         return HTTP._process_response(url, response, **kwargs)

--- a/overdrive.py
+++ b/overdrive.py
@@ -118,13 +118,16 @@ class OverdriveAPI(object):
             # inherit all of the credentials from the parent (the main
             # Overdrive account), other than the library ID.
             self.parent_library_id = collection.parent.external_account_id
+
+            # Everything else comes from the parent.
+            collection = collection.parent
         else:
             self.parent_library_id = None
             
         self.client_key = collection.username
         self.client_secret = collection.password
         self.website_id = collection.setting('website_id').value
-        
+
         if (not self.client_key or not self.client_secret or not self.website_id
             or not self.library_id):
             raise CannotLoadConfiguration(
@@ -989,13 +992,12 @@ class OverdriveAdvantageAccount(object):
         if not parent:
             # Without the parent's credentials we can't access the child.
             return None
-        name = self.type + " - " + self.name
+        name = parent.name + " / " + self.name
         child, ignore = get_one_or_create(
             _db, Collection, parent_id=parent.id, protocol=Collection.OVERDRIVE,
             external_account_id=self.library_id,
             create_method_kwargs=dict(name=name)
         )
-
         # Set or update the name of the collection to reflect the name of
         # the library, just in case that name has changed.
         child.name = name

--- a/overdrive.py
+++ b/overdrive.py
@@ -973,6 +973,27 @@ class OverdriveAdvantageAccount(object):
             yield cls(parent_library_id=parent_id, library_id=library_id,
                       name=name, type=type)
 
+    def to_collection(self, _db):
+        """Find or create a Collection object for this Overdrive Advantage
+        account.
+        """
+        # First find the parent Collection.
+        parent = get_one(
+            Collection, external_account_id=self.parent_library_id,
+            protocol=Collection.OVERDRIVE
+        )
+        if not parent:
+            # Without the parent's credentials we can't access the child.
+            return None
+        child = get_one_or_create(
+            Collection, parent=parent, protocol=Collection.OVERDRIVE,
+            external_account_id=self.library_id
+        )
+
+        # Set or update the name of the collection to reflect the name of
+        # the library.
+        child.name = self.type + " - " + self.name
+
         
 class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
     """Fill in bibliographic metadata for Overdrive records."""

--- a/overdrive.py
+++ b/overdrive.py
@@ -270,6 +270,8 @@ class OverdriveAPI(object):
         library = self.get_library()
         links = library.get('links', {})
         advantage = links.get('advantageAccounts')
+        if not advantage:
+            return
         if advantage:
             # This library has Overdrive Advantage accounts, or at
             # least a link where some may be found.
@@ -960,19 +962,17 @@ class OverdriveAdvantageAccount(object):
     """Holder and parser for data associated with Overdrive Advantage.
     """
     
-    def __init__(self, parent_library_id, library_id, name, type):
+    def __init__(self, parent_library_id, library_id, name):
         """Constructor.
         
         :param parent_library_id: The library ID of the parent Overdrive 
             account.
         :param library_id: The library ID of the Overdrive Advantage account.
         :param name: The name of the library whose Advantage account this is.
-        :param type: Should be the literal string 'Library Advantage Account'
         """
         self.parent_library_id = parent_library_id
         self.library_id = library_id
         self.name = name
-        self.type = type
 
     @classmethod
     def from_representation(cls, content):
@@ -991,9 +991,8 @@ class OverdriveAdvantageAccount(object):
             products_link = account['links']['products']['href']
             library_id = str(account.get('id'))
             name = account.get('name')
-            type = account.get('type')
             yield cls(parent_library_id=parent_id, library_id=library_id,
-                      name=name, type=type)
+                      name=name)
 
     def to_collection(self, _db):
         """Find or create a Collection object for this Overdrive Advantage

--- a/overdrive.py
+++ b/overdrive.py
@@ -443,7 +443,6 @@ class MockOverdriveAPI(OverdriveAPI):
         whether to queue a response.
         """
         response = self.access_token_response
-        set_trace()
         return HTTP._process_response(url, response, **kwargs)
 
     def mock_access_token_response(self, credential):

--- a/overdrive.py
+++ b/overdrive.py
@@ -115,12 +115,12 @@ class OverdriveAPI(object):
 
         self.library_id = collection.external_account_id
         if collection.parent:
-            # This is an Overdrive Advantage account. We're going to
-            # inherit all of the credentials from the parent (the main
-            # Overdrive account), other than the library ID.
+            # This is an Overdrive Advantage account.
             self.parent_library_id = collection.parent.external_account_id
-
-            # Everything else comes from the parent.
+            
+            # We're going to inherit all of the Overdrive credentials
+            # from the parent (the main Overdrive account), except for the
+            # library ID, which we already set.
             collection = collection.parent
         else:
             self.parent_library_id = None
@@ -409,6 +409,8 @@ class MockOverdriveAPI(OverdriveAPI):
         self.responses = []
 
         if not collection:
+            # OverdriveAPI needs a Collection, but not was provided.
+            # Just create a basic one.
             library = Library.instance(_db)
             collection, ignore = get_one_or_create(
                 _db, Collection,
@@ -431,9 +433,9 @@ class MockOverdriveAPI(OverdriveAPI):
 
         We mock the method rather than queueing up a mock response
         because only the first MockOverdriveAPI instantiation in a
-        given test actually needs to make this call. By mocking the
-        method we remove the need to communicate whether or not the
-        mock response should be queued.
+        given test actually makes this call. By mocking the method, we
+        remove the need to communicate we need to queue the mock
+        response.
         """
         token = self.mock_access_token("bearer token")
         return MockRequestsResponse(200, {}, token)

--- a/overdrive.py
+++ b/overdrive.py
@@ -263,8 +263,11 @@ class OverdriveAPI(object):
         :yield: A sequence of OverdriveAdvantageAccount objects.
         """
         library = self.get_library()
+        links = library.get('links', {})
         advantage = links.get('advantageAccounts')
         if advantage:
+            # This library has Overdrive Advantage accounts, or at
+            # least a link where some may be found.
             advantage_url = advantage.get('href')
             if not advantage_url:
                 return
@@ -947,24 +950,23 @@ class OverdriveAdvantageAccount(object):
         self.parent_library_id = parent_library_id
         self.library_id = library_id
         self.name = name
-        self.collection_token = collection_token
         self.type = type
 
     @classmethod
-    def from_representation(self, content):
+    def from_representation(cls, content):
         """Turn the representation of an advantageAccounts link into a list of
         OverdriveAdvantageAccount objects.
 
+        :param content: The data obtained by following an advantageAccounts
+            link.
         :yield: A sequence of OverdriveAdvantageAccount objects.
         """
-        data = json.loads(representation.content)
+        data = json.loads(content)
         parent_id = data.get('id')
         accounts = data.get('advantageAccounts', {})
         for account in accounts:
             name = account['name']
             products_link = account['links']['products']['href']
-            status_code, headers, content = self.get(products_link, {})
-            data = json.loads(content)
             library_id = account.get('id')
             name = account.get('name')
             type = account.get('type')

--- a/overdrive.py
+++ b/overdrive.py
@@ -991,7 +991,9 @@ class OverdriveAdvantageAccount(object):
         )
         if not parent:
             # Without the parent's credentials we can't access the child.
-            return None
+            raise ValueError(
+                "Cannot create a Collection whose parent does not already exist."
+            )
         name = parent.name + " / " + self.name
         child, ignore = get_one_or_create(
             _db, Collection, parent_id=parent.id, protocol=Collection.OVERDRIVE,

--- a/testing.py
+++ b/testing.py
@@ -15,6 +15,7 @@ from model import (
     Base,
     Catalog,
     Classification,
+    Collection,
     Complaint,
     Contributor,
     CoverageRecord,
@@ -637,6 +638,19 @@ class DatabaseTest(object):
         return
 
 
+    def _collection(self, name=None, protocol=Collection.OPDS_IMPORT,
+                    external_account_id=None, url=None, username=None,
+                    password=None):
+        name = name or self._str
+        collection, ignore = get_one_or_create(
+            self._db, Collection, name=name, protocol=protocol
+        )
+        collection.external_account_id = external_account_id
+        collection.url = url
+        collection.username = username
+        collection.password = password
+        return collection
+        
     def _catalog(self, name=u"Faketown Public Library"):
         source, ignore = get_one_or_create(self._db, DataSource, name=name)
         return get_one_or_create(

--- a/tests/files/overdrive/advantage_accounts.json
+++ b/tests/files/overdrive/advantage_accounts.json
@@ -1,0 +1,122 @@
+{
+	"id": 1225,
+	"links": {
+		"self": {
+			"href": "https://api.overdrive.com/v1/libraries/1225/advantageAccounts",
+			"type": "application/vnd.overdrive.api+json"
+		}
+	},
+	"advantageAccounts": [{
+		"id": 3,
+		"name": "The Other Side of Town Library",
+		"type": "Library Advantage Account",
+                "collectionToken": "v1L2B2gAAAK8BAAA1x",
+		"links": {
+			"self": {
+				"href": "https://api.overdrive.com/v1/libraries/1225/advantageAccounts/3",
+				"type": "application/vnd.overdrive.api+json"
+			},
+			"products": {
+				"href": "https://api.overdrive.com/v1/collections/v1L2B2gAAAK8BAAA1x/products",
+				"type": "application/vnd.overdrive.api+json"
+			}
+		},
+		"formats": [{
+			"id": "audiobook-wma",
+			"name": "OverDrive WMA Audiobook"
+		},
+		{
+			"id": "music-wma",
+			"name": "OverDrive Music"
+		},
+		{
+			"id": "video-wmv",
+			"name": "OverDrive Video"
+		},
+		{
+			"id": "ebook-pdf-adobe",
+			"name": "Adobe PDF eBook"
+		},
+		{
+			"id": "ebook-disney",
+			"name": "Disney Online Book"
+		},
+		{
+			"id": "ebook-epub-adobe",
+			"name": "Adobe EPUB eBook"
+		},
+		{
+			"id": "ebook-kindle",
+			"name": "Kindle Book"
+		},
+		{
+			"id": "audiobook-mp3",
+			"name": "OverDrive MP3 Audiobook"
+		},
+		{
+			"id": "ebook-pdf-open",
+			"name": "Open PDF eBook"
+		},
+		{
+			"id": "ebook-epub-open",
+			"name": "Open EPUB eBook"
+		}]
+	},
+	{
+		"id": 9,
+		"name": "The Common Community Library",
+		"type": "Library Advantage Account",
+                "collectionToken": "v1L2B2gAAAKoBAAA1B",
+		"links": {
+			"self": {
+				"href": "https://api.overdrive.com/v1/libraries/1225/advantageAccounts/9",
+				"type": "application/vnd.overdrive.api+json"
+			},
+			"products": {
+				"href": "https://api.overdrive.com/v1/collections/v1L2B2gAAAKoBAAA1B/products",
+				"type": "application/vnd.overdrive.api+json"
+			}
+		},
+		"formats": [{
+			"id": "audiobook-wma",
+			"name": "OverDrive WMA Audiobook"
+		},
+		{
+			"id": "music-wma",
+			"name": "OverDrive Music"
+		},
+		{
+			"id": "video-wmv",
+			"name": "OverDrive Video"
+		},
+		{
+			"id": "ebook-pdf-adobe",
+			"name": "Adobe PDF eBook"
+		},
+		{
+			"id": "ebook-disney",
+			"name": "Disney Online Book"
+		},
+		{
+			"id": "ebook-epub-adobe",
+			"name": "Adobe EPUB eBook"
+		},
+		{
+			"id": "ebook-kindle",
+			"name": "Kindle Book"
+		},
+		{
+			"id": "audiobook-mp3",
+			"name": "OverDrive MP3 Audiobook"
+		},
+		{
+			"id": "ebook-pdf-open",
+			"name": "Open PDF eBook"
+		},
+		{
+			"id": "ebook-epub-open",
+			"name": "Open EPUB eBook"
+		}]
+	}],
+	"totalItems": 2
+}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5340,7 +5340,7 @@ class TestCollection(DatabaseTest):
              'Used by library: "The only library"',
              'External account ID: "id"',
              'URL: "url"',
-             'Username: "url"',
+             'Username: "username"',
              'Setting "setting": "value"'
         ],
             data
@@ -5349,6 +5349,17 @@ class TestCollection(DatabaseTest):
         with_password = collection.explain(include_password=True)
         assert 'Password: "password"' in with_password
 
+        # If the collection is the child of another collection,
+        # its parent is mentioned.
+        child = Collection(
+            name="Child", parent=collection, external_account_id="id2"
+        )
+        data = child.explain()
+        eq_(['Name: "Child"',
+             'Parent: test collection',
+             'External account ID: "id2"'],
+            data
+        )
 
 class TestCatalog(DatabaseTest):
 

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -375,12 +375,9 @@ class TestOverdriveAdvantageAccount(OverdriveTest):
         raw, data = self.sample_json("advantage_accounts.json")
         [ac1, ac2] = OverdriveAdvantageAccount.from_representation(raw)
 
-        # The two Advantage accounts have the same parent library ID
-        # and the same type.
+        # The two Advantage accounts have the same parent library ID.
         eq_("1225", ac1.parent_library_id)
         eq_("1225", ac2.parent_library_id)
-        eq_("Library Advantage Account", ac1.type)
-        eq_("Library Advantage Account", ac2.type)
 
         # But they have different names and library IDs.
         eq_("3", ac1.library_id)
@@ -396,7 +393,6 @@ class TestOverdriveAdvantageAccount(OverdriveTest):
 
         account = OverdriveAdvantageAccount(
             "parent_id", "child_id", "Library Name",
-            "Library Advantage Account"
         )
 
         # We can't just create a Collection object for this object because

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -11,6 +11,7 @@ import pkgutil
 from overdrive import (
     OverdriveAPI,
     MockOverdriveAPI,
+    OverdriveAdvantageAccount,
     OverdriveRepresentationExtractor,
     OverdriveBibliographicCoverageProvider,
 )
@@ -331,6 +332,30 @@ class TestOverdriveRepresentationExtractor(OverdriveTest):
         ]
         eq_(1, awards.value)
         eq_(1, awards.weight)
+
+
+class TestOverdriveAdvantageAccount(OverdriveTest):
+
+    def test_from_representation(self):
+        """Test the creation of OverdriveAdvantageAccount objects
+        from Overdrive's representation of a list of accounts.
+        """
+        raw, data = self.sample_json("advantage_accounts.json")
+        [ac1, ac2] = OverdriveAdvantageAccount.from_representation(raw)
+
+        # The two Advantage accounts have the same parent library ID
+        # and the same type.
+        eq_("1225", ac1.parent_library_id)
+        eq_("1225", ac2.parent_library_id)
+        eq_("Library Advantage Account", ac1.type)
+        eq_("Library Advantage Account", ac2.type)
+
+        # But they have different names and library IDs.
+        eq_("3", ac1.library_id)
+        eq_("The Other Side of Town Library", ac1.name)
+
+        eq_("9", ac2.library_id)
+        eq_("The Common Community Library", ac2.name)
 
 
 class TestOverdriveBibliographicCoverageProvider(OverdriveTest):

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -140,8 +140,8 @@ class TestOverdriveAPI(OverdriveTest):
         self.api.queue_response(401)
 
         # We refresh the bearer token.
-        self.api.queue_response(
-            200, content=self.api.mock_access_token("new bearer token")
+        self.api.access_token_response = self.api.mock_access_token_response(
+            "new bearer token"
         )
 
         # Then we retry the GET but we get another 401.
@@ -156,7 +156,7 @@ class TestOverdriveAPI(OverdriveTest):
         """If we fail to refresh the OAuth bearer token, an exception is
         raised.
         """
-        self.api.bearer_token_response = MockRequestsResponse(401, {}, "")
+        self.api.access_token_response = MockRequestsResponse(401, {}, "")
 
         assert_raises_regexp(
             BadResponseException,

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -21,7 +21,6 @@ from coverage import (
 )
 
 from model import (
-    create,
     Collection,
     Contributor,
     DeliveryMechanism,


### PR DESCRIPTION
This branch makes it possible to represent an Overdrive Advantage account as a `Collection`. 

A library consortium may have an Overdrive account. The consortial collection is shared among all member libraries. On top of this, each member library may have an Overdrive Advantage account associated with the library consortium. Books in a library's OA account are only accessible to patrons of that library.

An OA account is associated with an Overdrive account, and uses that account's credentials to make requests. But it has its own ID which is used along with the library ID of the consortial Overdrive account.

Overdrive makes it easy for a library to see a combined collection that incorporates the consortial collection and the OA collection. In a world where each library has its own circulation manager, this is good enough. But under multi-tenancy, it's extremely inefficient--it means twenty or thirty `Collection`s on a single circulation manager that are almost entirely duplicates. It's more efficient to have one big `Collection` representing the consortial collection, and twenty or thirty tiny `Collection`s that only contain a few books.

This branch makes it possible for one `Collection` to have another `Collection` as its parent. In the Overdrive context, this means the child is an Overdrive Advantage account that uses the same credentials as its parent.

This branch also creates code that parses the list of Overdrive Advantage collections available for a given Overdrive account (documentation: https://developer.overdrive.com/docs/advantage-link), potentially turning those collections into `Collection` objects.