### PR TITLE
Support cataloguing collections

### DIFF
--- a/migration/20170321-remove-catalogs.sql
+++ b/migration/20170321-remove-catalogs.sql
@@ -1,1 +1,2 @@
+DROP TABLE catalogsidentifiers CASCADE;
 DROP TABLE catalogs CASCADE;

--- a/migration/20170321-remove-catalogs.sql
+++ b/migration/20170321-remove-catalogs.sql
@@ -1,0 +1,1 @@
+DROP TABLE catalogs CASCADE;

--- a/model.py
+++ b/model.py
@@ -8789,7 +8789,7 @@ collections_licensepools = Table(
 )
 
 collections_identifiers = Table(
-    'collectionsidentifiers', Base.metadata,
+    'collections_identifiers', Base.metadata,
     Column(
         'collection_id', Integer, ForeignKey('collections.id'),
         index=True, nullable=False

--- a/model.py
+++ b/model.py
@@ -8724,145 +8724,92 @@ collections_licensepools = Table(
      UniqueConstraint('collection_id', 'licensepool_id'),
  )
 
-    
-class Catalog(Base):
 
-    """A Catalog is like a Collection, but it doesn't hold any actual
-    LicensePools, it just records Identifiers.
 
-    The Collections associated with a Library in its circulation
-    manager will show up as Catalogs associated with the corresponding
-    Library in the metadata wrangler.
+class ClientServer(Base):
+    """A server that has authenticated access to this application.
+
+    Currently used to represent circulation managers that have access
+    to the metadata wrangler.
     """
-
-    __tablename__ = 'catalogs'
+    __tablename__ = 'servers'
 
     id = Column(Integer, primary_key=True)
-    name = Column(Unicode, unique=True, nullable=False)
-    client_id = Column(Unicode, unique=True, index=True)
-    _client_secret = Column(Unicode, nullable=False)
 
-    # A catalog can have one DataSource
-    data_source_id = Column(
-        Integer, ForeignKey('datasources.id'), index=True
-    )
+    # URL or human readable name to represent the server.
+    name = Column(Unicode)
 
-    # A catalog can include many Identifiers
-    catalog = relationship(
-        "Identifier", secondary=lambda: catalogs_identifiers,
-        backref="catalogs"
-    )
+    # Unique identifier
+    key = Column(Unicode, unique=True, index=True)
 
+    # Encrypted secret
+    _secret = Column(Unicode, nullable=False)
+
+    created = Column(DateTime)
+    last_accessed = Column(DateTime)
 
     def __repr__(self):
-        return "%s ID=%s DATASOURCE_ID=%d" % (
-            self.name, self.id, self.data_source.id
-        )
+        return (u"%s ID=%s" % (self.name, self.id)).encode('utf8')
 
     @hybrid_property
-    def client_secret(self):
-        """Gets encrypted client_secret from database"""
-        return self._client_secret
+    def secret(self):
+        """Gets encrypted client secret from database"""
+        return self._secret
 
-    @client_secret.setter
-    def _set_client_secret(self, plaintext_secret):
+    @secret.setter
+    def _set_secret(self, plaintext_secret):
         """Encrypts client secret string for database"""
-        self._client_secret = unicode(bcrypt.hashpw(
+        self._secret = unicode(bcrypt.hashpw(
             plaintext_secret, bcrypt.gensalt()
         ))
 
     def _correct_secret(self, plaintext_secret):
-        """Determines if a plaintext string is the client_secret"""
-        return (bcrypt.hashpw(plaintext_secret, self.client_secret)
-                == self.client_secret)
+        """Determines if a plaintext string is this client's secret"""
+        return (bcrypt.hashpw(plaintext_secret, self.secret) == self.secret)
 
     @classmethod
     def register(cls, _db, name):
-        """Creates a new catalog with client details and a datasource."""
-
+        """Creates a new server with client details."""
         name = unicode(name)
-        catalog = get_one(_db, cls, name=name)
-        if catalog:
-            raise ValueError(
-                "A catalog with the name '%s' already exists: %r" % (
-                name, catalog)
-            )
 
-        catalog_data_source, ignore = get_one_or_create(
-            _db, DataSource, name=name, offers_licenses=False
-        )
+        key, plaintext_secret = cls._generate_client_details()
+        while get_one(_db, cls, key=key):
+            # Generate a new key if it's not unique initially.
+            key, plaintext_secret = cls._generate_client_details()
 
-        client_id, plaintext_client_secret = cls._generate_client_details()
-        # Generate a new client_id if it's not unique initially.
-        while get_one(_db, cls, client_id=client_id):
-            client_id, plaintext_client_secret = cls._generate_client_details()
-
-        catalog, ignore = get_one_or_create(
-            _db, cls, name=name, client_id=unicode(client_id),
-            client_secret=unicode(plaintext_client_secret),
-            data_source=catalog_data_source
+        now = datetime.datetime.utcnow()
+        server, ignore = create(
+            _db, cls, name=name, key=unicode(key),
+            secret=unicode(plaintext_secret), created=now, last_accessed=now
         )
 
         _db.commit()
-        return catalog, plaintext_client_secret
+        return server, plaintext_secret
 
     @classmethod
     def _generate_client_details(cls):
-        client_id_chars = ('abcdefghijklmnopqrstuvwxyz'
+        key_chars = ('abcdefghijklmnopqrstuvwxyz'
                            'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
                            '0123456789')
-        client_secret_chars = client_id_chars + '!#$%&*+,-._'
+        secret_chars = key_chars + '!#$%&*+,-._'
 
         def make_client_string(chars, length):
             return u"".join([random.choice(chars) for x in range(length)])
-        client_id = make_client_string(client_id_chars, 25)
-        client_secret = make_client_string(client_secret_chars, 40)
+        key = make_client_string(key_chars, 25)
+        secret = make_client_string(secret_chars, 40)
 
-        return client_id, client_secret
+        return key, secret
 
     @classmethod
-    def authenticate(cls, _db, client_id, plaintext_client_secret):
-        catalog = get_one(_db, cls, client_id=unicode(client_id))
-        if (catalog and
-            catalog._correct_secret(plaintext_client_secret)):
-            return catalog
+    def authenticate(cls, _db, key, plaintext_secret):
+        server = get_one(_db, cls, key=unicode(key))
+        if (server and
+            server._correct_secret(plaintext_secret)):
+            server.last_accessed = datetime.datetime.utcnow()
+            _db.flush()
+            return server
         return None
 
-    def catalog_identifier(self, _db, identifier):
-        """Inserts an identifier into a catalog"""
-        if identifier not in self.catalog:
-            self.catalog.append(identifier)
-            _db.commit()
-
-    def works_updated_since(self, _db, timestamp):
-        """Returns all of a catalog's works that have been updated since the
-        last time the catalog was checked"""
-
-        query = _db.query(Work).join(Work.coverage_records)
-        query = query.join(Work.license_pools).join(Identifier)
-        query = query.join(Identifier.catalogs).filter(
-            Catalog.id==self.id
-        )
-        if timestamp:
-            query = query.filter(
-                WorkCoverageRecord.timestamp > timestamp
-            )
-
-        return query
-
-
-catalogs_identifiers = Table(
-    'catalogsidentifiers', Base.metadata,
-    Column(
-        'catalog_id', Integer, ForeignKey('catalogs.id'),
-        index=True, nullable=False
-    ),
-    Column(
-        'identifier_id', Integer, ForeignKey('identifiers.id'),
-        index=True, nullable=False
-    ),
-    UniqueConstraint('catalog_id', 'identifier_id'),
-)
 
 from sqlalchemy.sql import compiler
 from psycopg2.extensions import adapt as sqlescape

--- a/model.py
+++ b/model.py
@@ -8861,7 +8861,7 @@ class ClientServer(Base):
     @classmethod
     def register(cls, _db, url):
         """Creates a new server with client details."""
-        url = unicode(url)
+        url = cls.normalize_url(url)
         if get_one(_db, cls, url=url):
             raise ValueError(
                 "A ClientServer for '%s' already exists" % url
@@ -8878,7 +8878,7 @@ class ClientServer(Base):
             secret=unicode(plaintext_secret), created=now, last_accessed=now
         )
 
-        _db.commit()
+        _db.flush()
         return server, plaintext_secret
 
     @classmethod
@@ -8894,6 +8894,14 @@ class ClientServer(Base):
         secret = make_client_string(secret_chars, 40)
 
         return key, secret
+
+    @classmethod
+    def normalize_url(cls, url):
+        url = re.sub(r'^(http://|https://)', '', url)
+        url = re.sub(r'^www\.', '', url)
+        if url.endswith('/'):
+            url = url[:-1]
+        return unicode(url.lower())
 
     @classmethod
     def authenticate(cls, _db, key, plaintext_secret):

--- a/model.py
+++ b/model.py
@@ -8741,7 +8741,7 @@ class Collection(Base):
         """Inserts an identifier into a catalog"""
         if identifier not in self.catalog:
             self.catalog.append(identifier)
-            _db.commit()
+            _db.flush()
 
     def works_updated_since(self, _db, timestamp):
         """Returns all of a collection's works that have been updated

--- a/model.py
+++ b/model.py
@@ -8820,13 +8820,13 @@ collections_identifiers = Table(
 )
 
 
-class ClientServer(Base):
-    """A server that has authenticated access to this application.
+class IntegrationClient(Base):
+    """A client that has authenticated access to this application.
 
     Currently used to represent circulation managers that have access
     to the metadata wrangler.
     """
-    __tablename__ = 'servers'
+    __tablename__ = 'integrationclients'
 
     id = Column(Integer, primary_key=True)
 
@@ -8843,7 +8843,7 @@ class ClientServer(Base):
     last_accessed = Column(DateTime)
 
     def __repr__(self):
-        return (u"<ClientServer: URL=%s ID=%s>" % (self.url, self.id)).encode('utf8')
+        return (u"<IntegrationClient: URL=%s ID=%s>" % (self.url, self.id)).encode('utf8')
 
     @hybrid_property
     def secret(self):
@@ -8867,7 +8867,7 @@ class ClientServer(Base):
         url = cls.normalize_url(url)
         if get_one(_db, cls, url=url):
             raise ValueError(
-                "A ClientServer for '%s' already exists" % url
+                "An IntegrationClient for '%s' already exists" % url
             )
 
         key, plaintext_secret = cls._generate_client_details()

--- a/model.py
+++ b/model.py
@@ -8669,8 +8669,23 @@ class Collection(Base):
             )
 
         metadata_identifier = unicode(self.protocol + ':' + account_id)
-
         return base64.b64encode(metadata_identifier, '-_')
+
+    @classmethod
+    def from_metadata_identifier(cls, _db, metadata_identifier):
+        """Finds or creates a Collection on the metadata wrangler, based
+        on its unique metadata_identifier
+        """
+        collection = get_one(_db, Collection, name=metadata_identifier)
+        is_new = False
+
+        if not collection:
+            details = base64.b64decode(metadata_identifier, '-_')
+            protocol = details.split(':', 1)[0]
+            collection, is_new = create(_db, Collection,
+                name=metadata_identifier, protocol=protocol)
+
+        return collection, is_new
 
     def set_setting(self, key, value):
         """Create or update a key-value setting for this Collection."""

--- a/model.py
+++ b/model.py
@@ -8813,7 +8813,7 @@ class ClientServer(Base):
     id = Column(Integer, primary_key=True)
 
     # URL or human readable name to represent the server.
-    name = Column(Unicode)
+    name = Column(Unicode, unique=True)
 
     # Unique identifier
     key = Column(Unicode, unique=True, index=True)
@@ -8847,6 +8847,10 @@ class ClientServer(Base):
     def register(cls, _db, name):
         """Creates a new server with client details."""
         name = unicode(name)
+        if get_one(_db, cls, name=name):
+            raise ValueError(
+                "A ClientServer for '%s' already exists" % name
+            )
 
         key, plaintext_secret = cls._generate_client_details()
         while get_one(_db, cls, key=key):
@@ -8865,8 +8869,8 @@ class ClientServer(Base):
     @classmethod
     def _generate_client_details(cls):
         key_chars = ('abcdefghijklmnopqrstuvwxyz'
-                           'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-                           '0123456789')
+                     'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                     '0123456789')
         secret_chars = key_chars + '!#$%&*+,-._'
 
         def make_client_string(chars, length):

--- a/model.py
+++ b/model.py
@@ -8612,17 +8612,20 @@ class Collection(Base):
     # A dict capturing the column location of the unique collection
     # account identifier in the collections table.
     UNIQUE_IDENTIFIER_BY_PROTOCOL = {
-        # Overdrive 'client_key'
-        OVERDRIVE : username,
+        # Axis 360 'username'
+        AXIS_360 : username,
 
         # Bibliotheca 'account_id'
         BIBLIOTHECA : username,
 
-        # Axis 360 'username'
-        AXIS_360 : username,
-
         # OPDS_IMPORT 'url'
         OPDS_IMPORT : url,
+
+        # One Click 'basic_token'
+        ONE_CLICK : password,
+
+        # Overdrive 'client_key'
+        OVERDRIVE : username,
     }
 
     # A collection may have many child collections. For example,
@@ -8654,7 +8657,7 @@ class Collection(Base):
     def metadata_identifier(self):
         """Identifier based on collection details that uniquely represents
         this Collection on the metadata wrangler. This identifier is
-        composed of its protocol and its account identifier.
+        composed of the Collection protocol and account identifier.
 
         In the metadata wrangler, this identifier is used as the unique
         name of the collection.

--- a/model.py
+++ b/model.py
@@ -8612,20 +8612,20 @@ class Collection(Base):
     # A dict capturing the column location of the unique collection
     # account identifier in the collections table.
     UNIQUE_IDENTIFIER_BY_PROTOCOL = {
-        # Axis 360 'username'
-        AXIS_360 : username,
+        # Axis 360 'library_id'
+        AXIS_360 : external_account_id,
 
-        # Bibliotheca 'account_id'
-        BIBLIOTHECA : username,
+        # Bibliotheca 'library_id'
+        BIBLIOTHECA : external_account_id,
 
         # OPDS_IMPORT 'url'
         OPDS_IMPORT : url,
 
-        # One Click 'basic_token'
-        ONE_CLICK : password,
+        # One Click 'library_id'
+        ONE_CLICK : external_account_id,
 
-        # Overdrive 'client_key'
-        OVERDRIVE : username,
+        # Overdrive 'library_id'
+        OVERDRIVE : external_account_id,
     }
 
     # A collection may have many child collections. For example,

--- a/testing.py
+++ b/testing.py
@@ -650,11 +650,11 @@ class DatabaseTest(object):
         collection.password = password
         return collection
         
-    def _server(self, name=None):
-        name = name or self._url
+    def _server(self, url=None):
+        url = url or self._url
         return get_one_or_create(
             self._db, ClientServer,
-            name=name, key=u"abc", secret=u"def"
+            url=url, key=u"abc", secret=u"def"
         )[0]
 
     def _subject(self, type, identifier):

--- a/testing.py
+++ b/testing.py
@@ -14,7 +14,7 @@ from config import Configuration
 from model import (
     Base,
     Classification,
-    ClientServer,
+    IntegrationClient,
     Collection,
     Complaint,
     Contributor,
@@ -650,10 +650,10 @@ class DatabaseTest(object):
         collection.password = password
         return collection
         
-    def _server(self, url=None):
+    def _integration_client(self, url=None):
         url = url or self._url
         return get_one_or_create(
-            self._db, ClientServer,
+            self._db, IntegrationClient,
             url=url, key=u"abc", secret=u"def"
         )[0]
 

--- a/testing.py
+++ b/testing.py
@@ -13,8 +13,8 @@ from config import Configuration
 
 from model import (
     Base,
-    Catalog,
     Classification,
+    ClientServer,
     Collection,
     Complaint,
     Contributor,
@@ -650,11 +650,11 @@ class DatabaseTest(object):
         collection.password = password
         return collection
         
-    def _catalog(self, name=u"Faketown Public Library"):
-        source, ignore = get_one_or_create(self._db, DataSource, name=name)
+    def _server(self, name=None):
+        name = name or self._url
         return get_one_or_create(
-            self._db, Catalog, name=name, data_source=source,
-            client_id=u"abc", client_secret=u"def"
+            self._db, ClientServer,
+            name=name, key=u"abc", secret=u"def"
         )[0]
 
     def _subject(self, type, identifier):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -39,6 +39,7 @@ from model import (
     Catalog,
     CirculationEvent,
     Classification,
+    ClientServer,
     Collection,
     Complaint,
     Contributor,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5418,6 +5418,43 @@ class TestCollection(DatabaseTest):
         eq_([w1], self.collection.works_updated_since(self._db, timestamp).all())
 
 
+class TestCollectionForMetadataWrangler(DatabaseTest):
+
+    """Tests that requirements to the metadata wrangler's use of Collection
+    are being met by continued development on the Collection class.
+
+    If any of these tests are failing, development will be required on the
+    metadata wrangler to meet the needs of the new Collection class.
+    """
+
+    def test_all_protocols_have_unique_identifier_defined(self):
+        """Test that all acceptable Collection protocols have a unique
+        identifier defined in the Collection class.
+
+        The unique identifier must be properly set to identify the
+        collection on the metadata wrangler.
+        """
+        eq_(
+            sorted(Collection.PROTOCOLS),
+            sorted(Collection.UNIQUE_IDENTIFIER_BY_PROTOCOL)
+        )
+
+    def test_no_protocols_contain_colon(self):
+        """Test that no protocol names contain a ':', which would break
+        the metadata_identifier decoding process.
+        """
+        eq_([], filter(lambda p: ':' in p, Collection.PROTOCOLS))
+
+    def test_only_name_and_protocol_are_required(self):
+        """Test that only name and protocol are required fields on
+        the Collection class.
+        """
+        collection = create(
+            self._db, Collection, name='banana', protocol=Collection.OVERDRIVE
+        )[0]
+        eq_(True, isinstance(collection, Collection))
+
+
 class TestClientServer(DatabaseTest):
 
     def setup(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5458,6 +5458,26 @@ class TestClientServer(DatabaseTest):
         result = ClientServer.authenticate(self._db, u"bad_id", u"def")
         eq_(None, result)
 
+    def test_normalize_url(self):
+        # http/https protocol is removed.
+        url = 'https://fake.com'
+        eq_('fake.com', ClientServer.normalize_url(url))
+
+        url = 'http://really-fake.com'
+        eq_('really-fake.com', ClientServer.normalize_url(url))
+
+        # www is removed if it exists, along with any trailing /
+        url = 'https://www.also-fake.net/'
+        eq_('also-fake.net', ClientServer.normalize_url(url))
+
+        # Subdomains and paths are retained.
+        url = 'https://www.super.fake.org/wow/'
+        eq_('super.fake.org/wow', ClientServer.normalize_url(url))
+
+        # URL is lowercased.
+        url = 'http://OMG.soVeryFake.gov'
+        eq_('omg.soveryfake.gov', ClientServer.normalize_url(url))
+
 
 class TestMaterializedViews(DatabaseTest):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5324,10 +5324,9 @@ class TestCollection(DatabaseTest):
 
     def setup(self):
         super(TestCollection, self).setup()
-        self.collection = get_one_or_create(
-            self._db, Collection, name="test collection",
+        self.collection = self._collection(name="test collection",
             protocol=Collection.OVERDRIVE
-        )[0]
+        )
 
     def test_set_key_value_pair(self):
         """Test the ability to associate extra key-value pairs with
@@ -5427,7 +5426,7 @@ class TestClientServer(DatabaseTest):
 
     def test_encrypts_secret(self):
         server, new = create(
-            self._db, ClientServer, name=u"http://circ-manager.net",
+            self._db, ClientServer, url=u"http://circ-manager.net",
             key=u"test", secret=u"megatest"
         )
         assert server.secret != u"megatest"
@@ -5445,8 +5444,8 @@ class TestClientServer(DatabaseTest):
         eq_(True, isinstance(server.created, datetime.datetime))
         eq_(server.created, server.last_accessed)
 
-        # It raises an error if the name is already taken.
-        assert_raises(ValueError, ClientServer.register, self._db, server.name)
+        # It raises an error if the url is already registered.
+        assert_raises(ValueError, ClientServer.register, self._db, server.url)
 
     def test_authenticate(self):
 


### PR DESCRIPTION
This branch gets rid of the separate concept of the `Catalog` and uses `Collection` to hold its own Catalog on the metadata wrangler. It also creates a `ClientServer` class for authenticated server-to-server interactions. A couple additional areas for feedback:

- I don't want to hold the unique identifier (`Collection` username, password, url, etc.) all willy-nilly in the database, so on the metadata wangler a collection will have its "metadata_identifier" as its name. Thoughts?
- Identifying a ClientServer by its `url` -- any changes to that url will need to be handled in the admin interface by hitting an endpoint in the metadata wrangler, as will registering the server in the first place

This supports an upcoming metadata wrangler branch in fending off NYPL-Simplified/circulation#467.