### PR TITLE
Switch OneClickAPI over to the Collection-based system.

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -121,7 +121,7 @@ class Axis360API(object):
     def authorization_headers(self):
         authorization = u":".join([self.username, self.password, self.library_id])
         authorization = authorization.encode("utf_16_le")
-        authorization = base64.b64encode(authorization)
+        authorization = base64.standard_b64encode(authorization)
         return dict(Authorization="Basic " + authorization)
 
     def refresh_bearer_token(self):

--- a/axis.py
+++ b/axis.py
@@ -108,10 +108,7 @@ class Axis360API(object):
             )
         [collection] = collections 
 
-        try:
-            return cls(_db, collection)
-        except CannotLoadConfiguration, e:
-            return None
+        return cls(_db, collection)
         
     @property
     def source(self):

--- a/external_search.py
+++ b/external_search.py
@@ -32,6 +32,8 @@ class ExternalSearchIndex(object):
     def __init__(self, url=None, works_index=None):
     
         self.log = logging.getLogger("External search index")
+        self.works_index = None
+        self.works_alias = None
 
         if not ExternalSearchIndex.__client:
             if not url or not works_index:
@@ -59,7 +61,6 @@ class ExternalSearchIndex(object):
             ExternalSearchIndex.__client = Elasticsearch(
                 url, use_ssl=use_ssl, timeout=20, maxsize=25
             )
-
         self.indices = self.__client.indices
         self.search = self.__client.search
         self.index = self.__client.index
@@ -69,8 +70,6 @@ class ExternalSearchIndex(object):
         # Sets self.works_index and self.works_alias values.
         # Document upload runs against the works_index.
         # Search queries run against works_alias.
-        self.works_index = None
-        self.works_alias = None
         self.set_works_index_and_alias(works_index)
 
         def bulk(docs, **kwargs):

--- a/model.py
+++ b/model.py
@@ -4033,7 +4033,6 @@ class Work(Base):
 
     def update_external_index(self, client, add_coverage_record=True):
         client = client or ExternalSearchIndex()
-
         args = dict(index=client.works_index,
                     doc_type=client.work_document_type,
                     id=self.id)

--- a/oneclick.py
+++ b/oneclick.py
@@ -81,7 +81,6 @@ class OneClickAPI(object):
             )
         
         self.library_id = collection.external_account_id.encode("utf8")
-        self.username = collection.username.encode("utf8")
         self.token = collection.password.encode("utf8")
 
         # Convert the nickname for a server into an actual URL.
@@ -537,7 +536,7 @@ class MockOneClickAPI(OneClickAPI):
                 _db, Collection,
                 name="Test OneClick Collection",
                 protocol=Collection.ONE_CLICK, create_method_kwargs=dict(
-                    username=u'username_123', password=u'abcdef123hijklm',
+                    password=u'abcdef123hijklm',
                     external_account_id=u'library_id_123',
                 )
             )

--- a/oneclick.py
+++ b/oneclick.py
@@ -125,10 +125,7 @@ class OneClickAPI(object):
             )
         [collection] = collections 
 
-        try:
-            return cls(_db, collection)
-        except CannotLoadConfiguration, e:
-            return None
+        return cls(_db, collection)
 
     @property
     def source(self):

--- a/oneclick.py
+++ b/oneclick.py
@@ -16,12 +16,15 @@ from config import (
 from coverage import BibliographicCoverageProvider, CoverageFailure
 
 from model import (
+    Collection,
     Contributor,
+    get_one_or_create,
     DataSource,
     DeliveryMechanism,
     Edition,
     Hyperlink,
     Identifier,
+    Library,
     Representation,
     Subject,
     Work,
@@ -52,28 +55,44 @@ from util.http import (
 class OneClickAPI(object):
 
     API_VERSION = "v1"
+    PRODUCTION_BASE_URL = "https://api.oneclickdigital.com/"
+    QA_BASE_URL = "https://api.oneclickdigital.us/"
+    
+    # Map simple nicknames to server URLs.
+    SERVER_NICKNAMES = {
+        "production" : PRODUCTION_BASE_URL,
+        "qa" : QA_BASE_URL,
+    }
+
     DATE_FORMAT = "%Y-%m-%d" #ex: 2013-12-27
 
     # a complete response returns the json structure with more data fields than a basic response does
     RESPONSE_VERBOSITY = {0:'basic', 1:'compact', 2:'complete', 3:'extended', 4:'hypermedia'}
-
+   
     log = logging.getLogger("OneClick API")
 
-    def __init__(self, _db, library_id=None, username=None, password=None, 
-        remote_stage=None, base_url=None, basic_token=None, 
-        ebook_loan_length=None, eaudio_loan_length=None):
+    def __init__(self, _db, collection):
         self._db = _db
-            
-        self.library_id = library_id
-        self.username = username
-        self.password = password
-        self.remote_stage = remote_stage
-        self.base_url = base_url or ''
-        self.base_url = self.base_url + self.API_VERSION
-        self.token = basic_token
+
+        if collection.protocol != collection.ONE_CLICK:
+            raise ValueError(
+                "Collection protocol is %s, but passed into OneClickAPI!" %
+                collection.protocol
+            )
+        
+        self.library_id = collection.external_account_id.encode("utf8")
+        self.username = collection.username.encode("utf8")
+        self.token = collection.password.encode("utf8")
+
+        # Convert the nickname for a server into an actual URL.
+        base_url = collection.url or self.PRODUCTION_BASE_URL
+        if base_url in self.SERVER_NICKNAMES:
+            base_url = self.SERVER_NICKNAMES[base_url]
+        self.base_url = (base_url + self.API_VERSION).encode("utf8")
+
         # expiration defaults are OneClick-general
-        self.ebook_loan_length = ebook_loan_length
-        self.eaudio_loan_length = eaudio_loan_length
+        self.ebook_loan_length = collection.setting('ebook_loan_length').value or '21'
+        self.eaudio_loan_length = collection.setting('eaudio_loan_length').value or '21'
 
 
     @classmethod
@@ -91,38 +110,26 @@ class OneClickAPI(object):
 
     @classmethod
     def from_config(cls, _db):
-        config = Configuration.integration(Configuration.ONECLICK_INTEGRATION, required=True)
-        property_names = [
-            'library_id',
-            'username',
-            'password',
-            'remote_stage', 
-            'url', 
-            'basic_token', 
-            'ebook_loan_length', 
-            'eaudio_loan_length'
-        ]
-        property_values = {}
-        for name in property_names:
-            value = config.get(name)
-            if value:
-                value = value.encode("utf8")
-            property_values[name] = value
+        """Load a OneClickAPI instance for the 'default' OneClick
+        collection.
+        """
+        library = Library.instance(_db)
+        collections = [x for x in library.collections
+                       if x.protocol == Collection.ONE_CLICK]
+        if len(collections) == 0:
+            # There are no OneClick collections configured.
+            return None
 
-        if len(property_values.values()) == 0:
-            cls.log.info("No OneClick client configured.")
-            raise ValueError("No OneClick client configured.")
+        if len(collections) > 1:
+            raise ValueError(
+                "Multiple OneClick collections found for one library. This is not yet supported."
+            )
+        [collection] = collections 
 
-
-        api = cls(_db, library_id=property_values['library_id'], 
-            username=property_values['username'], password=property_values['password'], 
-            remote_stage=property_values['remote_stage'], base_url=property_values['url'], 
-            basic_token=property_values['basic_token'], 
-            ebook_loan_length=property_values['ebook_loan_length'], 
-            eaudio_loan_length=property_values['eaudio_loan_length'])
-
-        return api
-
+        try:
+            return cls(_db, collection)
+        except CannotLoadConfiguration, e:
+            return None
 
     @property
     def source(self):
@@ -521,34 +528,25 @@ class OneClickAPI(object):
 
 class MockOneClickAPI(OneClickAPI):
 
-    def __init__(self, _db, with_token=True, base_path=None, *args, **kwargs):
-        with temp_config() as config:
-            config[Configuration.INTEGRATIONS]['OneClick'] = {
-                'library_id' : 'library_id_123',
-                'username' : 'username_123',
-                'password' : 'password_123',
-                'remote_stage' : 'qa', 
-                'base_url' : 'www.oneclickapi.test', 
-                'basic_token' : 'abcdef123hijklm', 
-                "ebook_loan_length" : '21', 
-                "eaudio_loan_length" : '21'
-            }
-            super(MockOneClickAPI, self).__init__(_db, 
-                library_id='library_id_123', 
-                username='username_123', password='password_123', 
-                remote_stage='qa', base_url='www.oneclickapi.test', 
-                basic_token='abcdef123hijklm', 
-                ebook_loan_length='21', 
-                eaudio_loan_length='21')
-
-        if with_token:
-            self.token = "mock token"
+    def __init__(self, _db, collection=None, base_path=None):
+        if not collection:
+            # OneClickAPI needs a Collection, but none was provided.
+            # Just create a basic one.
+            library = Library.instance(_db)
+            collection, ignore = get_one_or_create(
+                _db, Collection,
+                name="Test OneClick Collection",
+                protocol=Collection.ONE_CLICK, create_method_kwargs=dict(
+                    username=u'username_123', password=u'abcdef123hijklm',
+                    external_account_id=u'library_id_123',
+                )
+            )
 
         self.responses = []
         self.requests = []
         base_path = base_path or os.path.split(__file__)[0]
         self.resource_path = os.path.join(base_path, "files", "oneclick")
-
+        return super(MockOneClickAPI, self).__init__(_db, collection)
 
     def queue_response(self, status_code, headers={}, content=None):
         from testing import MockRequestsResponse

--- a/overdrive.py
+++ b/overdrive.py
@@ -8,7 +8,6 @@ import logging
 import urlparse
 import urllib
 import sys
-
 from config import (
     temp_config, 
     Configuration,
@@ -407,6 +406,7 @@ class OverdriveAPI(object):
 class MockOverdriveAPI(OverdriveAPI):
 
     def __init__(self, _db, collection=None, *args, **kwargs):
+        self.access_token_requests = []
         self.requests = []
         self.responses = []
 
@@ -444,6 +444,7 @@ class MockOverdriveAPI(OverdriveAPI):
         to this method separately we remove the need to figure out
         whether to queue a response in a given test.
         """
+        self.access_token_requests.append((url, payload, headers, kwargs))
         response = self.access_token_response
         return HTTP._process_response(url, response, **kwargs)
 

--- a/overdrive.py
+++ b/overdrive.py
@@ -156,10 +156,7 @@ class OverdriveAPI(object):
             )
         [collection] = collections 
 
-        try:
-            return cls(_db, collection)
-        except CannotLoadConfiguration, e:
-            return None
+        return cls(_db, collection)
 
     @property
     def source(self):

--- a/overdrive.py
+++ b/overdrive.py
@@ -220,7 +220,7 @@ class OverdriveAPI(object):
     def token_post(self, url, payload, headers={}, **kwargs):
         """Make an HTTP POST request for purposes of getting an OAuth token."""
         s = "%s:%s" % (self.client_key, self.client_secret)
-        auth = base64.encodestring(s).strip()
+        auth = base64.standard_b64encode(s).strip()
         headers = dict(headers)
         headers['Authorization'] = "Basic %s" % auth
         return self._do_post(url, payload, headers, **kwargs)

--- a/threem.py
+++ b/threem.py
@@ -107,10 +107,7 @@ class ThreeMAPI(object):
             )
         [collection] = collections
 
-        try:
-            return cls(_db, collection)
-        except CannotLoadConfiguration, e:
-            return None
+        return cls(_db, collection)
 
     @property
     def source(self):

--- a/threem.py
+++ b/threem.py
@@ -138,7 +138,7 @@ class ThreeMAPI(object):
         signature_string = "\n".join(signature_components)
         digest = hmac.new(self.account_key, msg=signature_string,
                     digestmod=hashlib.sha256).digest()
-        signature = base64.b64encode(digest)
+        signature = base64.standard_b64encode(digest)
         return signature, now
 
     def full_url(self, path):

--- a/util/http.py
+++ b/util/http.py
@@ -27,7 +27,8 @@ class RemoteIntegrationException(Exception):
            (e.g. "Overdrive"), or the specific URL that had the problem.
         """
         super(RemoteIntegrationException, self).__init__(message)
-        if any(url_or_service.startswith(x) for x in ('http:', 'https:')):
+        if (url_or_service and
+            any(url_or_service.startswith(x) for x in ('http:', 'https:'))):
             self.url = url_or_service
             self.service = urlparse.urlparse(url_or_service).netloc
         else:


### PR DESCRIPTION
This branch corrects an earlier oversight, where I converted the API classes for other content sources over to the Collection-based system, but I didn't touch the OneClickAPI.

Some of the items found in the JSON OneClickAPI configuration are being removed in the conversion. I don't think we actually use them and I'm changing the way we treat them to reflect what I think actually happens within OneClickAPI. For example, the Collection.password field contains the Basic Auth token we get from OneCliek, not the 'password' we are given by OneClick, because  we use the Basic Auth token to authenticate requests (the purpose of a password) and we don't use the 'password' for anything.

There are also some other changes in here to support https://github.com/NYPL-Simplified/circulation/pull/473/files