### PR TITLE
Licensepooldeliverymechanism uses data source and identifier

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -1221,8 +1221,8 @@ class Lane(object):
         LPDM = LicensePoolDeliveryMechanism
         exists_clause = exists().where(
             and_(LicensePool.data_source_id==LPDM.data_source_id,
-                and_(LicensePool.identifier_id==LPDM.identifier_id)
-        ))
+                LicensePool.identifier_id==LPDM.identifier_id)
+        )
         query = query.filter(exists_clause)
             
         # Only find books with unsuppressed LicensePools.

--- a/lane.py
+++ b/lane.py
@@ -1217,15 +1217,14 @@ class Lane(object):
                 work_model.presentation_ready == True,
             )
 
-        # Only find books the default client can fulfill.
+        # Only find books that have some kind of DeliveryMechanism.
         LPDM = LicensePoolDeliveryMechanism
         exists_clause = exists().where(
             and_(LicensePool.data_source_id==LPDM.data_source_id,
-                and_(LicensePool.identifier_id==LPDM.identifier_id,
-                      DeliveryMechanism.default_client_can_fulfill==True
-        )))
+                and_(LicensePool.identifier_id==LPDM.identifier_id)
+        ))
         query = query.filter(exists_clause)
-        
+            
         # Only find books with unsuppressed LicensePools.
         if not show_suppressed:
             query = query.filter(LicensePool.suppressed==False)

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -911,9 +911,6 @@ class CirculationData(MetaToModelUtility):
                         loan.fulfillment = None
                     _db.delete(lpdm)
 
-            pool.delivery_mechanisms = new_lpdms
-
-                    
         changed_licenses = False
         if pool:
             # if we were not passed a last_checked value, then update pool as of now

--- a/migration/20170403-modify-licensepooldeliveries.sql
+++ b/migration/20170403-modify-licensepooldeliveries.sql
@@ -20,7 +20,7 @@ update licensepooldeliveries set
     	   lp.identifier_id as identifier_id,
 	   lp.data_source_id as data_source_id
     from licensepooldeliveries lpdm
-    	 join licensepools lp on lpdm.license_pool_id=lp.id limit 10
+    	 join licensepools lp on lpdm.license_pool_id=lp.id
 ) as subquery where licensepooldeliveries.id=subquery.delivery_id;
 
 -- Now that we have the data, create a unique index.

--- a/migration/20170403-modify-licensepooldeliveries.sql
+++ b/migration/20170403-modify-licensepooldeliveries.sql
@@ -1,0 +1,30 @@
+-- Create two new columns that will replace license_pool_id.
+ALTER TABLE licensepooldeliveries ADD COLUMN data_source_id integer;
+ALTER TABLE licensepooldeliveries ADD COLUMN identifier_id integer;
+
+alter table licensepooldeliveries
+    add constraint licensepooldeliveries_data_source_id_fkey
+    foreign key (data_source_id)
+    references datasources(id);
+
+alter table licensepooldeliveries
+    add constraint licensepooldeliveries_identifier_id_fkey
+    foreign key (identifier_id)
+    references identifiers(id);
+
+-- Copy in appropriate values using license_pool_id.
+update licensepooldeliveries set
+ data_source_id=subquery.data_source_id,
+ identifier_id=subquery.identifier_id from (
+    select lpdm.id as delivery_id,
+    	   lp.identifier_id as identifier_id,
+	   lp.data_source_id as data_source_id
+    from licensepooldeliveries lpdm
+    	 join licensepools lp on lpdm.license_pool_id=lp.id limit 10
+) as subquery where licensepooldeliveries.id=subquery.delivery_id;
+
+-- Now that we have the data, create a unique index.
+CREATE UNIQUE INDEX ix_licensepooldeliveries_datasource_identifier_mechanism on licensepools USING btree (data_source_id, identifier_id, delivery_mechanism_id, resource_id);
+
+-- Finally, remove the now-unnecessary license_pool_id.
+ALTER TABLE licensepooldeliveries DROP COLUMN license_pool_id;

--- a/model.py
+++ b/model.py
@@ -4787,6 +4787,7 @@ class LicensePoolDeliveryMechanism(Base):
         "LicensePool",
         primaryjoin="LicensePool.data_source_id==foreign(LicensePoolDeliveryMechanism.data_source_id) and LicensePool.identifier_id==foreign(LicensePoolDeliveryMechanism.identifier_id)",
         uselist=True,
+        foreign_keys=lambda:[LicensePoolDeliveryMechanism.data_source_id, LicensePoolDeliveryMechanism.identifier_id],
         back_populates='delivery_mechanisms',
     )
 
@@ -5902,6 +5903,7 @@ class LicensePool(Base):
     delivery_mechanisms = relationship(
         "LicensePoolDeliveryMechanism",
         primaryjoin="LicensePool.data_source_id==foreign(LicensePoolDeliveryMechanism.data_source_id) and LicensePool.identifier_id==foreign(LicensePoolDeliveryMechanism.identifier_id)",
+        foreign_keys=lambda:[LicensePool.data_source_id, LicensePool.identifier_id],
         uselist=True,
         back_populates='license_pools',
     )

--- a/model.py
+++ b/model.py
@@ -4791,6 +4791,11 @@ class LicensePoolDeliveryMechanism(Base):
                 # access, we might have removed the last open-access
                 # delivery mechanism for the pool. We need to check
                 # all of them to see if there's an open-access one.
+                #
+                # TODO: I think this is less efficient than it could
+                # be, given that all LicensePools for an Identifier
+                # are the same book. But this happens so infrequently
+                # that I'm not going to spend time optimizing it.
                 pool.open_access = False
                 for lpdm in pool.delivery_mechanisms:
                     if lpdm.rights_status.uri in RightsStatus.OPEN_ACCESS:
@@ -4820,6 +4825,7 @@ Index(
     LicensePoolDeliveryMechanism.data_source_id,
     LicensePoolDeliveryMechanism.identifier_id,
     LicensePoolDeliveryMechanism.delivery_mechanism_id,
+    LicensePoolDeliveryMechanism.resource_id,
 )
 
     

--- a/model.py
+++ b/model.py
@@ -4728,9 +4728,13 @@ class Measurement(Base):
 
 
 class LicensePoolDeliveryMechanism(Base):
-    """A mechanism for delivering a specific book.
+    """A mechanism for delivering a specific book from a specific
+    distributor.
 
-    This is mostly an association class between LicensePool and
+    It's presumed that all LicensePools for a given DataSource and
+    Identifier have the same set of LicensePoolDeliveryMechanisms.
+
+    This is mostly an association class between DataSource, Identifier and
     DeliveryMechanism, but it also may incorporate a specific Resource
     (i.e. a static link to a downloadable file) which explains exactly
     where to go for delivery.
@@ -4739,11 +4743,14 @@ class LicensePoolDeliveryMechanism(Base):
 
     id = Column(Integer, primary_key=True)
 
-    license_pool_id = Column(
-        Integer, ForeignKey('licensepools.id'), index=True,
-        nullable=False
+    data_source_id = Column(
+        Integer, ForeignKey('datasources.id'), index=True, nullable=False
     )
 
+    identifier_id = Column(
+        Integer, ForeignKey('datasources.id'), index=True, nullable=False
+    )
+    
     delivery_mechanism_id = Column(
         Integer, ForeignKey('deliverymechanisms.id'), 
         index=True,
@@ -4782,6 +4789,19 @@ class LicensePoolDeliveryMechanism(Base):
     def __repr__(self):
         return "%r %r" % (self.license_pool, self.delivery_mechanism)
 
+    __table_args__ = (
+        UniqueConstraint('data_source_id', 'identifier_id',
+                         'delivery_mechanism_id'),
+    )
+
+Index(
+    "ix_licensepooldeliveries_data_source_identifier_delivery_mechanism",
+    LicensePoolDeliveryMechanism.data_source_id,
+    LicensePoolDeliveryMechanism.identifier,
+    LicensePoolDeliveryMechanism.delivery_mechanism_id,
+)
+
+    
 class Hyperlink(Base):
     """A link between an Identifier and a Resource."""
 

--- a/model.py
+++ b/model.py
@@ -84,7 +84,6 @@ from sqlalchemy import (
     Enum,
     Float,
     ForeignKey,
-    ForeignKeyConstraint,
     Integer,
     Index,
     Numeric,

--- a/model.py
+++ b/model.py
@@ -6682,7 +6682,6 @@ class LicensePool(Base):
                 return pool, link
         return self, None
 
-
     def set_delivery_mechanism(
             self, content_type, drm_scheme, rights_uri, resource):
         """Ensure that this LicensePool (and any other LicensePools for the same

--- a/model.py
+++ b/model.py
@@ -4785,17 +4785,10 @@ class LicensePoolDeliveryMechanism(Base):
     # DeliveryMechanisms.
     license_pools = relationship(
         "LicensePool",
+        primaryjoin="LicensePool.data_source_id==foreign(LicensePoolDeliveryMechanism.data_source_id) and LicensePool.identifier_id==foreign(LicensePoolDeliveryMechanism.identifier_id)",
         uselist=True,
-        backref="delivery_mechanisms"
+        back_populates='delivery_mechanisms',
     )
-
-    __table_args__ = (
-        ForeignKeyConstraint(
-            [data_source_id, identifier_id],
-            ['licensepools.data_source_id', 'licensepools.identifier_id']
-        )
-    )
-
 
     def set_rights_status(self, uri):
         _db = Session.object_session(self)
@@ -5902,6 +5895,17 @@ class LicensePool(Base):
     # link for this LicensePool.
     _open_access_download_url = Column(Unicode, name="open_access_download_url")
 
+    # One LicensePool may have multiple DeliveryMechanisms, and vice
+    # versa. They're not directly connected; rather, all LicensePools
+    # for a given data_source_id and identifier_id share a set of
+    # DeliveryMechanisms.
+    delivery_mechanisms = relationship(
+        "LicensePoolDeliveryMechanism",
+        primaryjoin="LicensePool.data_source_id==foreign(LicensePoolDeliveryMechanism.data_source_id) and LicensePool.identifier_id==foreign(LicensePoolDeliveryMechanism.identifier_id)",
+        uselist=True,
+        back_populates='license_pools',
+    )
+    
     # A Collection can not have more than one LicensePool for a given
     # Identifier from a given DataSource.
     __table_args__ = (

--- a/model.py
+++ b/model.py
@@ -4786,13 +4786,13 @@ class LicensePoolDeliveryMechanism(Base):
     license_pools = relationship(
         "LicensePool",
         uselist=True,
-        back_populates='delivery_mechanisms'
+        backref="delivery_mechanisms"
     )
 
     __table_args__ = (
         ForeignKeyConstraint(
             [data_source_id, identifier_id],
-            [LicensePool.data_source_id, LicensePool.identifier_id]
+            ['licensepools.data_source_id', 'licensepools.identifier_id']
         )
     )
 
@@ -5901,7 +5901,7 @@ class LicensePool(Base):
     # This lets us cache the work of figuring out the best open access
     # link for this LicensePool.
     _open_access_download_url = Column(Unicode, name="open_access_download_url")
-    
+
     # A Collection can not have more than one LicensePool for a given
     # Identifier from a given DataSource.
     __table_args__ = (

--- a/testing.py
+++ b/testing.py
@@ -350,7 +350,8 @@ class DatabaseTest(object):
             media_type = Representation.EPUB_MEDIA_TYPE
             link, new = pool.identifier.add_link(
                 Hyperlink.OPEN_ACCESS_DOWNLOAD, url,
-                source, pool)
+                source, media_type
+            )
 
             # Add a DeliveryMechanism for this download
             pool.set_delivery_mechanism(

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -133,7 +133,6 @@ class TestCirculationData(DatabaseTest):
         # Start with one delivery mechanism for this pool.
         for lpdm in pool.delivery_mechanisms:
             self._db.delete(lpdm)
-        pool.delivery_mechanisms = []
 
         old_lpdm = pool.set_delivery_mechanism(
             Representation.PDF_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM,
@@ -160,7 +159,7 @@ class TestCirculationData(DatabaseTest):
         replacement_policy = ReplacementPolicy(formats=False)
         circulation_data.apply(pool, replacement_policy)
         
-        eq_(2, len(pool.delivery_mechanisms))
+        eq_(2, pool.delivery_mechanisms.count())
         eq_(set([Representation.PDF_MEDIA_TYPE, Representation.EPUB_MEDIA_TYPE]),
             set([lpdm.delivery_mechanism.content_type for lpdm in pool.delivery_mechanisms]))
         eq_(old_lpdm, loan.fulfillment)
@@ -170,7 +169,7 @@ class TestCirculationData(DatabaseTest):
         replacement_policy = ReplacementPolicy(formats=True)
         circulation_data.apply(pool, replacement_policy)
 
-        eq_(1, len(pool.delivery_mechanisms))
+        eq_(1, pool.delivery_mechanisms.count())
         eq_(Representation.EPUB_MEDIA_TYPE, pool.delivery_mechanisms[0].delivery_mechanism.content_type)
         eq_(None, loan.fulfillment)
         
@@ -252,7 +251,7 @@ class TestCirculationData(DatabaseTest):
         circulation_data.apply(pool, replace)
 
         # Now we have no formats at all.
-        eq_([], pool.delivery_mechanisms)
+        eq_(0, pool.delivery_mechanisms.count())
 
     def test_rights_status_default_rights_passed_in(self):
         identifier = IdentifierData(
@@ -281,7 +280,7 @@ class TestCirculationData(DatabaseTest):
         )
         circulation_data.apply(pool, replace)
         eq_(True, pool.open_access)
-        eq_(1, len(pool.delivery_mechanisms))
+        eq_(1, pool.delivery_mechanisms.count())
         # The rights status is the one that was passed in to CirculationData.
         eq_(RightsStatus.CC_BY, pool.delivery_mechanisms[0].rights_status.uri)
 
@@ -311,7 +310,7 @@ class TestCirculationData(DatabaseTest):
         )
         circulation_data.apply(pool, replace)
         eq_(True, pool.open_access)
-        eq_(1, len(pool.delivery_mechanisms))
+        eq_(1, pool.delivery_mechanisms.count())
         # The rights status is the default for the OA content server.
         eq_(RightsStatus.GENERIC_OPEN_ACCESS, pool.delivery_mechanisms[0].rights_status.uri)
 
@@ -340,7 +339,7 @@ class TestCirculationData(DatabaseTest):
         )
         circulation_data.apply(pool, replace)
         eq_(True, pool.open_access)
-        eq_(1, len(pool.delivery_mechanisms))
+        eq_(1, pool.delivery_mechanisms.count())
 
         # The delivery mechanism's rights status is the default for
         # the data source.
@@ -405,7 +404,7 @@ class TestCirculationData(DatabaseTest):
         )
         circulation_data.apply(pool, replace)
         eq_(True, pool.open_access)
-        eq_(1, len(pool.delivery_mechanisms))
+        eq_(1, pool.delivery_mechanisms.count())
         eq_(RightsStatus.CC_BY_ND, pool.delivery_mechanisms[0].rights_status.uri)
 
     def test_rights_status_commercial_link_with_rights(self):
@@ -442,7 +441,7 @@ class TestCirculationData(DatabaseTest):
         )
         circulation_data.apply(pool, replace)
         eq_(False, pool.open_access)
-        eq_(1, len(pool.delivery_mechanisms))
+        eq_(1, pool.delivery_mechanisms.count())
         eq_(RightsStatus.IN_COPYRIGHT, pool.delivery_mechanisms[0].rights_status.uri)
 
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1128,9 +1128,21 @@ class TestFilters(DatabaseTest):
         w7.license_pools[0].licenses_owned = 9
         w7.license_pools[0].licenses_available = 5
 
+        # w8 has a delivery mechanism that can't be rendered by the
+        # default client.
+        w8 = self._work(with_license_pool=True)
+        w8.presentation_edition.title = "I have a weird delivery mechanism"
+        [pool] = w8.license_pools
+        for dm in pool.delivery_mechanisms:
+            self._db.delete(dm)
+        pool.set_delivery_mechanism(
+            "weird content type", "weird DRM scheme", "weird rights URI",
+            None
+        )
+        
         # A normal query against Work/LicensePool finds all works.
         orig_q = self._db.query(Work).join(Work.license_pools)
-        eq_(7, orig_q.count())
+        eq_(8, orig_q.count())
 
         # only_show_ready_deliverable_works filters out everything but
         # w1 (owned licenses), w6 (open-access), and w7 (available

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1676,7 +1676,7 @@ class TestLicensePoolDeliveryMechanism(DatabaseTest):
             Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.NO_DRM,
             RightsStatus.CC_BY, None)
         
-        eq_(2, len(pool.delivery_mechanisms))
+        eq_(2, pool.delivery_mechanisms.count())
 
         # Now the pool is open access again
         eq_(True, pool.open_access)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1632,9 +1632,12 @@ class TestLicensePool(DatabaseTest):
 class TestLicensePoolDeliveryMechanism(DatabaseTest):
 
     def test_set_rights_status(self):
+        # Here's a non-open-access book.
         edition, pool = self._edition(with_license_pool=True)
         pool.open_access = False
-        lpdm = pool.delivery_mechanisms[0]
+        [lpdm] = pool.delivery_mechanisms
+
+        # We set its rights status to 'in copyright', and nothing changes.
         uri = RightsStatus.IN_COPYRIGHT
         status = lpdm.set_rights_status(uri)
         eq_(status, lpdm.rights_status)
@@ -1642,29 +1645,37 @@ class TestLicensePoolDeliveryMechanism(DatabaseTest):
         eq_(RightsStatus.NAMES.get(uri), status.name)
         eq_(False, pool.open_access)
 
+        # Setting it again won't change anything.
         status2 = lpdm.set_rights_status(uri)
         eq_(status, status2)
 
+        # Set the rights status to a different URL, we change to a different
+        # RightsStatus object.
         uri2 = "http://unknown"
         status3 = lpdm.set_rights_status(uri2)
         assert status != status3
         eq_(RightsStatus.UNKNOWN, status3.uri)
         eq_(RightsStatus.NAMES.get(RightsStatus.UNKNOWN), status3.name)
 
+        # Set the rights status to a URL that implies open access,
+        # and the status of the LicensePool is changed.
         open_access_uri = RightsStatus.GENERIC_OPEN_ACCESS
         open_access_status = lpdm.set_rights_status(open_access_uri)
         eq_(open_access_uri, open_access_status.uri)
         eq_(RightsStatus.NAMES.get(open_access_uri), open_access_status.name)
         eq_(True, pool.open_access)
 
+        # Set it back to a URL that does not imply open access, and
+        # the status of the LicensePool is changed back.
         non_open_access_status = lpdm.set_rights_status(uri)
         eq_(False, pool.open_access)
 
-        # Add a second license pool, so the pool has one open-access
-        # and one commercial delivery mechanism.
+        # Now add a second delivery mechanism, so the pool has one
+        # open-access and one commercial delivery mechanism.
         lpdm2 = pool.set_delivery_mechanism(
             Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.NO_DRM,
             RightsStatus.CC_BY, None)
+        
         eq_(2, len(pool.delivery_mechanisms))
 
         # Now the pool is open access again

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1687,28 +1687,29 @@ class TestLicensePoolDeliveryMechanism(DatabaseTest):
         eq_(False, pool.open_access)
 
     def test_uniqueness_constraint(self):
+        # with_open_access_download will create a LPDM
+        # for the open-access download.
         edition, pool = self._edition(with_license_pool=True,
                                       with_open_access_download=True)
-
+        [lpdm] = pool.delivery_mechanisms
+        
         # We can create a second LPDM with the same data type and DRM status,
         # so long as the resource is different.
-        [lpdm] = pool.delivery_mechanisms
-
         link, new = pool.identifier.add_link(
             Hyperlink.OPEN_ACCESS_DOWNLOAD, self._url,
             pool.data_source, "text/html"
         )
-
         pool.set_delivery_mechanism(
-                Representation.EPUB_MEDIA_TYPE,
-                DeliveryMechanism.NO_DRM,
-                RightsStatus.GENERIC_OPEN_ACCESS,
-                link.resource,
-            )
+            lpdm.delivery_mechanism.content_type,
+            lpdm.delivery_mechanism.drm_scheme,
+            lpdm.rights_status.uri,
+            link.resource,
+        )
+        [lpdm2] = [x for x in pool.delivery_mechanisms if x != lpdm]
+        eq_(lpdm2.delivery_mechanism, lpdm.delivery_mechanism)
+        assert lpdm2.resource != lpdm.resource
 
-        set_trace()
-        pass
-        
+
 class TestWork(DatabaseTest):
 
     def test_all_identifier_ids(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1686,6 +1686,29 @@ class TestLicensePoolDeliveryMechanism(DatabaseTest):
         lpdm2.set_rights_status(uri)
         eq_(False, pool.open_access)
 
+    def test_uniqueness_constraint(self):
+        edition, pool = self._edition(with_license_pool=True,
+                                      with_open_access_download=True)
+
+        # We can create a second LPDM with the same data type and DRM status,
+        # so long as the resource is different.
+        [lpdm] = pool.delivery_mechanisms
+
+        link, new = pool.identifier.add_link(
+            Hyperlink.OPEN_ACCESS_DOWNLOAD, self._url,
+            pool.data_source, "text/html"
+        )
+
+        pool.set_delivery_mechanism(
+                Representation.EPUB_MEDIA_TYPE,
+                DeliveryMechanism.NO_DRM,
+                RightsStatus.GENERIC_OPEN_ACCESS,
+                link.resource,
+            )
+
+        set_trace()
+        pass
+        
 class TestWork(DatabaseTest):
 
     def test_all_identifier_ids(self):


### PR DESCRIPTION
This branch changes the LicensePoolDeliveryMechanism class to identify a book in terms of its data source and identifier, rather than a specific LicensePool. This reflects the fact that distributors make books available in the same formats to everyone. Only the number of copies is different from one LicensePool to another.

I still want to get from LicensePool to LicensePoolDeliveryMechanism, but there's no longer a proper foreign key so I couldn't figure out how to implement a normal SQLAlchemy `relationship`. I ended up writing properties that return queries, which I think is fine. We'll see if it causes performance problems later on.