### PR TITLE
Merge Collection.protocol with ExternalIntegration.provider

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -200,10 +200,12 @@ class MockAxis360API(Axis360API):
                 external_account_id=u'c',
             )
         )
-        collection.external_integration.protocol=ExternalIntegration.AXIS_360
-        collection.external_integration.username = u'a'
-        collection.external_integration.password = u'b'
-        collection.external_integration.url = u"http://axis.test/"
+        integration = collection.create_external_integration(
+            protocol=ExternalIntegration.AXIS_360
+        )
+        integration.username = u'a'
+        integration.password = u'b'
+        integration.url = u"http://axis.test/"
         library.collections.append(collection)
         return collection
 

--- a/axis.py
+++ b/axis.py
@@ -67,10 +67,10 @@ class Axis360API(object):
     log = logging.getLogger("Axis 360 API")
 
     def __init__(self, collection):
-        if collection.provider != ExternalIntegration.AXIS_360:
+        if collection.protocol != ExternalIntegration.AXIS_360:
             raise ValueError(
-                "Collection provider is %s, but passed into Axis360API!" %
-                collection.provider
+                "Collection protocol is %s, but passed into Axis360API!" %
+                collection.protocol
             )
         self._db = Session.object_session(collection)
         self.library_id = collection.external_account_id.encode("utf8")
@@ -200,7 +200,7 @@ class MockAxis360API(Axis360API):
                 external_account_id=u'c',
             )
         )
-        collection.external_integration.provider=ExternalIntegration.AXIS_360
+        collection.external_integration.protocol=ExternalIntegration.AXIS_360
         collection.external_integration.username = u'a'
         collection.external_integration.password = u'b'
         collection.external_integration.url = u"http://axis.test/"
@@ -249,7 +249,7 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
 
     SERVICE_NAME = "Axis 360 Bibliographic Coverage Provider"
     DATA_SOURCE_NAME = DataSource.AXIS_360
-    PROVIDER = ExternalIntegration.AXIS_360
+    PROTOCOL = ExternalIntegration.AXIS_360
     INPUT_IDENTIFIER_TYPES = Identifier.AXIS_360_ID
     DEFAULT_BATCH_SIZE = 25
     

--- a/axis.py
+++ b/axis.py
@@ -27,6 +27,7 @@ from model import (
     Contributor,
     DataSource,
     DeliveryMechanism,
+    ExternalIntegration,
     LicensePool,
     Edition,
     Identifier,
@@ -66,10 +67,10 @@ class Axis360API(object):
     log = logging.getLogger("Axis 360 API")
 
     def __init__(self, collection):
-        if collection.protocol != collection.AXIS_360:
+        if collection.provider != ExternalIntegration.AXIS_360:
             raise ValueError(
-                "Collection protocol is %s, but passed into Axis360API!" %
-                collection.protocol
+                "Collection provider is %s, but passed into Axis360API!" %
+                collection.provider
             )
         self._db = Session.object_session(collection)
         self.library_id = collection.external_account_id.encode("utf8")
@@ -195,10 +196,11 @@ class MockAxis360API(Axis360API):
         collection, ignore = get_one_or_create(
             _db, Collection,
             name="Test Axis 360 Collection",
-            protocol=Collection.AXIS_360, create_method_kwargs=dict(
+            create_method_kwargs=dict(
                 external_account_id=u'c',
             )
         )
+        collection.external_integration.provider=ExternalIntegration.AXIS_360
         collection.external_integration.username = u'a'
         collection.external_integration.password = u'b'
         collection.external_integration.url = u"http://axis.test/"
@@ -247,7 +249,7 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
 
     SERVICE_NAME = "Axis 360 Bibliographic Coverage Provider"
     DATA_SOURCE_NAME = DataSource.AXIS_360
-    PROTOCOL = Collection.AXIS_360
+    PROVIDER = ExternalIntegration.AXIS_360
     INPUT_IDENTIFIER_TYPES = Identifier.AXIS_360_ID
     DEFAULT_BATCH_SIZE = 25
     

--- a/bibliotheca.py
+++ b/bibliotheca.py
@@ -25,6 +25,7 @@ from model import (
     Contributor,
     DataSource,
     DeliveryMechanism,
+    ExternalIntegration,
     Representation,
     Hyperlink,
     Identifier,
@@ -69,10 +70,10 @@ class BibliothecaAPI(object):
     
     def __init__(self, collection):
         
-        if collection.protocol != collection.BIBLIOTHECA:
+        if collection.provider != ExternalIntegration.BIBLIOTHECA:
             raise ValueError(
-                "Collection protocol is %s, but passed into BibliothecaAPI!" %
-                collection.protocol
+                "Collection provider is %s, but passed into BibliothecaAPI!" %
+                collection.provider
             )
 
         self._db = Session.object_session(collection)
@@ -204,11 +205,11 @@ class MockBibliothecaAPI(BibliothecaAPI):
         library = Library.instance(_db)
         collection, ignore = get_one_or_create(
             _db, Collection,
-            name="Test Bibliotheca Collection",
-            protocol=Collection.BIBLIOTHECA, create_method_kwargs=dict(
+            name="Test Bibliotheca Collection", create_method_kwargs=dict(
                 external_account_id=u'c',
             )
         )
+        collection.external_integration.provider=ExternalIntegration.BIBLIOTHECA
         collection.external_integration.username = u'a'
         collection.external_integration.password = u'b'
         collection.external_integration.url = "http://bibliotheca.test"
@@ -420,7 +421,7 @@ class BibliothecaBibliographicCoverageProvider(BibliographicCoverageProvider):
     """
     SERVICE_NAME = "Bibliotheca Bibliographic Coverage Provider"
     DATA_SOURCE_NAME = DataSource.BIBLIOTHECA
-    PROTOCOL = Collection.BIBLIOTHECA
+    PROVIDER = ExternalIntegration.BIBLIOTHECA
     INPUT_IDENTIFIER_TYPES = Identifier.BIBLIOTHECA_ID
 
     # 25 is the maximum batch size for the Bibliotheca API.

--- a/bibliotheca.py
+++ b/bibliotheca.py
@@ -209,10 +209,12 @@ class MockBibliothecaAPI(BibliothecaAPI):
                 external_account_id=u'c',
             )
         )
-        collection.external_integration.protocol=ExternalIntegration.BIBLIOTHECA
-        collection.external_integration.username = u'a'
-        collection.external_integration.password = u'b'
-        collection.external_integration.url = "http://bibliotheca.test"
+        integration = collection.create_external_integration(
+            protocol=ExternalIntegration.BIBLIOTHECA
+        )
+        integration.username = u'a'
+        integration.password = u'b'
+        integration.url = "http://bibliotheca.test"
         library.collections.append(collection)
         return collection
         

--- a/bibliotheca.py
+++ b/bibliotheca.py
@@ -70,10 +70,10 @@ class BibliothecaAPI(object):
     
     def __init__(self, collection):
         
-        if collection.provider != ExternalIntegration.BIBLIOTHECA:
+        if collection.protocol != ExternalIntegration.BIBLIOTHECA:
             raise ValueError(
-                "Collection provider is %s, but passed into BibliothecaAPI!" %
-                collection.provider
+                "Collection protocol is %s, but passed into BibliothecaAPI!" %
+                collection.protocol
             )
 
         self._db = Session.object_session(collection)
@@ -209,7 +209,7 @@ class MockBibliothecaAPI(BibliothecaAPI):
                 external_account_id=u'c',
             )
         )
-        collection.external_integration.provider=ExternalIntegration.BIBLIOTHECA
+        collection.external_integration.protocol=ExternalIntegration.BIBLIOTHECA
         collection.external_integration.username = u'a'
         collection.external_integration.password = u'b'
         collection.external_integration.url = "http://bibliotheca.test"
@@ -421,7 +421,7 @@ class BibliothecaBibliographicCoverageProvider(BibliographicCoverageProvider):
     """
     SERVICE_NAME = "Bibliotheca Bibliographic Coverage Provider"
     DATA_SOURCE_NAME = DataSource.BIBLIOTHECA
-    PROVIDER = ExternalIntegration.BIBLIOTHECA
+    PROTOCOL = ExternalIntegration.BIBLIOTHECA
     INPUT_IDENTIFIER_TYPES = Identifier.BIBLIOTHECA_ID
 
     # 25 is the maximum batch size for the Bibliotheca API.

--- a/coverage.py
+++ b/coverage.py
@@ -714,9 +714,9 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
     
     DEFAULT_BATCH_SIZE = 10
 
-    # Set this to the name of the provider managed by this type of
+    # Set this to the name of the protocol managed by this type of
     # CoverageProvider. If this CoverageProvider can manage collections
-    # for any provider, leave this as None.
+    # for any protocol, leave this as None.
     PROTOCOL = None
     
     def __init__(self, collection, **kwargs):

--- a/coverage.py
+++ b/coverage.py
@@ -768,8 +768,10 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
             collections = collections.join(
                 ExternalIntegration,
                 ExternalIntegration.id==Collection.external_integration_id).filter(
-                    ExternalIntegration.provider==cls.PROVIDER)
-
+                    ExternalIntegration.type==ExternalIntegration.LICENSE_TYPE
+                ).filter(
+                    ExternalIntegration.provider==cls.PROVIDER
+                )
         collections = collections.order_by(func.random())
         for collection in collections:
             yield cls(collection, **kwargs)

--- a/model.py
+++ b/model.py
@@ -9111,6 +9111,10 @@ class Collection(Base):
     def create_external_integration(self, protocol):
         """Create an ExternalIntegration for this Collection.
 
+        To be used immediately after creating a new Collection,
+        e.g. in by_name_and_protocol, from_metadata_identifier, and
+        various test methods that create mock Collections.
+
         If an external integration already exists, return it instead
         of creating another one.
 

--- a/model.py
+++ b/model.py
@@ -9081,12 +9081,19 @@ class Collection(Base):
     
     @classmethod
     def by_protocol(cls, _db, protocol):
-        """Query collections that get their licenses through the given protocol."""
-        return _db.query(Collection).join(
+        """Query collections that get their licenses through the given protocol.
+
+        :param protocol: Protocol to use. If this is None, all
+        Collections will be returned.
+        """
+        qu = _db.query(Collection)
+        if protocol:
+            qu = qu.join(
             ExternalIntegration,
             ExternalIntegration.id==Collection.external_integration_id).filter(
                 ExternalIntegration.type==ExternalIntegration.LICENSE_TYPE
             ).filter(ExternalIntegration.protocol==protocol)
+        return qu
     
     @property
     def protocol(self):

--- a/model.py
+++ b/model.py
@@ -8855,7 +8855,7 @@ class ExternalIntegration(Base):
     
     # Some LICENSE_TYPE protocols imply that the data and
     # licenses come from a specific data source.
-    DATA_SOURCE_FOR_LICENSE_PROTOCOLS = {
+    DATA_SOURCE_FOR_LICENSE_PROTOCOL = {
         OVERDRIVE : DataSource.OVERDRIVE,
         BIBLIOTHECA : DataSource.BIBLIOTHECA,
         AXIS_360 : DataSource.AXIS_360,

--- a/model.py
+++ b/model.py
@@ -9127,6 +9127,12 @@ class Collection(Base):
             _db, ExternalIntegration, id=self.external_integration_id,
             create_method_kwargs=dict(protocol=protocol, goal=goal)
         )
+        if external_integration.protocol != protocol:
+            raise ValueError(
+                "Located ExternalIntegration, but its protocol (%s) does not match desired protocol (%s)." % (
+                    external_integration.protocol, protocol
+                )
+            )
         self.external_integration_id = external_integration.id
         return external_integration
             
@@ -9141,7 +9147,7 @@ class Collection(Base):
         """
         if not self.external_integration_id:
             raise ValueError(
-                "No known external intergation for collection %s" % self.name
+                "No known external integration for collection %s" % self.name
             )
         _db = Session.object_session(self)
         return get_one(

--- a/monitor.py
+++ b/monitor.py
@@ -19,6 +19,7 @@ from model import (
     CollectionMissing,
     CoverageRecord,
     Edition,
+    ExternalIntegration,
     CustomListEntry,
     Identifier,
     LicensePool,
@@ -180,26 +181,26 @@ class Monitor(object):
 
 
 class CollectionMonitor(Monitor):
-    """A Monitor that does something for all Collections that implement
-    a certain protocol.
+    """A Monitor that does something for all Collections that come
+    from a certain provider.
 
     This class is designed to be subclassed rather than instantiated
     directly. Subclasses must define SERVICE_NAME and
-    PROTOCOL. Subclasses may define replacement values for
+    PROVIDER. Subclasses may define replacement values for
     KEEP_TIMESTAMP, INTERVAL_SECONDS, and DEFAULT_START_TIME.
     """
 
-    # Set this to the name of the protocol managed by this Monitor. If
-    # this value is set, the CollectionMonitor can only be
-    # instantiated with Collections that implement this protocol. If this is
-    # unset, the CollectionMonitor can be instantiated with any Collection,
-    # or with no Collection at all.
-    PROTOCOL = None
+    # Set this to the name of the license provider managed by this
+    # Monitor. If this value is set, the CollectionMonitor can only be
+    # instantiated with Collections that get their licenses from this
+    # provider. If this is unset, the CollectionMonitor can be
+    # instantiated with any Collection, or with no Collection at all.
+    PROVIDER = None
 
     def __init__(self, _db, collection):
         cls = self.__class__
         self.protocol = cls.PROTOCOL
-        if self.protocol:
+        if self.provider:
             if collection is None:
                 raise CollectionMissing()
         if self.protocol and collection.protocol != self.protocol:
@@ -214,7 +215,7 @@ class CollectionMonitor(Monitor):
     @classmethod
     def all(cls, _db, **constructor_kwargs):
         """Yield a sequence of CollectionMonitor objects: one for every
-        Collection that implements cls.PROTOCOL.
+        Collection provided by cls.PROVIDER.
 
         Monitors that have no Timestamp will be yielded first. After that,
         Monitors with older Timestamps will be yielded before Monitors with

--- a/oneclick.py
+++ b/oneclick.py
@@ -526,9 +526,10 @@ class MockOneClickAPI(OneClickAPI):
                 external_account_id=u'library_id_123',
             )
         )
-        collection.external_integration.type = ExternalIntegration.LICENSE_TYPE
-        collection.external_integration.protocol = ExternalIntegration.ONE_CLICK
-        collection.external_integration.password = u'abcdef123hijklm'
+        integration = collection.create_external_integration(
+            protocol=ExternalIntegration.ONE_CLICK
+        )        
+        integration.password = u'abcdef123hijklm'
         library.collections.append(collection)
         return collection
     

--- a/oneclick.py
+++ b/oneclick.py
@@ -75,10 +75,10 @@ class OneClickAPI(object):
     log = logging.getLogger("OneClick API")
 
     def __init__(self, collection):
-        if collection.provider != ExternalIntegration.ONE_CLICK:
+        if collection.protocol != ExternalIntegration.ONE_CLICK:
             raise ValueError(
-                "Collection provider is %s, but passed into OneClickAPI!" %
-                collection.provider
+                "Collection protocol is %s, but passed into OneClickAPI!" %
+                collection.protocol
             )
         self._db = Session.object_session(collection)
         self.collection_id = collection.id
@@ -527,7 +527,7 @@ class MockOneClickAPI(OneClickAPI):
             )
         )
         collection.external_integration.type = ExternalIntegration.LICENSE_TYPE
-        collection.external_integration.provider = ExternalIntegration.ONE_CLICK
+        collection.external_integration.protocol = ExternalIntegration.ONE_CLICK
         collection.external_integration.password = u'abcdef123hijklm'
         library.collections.append(collection)
         return collection
@@ -822,7 +822,7 @@ class OneClickBibliographicCoverageProvider(BibliographicCoverageProvider):
 
     SERVICE_NAME = "OneClick Bibliographic Coverage Provider"
     DATA_SOURCE_NAME = DataSource.ONECLICK
-    PROVIDER = ExternalIntegration.ONE_CLICK
+    PROTOCOL = ExternalIntegration.ONE_CLICK
     INPUT_IDENTIFIER_TYPES = Identifier.ONECLICK_ID
     DEFAULT_BATCH_SIZE = 25
 

--- a/oneclick.py
+++ b/oneclick.py
@@ -24,6 +24,7 @@ from model import (
     DataSource,
     DeliveryMechanism,
     Edition,
+    ExternalIntegration,
     Hyperlink,
     Identifier,
     Library,
@@ -74,10 +75,10 @@ class OneClickAPI(object):
     log = logging.getLogger("OneClick API")
 
     def __init__(self, collection):
-        if collection.protocol != collection.ONE_CLICK:
+        if collection.provider != ExternalIntegration.ONE_CLICK:
             raise ValueError(
-                "Collection protocol is %s, but passed into OneClickAPI!" %
-                collection.protocol
+                "Collection provider is %s, but passed into OneClickAPI!" %
+                collection.provider
             )
         self._db = Session.object_session(collection)
         self.collection_id = collection.id
@@ -521,10 +522,12 @@ class MockOneClickAPI(OneClickAPI):
         collection, ignore = get_one_or_create(
             _db, Collection,
             name="Test OneClick Collection",
-            protocol=Collection.ONE_CLICK, create_method_kwargs=dict(
+            create_method_kwargs=dict(
                 external_account_id=u'library_id_123',
             )
         )
+        collection.external_integration.type = ExternalIntegration.LICENSE_TYPE
+        collection.external_integration.provider = ExternalIntegration.ONE_CLICK
         collection.external_integration.password = u'abcdef123hijklm'
         library.collections.append(collection)
         return collection
@@ -819,7 +822,7 @@ class OneClickBibliographicCoverageProvider(BibliographicCoverageProvider):
 
     SERVICE_NAME = "OneClick Bibliographic Coverage Provider"
     DATA_SOURCE_NAME = DataSource.ONECLICK
-    PROTOCOL = Collection.ONE_CLICK
+    PROVIDER = ExternalIntegration.ONE_CLICK
     INPUT_IDENTIFIER_TYPES = Identifier.ONECLICK_ID
     DEFAULT_BATCH_SIZE = 25
 

--- a/opds_import.py
+++ b/opds_import.py
@@ -122,7 +122,7 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup):
 
     def __init__(self, _db, collection=None):
         integration = ExternalIntegration.lookup(
-            _db, provider=ExternalIntegration.METADATA_WRANGLER
+            _db, protocol=ExternalIntegration.METADATA_WRANGLER
         )
         if not integration:
             raise CannotLoadConfiguration(

--- a/opds_import.py
+++ b/opds_import.py
@@ -1277,7 +1277,7 @@ class OPDSImportMonitor(CollectionMonitor):
                 "OPDSImportMonitor can only be run in the context of a Collection."
             )
         
-        if collection.protocol != Collection.OPDS_IMPORT:
+        if collection.protocol != ExternalIntegration.OPDS_IMPORT:
             raise ValueError(
                 "Collection %s is configured for protocol %s, not OPDS import." % (
                     collection.name, collection.protocol

--- a/overdrive.py
+++ b/overdrive.py
@@ -1004,11 +1004,16 @@ class OverdriveAdvantageAccount(object):
                 "Cannot create a Collection whose parent does not already exist."
             )
         name = parent.name + " / " + self.name
-        child, ignore = get_one_or_create(
+        child, is_new = get_one_or_create(
             _db, Collection, parent_id=parent.id,
             external_account_id=self.library_id,
             create_method_kwargs=dict(name=name)
         )
+        if is_new:
+            # Make sure the child has its protocol set appropriately.
+            integration = child.create_external_integration(
+                ExternalIntegration.OVERDRIVE
+            )
 
         # Set or update the name of the collection to reflect the name of
         # the library, just in case that name has changed.

--- a/overdrive.py
+++ b/overdrive.py
@@ -109,10 +109,10 @@ class OverdriveAPI(object):
 
    
     def __init__(self, collection):
-        if collection.provider != ExternalIntegration.OVERDRIVE:
+        if collection.protocol != ExternalIntegration.OVERDRIVE:
             raise ValueError(
-                "Collection provider is %s, but passed into OverdriveAPI!" %
-                collection.provider
+                "Collection protocol is %s, but passed into OverdriveAPI!" %
+                collection.protocol
             )
         self._db = Session.object_session(collection)
         self.library_id = collection.external_account_id
@@ -402,7 +402,7 @@ class MockOverdriveAPI(OverdriveAPI):
                     external_account_id=u'c'
                 )
             )
-        collection.external_integration.provider = ExternalIntegration.OVERDRIVE
+        collection.external_integration.protocol = ExternalIntegration.OVERDRIVE
         collection.external_integration.username = u'a'
         collection.external_integration.password = u'b'
         collection.external_integration.set_setting('website_id', 'd')
@@ -993,7 +993,7 @@ class OverdriveAdvantageAccount(object):
         """
         # First find the parent Collection.
         try:
-            parent = Collection.by_provider(_db, ExternalIntegration.OVERDRIVE).filter(
+            parent = Collection.by_protocol(_db, ExternalIntegration.OVERDRIVE).filter(
                 Collection.external_account_id==self.parent_library_id
             ).one()
         except NoResultFound, e:
@@ -1023,7 +1023,7 @@ class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
 
     SERVICE_NAME = "Overdrive Bibliographic Coverage Provider"
     DATA_SOURCE_NAME = DataSource.OVERDRIVE
-    PROVIDER = ExternalIntegration.OVERDRIVE
+    PROTOCOL = ExternalIntegration.OVERDRIVE
     INPUT_IDENTIFIER_TYPES = Identifier.OVERDRIVE_ID
     
     def __init__(self, collection, api_class=OverdriveAPI, **kwargs):

--- a/overdrive.py
+++ b/overdrive.py
@@ -8,6 +8,9 @@ import logging
 import urlparse
 import urllib
 import sys
+from sqlalchemy.orm.exc import (
+    NoResultFound,
+)
 from sqlalchemy.orm.session import Session
 
 from config import (
@@ -24,6 +27,7 @@ from model import (
     DataSource,
     DeliveryMechanism,
     Edition,
+    ExternalIntegration,
     Hyperlink,
     Identifier,
     Library,
@@ -105,10 +109,10 @@ class OverdriveAPI(object):
 
    
     def __init__(self, collection):
-        if collection.protocol != collection.OVERDRIVE:
+        if collection.provider != ExternalIntegration.OVERDRIVE:
             raise ValueError(
-                "Collection protocol is %s, but passed into OverdriveAPI!" %
-                collection.protocol
+                "Collection provider is %s, but passed into OverdriveAPI!" %
+                collection.provider
             )
         self._db = Session.object_session(collection)
         self.library_id = collection.external_account_id
@@ -394,10 +398,11 @@ class MockOverdriveAPI(OverdriveAPI):
         collection, ignore = get_one_or_create(
             _db, Collection,
                 name="Test Overdrive Collection",
-                protocol=Collection.OVERDRIVE, create_method_kwargs=dict(
+                create_method_kwargs=dict(
                     external_account_id=u'c'
                 )
             )
+        collection.external_integration.provider = ExternalIntegration.OVERDRIVE
         collection.external_integration.username = u'a'
         collection.external_integration.password = u'b'
         collection.external_integration.set_setting('website_id', 'd')
@@ -987,21 +992,22 @@ class OverdriveAdvantageAccount(object):
         collection, Overdrive Advantage collection)
         """
         # First find the parent Collection.
-        parent = get_one(
-            _db, Collection, external_account_id=self.parent_library_id,
-            protocol=Collection.OVERDRIVE
-        )
-        if not parent:
+        try:
+            parent = Collection.by_provider(_db, ExternalIntegration.OVERDRIVE).filter(
+                Collection.external_account_id==self.parent_library_id
+            ).one()
+        except NoResultFound, e:
             # Without the parent's credentials we can't access the child.
             raise ValueError(
                 "Cannot create a Collection whose parent does not already exist."
             )
         name = parent.name + " / " + self.name
         child, ignore = get_one_or_create(
-            _db, Collection, parent_id=parent.id, protocol=Collection.OVERDRIVE,
+            _db, Collection, parent_id=parent.id,
             external_account_id=self.library_id,
             create_method_kwargs=dict(name=name)
         )
+
         # Set or update the name of the collection to reflect the name of
         # the library, just in case that name has changed.
         child.name = name
@@ -1017,7 +1023,7 @@ class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
 
     SERVICE_NAME = "Overdrive Bibliographic Coverage Provider"
     DATA_SOURCE_NAME = DataSource.OVERDRIVE
-    PROTOCOL = Collection.OVERDRIVE
+    PROVIDER = ExternalIntegration.OVERDRIVE
     INPUT_IDENTIFIER_TYPES = Identifier.OVERDRIVE_ID
     
     def __init__(self, collection, api_class=OverdriveAPI, **kwargs):

--- a/overdrive.py
+++ b/overdrive.py
@@ -402,10 +402,12 @@ class MockOverdriveAPI(OverdriveAPI):
                     external_account_id=u'c'
                 )
             )
-        collection.external_integration.protocol = ExternalIntegration.OVERDRIVE
-        collection.external_integration.username = u'a'
-        collection.external_integration.password = u'b'
-        collection.external_integration.set_setting('website_id', 'd')
+        integration = collection.create_external_integration(
+            protocol=ExternalIntegration.OVERDRIVE
+        )
+        integration.username = u'a'
+        integration.password = u'b'
+        integration.set_setting('website_id', 'd')
         library.collections.append(collection)
         return collection
     

--- a/scripts.py
+++ b/scripts.py
@@ -157,8 +157,8 @@ class RunMonitorScript(Script):
 
 
 class RunCollectionMonitorScript(Script):
-    """Run a CollectionMonitor on every Collection that comes from a
-    certain provider.
+    """Run a CollectionMonitor on every Collection that comes through a
+    certain protocol.
 
     TODO: Currently the Monitors are run one at a time. It should
     be possible to take a command-line argument that runs all the
@@ -780,15 +780,15 @@ class ConfigureCollectionScript(Script):
         )
         parser.add_argument(
             '--username',
-            help='Use this username to authenticate with the license provider. Sometimes called a "key".',
+            help='Use this username to authenticate with the license protocol. Sometimes called a "key".',
         )
         parser.add_argument(
             '--password',
-            help='Use this password to authenticate with the license provider. Sometimes called a "secret".',
+            help='Use this password to authenticate with the license protocol. Sometimes called a "secret".',
         )
         parser.add_argument(
             '--setting',
-            help='Set a provider-specific setting on the collection, such as Overdrive\'s "website_id". Format: --setting="website_id=89"',
+            help='Set a protocol-specific setting on the collection, such as Overdrive\'s "website_id". Format: --setting="website_id=89"',
             action="append",
         )
         library_names = cls._library_names(_db)
@@ -816,25 +816,24 @@ class ConfigureCollectionScript(Script):
         args = self.parse_command_line(_db, cmd_args=cmd_args)
 
         # Find or create the collection
-        provider = None
+        protocol = None
         name = args.name
-        if args.provider:
-            # We have both name and provider, so we can create the Collection
-            # if it doesn't already exist.
-            collection, is_new = Collection.by_name_and_provider(
-                _db, name, provider
-            )
-        else:
-            # We only have name, so we can only find a Collection
-            # that already exists.
-            collection = get_one(_db, Collection, Collection.name==name)
-            if not collection:
+        protocol = args.protocol
+        collection = get_one(_db, Collection, Collection.name==name)
+        if not collection:
+            if protocol:
+                collection, is_new = Collection.by_name_and_protocol(
+                    _db, name, protocol
+                )
+            else:
+                # We didn't find a Collection, and we don't have a protocol,
+                # so we can't create a new Collection.
                 raise ValueError(
-                    'No collection called "%s". You can create it, but you must specify a provider.' % name
+                    'No collection called "%s". You can create it, but you must specify a protocol.' % name
                 )
         integration = collection.external_integration
-        if provider:
-            integration.provider = provider
+        if protocol:
+            integration.protocol = protocol
         if args.external_account_id:
             collection.external_account_id = args.external_account_id
 

--- a/testing.py
+++ b/testing.py
@@ -678,14 +678,16 @@ class DatabaseTest(object):
         )
         return library
     
-    def _collection(self, name=None, protocol=Collection.OPDS_IMPORT,
+    def _collection(self, name=None, provider=ExternalIntegration.OPDS_IMPORT,
                     external_account_id=None, url=None, username=None,
                     password=None):
         name = name or self._str
         collection, ignore = get_one_or_create(
-            self._db, Collection, name=name, protocol=protocol
+            self._db, Collection, name=name
         )
         collection.external_account_id = external_account_id
+        collection.external_integration.type = ExternalIntegration.LICENSE_TYPE
+        collection.external_integration.provider = provider
         collection.external_integration.url = url
         collection.external_integration.username = username
         collection.external_integration.password = password
@@ -753,7 +755,7 @@ class MockCoverageProvider(object):
 
     # This CoverageProvider can work with any Collection that supports
     # the OPDS import protocol (e.g. DatabaseTest._default_collection).
-    PROTOCOL = Collection.OPDS_IMPORT
+    PROTOCOL = ExternalIntegration.OPDS_IMPORT
 
 
 class InstrumentedCoverageProvider(MockCoverageProvider,

--- a/testing.py
+++ b/testing.py
@@ -678,7 +678,7 @@ class DatabaseTest(object):
         )
         return library
     
-    def _collection(self, name=None, provider=ExternalIntegration.OPDS_IMPORT,
+    def _collection(self, name=None, protocol=ExternalIntegration.OPDS_IMPORT,
                     external_account_id=None, url=None, username=None,
                     password=None):
         name = name or self._str
@@ -687,7 +687,7 @@ class DatabaseTest(object):
         )
         collection.external_account_id = external_account_id
         collection.external_integration.type = ExternalIntegration.LICENSE_TYPE
-        collection.external_integration.provider = provider
+        collection.external_integration.protocol = protocol
         collection.external_integration.url = url
         collection.external_integration.username = username
         collection.external_integration.password = password

--- a/testing.py
+++ b/testing.py
@@ -453,9 +453,9 @@ class DatabaseTest(object):
         )
         return credential
     
-    def _external_integration(self, provider, type=None, settings=None, **kwargs):
+    def _external_integration(self, protocol, type=None, settings=None, **kwargs):
         integration, is_new = get_one_or_create(
-            self._db, ExternalIntegration, provider=provider, type=type
+            self._db, ExternalIntegration, protocol=protocol, type=type
         )
 
         for attr, value in kwargs.items():

--- a/testing.py
+++ b/testing.py
@@ -453,9 +453,9 @@ class DatabaseTest(object):
         )
         return credential
     
-    def _external_integration(self, protocol, type=None, settings=None, **kwargs):
+    def _external_integration(self, protocol, goal=None, settings=None, **kwargs):
         integration, is_new = get_one_or_create(
-            self._db, ExternalIntegration, protocol=protocol, type=type
+            self._db, ExternalIntegration, protocol=protocol, goal=goal
         )
 
         for attr, value in kwargs.items():
@@ -686,11 +686,10 @@ class DatabaseTest(object):
             self._db, Collection, name=name
         )
         collection.external_account_id = external_account_id
-        collection.external_integration.type = ExternalIntegration.LICENSE_TYPE
-        collection.external_integration.protocol = protocol
-        collection.external_integration.url = url
-        collection.external_integration.username = username
-        collection.external_integration.password = password
+        integration = collection.create_external_integration(protocol)
+        integration.url = url
+        integration.username = username
+        integration.password = password
         return collection
 
     @property

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -29,6 +29,7 @@ from model import (
     DataSource,
     DeliveryMechanism,
     Edition,
+    ExternalIntegration,
     Hyperlink,
     Identifier,
     PresentationCalculationPolicy,
@@ -829,7 +830,7 @@ class TestCollectionCoverageProvider(CoverageProviderTest):
         """Verify that class variables become appropriate instance
         variables.
         """
-        collection = self._collection(protocol=Collection.OPDS_IMPORT)
+        collection = self._collection(protocol=ExternalIntegration.OPDS_IMPORT)
         provider = AlwaysSuccessfulCollectionCoverageProvider(collection)
         eq_(provider.DATA_SOURCE_NAME, provider.data_source.name)
 
@@ -842,7 +843,7 @@ class TestCollectionCoverageProvider(CoverageProviderTest):
         )
 
     def test_collection_protocol_must_match_class_protocol(self):
-        collection = self._collection(protocol=Collection.OVERDRIVE)
+        collection = self._collection(protocol=ExternalIntegration.OVERDRIVE)
         assert_raises_regexp(
             ValueError,
             "Collection protocol \(Overdrive\) does not match CoverageProvider protocol \(OPDS Import\)",
@@ -871,9 +872,9 @@ class TestCollectionCoverageProvider(CoverageProviderTest):
         objects, one for each Collection that implements the
         appropriate protocol.
         """
-        opds1 = self._collection(protocol=Collection.OPDS_IMPORT)
-        opds2 = self._collection(protocol=Collection.OPDS_IMPORT)
-        overdrive = self._collection(protocol=Collection.OVERDRIVE)
+        opds1 = self._collection(protocol=ExternalIntegration.OPDS_IMPORT)
+        opds2 = self._collection(protocol=ExternalIntegration.OPDS_IMPORT)
+        overdrive = self._collection(protocol=ExternalIntegration.OVERDRIVE)
         providers = list(
             AlwaysSuccessfulCollectionCoverageProvider.all(self._db, batch_size=34)
         )
@@ -1108,9 +1109,9 @@ class TestCollectionCoverageProvider(CoverageProviderTest):
         # CIRCULATION_DATA are data for an Overdrive book.)
         class OverdriveProvider(AlwaysSuccessfulCollectionCoverageProvider):
             DATA_SOURCE_NAME = DataSource.OVERDRIVE
-            PROTOCOL = Collection.OVERDRIVE
+            PROTOCOL = ExternalIntegration.OVERDRIVE
             IDENTIFIER_TYPES = Identifier.OVERDRIVE_ID
-        collection = self._collection(protocol=Collection.OVERDRIVE)
+        collection = self._collection(protocol=ExternalIntegration.OVERDRIVE)
         provider = OverdriveProvider(collection)
 
         # We get a CoverageFailure if we don't pass in any data at all.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5660,7 +5660,7 @@ class TestCollection(DatabaseTest):
 
         data = self.collection.explain()
         eq_(['Name: "test collection"',
-             'Provider: "Overdrive"',
+             'Protocol: "Overdrive"',
              'Used by library: "The only library"',
              'External account ID: "id"',
              'URL: "url"',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5564,7 +5564,9 @@ class TestExternalIntegration(DatabaseTest):
 
     def setup(self):
         super(TestExternalIntegration, self).setup()
-        self.external_integration, ignore = create(self._db, ExternalIntegration)
+        self.external_integration, ignore = create(
+            self._db, ExternalIntegration, goal=self._str, protocol=self._str
+        )
 
     def test_data_source(self):
         # For most collections, the protocol determines the
@@ -5705,9 +5707,13 @@ class TestCollection(DatabaseTest):
         child = Collection(
             name="Child", parent=self.collection, external_account_id="id2"
         )
+        child.create_external_integration(
+            protocol=ExternalIntegration.OVERDRIVE
+        )
         data = child.explain()
         eq_(['Name: "Child"',
              'Parent: test collection',
+             'Protocol: "Overdrive"',
              'External account ID: "id2"'],
             data
         )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5642,6 +5642,8 @@ class TestCollection(DatabaseTest):
             set(Collection.by_protocol(self._db, overdrive).all()))
         eq_(([c2]),
             Collection.by_protocol(self._db, bibliotheca).all())
+        eq_(set([self.collection, c1, c2]),
+            set(Collection.by_protocol(self._db, None).all()))
 
         
     def test_explain(self):
@@ -5717,7 +5719,7 @@ class TestCollection(DatabaseTest):
         )
         eq_(True, is_new)
         eq_(self.collection.metadata_identifier, mirror_collection.name)
-        eq_(self.collection.external_integration.provider, mirror_collection.external_integration.provider)
+        eq_(self.collection.external_integration.protocol, mirror_collection.external_integration.protocol)
 
         # If the mirrored collection already exists, it is returned.
         collection = self._collection(external_account_id=self._url)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5567,7 +5567,7 @@ class TestExternalIntegration(DatabaseTest):
         self.external_integration, ignore = create(self._db, ExternalIntegration)
 
     def test_data_source(self):
-        # For most collections, the provider determines the
+        # For most collections, the protocol determines the
         # data source.
         collection = self._collection(protocol=ExternalIntegration.OVERDRIVE)
         eq_(DataSource.OVERDRIVE, collection.data_source.name)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -18,6 +18,7 @@ from model import (
     Collection,
     CollectionMissing,
     DataSource,
+    ExternalIntegration,
     Identifier,
     Subject,
     Timestamp,
@@ -179,11 +180,11 @@ class TestCollectionMonitor(DatabaseTest):
 
         class OverdriveMonitor(CollectionMonitor):
             SERVICE_NAME = "Test Monitor 2"
-            PROTOCOL = Collection.OVERDRIVE
+            PROTOCOL = ExternalIntegration.OVERDRIVE
 
         # Two collections.
-        c1 = self._collection(protocol=Collection.OVERDRIVE)
-        c2 = self._collection(protocol=Collection.BIBLIOTHECA)
+        c1 = self._collection(protocol=ExternalIntegration.OVERDRIVE)
+        c2 = self._collection(protocol=ExternalIntegration.BIBLIOTHECA)
 
         # The NoProtocolMonitor can be instantiated with either one,
         # or with no Collection at all.
@@ -207,7 +208,7 @@ class TestCollectionMonitor(DatabaseTest):
         """Test that we can create a list of Monitors using all()."""
         class OPDSCollectionMonitor(CollectionMonitor):
             SERVICE_NAME = "Test Monitor"
-            PROTOCOL = Collection.OPDS_IMPORT
+            PROTOCOL = ExternalIntegration.OPDS_IMPORT
         
         # Here we have three OPDS import Collections...
         o1 = self._collection()
@@ -215,7 +216,7 @@ class TestCollectionMonitor(DatabaseTest):
         o3 = self._collection()
 
         # ...and a Bibliotheca collection.
-        b1 = self._collection(protocol=Collection.BIBLIOTHECA)
+        b1 = self._collection(protocol=ExternalIntegration.BIBLIOTHECA)
 
         # o1 just had its Monitor run.
         Timestamp.stamp(self._db, OPDSCollectionMonitor.SERVICE_NAME, o1)
@@ -227,7 +228,7 @@ class TestCollectionMonitor(DatabaseTest):
         an_hour_ago = now - datetime.timedelta(seconds=3600)
         Timestamp.stamp(self._db, OPDSCollectionMonitor.SERVICE_NAME,
                         o3, an_hour_ago)
-        
+
         monitors = list(OPDSCollectionMonitor.all(self._db))
 
         # Three OPDSCollectionMonitors were returned, one for each

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -1298,7 +1298,7 @@ class TestOPDSImportMonitor(OPDSImporterTest):
             OPDSImporter,
         )
 
-        self._default_collection.protocol = Collection.OVERDRIVE
+        self._default_collection.protocol = ExternalIntegration.OVERDRIVE
         assert_raises_regexp(
             ValueError,
             "Collection .* is configured for protocol Overdrive, not OPDS import.",

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -86,7 +86,7 @@ class TestMetadataWranglerOPDSLookup(DatabaseTest):
             username='abc', password='def', url="http://metadata.in"
         )
         self.collection = self._collection(
-            protocol=Collection.OVERDRIVE, external_account_id=u'library'
+            protocol=ExternalIntegration.OVERDRIVE, external_account_id=u'library'
         )
 
     def test_authenticates_wrangler_requests(self):
@@ -950,7 +950,7 @@ class TestOPDSImporter(OPDSImporterTest):
     def test_build_identifier_mapping(self):
         """Reverse engineers an identifier_mapping based on a list of URNs"""
 
-        collection = self._collection(protocol=Collection.AXIS_360)
+        collection = self._collection(protocol=ExternalIntegration.AXIS_360)
         lp = self._licensepool(
             None, collection=collection,
             data_source_name=DataSource.AXIS_360

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -1298,7 +1298,7 @@ class TestOPDSImportMonitor(OPDSImporterTest):
             OPDSImporter,
         )
 
-        self._default_collection.protocol = ExternalIntegration.OVERDRIVE
+        self._default_collection.external_integration.protocol = ExternalIntegration.OVERDRIVE
         assert_raises_regexp(
             ValueError,
             "Collection .* is configured for protocol Overdrive, not OPDS import.",
@@ -1308,7 +1308,7 @@ class TestOPDSImportMonitor(OPDSImporterTest):
             OPDSImporter,
         )
 
-        self._default_collection.protocol = Collection.OPDS_IMPORT
+        self._default_collection.external_integration.protocol = ExternalIntegration.OPDS_IMPORT
         self._default_collection.external_integration.setting('data_source').value = None
         assert_raises_regexp(
             ValueError,

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -184,7 +184,7 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         """
         # Here's an Overdrive collection.
         main = self._collection(
-            provider=ExternalIntegration.OVERDRIVE, external_account_id="1",
+            protocol=ExternalIntegration.OVERDRIVE, external_account_id="1",
         )
         main.external_integration.username = "user"
         main.external_integration.password = "password"
@@ -198,7 +198,7 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         # Here's an Overdrive Advantage collection associated with the
         # main Overdrive collection.
         child = self._collection(
-            provider=ExternalIntegration.OVERDRIVE, external_account_id="2",
+            protocol=ExternalIntegration.OVERDRIVE, external_account_id="2",
         )
         child.parent = main
         overdrive_child = MockOverdriveAPI(child)
@@ -421,7 +421,7 @@ class TestOverdriveAdvantageAccount(OverdriveTestWithAPI):
         
         # So, create a Collection to be the parent.
         parent = self._collection(
-            name="Parent", provider=ExternalIntegration.OVERDRIVE,
+            name="Parent", protocol=ExternalIntegration.OVERDRIVE,
             external_account_id="parent_id"
         )
 
@@ -433,7 +433,7 @@ class TestOverdriveAdvantageAccount(OverdriveTestWithAPI):
         eq_(ExternalIntegration.LICENSE_TYPE,
             collection.external_integration.type)
         eq_(ExternalIntegration.OVERDRIVE,
-            collection.provider)
+            collection.protocol)
 
         # To ensure uniqueness, the collection was named after its
         # parent.

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -430,8 +430,8 @@ class TestOverdriveAdvantageAccount(OverdriveTestWithAPI):
         eq_(p, parent)
         eq_(parent, collection.parent)
         eq_(collection.external_account_id, account.library_id)
-        eq_(ExternalIntegration.LICENSE_TYPE,
-            collection.external_integration.type)
+        eq_(ExternalIntegration.LICENSE_GOAL,
+            collection.external_integration.goal)
         eq_(ExternalIntegration.OVERDRIVE,
             collection.protocol)
 

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -25,6 +25,7 @@ from model import (
     Contributor,
     DeliveryMechanism,
     Edition,
+    ExternalIntegration,
     Identifier,
     Representation,
     Subject,
@@ -183,7 +184,7 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         """
         # Here's an Overdrive collection.
         main = self._collection(
-            protocol=Collection.OVERDRIVE, external_account_id="1",
+            provider=ExternalIntegration.OVERDRIVE, external_account_id="1",
         )
         main.external_integration.username = "user"
         main.external_integration.password = "password"
@@ -197,7 +198,7 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         # Here's an Overdrive Advantage collection associated with the
         # main Overdrive collection.
         child = self._collection(
-            protocol=Collection.OVERDRIVE, external_account_id="2",
+            provider=ExternalIntegration.OVERDRIVE, external_account_id="2",
         )
         child.parent = main
         overdrive_child = MockOverdriveAPI(child)
@@ -420,7 +421,7 @@ class TestOverdriveAdvantageAccount(OverdriveTestWithAPI):
         
         # So, create a Collection to be the parent.
         parent = self._collection(
-            name="Parent", protocol=Collection.OVERDRIVE,
+            name="Parent", provider=ExternalIntegration.OVERDRIVE,
             external_account_id="parent_id"
         )
 
@@ -429,7 +430,10 @@ class TestOverdriveAdvantageAccount(OverdriveTestWithAPI):
         eq_(p, parent)
         eq_(parent, collection.parent)
         eq_(collection.external_account_id, account.library_id)
-        eq_(Collection.OVERDRIVE, collection.protocol)
+        eq_(ExternalIntegration.LICENSE_TYPE,
+            collection.external_integration.type)
+        eq_(ExternalIntegration.OVERDRIVE,
+            collection.provider)
 
         # To ensure uniqueness, the collection was named after its
         # parent.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -222,7 +222,7 @@ class TestRunCollectionMonitorScript(DatabaseTest):
     def test_all(self):
         class OPDSCollectionMonitor(CollectionMonitor):
             SERVICE_NAME = "Test Monitor"
-            PROVIDER = ExternalIntegration.OPDS_IMPORT
+            PROTOCOL = ExternalIntegration.OPDS_IMPORT
 
             def __init__(self, _db, test_argument=None, **kwargs):
                 self.test_argument = test_argument
@@ -237,7 +237,7 @@ class TestRunCollectionMonitorScript(DatabaseTest):
         o3 = self._collection()
 
         # ...and a Bibliotheca collection.
-        b1 = self._collection(provider=ExternalIntegration.BIBLIOTHECA)
+        b1 = self._collection(protocol=ExternalIntegration.BIBLIOTHECA)
 
         script = RunCollectionMonitorScript(
             OPDSCollectionMonitor, self._db, test_argument="test value"
@@ -1089,10 +1089,10 @@ class TestShowCollectionsScript(DatabaseTest):
 
     def test_with_multiple_collections(self):
         c1 = self._collection(name="Collection 1",
-                              provider=ExternalIntegration.OVERDRIVE)
+                              protocol=ExternalIntegration.OVERDRIVE)
         c1.collection_password="a"
         c2 = self._collection(name="Collection 2",
-                              provider=ExternalIntegration.BIBLIOTHECA)
+                              protocol=ExternalIntegration.BIBLIOTHECA)
         c2.collection_password="b"
 
         # The output of this script is the result of running explain()
@@ -1139,7 +1139,7 @@ class TestConfigureCollectionScript(DatabaseTest):
         # necessary to create it.
         assert_raises_regexp(
             ValueError,
-            'No collection called "collection". You can create it, but you must specify a provider.',
+            'No collection called "collection". You can create it, but you must specify a protocol.',
             script.do_run, self._db, ["--name=collection"]
         )
 
@@ -1148,7 +1148,7 @@ class TestConfigureCollectionScript(DatabaseTest):
             ValueError,
             'Incorrect format for setting: "key". Should be "key=value"',
             script.do_run, self._db, [
-                "--name=collection", "--provider=Overdrive",
+                "--name=collection", "--protocol=Overdrive",
                 "--setting=key"
             ]
         )
@@ -1158,7 +1158,7 @@ class TestConfigureCollectionScript(DatabaseTest):
             ValueError,
             'No such library: "nosuchlibrary". I only know about: "L1"',
             script.do_run, self._db, [
-                "--name=collection", "--provider=Overdrive",
+                "--name=collection", "--protocol=Overdrive",
                 "--library=nosuchlibrary"
             ]
         )
@@ -1182,7 +1182,7 @@ class TestConfigureCollectionScript(DatabaseTest):
         # setting, and associate it with two libraries.
         output = StringIO()
         script.do_run(
-            self._db, ["--name=New Collection", "--provider=Overdrive",
+            self._db, ["--name=New Collection", "--protocol=Overdrive",
                        "--library=L2", "--library=L1",
                        "--setting=library_id=1234",
                        "--external-account-id=acctid",
@@ -1219,7 +1219,7 @@ class TestConfigureCollectionScript(DatabaseTest):
         # The collection exists.
         collection = self._collection(
             name="Collection 1",
-            provider=ExternalIntegration.OVERDRIVE
+            protocol=ExternalIntegration.OVERDRIVE
         )
         script = ConfigureCollectionScript()
         output = StringIO()
@@ -1229,14 +1229,14 @@ class TestConfigureCollectionScript(DatabaseTest):
             self._db, [
                 "--name=Collection 1",
                 "--url=foo",
-                "--provider=%s" % ExternalIntegration.BIBLIOTHECA
+                "--protocol=%s" % ExternalIntegration.BIBLIOTHECA
             ],
             output
         )
 
         # The collection has been changed.
         eq_("foo", collection.external_integration.url)
-        eq_(ExternalIntegration.BIBLIOTHECA, collection.provider)
+        eq_(ExternalIntegration.BIBLIOTHECA, collection.protocol)
         
         expect = ("Configuration settings stored.\n"
                   + "\n".join(collection.explain()) + "\n")

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -30,6 +30,7 @@ from model import (
     CustomList,
     DataSource,
     Edition,
+    ExternalIntegration,
     Identifier,
     Library,
     LicensePool,
@@ -221,7 +222,7 @@ class TestRunCollectionMonitorScript(DatabaseTest):
     def test_all(self):
         class OPDSCollectionMonitor(CollectionMonitor):
             SERVICE_NAME = "Test Monitor"
-            PROTOCOL = Collection.OPDS_IMPORT
+            PROVIDER = ExternalIntegration.OPDS_IMPORT
 
             def __init__(self, _db, test_argument=None, **kwargs):
                 self.test_argument = test_argument
@@ -236,7 +237,7 @@ class TestRunCollectionMonitorScript(DatabaseTest):
         o3 = self._collection()
 
         # ...and a Bibliotheca collection.
-        b1 = self._collection(protocol=Collection.BIBLIOTHECA)
+        b1 = self._collection(provider=ExternalIntegration.BIBLIOTHECA)
 
         script = RunCollectionMonitorScript(
             OPDSCollectionMonitor, self._db, test_argument="test value"
@@ -1087,11 +1088,11 @@ class TestShowCollectionsScript(DatabaseTest):
         eq_("No collections found.\n", output.getvalue())
 
     def test_with_multiple_collections(self):
-        c1, ignore = create(self._db, Collection, name="Collection 1",
-                            protocol=Collection.OVERDRIVE)
+        c1 = self._collection(name="Collection 1",
+                              provider=ExternalIntegration.OVERDRIVE)
         c1.collection_password="a"
-        c2, ignore = create(self._db, Collection, name="Collection 2",
-                            protocol=Collection.BIBLIOTHECA)
+        c2 = self._collection(name="Collection 2",
+                              provider=ExternalIntegration.BIBLIOTHECA)
         c2.collection_password="b"
 
         # The output of this script is the result of running explain()
@@ -1138,7 +1139,7 @@ class TestConfigureCollectionScript(DatabaseTest):
         # necessary to create it.
         assert_raises_regexp(
             ValueError,
-            'No collection called "collection". You can create it, but you must specify a protocol.',
+            'No collection called "collection". You can create it, but you must specify a provider.',
             script.do_run, self._db, ["--name=collection"]
         )
 
@@ -1147,7 +1148,7 @@ class TestConfigureCollectionScript(DatabaseTest):
             ValueError,
             'Incorrect format for setting: "key". Should be "key=value"',
             script.do_run, self._db, [
-                "--name=collection", "--protocol=Overdrive",
+                "--name=collection", "--provider=Overdrive",
                 "--setting=key"
             ]
         )
@@ -1157,7 +1158,7 @@ class TestConfigureCollectionScript(DatabaseTest):
             ValueError,
             'No such library: "nosuchlibrary". I only know about: "L1"',
             script.do_run, self._db, [
-                "--name=collection", "--protocol=Overdrive",
+                "--name=collection", "--provider=Overdrive",
                 "--library=nosuchlibrary"
             ]
         )
@@ -1181,7 +1182,7 @@ class TestConfigureCollectionScript(DatabaseTest):
         # setting, and associate it with two libraries.
         output = StringIO()
         script.do_run(
-            self._db, ["--name=New Collection", "--protocol=Overdrive",
+            self._db, ["--name=New Collection", "--provider=Overdrive",
                        "--library=L2", "--library=L1",
                        "--setting=library_id=1234",
                        "--external-account-id=acctid",
@@ -1216,9 +1217,9 @@ class TestConfigureCollectionScript(DatabaseTest):
 
     def test_reconfigure_collection(self):
         # The collection exists.
-        collection, ignore = create(
-            self._db, Collection, name="Collection 1",
-            protocol=Collection.OVERDRIVE
+        collection = self._collection(
+            name="Collection 1",
+            provider=ExternalIntegration.OVERDRIVE
         )
         script = ConfigureCollectionScript()
         output = StringIO()
@@ -1228,14 +1229,14 @@ class TestConfigureCollectionScript(DatabaseTest):
             self._db, [
                 "--name=Collection 1",
                 "--url=foo",
-                "--protocol=%s" % Collection.BIBLIOTHECA
+                "--provider=%s" % ExternalIntegration.BIBLIOTHECA
             ],
             output
         )
 
         # The collection has been changed.
         eq_("foo", collection.external_integration.url)
-        eq_(Collection.BIBLIOTHECA, collection.protocol)
+        eq_(ExternalIntegration.BIBLIOTHECA, collection.provider)
         
         expect = ("Configuration settings stored.\n"
                   + "\n".join(collection.explain()) + "\n")


### PR DESCRIPTION
This branch combines two fields created for the multi-tenancy branch, Collection.protocol and ExternalIntegration.provider. The new field is called ExternalIntegration.protocol. "protocol" is a better name than "provider" because it covers things like "OPDS Import" and "CDN" which are closer to protocols than to companies or services. There's also a name conflict between "provider" and our "CoverageProvider" concept, which would have led to a CoverageProvider being associated with a provider.

Since these fields were created for a branch that hasn't been released, I haven't written migration scripts for it -- anyone who might benefit from these scripts should instead drop their database and let it get rebuilt, and anyone who doesn't need these scripts won't be able to run them.