### PR TITLE
Store collection configuration as UTF-8 strings instead of Unicode

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -212,8 +212,8 @@ class MockAxis360API(Axis360API):
             _db, Collection,
             name="Test Axis 360 Collection",
             protocol=Collection.AXIS_360, create_method_kwargs=dict(
-                username='a', password='b', external_account_id='c',
-                url="http://axis.test/"
+                username=u'a', password=u'b', external_account_id=u'c',
+                url=u"http://axis.test/"
             )
         )
         library.collections.append(collection)

--- a/axis.py
+++ b/axis.py
@@ -72,9 +72,9 @@ class Axis360API(object):
 
         self._db = _db
 
-        self.library_id = collection.external_account_id
-        self.username = collection.username
-        self.password = collection.password
+        self.library_id = collection.external_account_id.encode("utf8")
+        self.username = collection.username.encode("utf8")
+        self.password = collection.password.encode("utf8")
 
         # Convert the nickname for a server into an actual URL.
         base_url = collection.url or self.PRODUCTION_BASE_URL

--- a/overdrive.py
+++ b/overdrive.py
@@ -125,9 +125,9 @@ class OverdriveAPI(object):
         else:
             self.parent_library_id = None
             
-        self.client_key = collection.username
-        self.client_secret = collection.password
-        self.website_id = collection.setting('website_id').value
+        self.client_key = collection.username.encode("utf8")
+        self.client_secret = collection.password.encode("utf8")
+        self.website_id = collection.setting('website_id').value.encode("utf8")
 
         if (not self.client_key or not self.client_secret or not self.website_id
             or not self.library_id):

--- a/overdrive.py
+++ b/overdrive.py
@@ -418,7 +418,7 @@ class MockOverdriveAPI(OverdriveAPI):
                 _db, Collection,
                 name="Test Overdrive Collection",
                 protocol=Collection.OVERDRIVE, create_method_kwargs=dict(
-                    username='a', password='b', external_account_id='c'
+                    username=u'a', password=u'b', external_account_id=u'c'
                 )
             )
             collection.set_setting('website_id', 'd')

--- a/threem.py
+++ b/threem.py
@@ -223,7 +223,7 @@ class MockThreeMAPI(ThreeMAPI):
             _db, Collection,
             name="Test Bibliotheca Collection",
             protocol=Collection.BIBLIOTHECA, create_method_kwargs=dict(
-                username='a', password='b', external_account_id='c',
+                username=u'a', password=u'b', external_account_id=u'c',
                 url="http://bibliotheca.test"
             )
         )

--- a/threem.py
+++ b/threem.py
@@ -77,9 +77,9 @@ class ThreeMAPI(object):
         self.version = (
             collection.setting('version').value or self.DEFAULT_VERSION
         )
-        self.account_id = collection.username
-        self.account_key = collection.password
-        self.library_id = collection.external_account_id
+        self.account_id = collection.username.encode("utf8")
+        self.account_key = collection.password.encode("utf8")
+        self.library_id = collection.external_account_id.encode("utf8")
         self.base_url = collection.url or self.DEFAULT_BASE_URL
         
         if not self.account_id or not self.account_key or not self.library_id:


### PR DESCRIPTION
When collection information came from a JSON file, I had code that converted it all from Unicode to UTF-8. When I changed that information to come from the database, I took out the conversion code because it didn't seem to make a difference. It doesn't make a difference in the unit tests, which initialize mock APIs with bytestrings, but it does make a difference in real life, when you try to digitally sign a request using a Unicode string as the key.

This branch restores the UTF-8 encoding code and changes the mock APIs to set up configuration with Unicode strings to make sure the problem doesn't recur.