### PR TITLE
Circulationdata without collection

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -233,7 +233,8 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
 
     Currently this is only used by BibliographicRefreshScript. It's
     not normally necessary because the Axis 360 API combines
-    bibliographic and availability data.
+    bibliographic and availability data. We rely on Monitors to fetch 
+    availability data and fill in the bibliographic data as necessary.
     """
 
     SERVICE_NAME = "Axis 360 Bibliographic Coverage Provider"

--- a/bibliotheca.py
+++ b/bibliotheca.py
@@ -406,7 +406,9 @@ class ItemListParser(XMLParser):
 class BibliothecaBibliographicCoverageProvider(BibliographicCoverageProvider):
     """Fill in bibliographic metadata for Bibliotheca records.
 
-    Then mark the works as presentation-ready.
+    This will occasionally fill in some availability information for a
+    single Collection, but we rely on Monitors to keep availability
+    information up to date for all Collections.
     """
     SERVICE_NAME = "Bibliotheca Bibliographic Coverage Provider"
     DATA_SOURCE_NAME = DataSource.BIBLIOTHECA

--- a/coverage.py
+++ b/coverage.py
@@ -892,12 +892,13 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
         CoverageFailure (if not).
         """
         error = None
-        if not circulationdata:
+        if circulationdata:
+            primary_identifier = circulationdata.primary_identifier(self._db)
+            if identifier != primary_identifier:
+                error = "Identifier did not match CirculationData's primary identifier."
+        else:
             error = "Did not receive circulationdata from input source"
 
-        primary_identifier = circulationdata.primary_identifier(self._db)
-        if identifier != primary_identifier:
-            error = "Identifier did not match CirculationData's primary identifier."
         if error:
             return self.failure(identifier, error, transient=True)
                                 
@@ -908,7 +909,7 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
         except Exception as e:
             self.log.warn(
                 "Error applying circulationdata to collection %s: %s",
-                collection.name, e, exc_info=e
+                self.collection.name, e, exc_info=e
             )
             return self.failure(identifier, repr(e), transient=True)
 

--- a/coverage.py
+++ b/coverage.py
@@ -691,9 +691,11 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
     left alone.
 
     For this reason it's important that subclasses of this
-    CoverageProvider only deal with bibliographic information, and
-    never circulation information. (Circulation information includes
-    formatting information and links to open-access downloads.)
+    CoverageProvider only deal with bibliographic information and
+    format availability information (such as links to open-access
+    downloads). You'll have problems if you try to use
+    CollectionCoverageProvider to keep track of information like the
+    number of licenses available for a book.
 
     In addition to defining the class variables defined by
     CoverageProvider, you must define the class variable PROTOCOL when
@@ -923,12 +925,12 @@ class BibliographicCoverageProvider(CollectionCoverageProvider):
     e.g. ensures that we get Overdrive coverage for all Overdrive IDs
     in a collection.
 
-    TODO: The current BibliographicCoverageProviders deal with
-    circulation information, which is now a no-no. I'm not going to
-    address the issue in this branch. We need to figure out a way to
-    split up the work that needs to happen once (getting the book
-    cover) from the work that needs to happen independently for each
-    Collection (getting the available formats).
+    Although a BibliographicCoverageProvider may gather
+    CirculationData for a book, it cannot guarantee equal coverage for
+    all Collections that contain that book. CirculationData should be
+    limited to things like formats that don't vary between
+    Collections, and you should use a CollectionMonitor to make sure
+    your circulation information is up-to-date for each Collection.
     """
     def handle_success(self, identifier):
         """Once a book has bibliographic coverage, it can be given a

--- a/coverage.py
+++ b/coverage.py
@@ -907,9 +907,13 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
                 self._db, self.collection, replace=self.replacement_policy
             )
         except Exception as e:
+            if self.collection:
+                collection_name = " to collection %s" % self.collection.name
+            else:
+                collection_name = ""
             self.log.warn(
-                "Error applying circulationdata to collection %s: %s",
-                self.collection.name, e, exc_info=e
+                "Error applying circulationdata%s: %s",
+                collection_name, e, exc_info=e
             )
             return self.failure(identifier, repr(e), transient=True)
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -766,7 +766,12 @@ class CirculationData(MetaToModelUtility):
         description_string += ' licenses_available=%(licenses_available)s| default_rights_uri=%(default_rights_uri)s|' 
         description_string += ' links=%(links)r| formats=%(formats)r| data_source=%(data_source)s|>'
 
-        description_data = {'primary_identifier':self.primary_identifier, 'licenses_owned':self.licenses_owned}
+        
+        description_data = {'licenses_owned':self.licenses_owned}
+        if self._primary_identifier:
+            description_data['primary_identifier'] = self._primary_identifier
+        else:
+            description_data['primary_identifier'] = self.primary_identifier_obj
         description_data['licenses_available'] = self.licenses_available
         description_data['default_rights_uri'] = self.default_rights_uri
         description_data['links'] = self.links

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1530,14 +1530,11 @@ class Metadata(MetaToModelUtility):
 
         # The Metadata object may include a CirculationData object which
         # contains information about availability such as open-access
-        # links. If a Collection was passed in to apply(), we can make sure
+        # links. Make sure
         # that that Collection has a LicensePool for this book and that
         # its information is up-to-date.
-        pool = None
-        if self.circulation and collection:
-            pool, is_new = self.circulation.license_pool(_db, collection)
-            if pool:
-                self.circulation.apply(pool, replace)
+        if self.circulation:
+            self.circulation.apply(_db, collection, replace)
 
         # obtains a presentation_edition for the title, which will later be used to get a mirror link.
         for link in self.links:
@@ -1554,7 +1551,7 @@ class Metadata(MetaToModelUtility):
                 # We don't need to mirror this image, but we do need
                 # to make sure that its thumbnail exists locally and
                 # is associated with the original image.
-                self.make_thumbnail(data_source, link, link_obj, pool)
+                self.make_thumbnail(data_source, link, link_obj)
 
 
         # Finally, update the coverage record for this edition
@@ -1565,12 +1562,9 @@ class Metadata(MetaToModelUtility):
         return edition, made_core_changes
 
         
-    def make_thumbnail(self, data_source, link, link_obj, pool=None):
+    def make_thumbnail(self, data_source, link, link_obj):
         """Make sure a Hyperlink representing an image is connected
         to its thumbnail.
-
-        TODO: pool needs to go away. Many license pools for the
-        same book should be able to use the same thumbnail.
         """
         thumbnail = link.thumbnail
         if not thumbnail:

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -973,18 +973,16 @@ class CirculationData(MetaToModelUtility):
         # Finally, if we have data for a specific Collection's license
         # for this book, find its LicensePool and update it.
         changed_availability = False
-        if pool:
-            availability_needs_update = self._availability_needs_update(pool)
-            if availability_needs_update:
-                # Update availabily information. This may result in
-                # the issuance of additional circulation events.
-                changed_availability = pool.update_availability(
-                    new_licenses_owned=self.licenses_owned,
-                    new_licenses_available=self.licenses_available,
-                    new_licenses_reserved=self.licenses_reserved,
-                    new_patrons_in_hold_queue=self.patrons_in_hold_queue,
-                    as_of=self.last_checked
-                )
+        if pool and self._availability_needs_update(pool):
+            # Update availabily information. This may result in
+            # the issuance of additional circulation events.
+            changed_availability = pool.update_availability(
+                new_licenses_owned=self.licenses_owned,
+                new_licenses_available=self.licenses_available,
+                new_licenses_reserved=self.licenses_reserved,
+                new_patrons_in_hold_queue=self.patrons_in_hold_queue,
+                as_of=self.last_checked
+            )
                     
         made_changes = (made_changes or changed_availability
                         or open_access_status_changed)

--- a/model.py
+++ b/model.py
@@ -866,7 +866,7 @@ class DataSource(Base):
     custom_lists = relationship("CustomList", backref="data_source")
 
     # One DataSource can have provide many LicensePoolDeliveryMechanisms.
-    licensepool_deliveries = relationship(
+    delivery_mechanisms = relationship(
         "LicensePoolDeliveryMechanism", backref="data_source",
         foreign_keys=lambda: [LicensePoolDeliveryMechanism.data_source_id]
     )
@@ -1416,7 +1416,7 @@ class Identifier(Base):
     )
 
     # One Identifier can have have many LicensePoolDeliveryMechanisms.
-    licensepool_deliveries = relationship(
+    delivery_mechanisms = relationship(
         "LicensePoolDeliveryMechanism", backref="identifier",
         foreign_keys=lambda: [LicensePoolDeliveryMechanism.identifier_id]
     )
@@ -4773,6 +4773,46 @@ class LicensePoolDeliveryMechanism(Base):
     rightsstatus_id = Column(
         Integer, ForeignKey('rightsstatus.id'), index=True)
 
+    @classmethod
+    def set(cls, data_source, identifier, content_type, drm_scheme, rights_uri,
+            resource=None):
+        """Register the fact that a distributor makes a title available in a
+        certain format.
+
+        :param data_source: A DataSource identifying the distributor.
+        :param identifier: An Identifier identifying the title.
+        :param content_type: The title is available in this media type.
+        :param drm_scheme: Access to the title is confounded by this
+            DRM scheme.
+        :param rights_uri: A URI representing the public's rights to the
+            title.
+        :param resource: A Resource representing the book itself in
+            a freely redistributable form.
+        """
+        _db = Session.object_session(data_source)
+        delivery_mechanism, ignore = DeliveryMechanism.lookup(
+            _db, content_type, drm_scheme
+        )
+        rights_status = RightsStatus.lookup(_db, rights_uri)
+        lpdm, ignore = get_one_or_create(
+            _db, LicensePoolDeliveryMechanism,
+            identifier=identifier,
+            data_source=data_source,
+            delivery_mechanism=delivery_mechanism,
+            resource=resource
+        )
+        lpdm.rights_status = rights_status
+
+        # Adding an open access LPDM makes all LicensePools that use
+        # it open access. Adding a non-open access LPDM doesn't change
+        # anything because the book might have another LPDM that is
+        # open access.
+        if lpdm.rights_status.uri in RightsStatus.OPEN_ACCESS:
+            for pool in lpdm.license_pools:
+                pool.open_access = True
+        return lpdm
+
+        
     def set_rights_status(self, uri):
         _db = Session.object_session(self)
         status = RightsStatus.lookup(_db, uri)
@@ -6682,35 +6722,14 @@ class LicensePool(Base):
                 return pool, link
         return self, None
 
-    def set_delivery_mechanism(
-            self, content_type, drm_scheme, rights_uri, resource):
+    def set_delivery_mechanism(self, *args, **kwargs):
         """Ensure that this LicensePool (and any other LicensePools for the same
         book) have a LicensePoolDeliveryMechanism for this media type,
         DRM scheme, rights status, and resource.
         """
-        _db = Session.object_session(self)
-        delivery_mechanism, ignore = DeliveryMechanism.lookup(
-            _db, content_type, drm_scheme
+        return LicensePoolDeliveryMechanism.set(
+            self.data_source, self.identifier, *args, **kwargs
         )
-        rights_status = RightsStatus.lookup(_db, rights_uri)
-        lpdm, ignore = get_one_or_create(
-            _db, LicensePoolDeliveryMechanism,
-            identifier=self.identifier,
-            data_source=self.data_source,
-            delivery_mechanism=delivery_mechanism,
-            resource=resource
-        )
-        lpdm.rights_status = rights_status
-
-        # Adding an open access LPDM makes all LicensePools that use
-        # it open access. Adding a non-open access LPDM doesn't change
-        # anything because the book might have another LPDM that is
-        # open access.
-        if lpdm.rights_status.uri in RightsStatus.OPEN_ACCESS:
-            for pool in lpdm.license_pools:
-                pool.open_access = True
-        return lpdm
-
 
 Index("ix_licensepools_data_source_id_identifier_id_collection_id", LicensePool.collection_id, LicensePool.data_source_id, LicensePool.identifier_id, unique=True)
 

--- a/opds_import.py
+++ b/opds_import.py
@@ -458,6 +458,12 @@ class OPDSImporter(object):
                 c_circulation_dict = m_data_dict.get('circulation')
                 xml_circulation_dict = xml_data_dict.get('circulation', {})
                 c_data_dict = self.combine(c_circulation_dict, xml_circulation_dict)
+
+            # Unless there's something useful in c_data_dict, we're
+            # not going to put anything under metadata.circulation,
+            # and any partial data that got added to
+            # metadata.circulation is going to be removed.
+            metadata[internal_identifier.urn].circulation = None
             if c_data_dict:
                 circ_links_dict = {}
                 # extract just the links to pass to CirculationData constructor
@@ -480,7 +486,7 @@ class OPDSImporter(object):
                     #
                     # TODO: This will need to be revisited when we add
                     # ODL support.
-                    metadata[internal_identifier.urn].circulation = None
+                    pass
         return metadata, identified_failures
 
     @classmethod

--- a/overdrive.py
+++ b/overdrive.py
@@ -1000,7 +1000,12 @@ class OverdriveAdvantageAccount(object):
         return parent, child
         
 class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
-    """Fill in bibliographic metadata for Overdrive records."""
+    """Fill in bibliographic metadata for Overdrive records.
+
+    This will occasionally fill in some availability information for a
+    single Collection, but we rely on Monitors to keep availability
+    information up to date for all Collections.
+    """
 
     SERVICE_NAME = "Overdrive Bibliographic Coverage Provider"
     DATA_SOURCE_NAME = DataSource.OVERDRIVE

--- a/testing.py
+++ b/testing.py
@@ -259,8 +259,6 @@ class DatabaseTest(object):
                 presentation_edition, pool = presentation_edition
         else:
             pool = presentation_edition.license_pool
-        if with_open_access_download:
-            pool.open_access = True
         if new_edition:
             presentation_edition.calculate_presentation()
         work, ignore = get_one_or_create(
@@ -289,6 +287,10 @@ class DatabaseTest(object):
             # fake that the work is presentation ready.
             work.presentation_ready = True
             work.calculate_opds_entries(verbose=False)
+
+        if with_open_access_download:
+            pool.open_access = True
+
         return work
 
     def _coverage_record(self, edition, coverage_source, operation=None,

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -220,7 +220,7 @@ class TestParsers(AxisTest):
         eq_(None, bib1)
         eq_(None, bib2)
 
-        eq_("0003642860", av1.primary_identifier.identifier)
+        eq_("0003642860", av1.primary_identifier(self._db).identifier)
         eq_(9, av1.licenses_owned)
         eq_(9, av1.licenses_available)
         eq_(0, av1.patrons_in_hold_queue)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -919,7 +919,14 @@ class TestCollectionCoverageProvider(CoverageProviderTest):
         failure = provider._set_circulationdata(identifier, empty)
         eq_("Identifier did not match CirculationData's primary identifier.",
             failure.exception)
-        
+
+        # Here, the data is okay, but the ReplacementPolicy is
+        # going to cause an error the first time we try to use it.
+        correct = CirculationData(provider.data_source,
+                                  identifier)
+        provider.replacement_policy = object()
+        failure = provider._set_circulationdata(identifier, correct)
+        assert isinstance(failure, CoverageFailure)
             
     def test_set_metadata_incorporates_replacement_policy(self):
         """Make sure that if a ReplacementPolicy is passed in to

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -944,9 +944,24 @@ class TestCollectionCoverageProvider(CoverageProviderTest):
             self._default_collection, replacement_policy=replacement_policy
         )
 
-        metadata = Metadata(provider.data_source)
+        metadata = Metadata(provider.data_source, primary_identifier=identifier)
         # We've got a CirculationData object that includes an open-access download.
         link = LinkData(rel=Hyperlink.OPEN_ACCESS_DOWNLOAD, href="http://foo.com/")
+
+        # We get an error if the CirculationData's identifier is
+        # doesn't match what we pass in.
+        circulationdata = CirculationData(
+            provider.data_source, 
+            primary_identifier=self._identifier(),
+            links=[link]
+        )
+        failure = provider.set_metadata_and_circulation_data(
+            identifier, metadata, circulationdata
+        )
+        eq_("Identifier did not match CirculationData's primary identifier.",
+            failure.exception)
+
+        # Otherwise, the data is applied.
         circulationdata = CirculationData(
             provider.data_source, 
             primary_identifier=metadata.primary_identifier, 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -899,6 +899,28 @@ class TestCollectionCoverageProvider(CoverageProviderTest):
             assert isinstance(provider, AlwaysSuccessfulCollectionCoverageProvider)
             eq_(34, provider.batch_size)
 
+    def test_set_circulationdata_errors(self):
+        provider = AlwaysSuccessfulCollectionCoverageProvider(
+            self._default_collection
+        )
+        identifier = self._identifier()
+        
+        failure = provider._set_circulationdata(identifier, None)
+        eq_("Did not receive circulationdata from input source",
+            failure.exception)
+
+        empty = CirculationData(provider.data_source, primary_identifier=None)
+        failure = provider._set_circulationdata(identifier, empty)
+        eq_("Identifier did not match CirculationData's primary identifier.",
+            failure.exception)
+
+        wrong = CirculationData(provider.data_source,
+                                primary_identifier=self._identifier())
+        failure = provider._set_circulationdata(identifier, empty)
+        eq_("Identifier did not match CirculationData's primary identifier.",
+            failure.exception)
+        
+            
     def test_set_metadata_incorporates_replacement_policy(self):
         """Make sure that if a ReplacementPolicy is passed in to
         set_metadata(), the policy's settings (and those of its

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1409,6 +1409,7 @@ class TestLicensePool(DatabaseTest):
             data_source_name=DataSource.STANDARD_EBOOKS,
             with_open_access_download=False,
         )
+        no_resource.open_access = True
         eq_(True, better(no_resource, None))
         eq_(False, better(no_resource, gutenberg_1))
 
@@ -2722,8 +2723,14 @@ class TestWorkConsolidation(DatabaseTest):
         edition1, ignore = self._edition(with_license_pool=True)
         edition2, ignore = self._edition(
             title=edition1.title, authors=edition1.author,
-            with_license_pool=True)
+            with_license_pool=True
+        )
 
+        # For purposes of this test, let's pretend these books are
+        # open-access.
+        edition1.license_pool.open_access = True
+        edition2.license_pool.open_access = True
+        
         # Calling calculate_work() on the first edition creates a Work.
         work1, created = edition1.license_pool.calculate_work()
         eq_(created, True)
@@ -2845,6 +2852,8 @@ class TestWorkConsolidation(DatabaseTest):
         author = "Single Author"
         ed1, open1 = self._edition(title=title, authors=author, with_license_pool=True)
         ed2, open2 = self._edition(title=title, authors=author, with_license_pool=True)
+        open1.open_access = True
+        open2.open_access = True
         ed3, restricted3 = self._edition(
             title=title, authors=author, data_source_name=DataSource.OVERDRIVE,
             with_license_pool=True)
@@ -3007,11 +3016,13 @@ class TestWorkConsolidation(DatabaseTest):
         # Here's a Work with an open-access edition of "abcd".
         work = self._work(with_license_pool=True)
         [book] = work.license_pools
+        book.open_access = True
         book.presentation_edition.permanent_work_id = "abcd"
-
+        
         # Due to a earlier error, the Work also contains an
         # open-access _audiobook_ of "abcd".
         edition, audiobook = self._edition(with_license_pool=True)
+        audiobook.open_access = True
         audiobook.presentation_edition.medium=Edition.AUDIO_MEDIUM
         audiobook.presentation_edition.permanent_work_id = "abcd"
         work.license_pools.append(audiobook)
@@ -3200,6 +3211,7 @@ class TestWorkConsolidation(DatabaseTest):
 
         # Here's a LicensePool with no corresponding Work.
         edition, lp = self._edition(with_license_pool=True)
+        lp.open_access = True
         edition.permanent_work_id="abcd"
 
         # open_access_for_permanent_work_id creates the Work.

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -691,6 +691,7 @@ class TestOPDS(DatabaseTest):
         work = self._work(title="open access", with_open_access_download=True)
         no_license_pool = self._work(title="no license pool", with_license_pool=False)
         no_download = self._work(title="no download", with_license_pool=True)
+        no_download.license_pools[0].open_access = True
         not_open_access = self._work("not open access", with_license_pool=True)
         not_open_access.license_pools[0].open_access = False
         self._db.commit()

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -240,8 +240,9 @@ class TestOverdriveRepresentationExtractor(OverdriveTestWithAPI):
         circulationdata = OverdriveRepresentationExtractor.book_info_to_circulation(info)
 
         # Related IDs.
+        identifier = circulationdata.primary_identifier(self._db)
         eq_((Identifier.OVERDRIVE_ID, '2a005d55-a417-4053-b90d-7a38ca6d2065'),
-            (circulationdata.primary_identifier.type, circulationdata.primary_identifier.identifier))
+            (identifier.type, identifier.identifier))
 
 
     def test_book_info_with_metadata(self):


### PR DESCRIPTION
This branch changes `CirculationData.apply()` to take an optional Collection instead of a LicensePool. If you provide a Collection, it automatically finds or creates the appropriate LicensePool. If you don't provide a Collection, that's fine, but you can't `apply()` any information that goes into a LicensePool (such as number of available copies). You can only `apply()` formatting information (which as of my previous branch is associated with DataSource and Identifier, not LicensePool).

This is a much less intrusive change than moving link and format information from `CollectionData` to `Metadata`.

It turns out every time we currently call `CirculationData.apply()` we will have a Collection in mind, because we either call it from `CollectionMonitor` or `BibliographicCoverageProvider`. The real work was done in the previous branch, which made sure that the work done by `BibliographicCoverageProvider` in creating `LicensePoolDeliveryMechanism`s applies to all LicensePools for a given book. Now that that's in place we don't actually have to change `BibliographicCoverageProvider`.

I thought about changing `BibliographicCoverageProvider` so it wasn't a `CollectionCoverageProvider`, and we could do that for the Overdrive coverage provider, but not for the others. The problem is we need a Collection to get access to the third-party data in the first place. Collection is where we keep the API credentials. With the Overdrive API you can ask about a book that's not in your collection, but you can't do that with the Bibliotheca, Axis 360, or (I think) OneClick API.

So although this branch makes a pretty big change to `CirculationData`, we don't actually make use of it yet and I'm not sure if we ever will. Maybe in the open-access context it will make sense.
