### PR TITLE
Patron has library

### DIFF
--- a/migration/20170509-add-library-to-patron.sql
+++ b/migration/20170509-add-library-to-patron.sql
@@ -16,3 +16,5 @@ ALTER TABLE patrons ADD CONSTRAINT patrons_library_id_username_key UNIQUE (libra
 CREATE INDEX ix_patron_library_id_authorization_identifier ON patrons USING btree (library_id, authorization_identifier);
 CREATE INDEX ix_patron_library_id_external_identifier ON patrons USING btree (library_id, external_identifier);
 CREATE INDEX ix_patron_library_id_username ON patrons USING btree (library_id, username);
+
+UPDATE patrons set library_id = (select id from libraries limit 1);

--- a/migration/20170509-add-library-to-patron.sql
+++ b/migration/20170509-add-library-to-patron.sql
@@ -1,0 +1,18 @@
+-- It used to be that patrons.username,
+-- patrons.authorization_identifier, and patrons.external_identifier
+-- each had to be unique. Now, the *combination* of each of those fields
+-- with patrons.library_id must be unique.
+
+DROP INDEX ix_patrons_authorization_identifier;
+DROP INDEX ix_patrons_external_identifier;
+DROP INDEX ix_patrons_username;
+
+ALTER TABLE patrons ADD COLUMN library_id integer;
+
+ALTER TABLE patrons ADD CONSTRAINT patrons_library_id_authorization_identifier_key UNIQUE (library_id, authorization_identifier);
+ALTER TABLE patrons ADD CONSTRAINT patrons_library_id_external_identifier_key UNIQUE (library_id, external_identifier);
+ALTER TABLE patrons ADD CONSTRAINT patrons_library_id_username_key UNIQUE (library_id, username);
+
+CREATE INDEX ix_patron_library_id_authorization_identifier ON patrons USING btree (library_id, authorization_identifier);
+CREATE INDEX ix_patron_library_id_external_identifier ON patrons USING btree (library_id, external_identifier);
+CREATE INDEX ix_patron_library_id_username ON patrons USING btree (library_id, username);

--- a/migration/20170509-add-library-to-patron.sql
+++ b/migration/20170509-add-library-to-patron.sql
@@ -8,6 +8,8 @@ DROP INDEX ix_patrons_external_identifier;
 DROP INDEX ix_patrons_username;
 
 ALTER TABLE patrons ADD COLUMN library_id integer;
+ALTER TABLE patrons ADD CONSTRAINT patrons_library_id_fkey FOREIGN KEY (library_id) REFERENCES libraries(id);
+
 
 ALTER TABLE patrons ADD CONSTRAINT patrons_library_id_authorization_identifier_key UNIQUE (library_id, authorization_identifier);
 ALTER TABLE patrons ADD CONSTRAINT patrons_library_id_external_identifier_key UNIQUE (library_id, external_identifier);

--- a/model.py
+++ b/model.py
@@ -397,7 +397,7 @@ class Patron(Base):
     # This is not stored as a ForeignIdentifier because it corresponds
     # to the patron's identifier in the library responsible for the
     # Simplified instance, not a third party.
-    external_identifier = Column(Unicode, index=True)
+    external_identifier = Column(Unicode)
 
     # The patron's account type, as reckoned by an external library
     # system. Different account types may be subject to different
@@ -410,12 +410,12 @@ class Patron(Base):
 
     # An identifier used by the patron that gives them the authority
     # to borrow books. This identifier may change over time.
-    authorization_identifier = Column(Unicode, index=True)
+    authorization_identifier = Column(Unicode)
 
     # An identifier used by the patron that authenticates them,
     # but does not give them the authority to borrow books. i.e. their
     # website username.
-    username = Column(Unicode, index=True)
+    username = Column(Unicode)
 
     # The last time this record was synced up with an external library
     # system.
@@ -534,6 +534,11 @@ class Patron(Base):
                 _db.delete(annotation)
         self._synchronize_annotations = value
 
+Index("ix_patron_library_id_external_identifier", Patron.library_id, Patron.external_identifier)
+Index("ix_patron_library_id_authorization_identifier", Patron.library_id, Patron.authorization_identifier)
+Index("ix_patron_library_id_username", Patron.library_id, Patron.username)
+
+        
 class PatronProfileStorage(ProfileStorage):
     """Interface between a Patron object and the User Profile Management
     Protocol.

--- a/model.py
+++ b/model.py
@@ -8718,7 +8718,9 @@ class Library(Base):
     # consumption by the library registry.
     library_registry_shared_secret = Column(Unicode, unique=True)
 
-    patrons = relationship('Patron', backref='library')
+    patrons = relationship(
+        'Patron', backref='library', cascade="all, delete, delete-orphan"
+    )
     
     def __repr__(self):
         return '<Library: name="%s", short name="%s", uuid="%s", library registry short name="%s">' % (

--- a/testing.py
+++ b/testing.py
@@ -654,6 +654,14 @@ class DatabaseTest(object):
         return
 
 
+    def _library(self, name=None, short_name=None):
+        name=name or self._str
+        short_name = short_name or self._str
+        library, ignore = get_one_or_create(
+            self._db, Library, name=name, short_name=short_name
+        )
+        return library
+    
     def _collection(self, name=None, protocol=Collection.OPDS_IMPORT,
                     external_account_id=None, url=None, username=None,
                     password=None):

--- a/testing.py
+++ b/testing.py
@@ -176,10 +176,13 @@ class DatabaseTest(object):
     def _url(self):
         return "http://foo.com/" + self._str
 
-    def _patron(self, external_identifier=None):
+    def _patron(self, external_identifier=None, library=None):
         external_identifier = external_identifier or self._str
+        library = library or self._default_library
         return get_one_or_create(
-            self._db, Patron, external_identifier=external_identifier)[0]
+            self._db, Patron, external_identifier=external_identifier,
+            library=library
+        )[0]
 
     def _contributor(self, sort_name=None, name=None, **kw_args):
         name = sort_name or name or self._str


### PR DESCRIPTION
This branch adds `library_id` to the `patrons` table, associating each patron with a library. Fields that were formerly unique across the `patrons` table are now unique only in combination with `library_id`. So two patrons can have the same username so long as they belong to different libraries.

This is for https://github.com/NYPL-Simplified/circulation/issues/487