### PR TITLE
Added a database table for storing admin authentication service config.

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -73,11 +73,11 @@ class Axis360API(object):
         self._db = _db
 
         self.library_id = collection.external_account_id.encode("utf8")
-        self.username = collection.username.encode("utf8")
-        self.password = collection.password.encode("utf8")
+        self.username = collection.external_integration.username.encode("utf8")
+        self.password = collection.external_integration.password.encode("utf8")
 
         # Convert the nickname for a server into an actual URL.
-        base_url = collection.url or self.PRODUCTION_BASE_URL
+        base_url = collection.external_integration.url or self.PRODUCTION_BASE_URL
         if base_url in self.SERVER_NICKNAMES:
             base_url = self.SERVER_NICKNAMES[base_url]
         self.base_url = base_url
@@ -209,10 +209,12 @@ class MockAxis360API(Axis360API):
             _db, Collection,
             name="Test Axis 360 Collection",
             protocol=Collection.AXIS_360, create_method_kwargs=dict(
-                username=u'a', password=u'b', external_account_id=u'c',
-                url=u"http://axis.test/"
+                external_account_id=u'c',
             )
         )
+        collection.external_integration.username = u'a'
+        collection.external_integration.password = u'b'
+        collection.external_integration.url = u"http://axis.test/"
         library.collections.append(collection)
         super(MockAxis360API, self).__init__(_db, collection, *args, **kwargs)
         if with_token:

--- a/migration/20170328-move-collection-info-to-external-integration.sql
+++ b/migration/20170328-move-collection-info-to-external-integration.sql
@@ -1,0 +1,61 @@
+-- For OPDS Import collections, move the url to external_account_id.
+UPDATE collections SET external_account_id = url WHERE protocol = 'OPDS Import';
+UPDATE collections SET url = NULL WHERE protocol = 'OPDS Import';
+
+
+-- Create the external integrations table, with a temporary column for the collection id.
+CREATE TABLE externalintegrations (
+  id SERIAL NOT NULL PRIMARY KEY,
+  url varchar,
+  username varchar,
+  password varchar,
+  collection_id integer
+);
+
+
+-- Create the column for the external_integration_id.
+ALTER TABLE collections ADD COLUMN external_integration_id integer REFERENCES externalintegrations(id);
+
+
+-- Create an external integration for each collection.
+WITH insert_query AS (
+  INSERT INTO externalintegrations (url, username, password, collection_id)
+  SELECT c.url, c.username, c.password, c.id
+  FROM collections c
+  RETURNING *
+  )
+UPDATE collections c
+SET external_integration_id = insert_query.id
+FROM insert_query
+WHERE c.id = insert_query.collection_id;
+
+
+-- Remove the temporary column.
+ALTER TABLE externalintegrations DROP COLUMN collection_id;
+
+
+-- Remove the collection columns that have been moved.
+ALTER TABLE collections DROP COLUMN url;
+ALTER TABLE collections DROP COLUMN username;
+ALTER TABLE collections DROP COLUMN password;
+
+
+-- Create the external integration settings table.
+CREATE TABLE externalintegrationsettings (
+  id SERIAL NOT NULL PRIMARY KEY,
+  external_integration_id integer REFERENCES externalintegrations(id),
+  key varchar,
+  value varchar,
+  UNIQUE (external_integration_id, key)
+);
+
+
+-- Move everything from the collection settings table to the external integration settings table.
+INSERT INTO externalintegrationsettings (external_integration_id, key, value)
+SELECT c.external_integration_id, cs.key, cs.value
+FROM collectionsettings cs
+JOIN collections c ON c.id = cs.collection_id;
+
+
+-- Drop the collection settings table.
+DROP TABLE collectionsettings;

--- a/model.py
+++ b/model.py
@@ -8642,15 +8642,10 @@ class AdminAuthenticationService(Base):
     @property
     def external_integration(self):
         _db = Session.object_session(self)
-        if self.external_integration_id:
-            external_integration = get_one(
-                _db, ExternalIntegration, id=self.external_integration_id,
-            )
-        else:
-            external_integration, ignore = create(
-              _db, ExternalIntegration
-            )
-            self.external_integration_id = external_integration.id
+        external_integration, ignore = get_one_or_create(
+            _db, ExternalIntegration, id=self.external_integration_id,
+        )
+        self.external_integration_id = external_integration.id
         return external_integration
 
 
@@ -8723,15 +8718,10 @@ class Collection(Base):
     @property
     def external_integration(self):
         _db = Session.object_session(self)
-        if self.external_integration_id:
-            external_integration = get_one(
-                _db, ExternalIntegration, id=self.external_integration_id,
-            )
-        else:
-            external_integration, ignore = create(
-              _db, ExternalIntegration
-            )
-            self.external_integration_id = external_integration.id
+        external_integration, ignore = get_one_or_create(
+            _db, ExternalIntegration, id=self.external_integration_id,
+        )
+        self.external_integration_id = external_integration.id
         return external_integration
 
     @property

--- a/model.py
+++ b/model.py
@@ -8557,12 +8557,73 @@ class Admin(Base):
         _db.commit()
 
 
-class AuthenticationService(object):
-    """An AuthenticationService contains configuration for a third-party
-    service that can authenticate people. There will be a subclass of
-    AuthenticationService for each type of person that needs to be
-    authenticated.
+class ExternalIntegration(Base):
+
+    """An external integration contains configuration for connecting
+    to a third-party API.
     """
+
+    __tablename__ = 'externalintegrations'
+    id = Column(Integer, primary_key=True)
+
+    # If there is a special URL to use for access to this API,
+    # put it here. This is most common for OPDS and ODL integrations.
+    url = Column(Unicode, nullable=True)
+
+    # If access requires authentication, these fields represent the
+    # username/password or key/secret combination necessary to
+    # authenticate. If there's a secret but no key, it's stored in
+    # 'password'.
+    username = Column(Unicode, nullable=True)
+    password = Column(Unicode, nullable=True)
+
+    # Any additional configuration information goes into the
+    # externalintegrationsettings table.
+    settings = relationship(
+        "ExternalIntegrationSetting", backref="external_integration"
+    )
+
+    def set_setting(self, key, value):
+        """Create or update a key-value setting for this ExternalIntegration."""
+        setting = self.setting(key)
+        setting.value = value
+        return setting
+    
+    def setting(self, key):
+        """Find or create a ExternalIntegrationSetting on this ExternalIntegration.
+
+        :param key: Name of the setting.
+        :return: A ExternalIntegrationSetting
+        """
+        _db = Session.object_session(self)
+        setting, is_new = get_one_or_create(
+            _db, ExternalIntegrationSetting, external_integration=self, key=key
+        )
+        return setting
+
+class ExternalIntegrationSetting(Base):
+    """An extra piece of information associated with an ExternalIntegration.
+
+    e.g. the "website ID" associated with an Overdrive collection, or the
+    JSON credentials for Google OAuth.
+    """
+    __tablename__ = 'externalintegrationsettings'
+    id = Column(Integer, primary_key=True)
+    external_integration_id = Column(Integer, ForeignKey('externalintegrations.id'), index=True)
+    key = Column(Unicode, index=True)
+    value = Column(Unicode)
+
+    __table_args__ = (
+        UniqueConstraint('external_integration_id', 'key'),
+    )
+
+
+class AdminAuthenticationService(Base):
+    """An AdminAuthenticationService contains configuration for a third-party
+    service that can authenticate admins.
+    """
+
+    __tablename__ = "adminauthenticationservices"
 
     id = Column(Integer, primary_key=True)
 
@@ -8575,16 +8636,22 @@ class AuthenticationService(object):
 
     PROVIDERS = [GOOGLE_OAUTH]
 
-    # Additional provider-specific settings are stored as
-    # stringified JSON in the 'settings' field
-    settings = Column(Unicode)
+    external_integration_id = Column(
+        Integer, ForeignKey('externalintegrations.id'), index=True)
 
-class AdminAuthenticationService(Base, AuthenticationService):
-    """An AdminAuthenticationService contains configuration for a third-party
-    service that can authenticate admins.
-    """
-
-    __tablename__ = "adminauthenticationservices"
+    @property
+    def external_integration(self):
+        _db = Session.object_session(self)
+        if self.external_integration_id:
+            external_integration = get_one(
+                _db, ExternalIntegration, id=self.external_integration_id,
+            )
+        else:
+            external_integration, ignore = create(
+              _db, ExternalIntegration
+            )
+            self.external_integration_id = external_integration.id
+        return external_integration
 
 
 class Collection(Base):
@@ -8615,22 +8682,11 @@ class Collection(Base):
     # called a "library ID".
     external_account_id = Column(Unicode, nullable=True)
 
-    # If there is a special URL to use for access to this collection,
-    # put it here. This is most common for OPDS and ODL integrations.
-    url = Column(Unicode, nullable=True)
-
-    # If access requires authentication, these fields represent the
-    # username/password or key/secret combination necessary to
-    # authenticate. If there's a secret but no key, it's stored in
-    # 'password'.
-    username = Column(Unicode, nullable=True)
-    password = Column(Unicode, nullable=True)
-
-    # Any additional configuration information goes into the
-    # collectionsettings table.
-    settings = relationship(
-        "CollectionSetting", backref="collection"
-    )
+    # How do we connect to the provider of this collection? Any
+    # url, authentication information, or additional configuration
+    # goes into the external integration.
+    external_integration_id = Column(
+        Integer, ForeignKey('externalintegrations.id'), index=True)
 
     # A Collection may specialize some other Collection. For instance,
     # an Overdrive Advantage collection is a specialization of an
@@ -8638,25 +8694,6 @@ class Collection(Base):
     # secret as the Overdrive collection, but it has a distinct
     # external_account_id.
     parent_id = Column(Integer, ForeignKey('collections.id'), index=True)
-
-    # A dict capturing the column location of the unique collection
-    # account identifier in the collections table.
-    UNIQUE_IDENTIFIER_BY_PROTOCOL = {
-        # Axis 360 'library_id'
-        AXIS_360 : external_account_id,
-
-        # Bibliotheca 'library_id'
-        BIBLIOTHECA : external_account_id,
-
-        # OPDS_IMPORT 'url'
-        OPDS_IMPORT : url,
-
-        # One Click 'library_id'
-        ONE_CLICK : external_account_id,
-
-        # Overdrive 'library_id'
-        OVERDRIVE : external_account_id,
-    }
 
     # A collection may have many child collections. For example,
     # An Overdrive collection may have many children corresponding
@@ -8684,10 +8721,23 @@ class Collection(Base):
     )
 
     @property
+    def external_integration(self):
+        _db = Session.object_session(self)
+        if self.external_integration_id:
+            external_integration = get_one(
+                _db, ExternalIntegration, id=self.external_integration_id,
+            )
+        else:
+            external_integration, ignore = create(
+              _db, ExternalIntegration
+            )
+            self.external_integration_id = external_integration.id
+        return external_integration
+
+    @property
     def unique_account_id(self):
         """Identifier that uniquely represents this Collection of works"""
-        account_id_column = self.UNIQUE_IDENTIFIER_BY_PROTOCOL.get(self.protocol)
-        unique_account_id = getattr(self, account_id_column.name)
+        unique_account_id = self.external_account_id
 
         if not unique_account_id:
             raise ValueError("Unique account identifier not set")
@@ -8727,24 +8777,6 @@ class Collection(Base):
 
         return collection, is_new
 
-    def set_setting(self, key, value):
-        """Create or update a key-value setting for this Collection."""
-        setting = self.setting(key)
-        setting.value = value
-        return setting
-    
-    def setting(self, key):
-        """Find or create a CollectionSetting on this Collection.
-
-        :param key: Name of the setting.
-        :return: A CollectionSetting
-        """
-        _db = Session.object_session(self)
-        setting, is_new = get_one_or_create(
-            _db, CollectionSetting, collection=self, key=key
-        )
-        return setting
-
     def explain(self, include_password=False):
         """Create a series of human-readable strings to explain a collection's
         settings.
@@ -8767,13 +8799,14 @@ class Collection(Base):
             ))
         if self.external_account_id:
             lines.append('External account ID: "%s"' % self.external_account_id)
-        if self.url:
-            lines.append('URL: "%s"' % self.url)
-        if self.username:
-            lines.append('Username: "%s"' % self.username)
-        if self.password and include_password:
-            lines.append('Password: "%s"' % self.password)
-        for setting in self.settings:
+        integration = self.external_integration
+        if integration.url:
+            lines.append('URL: "%s"' % integration.url)
+        if integration.username:
+            lines.append('Username: "%s"' % integration.username)
+        if integration.password and include_password:
+            lines.append('Password: "%s"' % integration.password)
+        for setting in integration.settings:
             lines.append('Setting "%s": "%s"' % (setting.key, setting.value))
         return lines
 
@@ -8798,23 +8831,6 @@ class Collection(Base):
             )
 
         return query
-
-
-class CollectionSetting(Base):
-    """An extra piece of information associated with a Collection.
-
-    e.g. the "website ID" associated with an Overdrive collection, which
-    does not map onto any of the attributes of Collection.
-    """
-    __tablename__ = 'collectionsettings'
-    id = Column(Integer, primary_key=True)
-    collection_id = Column(Integer, ForeignKey('collections.id'), index=True)
-    key = Column(Unicode, index=True)
-    value = Column(Unicode)
-
-    __table_args__ = (
-        UniqueConstraint('collection_id', 'key'),
-    )
 
 
 collections_libraries = Table(

--- a/model.py
+++ b/model.py
@@ -8557,6 +8557,36 @@ class Admin(Base):
         _db.commit()
 
 
+class AuthenticationService(object):
+    """An AuthenticationService contains configuration for a third-party
+    service that can authenticate people. There will be a subclass of
+    AuthenticationService for each type of person that needs to be
+    authenticated.
+    """
+
+    id = Column(Integer, primary_key=True)
+
+    name = Column(Unicode, unique=True, nullable=False, index=True)
+
+    provider = Column(Unicode, nullable=False, index=True)
+
+    # Supported values for the 'provider' field
+    GOOGLE_OAUTH = 'Google OAuth'
+
+    PROVIDERS = [GOOGLE_OAUTH]
+
+    # Additional provider-specific settings are stored as
+    # stringified JSON in the 'settings' field
+    settings = Column(Unicode)
+
+class AdminAuthenticationService(Base, AuthenticationService):
+    """An AdminAuthenticationService contains configuration for a third-party
+    service that can authenticate admins.
+    """
+
+    __tablename__ = "adminauthenticationservices"
+
+
 class Collection(Base):
 
     """A Collection is a set of LicensePools obtained through some mechanism.

--- a/model.py
+++ b/model.py
@@ -8567,7 +8567,7 @@ class ExternalIntegration(Base):
     id = Column(Integer, primary_key=True)
 
     # If there is a special URL to use for access to this API,
-    # put it here. This is most common for OPDS and ODL integrations.
+    # put it here.
     url = Column(Unicode, nullable=True)
 
     # If access requires authentication, these fields represent the

--- a/oneclick.py
+++ b/oneclick.py
@@ -81,17 +81,17 @@ class OneClickAPI(object):
             )
         
         self.library_id = collection.external_account_id.encode("utf8")
-        self.token = collection.password.encode("utf8")
+        self.token = collection.external_integration.password.encode("utf8")
 
         # Convert the nickname for a server into an actual URL.
-        base_url = collection.url or self.PRODUCTION_BASE_URL
+        base_url = collection.external_integration.url or self.PRODUCTION_BASE_URL
         if base_url in self.SERVER_NICKNAMES:
             base_url = self.SERVER_NICKNAMES[base_url]
         self.base_url = (base_url + self.API_VERSION).encode("utf8")
 
         # expiration defaults are OneClick-general
-        self.ebook_loan_length = collection.setting('ebook_loan_length').value or '21'
-        self.eaudio_loan_length = collection.setting('eaudio_loan_length').value or '21'
+        self.ebook_loan_length = collection.external_integration.setting('ebook_loan_length').value or '21'
+        self.eaudio_loan_length = collection.external_integration.setting('eaudio_loan_length').value or '21'
 
 
     @classmethod
@@ -533,10 +533,10 @@ class MockOneClickAPI(OneClickAPI):
                 _db, Collection,
                 name="Test OneClick Collection",
                 protocol=Collection.ONE_CLICK, create_method_kwargs=dict(
-                    password=u'abcdef123hijklm',
                     external_account_id=u'library_id_123',
                 )
             )
+            collection.external_integration.password = u'abcdef123hijklm'
 
         self.responses = []
         self.requests = []

--- a/overdrive.py
+++ b/overdrive.py
@@ -124,9 +124,9 @@ class OverdriveAPI(object):
         else:
             self.parent_library_id = None
             
-        self.client_key = collection.username.encode("utf8")
-        self.client_secret = collection.password.encode("utf8")
-        self.website_id = collection.setting('website_id').value.encode("utf8")
+        self.client_key = collection.external_integration.username.encode("utf8")
+        self.client_secret = collection.external_integration.password.encode("utf8")
+        self.website_id = collection.external_integration.setting('website_id').value.encode("utf8")
 
         if (not self.client_key or not self.client_secret or not self.website_id
             or not self.library_id):
@@ -415,10 +415,12 @@ class MockOverdriveAPI(OverdriveAPI):
                 _db, Collection,
                 name="Test Overdrive Collection",
                 protocol=Collection.OVERDRIVE, create_method_kwargs=dict(
-                    username=u'a', password=u'b', external_account_id=u'c'
+                    external_account_id=u'c'
                 )
             )
-            collection.set_setting('website_id', 'd')
+            collection.external_integration.username = u'a'
+            collection.external_integration.password = u'b'
+            collection.external_integration.set_setting('website_id', 'd')
             library.collections.append(collection)
         
         # The constructor will always make a request for the collection token.

--- a/scripts.py
+++ b/scripts.py
@@ -796,12 +796,14 @@ class ConfigureCollectionScript(Script):
             collection.protocol = protocol
         if args.external_account_id:
             collection.external_account_id = args.external_account_id
+
+        integration = collection.external_integration
         if args.url:
-            collection.url = args.url
+            integration.url = args.url
         if args.username:
-            collection.username = args.username
+            integration.username = args.username
         if args.password:
-            collection.password = args.password
+            integration.password = args.password
         if args.setting:
             for setting in args.setting:
                 if not '=' in setting:
@@ -810,7 +812,8 @@ class ConfigureCollectionScript(Script):
                         % setting
                     )
                 key, value = setting.split('=', 1)
-                collection.setting(key).value = value
+                integration.setting(key).value = value
+
         if hasattr(args, 'library'):
             for name in args.library:
                 library = get_one(_db, Library, short_name=name)

--- a/testing.py
+++ b/testing.py
@@ -645,9 +645,9 @@ class DatabaseTest(object):
             self._db, Collection, name=name, protocol=protocol
         )
         collection.external_account_id = external_account_id
-        collection.url = url
-        collection.username = username
-        collection.password = password
+        collection.external_integration.url = url
+        collection.external_integration.username = username
+        collection.external_integration.password = password
         return collection
         
     def _integration_client(self, url=None):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -50,6 +50,7 @@ from model import (
     DelegatedPatronIdentifier,
     DeliveryMechanism,
     DRMDeviceIdentifier,
+    ExternalIntegration,
     Genre,
     Hold,
     Hyperlink,
@@ -5321,6 +5322,30 @@ class TestLibrary(DatabaseTest):
         assert 'Shared secret (for library registry): "secret"' in with_secret
 
 
+class TestExternalIntegration(DatabaseTest):
+
+    def setup(self):
+        super(TestExternalIntegration, self).setup()
+        self.external_integration, ignore = create(self._db, ExternalIntegration)
+
+    def test_set_key_value_pair(self):
+        """Test the ability to associate extra key-value pairs with
+        an ExternalIntegration.
+        """
+        eq_([], self.external_integration.settings)
+
+        setting = self.external_integration.set_setting("website_id", "id1")
+        eq_("website_id", setting.key)
+        eq_("id1", setting.value)
+
+        # Calling set() again updates the key-value pair.
+        eq_([setting], self.external_integration.settings)
+        setting2 = self.external_integration.set_setting("website_id", "id2")
+        eq_(setting, setting2)
+        eq_("id2", setting2.value)
+
+        eq_(setting2, self.external_integration.setting("website_id"))
+
 class TestCollection(DatabaseTest):
 
     def setup(self):
@@ -5329,37 +5354,19 @@ class TestCollection(DatabaseTest):
             name="test collection", protocol=Collection.OVERDRIVE
         )
 
-    def test_set_key_value_pair(self):
-        """Test the ability to associate extra key-value pairs with
-        a Collection.
-        """
-        eq_([], self.collection.settings)
-
-        setting = self.collection.set_setting("website_id", "id1")
-        eq_("website_id", setting.key)
-        eq_("id1", setting.value)
-
-        # Calling set() again updates the key-value pair.
-        eq_([setting], self.collection.settings)
-        setting2 = self.collection.set_setting("website_id", "id2")
-        eq_(setting, setting2)
-        eq_("id2", setting2.value)
-
-        eq_(setting2, self.collection.setting("website_id"))
-
     def test_explain(self):
         """Test that Collection.explain gives all relevant information
-        about a Library.
+        about a Collection.
         """
         library = Library.instance(self._db)
         library.name = "The only library"
         library.collections.append(self.collection)
         
         self.collection.external_account_id = "id"
-        self.collection.url = "url"
-        self.collection.username = "username"
-        self.collection.password = "password"
-        setting = self.collection.set_setting("setting", "value")
+        self.collection.external_integration.url = "url"
+        self.collection.external_integration.username = "username"
+        self.collection.external_integration.password = "password"
+        setting = self.collection.external_integration.set_setting("setting", "value")
 
         data = self.collection.explain()
         eq_(['Name: "test collection"',
@@ -5379,11 +5386,12 @@ class TestCollection(DatabaseTest):
         # If the collection is the child of another collection,
         # its parent is mentioned.
         child = Collection(
-            name="Child", parent=self.collection, external_account_id="id2"
+            name="Child", parent=self.collection, protocol=self.collection.protocol, external_account_id="id2"
         )
         data = child.explain()
         eq_(['Name: "Child"',
              'Parent: test collection',
+             'Protocol: "Overdrive"',
              'External account ID: "id2"'],
             data
         )
@@ -5405,9 +5413,9 @@ class TestCollection(DatabaseTest):
 
         # If there's a parent, its unique id is incorporated into the result.
         child = self._collection(
-            name="Child", protocol=Collection.OPDS_IMPORT, url=self._url)
+            name="Child", protocol=Collection.OPDS_IMPORT, external_account_id=self._url)
         child.parent = self.collection
-        expected = build_expected(Collection.OPDS_IMPORT, 'id+%s' % child.url)
+        expected = build_expected(Collection.OPDS_IMPORT, 'id+%s' % child.external_account_id)
         eq_(expected, child.metadata_identifier)
 
     def test_from_metadata_identifier(self):
@@ -5421,7 +5429,7 @@ class TestCollection(DatabaseTest):
         eq_(self.collection.protocol, mirror_collection.protocol)
 
         # If the mirrored collection already exists, it is returned.
-        collection = self._collection(url=self._url)
+        collection = self._collection(external_account_id=self._url)
         mirror_collection = create(
             self._db, Collection,
             name=collection.metadata_identifier,
@@ -5473,18 +5481,6 @@ class TestCollectionForMetadataWrangler(DatabaseTest):
     If any of these tests are failing, development will be required on the
     metadata wrangler to meet the needs of the new Collection class.
     """
-
-    def test_all_protocols_have_unique_identifier_defined(self):
-        """Test that all acceptable Collection protocols have a unique
-        identifier defined in the Collection class.
-
-        The unique identifier must be properly set to identify the
-        collection on the metadata wrangler.
-        """
-        eq_(
-            sorted(Collection.PROTOCOLS),
-            sorted(Collection.UNIQUE_IDENTIFIER_BY_PROTOCOL)
-        )
 
     def test_only_name_and_protocol_are_required(self):
         """Test that only name and protocol are required fields on

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -171,9 +171,10 @@ class TestOverdriveAPI(OverdriveTest):
         # Here's an Overdrive collection.
         main = self._collection(
             protocol=Collection.OVERDRIVE, external_account_id="1",
-            username="user", password="password"
         )
-        main.setting('website_id').value = '100'
+        main.external_integration.username = "user"
+        main.external_integration.password = "password"
+        main.external_integration.setting('website_id').value = '100'
 
         # Here's an Overdrive API client for that collection.
         overdrive_main = MockOverdriveAPI(self._db, main)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1101,10 +1101,10 @@ class TestConfigureCollectionScript(DatabaseTest):
         # The collection was created and configured properly.
         collection = get_one(self._db, Collection)
         eq_("New Collection", collection.name)
-        eq_("url", collection.url)
+        eq_("url", collection.external_integration.url)
         eq_("acctid", collection.external_account_id)
-        eq_("username", collection.username)
-        eq_("password", collection.password)
+        eq_("username", collection.external_integration.username)
+        eq_("password", collection.external_integration.password)
 
         # Two libraries now have access to the collection.
         eq_([collection], l1.collections)
@@ -1112,7 +1112,7 @@ class TestConfigureCollectionScript(DatabaseTest):
         eq_([], l3.collections)
 
         # One CollectionSetting was set on the collection.
-        [setting] = collection.settings
+        [setting] = collection.external_integration.settings
         eq_("library_id", setting.key)
         eq_("1234", setting.value)
 
@@ -1141,7 +1141,7 @@ class TestConfigureCollectionScript(DatabaseTest):
         )
 
         # The collection has been changed.
-        eq_("foo", collection.url)
+        eq_("foo", collection.external_integration.url)
         eq_(Collection.BIBLIOTHECA, collection.protocol)
         
         expect = ("Configuration settings stored.\n"

--- a/threem.py
+++ b/threem.py
@@ -75,12 +75,12 @@ class ThreeMAPI(object):
 
         self._db = _db
         self.version = (
-            collection.setting('version').value or self.DEFAULT_VERSION
+            collection.external_integration.setting('version').value or self.DEFAULT_VERSION
         )
-        self.account_id = collection.username.encode("utf8")
-        self.account_key = collection.password.encode("utf8")
+        self.account_id = collection.external_integration.username.encode("utf8")
+        self.account_key = collection.external_integration.password.encode("utf8")
         self.library_id = collection.external_account_id.encode("utf8")
-        self.base_url = collection.url or self.DEFAULT_BASE_URL
+        self.base_url = collection.external_integration.url or self.DEFAULT_BASE_URL
         
         if not self.account_id or not self.account_key or not self.library_id:
             raise CannotLoadConfiguration(
@@ -220,10 +220,12 @@ class MockThreeMAPI(ThreeMAPI):
             _db, Collection,
             name="Test Bibliotheca Collection",
             protocol=Collection.BIBLIOTHECA, create_method_kwargs=dict(
-                username=u'a', password=u'b', external_account_id=u'c',
-                url="http://bibliotheca.test"
+                external_account_id=u'c',
             )
         )
+        collection.external_integration.username = u'a'
+        collection.external_integration.password = u'b'
+        collection.external_integration.url = "http://bibliotheca.test"
         library.collections.append(collection)
         super(MockThreeMAPI, self).__init__(
             _db, collection, *args, **kwargs


### PR DESCRIPTION
This is a proposal for storing AuthenticationService configuration in the database. 

I'm not sure what if anything should be shared between admin authentication and patron authentication. For the apps we have now, admin and patrons use different auth providers. But for example, we could authenticate patrons with Google OAuth if someone wanted that, and in that case the auth configuration could be the same except the allowed domains.

Here I did something in the middle and created a db table specifically for admin auth config, but made a base class so it will have the same columns as the patron auth config table.

I'd like some feedback on this before I get too much farther with the admin interface changes.