### PR TITLE
CustomListEntry links to Work, not LicensePool

### DIFF
--- a/external_list.py
+++ b/external_list.py
@@ -193,7 +193,7 @@ class TitleFromExternalList(object):
             
         list_entry.annotation = self.annotation
 
-        list_entry.set_license_pool(self.metadata, metadata_client)
+        list_entry.set_work(self.metadata, metadata_client)
         return list_entry, is_new
 
     def to_edition(self, _db, metadata_client, overwrite_old_data=False):

--- a/lane.py
+++ b/lane.py
@@ -1168,7 +1168,11 @@ class Lane(object):
             # add a DISTINCT clause.
             distinct = True
 
-            q = q.join(LicensePool.custom_list_entries)
+            if work_model == Work:
+                clause = CustomListEntry.work_id==work_model.id
+            else:
+                clause = CustomListEntry.work_id==work_model.works_id
+            q = q.join(CustomListEntry, clause)
             if self.list_data_source_id:
                 q = q.join(CustomListEntry.customlist).filter(
                     CustomList.data_source_id==self.list_data_source_id)

--- a/nyt.py
+++ b/nyt.py
@@ -206,8 +206,8 @@ class NYTBestSellerList(list):
         for i in self:
             list_item, was_new = i.to_custom_list_entry(
                 custom_list, self.metadata_client)
-            # If possible, associate the item with a LicensePool.
-            list_item.set_license_pool()
+            # If possible, associate the item with a Work.
+            list_item.set_work()
 
 
 class NYTBestSellerListTitle(TitleFromExternalList):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5028,7 +5028,7 @@ class TestCustomList(DatabaseTest):
         eq_(True, isinstance(workless_entry, CustomListEntry))
         eq_(workless_edition, workless_entry.edition)
         eq_(True, workless_entry.first_appearance > now)
-        eq_(None, workless_entry.license_pool)
+        eq_(None, workless_entry.work)
         # And the CustomList will be seen as updated.
         eq_(True, custom_list.updated > now)
 
@@ -5088,8 +5088,8 @@ class TestCustomList(DatabaseTest):
         eq_(previous_list_update_time, custom_list.updated)
         # But it will change the edition to the one that's requested.
         eq_(equivalent, workless_entry.edition)
-        # And/or add a license_pool if one is newly available.
-        eq_(lp, equivalent_entry.license_pool)
+        # And/or add a .work if one is newly available.
+        eq_(lp.work, equivalent_entry.work)
 
     def test_remove_entry(self):
         custom_list, editions = self._customlist(num_entries=2)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5156,7 +5156,7 @@ class TestCustomList(DatabaseTest):
 
 class TestCustomListEntry(DatabaseTest):
 
-    def test_set_license_pool(self):
+    def test_set_work(self):
 
         # Start with a custom list with no entries
         list, ignore = self._customlist(num_entries=0)
@@ -5170,20 +5170,32 @@ class TestCustomListEntry(DatabaseTest):
         )
 
         eq_(edition, entry.edition)
-        eq_(None, entry.license_pool)
+        eq_(None, entry.work)
 
         # Here's another edition, with a license pool.
         other_edition, lp = self._edition(with_open_access_download=True)
-
+       
         # And its identifier is equivalent to the entry's edition's identifier.
         data_source = DataSource.lookup(self._db, DataSource.OCLC)
         lp.identifier.equivalent_to(data_source, edition.primary_identifier, 1)
 
-        # If we call set_license_pool, it should find the license pool
-        # from the equivalent identifier.
-        entry.set_license_pool()
+        # If we call set_work, it does nothing, because there is no work
+        # associated with either edition.
+        entry.set_work()
 
-        eq_(lp, entry.license_pool)
+        # But if we assign a Work with the LicensePool, and try again...
+        work, ignore = lp.calculate_work()
+        entry.set_work()
+        eq_(work, other_edition.work)
+        
+        # set_work() traces the line from the CustomListEntry to its
+        # Edition to the equivalent Edition to its Work, and associates
+        # that Work with the CustomListEntry.
+        eq_(work, entry.work)
+
+        # Even though the CustomListEntry's edition is not directly
+        # associated with the Work.
+        eq_(None, edition.work)
 
     def test_update(self):
         custom_list, [edition] = self._customlist(entries_exist_as_works=False)
@@ -5235,7 +5247,7 @@ class TestCustomListEntry(DatabaseTest):
         eq_(u"Whoo, go books!", entry.annotation)
         # The Edition and LicensePool are updated to have a Work.
         eq_(entry.edition, work.presentation_edition)
-        eq_(entry.license_pool, equivalent.license_pool)
+        eq_(entry.work, equivalent.work)
         # The equivalent entry has been deleted.
         eq_([], self._db.query(CustomListEntry).\
                 filter(CustomListEntry.id==equivalent_entry.id).all())


### PR DESCRIPTION
This branch gets rid of the CustomListEntry.license_pool_id field and institutes CustomListEntry.work_id instead. When a Lane is built off of a CustomList, we join against the work ID instead of the license pool ID.

We don't want a book to show up in a Lane twice just because its Work has two LicensePools, but there's already a DISTINCT clause in the relevant part of Lane.apply_filters() (lane.py line 1169), to take care of the case where a book shows up twice because it's on multiple list. That should also take care of the case where a Work has multiple LicensePools.

Getting rid of this connection is a prerequisite for allowing multiple LicensePools for the same identifier (which is a prerequisite for supporting multiple collections that might offer the same book).

I've run the circulation tests and the content tests against this branch and didn't encounter any problems. I'm pretty sure those components only interact with CustomListEntries via Lanes.