### PR TITLE
Support bibblio integration

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -9,7 +9,7 @@ import subprocess
 from lxml import etree
 from functools import wraps
 from flask import url_for, make_response
-from flask.ext.babel import lazy_gettext as _
+from flask_babel import lazy_gettext as _
 from util.flask_util import problem
 from util.problem_detail import ProblemDetail
 import traceback

--- a/migration/20170321-remove-catalogs.sql
+++ b/migration/20170321-remove-catalogs.sql
@@ -1,2 +1,2 @@
-DROP TABLE catalogsidentifiers CASCADE;
-DROP TABLE catalogs CASCADE;
+DROP TABLE IF EXISTS catalogsidentifiers CASCADE;
+DROP TABLE IF EXISTS catalogs CASCADE;

--- a/model.py
+++ b/model.py
@@ -999,7 +999,8 @@ class DataSource(Base):
                 (cls.NOVELIST, False, True, Identifier.NOVELIST_ID, None),
                 (cls.PRESENTATION_EDITION, False, False, None, None),
                 (cls.INTERNAL_PROCESSING, True, False, None, None),
-                (cls.FEEDBOOKS, True, False, Identifier.URI, None)
+                (cls.FEEDBOOKS, True, False, Identifier.URI, None),
+                (cls.BIBBLIO, False, True, Identifier.BIBBLIO_CONTENT_ITEM_ID, None)
         ):
 
             extra = dict()
@@ -1318,6 +1319,7 @@ class Identifier(Base):
     URI = u"URI"
     DOI = u"DOI"
     UPC = u"UPC"
+    BIBBLIO_CONTENT_ITEM_ID = u"Bibblio Content Item ID"
 
     DEPRECATED_NAMES = {
         u"3M ID" : BIBLIOTHECA_ID

--- a/model.py
+++ b/model.py
@@ -781,6 +781,7 @@ class DataSource(Base):
     PRESENTATION_EDITION = u"Presentation edition generator"
     INTERNAL_PROCESSING = u"Library Simplified Internal Process"
     FEEDBOOKS = u"FeedBooks"
+    BIBBLIO = u"Bibblio"
     
     DEPRECATED_NAMES = {
         u"3M" : BIBLIOTHECA

--- a/model.py
+++ b/model.py
@@ -3628,6 +3628,11 @@ class Work(Base):
                 if edition.cover_thumbnail_url:
                     cover_urls.append(edition.cover_thumbnail_url)
 
+        if not cover_urls:
+            # All of the target Works have already had their
+            # covers suppressed. Nothing to see here.
+            return
+
         covers = _db.query(Resource).join(Hyperlink.identifier).\
             join(Identifier.licensed_through).filter(
                 Resource.url.in_(cover_urls),

--- a/problem_details.py
+++ b/problem_details.py
@@ -1,6 +1,6 @@
 from util.problem_detail import ProblemDetail as pd
 from util.http import INTEGRATION_ERROR
-from flask.ext.babel import lazy_gettext as _
+from flask_babel import lazy_gettext as _
 
 # Generic problem detail documents that recapitulate HTTP errors.
 # call detailed() to add more specific information.

--- a/scripts.py
+++ b/scripts.py
@@ -924,8 +924,12 @@ class WorkProcessingScript(IdentifierInputScript):
 
         args = self.parse_command_line(self._db)
         self.identifier_type = args.identifier_type
-        self.identifiers = args.identifiers
         self.data_source = args.identifier_data_source
+
+        self.identifiers = self.parse_identifier_list(
+            self._db, self.identifier_type, self.data_source,
+            args.identifier_strings
+        )
 
         self.batch_size = batch_size
         self.query = self.make_query(

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -1,6 +1,6 @@
 import json
 from flask import Flask
-from flask.ext.babel import (
+from flask_babel import (
     Babel,
     lazy_gettext as _
 )

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -66,7 +66,7 @@ from classifier import (
 
 from external_search import DummyExternalSearchIndex
 import xml.etree.ElementTree as ET
-from flask.ext.babel import lazy_gettext as _
+from flask_babel import lazy_gettext as _
 
 class TestBaseAnnotator(DatabaseTest):
 

--- a/user_profile.py
+++ b/user_profile.py
@@ -1,7 +1,7 @@
 from nose.tools import set_trace
 import json
 from problem_details import *
-from flask.ext.babel import lazy_gettext as _
+from flask_babel import lazy_gettext as _
 
 class ProfileController(object):
     """Implement the User Profile Management Protocol.

--- a/util/epub.py
+++ b/util/epub.py
@@ -1,0 +1,77 @@
+import contextlib
+import logging
+import os, sys
+from lxml import etree
+from nose.tools import set_trace
+from StringIO import StringIO
+from zipfile import ZipFile
+
+from http import HTTP
+
+
+class EpubAccessor(object):
+
+    CONTAINER_FILE = "META-INF/container.xml"
+    IDPF_NAMESPACE = "http://www.idpf.org/2007/opf"
+
+    @classmethod
+    @contextlib.contextmanager
+    def open_epub(cls, url, content=None):
+        """Cracks open an EPUB to expose its contents
+
+        :param url: A url representing the EPUB, only used for errors and in
+            the absence of the `content` parameter
+        :param content: A string representing the compressed EPUB
+
+        :return: A tuple containing a ZipFile of the EPUB and the path to its
+        package
+        """
+        if not (url or content):
+            raise ValueError("Cannot open epub without url or content")
+        if url and not content:
+            # Get the epub from the url if no content has been made available.
+            content = HTTP.get_with_timeout(url).content
+        content = StringIO(content)
+
+        with ZipFile(content) as zip_file:
+            if not cls.CONTAINER_FILE in zip_file.namelist():
+                raise ValueError("Invalid EPUB file, not modifying: %s" % url)
+
+            with zip_file.open(cls.CONTAINER_FILE) as container_file:
+                container = container_file.read()
+                rootfiles_element = etree.fromstring(container).find("{urn:oasis:names:tc:opendocument:xmlns:container}rootfiles")
+
+                if rootfiles_element is None:
+                    raise ValueError("Invalid EPUB file, not modifying: %s" % url)
+
+                rootfile_element = rootfiles_element.find("{urn:oasis:names:tc:opendocument:xmlns:container}rootfile")
+                if rootfile_element is None:
+                    raise ValueError("Invalid EPUB file, not modifying: %s" % url)
+
+                package_document_path = rootfile_element.get('full-path')
+            yield zip_file, package_document_path
+
+    @classmethod
+    def get_element_from_package(cls, zip_file, package_document_path, element_tag):
+        """Pulls one or more elements from the package_document"""
+        [element] = cls.get_elements_from_package(
+            zip_file, package_document_path, [element_tag]
+        )
+        return element
+
+    @classmethod
+    def get_elements_from_package(cls, zip_file, package_document_path, element_tags):
+        """Pulls one or more elements from the package_document"""
+        if not isinstance(element_tags, list):
+            element_tags = [element_tags]
+        elements = list()
+        with zip_file.open(package_document_path) as package_file:
+            package = package_file.read()
+            for element_tag in element_tags:
+                element = etree.fromstring(package).find(
+                    "{%s}%s" % (cls.IDPF_NAMESPACE, element_tag)
+                )
+                if element is None:
+                    raise ValueError("Invalid EPUB file: '%s' could not be found" % element_tag)
+                elements.append(element)
+        return elements

--- a/util/http.py
+++ b/util/http.py
@@ -1,7 +1,7 @@
 from nose.tools import set_trace
 import requests
 import urlparse
-from flask.ext.babel import lazy_gettext as _
+from flask_babel import lazy_gettext as _
 from problem_detail import ProblemDetail as pd
 
 INTEGRATION_ERROR = pd(

--- a/util/problem_detail.py
+++ b/util/problem_detail.py
@@ -4,7 +4,7 @@ As per http://datatracker.ietf.org/doc/draft-ietf-appsawg-http-problem/
 """
 import json as j
 import logging
-from flask.ext.babel import LazyString
+from flask_babel import LazyString
 
 JSON_MEDIA_TYPE = "application/api-problem+json"
 


### PR DESCRIPTION
This branch supports the Bibblio integration currently baked into the content_server (though it will have to move into circulation if we decide we want to catalogue nonfiction books outside of the public domain). Changes include:

- Creating a Bibblio DataSource and identifier type for works catalogued as Bibblio Content Items.
- Extracting an `EpubAccessor` utility class from Amy's work from the content_server. It cracks open an EPUB and get at the manifest and other goodies within and uses contextlib to make sure the EPUB is closed up again afterwards.
- Removing all references to the deprecated `flask.ext.babel`, referencing the `flask_babel` module instead.
- Adding an `IF EXISTS` clause to an otherwise occasionally broken migration.
- Using the preferred `[[` function in bash conditionals.