### PR TITLE
Fix Best Sellers & Staff Picks lanes

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -579,11 +579,16 @@ class Lane(object):
             exclude_genres=exclude_genres, fiction=fiction
         )
 
-        # CustomList information must be set after sublanes.
-        # Otherwise, sublanes won't be restricted by the list.
-        self.set_customlist_information(
-            list_data_source, list_identifier, list_seen_in_previous_days
-        )
+        if list_data_source or list_identifier:
+            # CustomList information must be set after sublanes.
+            # Otherwise, sublanes won't be restricted by the list.
+            self.set_customlist_information(
+                list_data_source, list_identifier, list_seen_in_previous_days
+            )
+        else:
+            self.list_data_source_id = None
+            self.list_ids = list()
+            self.list_featured_works_query = None
 
         # Best-seller and staff pick lanes go at the top.
         base_args = dict(
@@ -650,6 +655,9 @@ class Lane(object):
         for sublane in self.sublanes:
             # If the sublanes were set beforehand, they need to
             # inherit this information now.
+            #
+            # TODO: Find a different way to combine list restrictions
+            # from parent lanes. This is a placeholder.
             sublane.set_customlist_information(None, None, None)
 
         self.set_from_parent(

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -321,7 +321,29 @@ class TestLane(DatabaseTest):
         eq_(True, all_language_lane.includes_language('eng'))
         eq_(True, all_language_lane.includes_language('fre'))
 
-        
+    def test_set_customlist_ignored_when_no_list(self):
+
+        class SetCustomListErrorLane(Lane):
+            def set_customlist_information(self, *args, **kwargs):
+                raise RuntimeError()
+
+        # Because this lane has no list-related information, the
+        # RuntimeError shouldn't pop up at all.
+        lane = SetCustomListErrorLane(self._db, self._str)
+
+        # The minute we put in some list information, it does!
+        assert_raises(
+            RuntimeError, SetCustomListErrorLane, self._db, self._str,
+            list_data_source=DataSource.NYT
+        )
+
+        # It can be a DataSource, or a CustomList identifier. World == oyster.
+        assert_raises(
+            RuntimeError, SetCustomListErrorLane, self._db, self._str,
+            list_identifier=u"Staff Picks"
+        )
+
+
 class TestLanes(DatabaseTest):
 
     def test_all_matching_genres(self):


### PR DESCRIPTION
This branch fixes the problems that @leonardr spotted in the Staff Picks and Best Sellers lanes where every single book was being included in both. It also seeks to find matching books by both LicensePool and Edition, since in the QA database it appears that finding a CustomListEntry by its connected via LicensePool is highly unlikely.