### PR TITLE
Move open access download url to LicensePool

### DIFF
--- a/files/materialized_view_works.sql
+++ b/files/materialized_view_works.sql
@@ -12,7 +12,6 @@ as
     editions.language,
     editions.cover_full_url,
     editions.cover_thumbnail_url,
-    editions.open_access_download_url,
     editions.series,
     editions.series_position,
     datasources.name,
@@ -29,6 +28,7 @@ as
     works.simple_opds_entry,
     works.verbose_opds_entry,
     licensepools.id AS license_pool_id,
+    licensepools.open_access_download_url,
     licensepools.availability_time
 
    FROM works

--- a/files/materialized_view_works_workgenres.sql
+++ b/files/materialized_view_works_workgenres.sql
@@ -12,7 +12,6 @@ as
     editions.language,
     editions.cover_full_url,
     editions.cover_thumbnail_url,
-    editions.open_access_download_url,
     editions.series,
     editions.series_position,
     datasources.name,
@@ -32,6 +31,7 @@ as
     works.simple_opds_entry,
     works.verbose_opds_entry,
     licensepools.id AS license_pool_id,
+    licensepools.open_access_download_url,
     licensepools.availability_time
 
    FROM works

--- a/migration/20170303-1-recreate-materialize-views.sql
+++ b/migration/20170303-1-recreate-materialize-views.sql
@@ -1,0 +1,226 @@
+drop materialized view mv_works_editions_datasources_identifiers;
+create materialized view mv_works_editions_datasources_identifiers
+as
+ SELECT 
+    distinct works.id AS works_id,
+    editions.id AS editions_id,
+    editions.data_source_id,
+    editions.primary_identifier_id,
+    editions.sort_title,
+    editions.permanent_work_id,
+    editions.sort_author,
+    editions.medium,
+    editions.language,
+    editions.cover_full_url,
+    editions.cover_thumbnail_url,
+    editions.series,
+    editions.series_position,
+    datasources.name,
+    identifiers.type,
+    identifiers.identifier,
+    works.audience,
+    works.target_age,
+    works.fiction,
+    works.quality,
+    works.rating,
+    works.popularity,
+    works.random,
+    works.last_update_time,
+    works.simple_opds_entry,
+    works.verbose_opds_entry,
+    licensepools.id AS license_pool_id,
+    licensepools.open_access_download_url,
+    licensepools.availability_time
+
+   FROM works
+     JOIN editions ON editions.id = works.presentation_edition_id
+     JOIN licensepools ON editions.id = licensepools.presentation_edition_id
+     JOIN datasources ON licensepools.data_source_id = datasources.id
+     JOIN identifiers on editions.primary_identifier_id = identifiers.id
+  WHERE works.presentation_ready = true
+    AND works.simple_opds_entry IS NOT NULL
+  
+  ORDER BY editions.sort_title, editions.sort_author, licensepools.availability_time;
+
+-- Create a unique index so that searches can look up books by work ID.
+
+create unique index mv_works_editions_work_id on mv_works_editions_datasources_identifiers (works_id);
+
+-- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
+
+create index mv_works_editions_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id);
+
+-- Similarly, an index on everything, sorted by descending update time.
+
+create index mv_works_editions_by_modification on mv_works_editions_datasources_identifiers (last_update_time DESC, sort_author, sort_title, works_id);
+
+-- We need three versions of each index:
+--- One that orders by sort_author, sort_title, and works_id
+--- One that orders by sort_title, sort_author, and works_id
+--- One that orders by availability_time (descending!), sort_title, sort_author, and works_id
+
+-- English adult fiction
+
+create index mv_works_editions_english_adult_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_editions_english_adult_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_editions_english_adult_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+-- English adult nonfiction
+
+create index mv_works_editions_english_adult_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_editions_english_adult_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_editions_english_adult_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+-- Nonenglish adult fiction
+--- These are also ordered by language
+
+create index mv_works_editions_nonenglish_adult_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+-- Nonenglish adult nonfiction
+--- These are also ordered by language
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+-- YA/Children's fiction, regardless of language
+
+create index mv_works_editions_ya_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_editions_ya_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_editions_ya_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+-- YA/Children's nonfiction, regardless of language
+
+create index mv_works_editions_ya_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_editions_ya_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_editions_ya_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+
+
+drop materialized view mv_works_editions_workgenres_datasources_identifiers;
+create materialized view mv_works_editions_workgenres_datasources_identifiers
+as
+ SELECT 
+    works.id AS works_id,
+    editions.id AS editions_id,
+    editions.data_source_id,
+    editions.primary_identifier_id,
+    editions.sort_title,
+    editions.permanent_work_id,
+    editions.sort_author,
+    editions.medium,
+    editions.language,
+    editions.cover_full_url,
+    editions.cover_thumbnail_url,
+    editions.series,
+    editions.series_position,
+    datasources.name,
+    identifiers.type,
+    identifiers.identifier,
+    workgenres.id AS workgenres_id,
+    workgenres.genre_id,
+    workgenres.affinity,
+    works.audience,
+    works.target_age,
+    works.fiction,
+    works.quality,
+    works.rating,
+    works.popularity,
+    works.random,
+    works.last_update_time,
+    works.simple_opds_entry,
+    works.verbose_opds_entry,
+    licensepools.id AS license_pool_id,
+    licensepools.open_access_download_url,
+    licensepools.availability_time
+
+   FROM works
+     JOIN editions ON editions.id = works.presentation_edition_id
+     JOIN licensepools ON editions.id = licensepools.presentation_edition_id
+     JOIN datasources ON licensepools.data_source_id = datasources.id
+     JOIN identifiers on editions.primary_identifier_id = identifiers.id
+     JOIN workgenres ON works.id = workgenres.work_id
+  WHERE works.presentation_ready = true
+    AND works.simple_opds_entry IS NOT NULL
+
+  ORDER BY (editions.sort_title, editions.sort_author, licensepools.availability_time);
+
+-- Create a work/genre lookup.
+create unique index mv_works_genres_work_id_genre_id on mv_works_editions_workgenres_datasources_identifiers (works_id, genre_id);
+
+-- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
+
+create index mv_works_genres_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id);
+
+-- Similarly, an index on everything, sorted by descending update time.
+
+create index mv_works_genres_by_modification on mv_works_editions_workgenres_datasources_identifiers (last_update_time DESC, sort_author, sort_title, works_id);
+
+-- We need three versions of each index:
+--- One that orders by sort_author, sort_title, and works_id
+--- One that orders by sort_title, sort_author, and works_id
+--- One that orders by availability_time (descending!), sort_title, sort_author, and works_id
+
+-- English adult fiction
+
+create index mv_works_genres_english_adult_fiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_genres_english_adult_fiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_genres_english_adult_fiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+-- English adult nonfiction
+
+create index mv_works_genres_english_adult_nonfiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_genres_english_adult_nonfiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_genres_english_adult_nonfiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+-- Nonenglish adult fiction
+--- These are also ordered by language
+
+create index mv_works_genres_nonenglish_adult_fiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_fiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_fiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+-- Nonenglish adult nonfiction
+--- These are also ordered by language
+
+create index mv_works_genres_nonenglish_adult_nonfiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_nonfiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_genres_nonenglish_adult_nonfiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+-- YA/Children's fiction, regardless of language
+
+create index mv_works_genres_ya_fiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_genres_ya_fiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_genres_ya_fiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+-- YA/Children's nonfiction, regardless of language
+
+create index mv_works_genres_ya_nonfiction_by_author on mv_works_editions_workgenres_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_genres_ya_nonfiction_by_title on mv_works_editions_workgenres_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_genres_ya_nonfiction_by_availability on mv_works_editions_workgenres_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;

--- a/migration/20170303-move-open-access-download-url-to-licensepool.sql
+++ b/migration/20170303-move-open-access-download-url-to-licensepool.sql
@@ -1,0 +1,12 @@
+alter table licensepools add open_access_download_url character varying;
+update licensepools set open_access_download_url = subq.url from (
+       select e.id as eid, e.open_access_download_url as url
+       from editions e
+       join licensepools lp on lp.identifier_id=e.primary_identifier_id
+       where e.open_access_download_url is not null;
+)
+as subq where licensepools.presentation_edition_id=subq.eid;
+
+-- It doesn't hurt anything to keep editions.open_access_download_url
+-- around for a while, in case there's been a mistake.
+-- alter table editions drop open_access_download_url;

--- a/model.py
+++ b/model.py
@@ -6493,6 +6493,8 @@ class LicensePool(Base):
 
         open_access = Hyperlink.OPEN_ACCESS_DOWNLOAD
         _db = Session.object_session(self)
+        if not self.identifier:
+            return
         q = Identifier.resources_for_identifier_ids(
             _db, [self.identifier.id], open_access
         )

--- a/opds.py
+++ b/opds.py
@@ -291,9 +291,7 @@ class Annotator(object):
                 continue
             edition = p.presentation_edition
             if p.open_access:
-                # Make sure there's a usable link--it might be
-                # audio-only or something.
-                if edition and edition.open_access_download_url:
+                if p.best_open_access_link:
                     active_license_pool = p
                     # We have an unlimited source for this book.
                     # There's no need to keep looking.

--- a/testing.py
+++ b/testing.py
@@ -253,7 +253,6 @@ class DatabaseTest(object):
             pool = presentation_edition.license_pool
         if with_open_access_download:
             pool.open_access = True
-            presentation_edition.set_open_access_link()
         if new_edition:
             presentation_edition.calculate_presentation()
         work, ignore = get_one_or_create(

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -111,7 +111,7 @@ class TestCirculationData(DatabaseTest):
 
         [epub, pdf] = sorted(pool.delivery_mechanisms, 
                              key=lambda x: x.delivery_mechanism.content_type)
-        eq_(epub.resource, edition.license_pool.best_open_access_link)
+        eq_(epub.resource, edition.license_pool.best_open_access_resource)
 
         eq_(Representation.PDF_MEDIA_TYPE, pdf.delivery_mechanism.content_type)
         eq_(DeliveryMechanism.ADOBE_DRM, pdf.delivery_mechanism.drm_scheme)


### PR DESCRIPTION
`Edition.open_access_download_url` has been moved to `LicensePool.open_access_download_url`. This change is necessary for multi-tenancy because two libraries may use the same `Edition` to describe the metadata of a book they serve from different `LicensePools`. Nothing related to the `LicensePool` can go into the `Edition`.

This change feels better, anyway. The `open_access_download_url` field becomes a cache for the `LicensePool.best_open_access_link` method.

This changes the SQL used to create the materialized views, which means we need to drop them and recreate them. It's probably going to change again pretty soon, though.