### PR TITLE
Fixed problem that caused app to use test database

### DIFF
--- a/model.py
+++ b/model.py
@@ -8484,7 +8484,7 @@ class Library(Base):
     # consumption by the library registry.
     library_registry_shared_secret = Column(Unicode, unique=True)
 
-    def __repr__(cls):
+    def __repr__(self):
         return '<Library: name="%s", short name="%s", uuid="%s", library registry short name="%s">' % (
             self.name, self.short_name, self.uuid, self.library_registry_short_name
         )

--- a/test
+++ b/test
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# TESTING=true sets log level so there is less output during tests.
 # PYTHONWARNINGS=ignore suppresses SQLAlchemy and other warnings.
 # --nocapture lets you output to stdout, while the tests is still running (arguably more useful while debugging a single test, 
 # rather than running the whole batch).
@@ -7,5 +8,5 @@
 # Also check out: --failed  (Run the tests that failed in the last test run.)  
 # It's helpful when isolating the few tests you need to pay attention to after a full test suite run.
 
-PYTHONWARNINGS=ignore nosetests --nocapture -w tests
+TESTING=true PYTHONWARNINGS=ignore nosetests --nocapture -w tests
 

--- a/testing.py
+++ b/testing.py
@@ -10,7 +10,7 @@ import tempfile
 from nose.tools import set_trace
 from sqlalchemy.orm.session import Session
 from config import Configuration
-os.environ['TESTING'] = 'true'
+
 from model import (
     Base,
     Catalog,


### PR DESCRIPTION
A recent change to core introduced an import of testing.py during app initialization, and testing.py was setting os.environ['TESTING'] to true, which caused the app to use the test database. 

I tried removing the line that set os.environ['TESTING'], and it didn't seem to cause any problems with the tests, but log.py was checking to determine the log level. I moved the variable to get set in `./test`, but maybe there's a better place for it. It won't be set when running a single test with nose, for example. And it would also need to be added to `./test` in the apps.