### PR TITLE
Remove Hyperlink.license_pool

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -873,7 +873,7 @@ class CirculationData(MetaToModelUtility):
             if link.rel in Hyperlink.CIRCULATION_ALLOWED:
                 link_obj, ignore = identifier.add_link(
                     rel=link.rel, href=link.href, data_source=data_source, 
-                    license_pool=pool, media_type=link.media_type,
+                    media_type=link.media_type,
                     content=link.content
                 )
                 link_objects[link] = link_obj
@@ -1452,7 +1452,7 @@ class Metadata(MetaToModelUtility):
             if link.rel in Hyperlink.METADATA_ALLOWED:
                 link_obj, ignore = identifier.add_link(
                     rel=link.rel, href=link.href, data_source=data_source, 
-                    license_pool=None, media_type=link.media_type,
+                    media_type=link.media_type,
                     content=link.content
                 )
             link_objects[link] = link_obj
@@ -1547,7 +1547,7 @@ class Metadata(MetaToModelUtility):
         thumbnail_obj, ignore = link_obj.identifier.add_link(
             rel=thumbnail.rel, href=thumbnail.href, 
             data_source=data_source, 
-            license_pool=pool, media_type=thumbnail.media_type,
+            media_type=thumbnail.media_type,
             content=thumbnail.content
         )
         # And make sure the thumbnail knows it's a thumbnail of the main

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1498,11 +1498,6 @@ class Metadata(MetaToModelUtility):
             if pool:
                 self.circulation.apply(pool, replace)
 
-            # we updated the pool.  but do the associated links know?
-            for link in self.links:
-                link_obj = link_objects[link]
-                link_obj.license_pool = pool
-
         # obtains a presentation_edition for the title, which will later be used to get a mirror link.
         for link in self.links:
             link_obj = link_objects[link]

--- a/migration/20170402-drop-hyperlink-license-pool-id.sql
+++ b/migration/20170402-drop-hyperlink-license-pool-id.sql
@@ -1,0 +1,5 @@
+-- Remove the connection between Hyperlink and LicensePool, which
+-- was never used and is now in the way.
+DROP INDEX ix_hyperlinks_license_pool_id;
+ALTER TABLE hyperlinks DROP CONSTRAINT hyperlinks_license_pool_id_fkey;
+ALTER TABLE hyperlinks DROP COLUMN license_pool_id;

--- a/model.py
+++ b/model.py
@@ -1641,8 +1641,8 @@ class Identifier(Base):
         return Identifier.recursively_equivalent_identifier_ids(
             _db, [self.id], levels, threshold)
 
-    def add_link(self, rel, href, data_source, license_pool=None,
-                 media_type=None, content=None, content_path=None):
+    def add_link(self, rel, href, data_source, media_type=None, content=None,
+                 content_path=None):
         """Create a link between this Identifier and a (potentially new)
         Resource.
 
@@ -1651,11 +1651,6 @@ class Identifier(Base):
         created. It might be good to move that code into here.
         """
         _db = Session.object_session(self)
-
-        if license_pool and license_pool.identifier != self:
-            raise ValueError(
-                "License pool is associated with %r, not %r!" % (
-                    license_pool.identifier, self))
         
         # Find or create the Resource.
         if not href:
@@ -6154,7 +6149,7 @@ class LicensePool(Base):
                representation associated with the resource.
         """
         return self.identifier.add_link(
-            rel, href, data_source, self, media_type, content, content_path)
+            rel, href, data_source, media_type, content, content_path)
 
     def needs_update(self):
         """Is it time to update the circulation info for this license pool?"""

--- a/model.py
+++ b/model.py
@@ -1669,7 +1669,6 @@ class Identifier(Base):
         link, new_link = get_one_or_create(
             _db, Hyperlink, rel=rel, data_source=data_source,
             identifier=self, resource=resource,
-            create_method_kwargs=dict(license_pool=license_pool)
         )
 
         if content or content_path:
@@ -4820,14 +4819,6 @@ class Hyperlink(Base):
     data_source_id = Column(
         Integer, ForeignKey('datasources.id'), index=True, nullable=False)
 
-    # A Resource may also be associated with some LicensePool which
-    # controls scarce access to it.
-    #
-    # TODO: This probably needs to go, or at least become a many-to-one
-    # thing.
-    license_pool_id = Column(
-        Integer, ForeignKey('licensepools.id'), index=True)
-
     # The link relation between the Identifier and the Resource.
     rel = Column(Unicode, index=True, nullable=False)
 
@@ -5825,9 +5816,6 @@ class LicensePool(Base):
     # One LicensePool can have many CirculationEvents
     circulation_events = relationship(
         "CirculationEvent", backref="license_pool")
-
-    # One LicensePool may have many associated Hyperlinks.
-    links = relationship("Hyperlink", backref="license_pool")
 
     # One LicensePool can be associated with many Complaints.
     complaints = relationship('Complaint', backref='license_pool')

--- a/testing.py
+++ b/testing.py
@@ -350,11 +350,11 @@ class DatabaseTest(object):
             media_type = Representation.EPUB_MEDIA_TYPE
             link, new = pool.identifier.add_link(
                 Hyperlink.OPEN_ACCESS_DOWNLOAD, url,
-                source, pool)
+                source, media_type)
 
             # Add a DeliveryMechanism for this download
             pool.set_delivery_mechanism(
-                Representation.EPUB_MEDIA_TYPE,
+                media_type,
                 DeliveryMechanism.NO_DRM,
                 RightsStatus.GENERIC_OPEN_ACCESS,
                 link.resource,

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -543,8 +543,7 @@ class TestMetaToModelUtility(DatabaseTest):
 
         link_obj, ignore = edition.primary_identifier.add_link(
             rel=link.rel, href=link.href, data_source=data_source,
-            license_pool=pool, media_type=link.media_type,
-            content=link.content,
+            media_type=link.media_type, content=link.content,
         )
 
         h.queue_response(403)
@@ -588,8 +587,7 @@ class TestMetaToModelUtility(DatabaseTest):
 
         link_obj, ignore = edition.primary_identifier.add_link(
             rel=link.rel, href=link.href, data_source=data_source,
-            license_pool=pool, media_type=link.media_type,
-            content=link.content,
+            media_type=link.media_type, content=link.content
         )
 
         h.queue_response(200, media_type=Representation.EPUB_MEDIA_TYPE)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -834,37 +834,6 @@ class TestMetadata(DatabaseTest):
         eq_([link2, link5, link4, link3], filtered_links)
 
 
-    def test_make_thumbnail_assigns_pool(self):
-        identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
-        #identifier = self._identifier()
-        #identifier = IdentifierData(type=Identifier.GUTENBERG_ID, identifier=edition.primary_identifier)
-        edition = self._edition(identifier_id=identifier.identifier)
-
-        link = LinkData(
-            rel=Hyperlink.THUMBNAIL_IMAGE, href="http://thumbnail.com/",
-            media_type=Representation.JPEG_MEDIA_TYPE,
-        )
-
-        metadata = Metadata(data_source=edition.data_source, 
-            primary_identifier=identifier,
-            links=[link], 
-        )
-
-        circulation = CirculationData(data_source=edition.data_source, 
-            primary_identifier=identifier)
-
-        metadata.circulation = circulation
-
-        collection = self._default_collection
-        metadata.apply(edition, collection)
-        thumbnail_link = edition.primary_identifier.links[0]
-
-        circulation_pool, is_new = circulation.license_pool(
-            self._db, collection
-        )
-        eq_(thumbnail_link.license_pool, circulation_pool)
-
-
 class TestAssociateWithIdentifiersBasedOnPermanentWorkID(DatabaseTest):
 
     def test_success(self):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -255,8 +255,7 @@ class TestMetadataImporter(DatabaseTest):
 
         link_obj, ignore = edition.primary_identifier.add_link(
             rel=link.rel, href=link.href, data_source=data_source,
-            license_pool=pool, media_type=link.media_type,
-            content=link.content,
+            media_type=link.media_type, content=link.content
         )
         h.queue_response(403)
         
@@ -298,8 +297,7 @@ class TestMetadataImporter(DatabaseTest):
 
         link_obj, ignore = edition.primary_identifier.add_link(
             rel=link.rel, href=link.href, data_source=data_source,
-            license_pool=pool, media_type=link.media_type,
-            content=link.content,
+            media_type=link.media_type, content=link.content
         )
 
         m = Metadata(data_source=data_source)
@@ -332,8 +330,7 @@ class TestMetadataImporter(DatabaseTest):
 
         link_obj, ignore = edition.primary_identifier.add_link(
             rel=link.rel, href=link.href, data_source=data_source,
-            license_pool=pool, media_type=link.media_type,
-            content=link.content,
+            media_type=link.media_type, content=link.content
         )
 
         h.queue_response(200, media_type=Representation.JPEG_MEDIA_TYPE)
@@ -424,8 +421,7 @@ class TestMetadataImporter(DatabaseTest):
 
         link_obj, ignore = edition.primary_identifier.add_link(
             rel=link.rel, href=link.href, data_source=data_source,
-            license_pool=pool, media_type=link.media_type,
-            content=link.content,
+            media_type=link.media_type, content=link.content
         )
 
         h.queue_response(200, media_type=Representation.EPUB_MEDIA_TYPE)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3658,7 +3658,6 @@ class TestHyperlink(DatabaseTest):
         eq_("text/plain", rep.media_type)
         eq_("The content", rep.content)
         eq_(Hyperlink.DESCRIPTION, hyperlink.rel)
-        eq_(pool, hyperlink.license_pool)
         eq_(identifier, hyperlink.identifier)
 
     def test_add_link_fails_if_license_pool_and_identifier_dont_match(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1325,14 +1325,14 @@ class TestLicensePool(DatabaseTest):
         media_type = Representation.EPUB_MEDIA_TYPE
         link2, new = pool.identifier.add_link(
             Hyperlink.OPEN_ACCESS_DOWNLOAD, url,
-            source, pool
+            source, media_type
         )
         oa2 = link2.resource
 
         # And let's add a link that's not an open-access download.
         url = self._url
         image, new = pool.identifier.add_link(
-            Hyperlink.IMAGE, url, source, pool
+            Hyperlink.IMAGE, url, source, Representation.JPEG_MEDIA_TYPE
         )
         self._db.commit()
 
@@ -3659,16 +3659,6 @@ class TestHyperlink(DatabaseTest):
         eq_("The content", rep.content)
         eq_(Hyperlink.DESCRIPTION, hyperlink.rel)
         eq_(identifier, hyperlink.identifier)
-
-    def test_add_link_fails_if_license_pool_and_identifier_dont_match(self):
-        edition, pool = self._edition(with_license_pool=True)
-        data_source = pool.data_source
-        identifier = self._identifier()
-        assert_raises_regexp(
-            ValueError, re.compile("License pool is associated with .*, not .*!"),
-            identifier.add_link,
-            Hyperlink.DESCRIPTION, "http://foo.com/", data_source, 
-            pool, "text/plain", "The content")
 
     def test_default_filename(self):
         m = Hyperlink._default_filename


### PR DESCRIPTION
This branch removes a connection between Hyperlink and LicensePool which I'm pretty sure was never used for anything. It no longer makes sense now that there can be more than one LicensePool for a given book.