### PR TITLE
Support incorporate related lanes into entry

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -201,14 +201,15 @@ class Annotator(object):
     def authors(cls, work, license_pool, edition, identifier):
         """Create one or more <author> tags for the given work."""
         authors = list()
-        listed = list()
+        listed = set()
         for author in edition.author_contributors:
             name = author.display_name or author.sort_name
-            if name.lower() in listed:
+            name_key = name.lower()
+            if name_key in listed:
                 continue
 
             authors.append(AtomFeed.author(AtomFeed.name(name)))
-            listed.append(name.lower())
+            listed.add(name_key)
 
         if authors:
             return authors

--- a/opds.py
+++ b/opds.py
@@ -201,10 +201,14 @@ class Annotator(object):
     def authors(cls, work, license_pool, edition, identifier):
         """Create one or more <author> tags for the given work."""
         authors = list()
+        listed = list()
         for author in edition.author_contributors:
-            authors.append(AtomFeed.author(AtomFeed.name(
-                author.display_name or author.sort_name
-            )))
+            name = author.display_name or author.sort_name
+            if name.lower() in listed:
+                continue
+
+            authors.append(AtomFeed.author(AtomFeed.name(name)))
+            listed.append(name.lower())
 
         if authors:
             return authors

--- a/opds.py
+++ b/opds.py
@@ -200,7 +200,15 @@ class Annotator(object):
     @classmethod
     def authors(cls, work, license_pool, edition, identifier):
         """Create one or more <author> tags for the given work."""
-        return [AtomFeed.author(AtomFeed.name(edition.author or ""))]
+        authors = list()
+        for author in edition.author_contributors:
+            authors.append(AtomFeed.author(AtomFeed.name(
+                author.display_name or author.sort_name
+            )))
+
+        if authors:
+            return authors
+        return [AtomFeed.author(AtomFeed.name(""))]
 
     @classmethod
     def series(cls, series_name, series_position):

--- a/testing.py
+++ b/testing.py
@@ -192,7 +192,8 @@ class DatabaseTest(object):
     def _edition(self, data_source_name=DataSource.GUTENBERG,
                     identifier_type=Identifier.GUTENBERG_ID,
                     with_license_pool=False, with_open_access_download=False,
-                    title=None, language="eng", authors=None, identifier_id=None):
+                    title=None, language="eng", authors=None, identifier_id=None,
+                    series=None):
         id = identifier_id or self._str
         source = DataSource.lookup(self._db, data_source_name)
         wr = Edition.for_foreign_id(
@@ -200,6 +201,8 @@ class DatabaseTest(object):
         if not title:
             title = self._str
         wr.title = unicode(title)
+        if series:
+            wr.series = series
         if language:
             wr.language = language
         if authors is None:
@@ -211,7 +214,7 @@ class DatabaseTest(object):
             wr.author = unicode(authors[0])
         for author in authors[1:]:
             wr.add_contributor(unicode(author), Contributor.AUTHOR_ROLE)
-            
+
         if with_license_pool or with_open_access_download:
             pool = self._licensepool(wr, data_source_name=data_source_name,
                                      with_open_access_download=with_open_access_download)  
@@ -222,7 +225,7 @@ class DatabaseTest(object):
 
     def _work(self, title=None, authors=None, genre=None, language=None,
               audience=None, fiction=True, with_license_pool=False, 
-              with_open_access_download=False, quality=0.5,
+              with_open_access_download=False, quality=0.5, series=None,
               presentation_edition=None):
         pool = None
         if with_open_access_download:
@@ -246,7 +249,8 @@ class DatabaseTest(object):
                 authors=authors,
                 with_license_pool=with_license_pool,
                 with_open_access_download=with_open_access_download,
-                data_source_name=data_source_name
+                data_source_name=data_source_name,
+                series=series,
             )
             if with_license_pool:
                 presentation_edition, pool = presentation_edition

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -222,6 +222,19 @@ class TestAnnotators(DatabaseTest):
             work.presentation_edition.primary_identifier)
         eq_(tag_string, etree.tostring(same_tag))
 
+    def test_duplicate_author_names_are_ignored(self):
+        """Ignores duplicate author names"""
+        work = self._work(with_license_pool=True)
+        duplicate = self._contributor()[0]
+        duplicate.sort_name = work.author
+
+        edition = work.presentation_edition
+        edition.add_contributor(duplicate, Contributor.AUTHOR_ROLE)
+
+        eq_(1, len(Annotator.authors(
+            work, work.license_pools[0], edition, edition.primary_identifier
+        )))
+
     def test_all_annotators_mention_every_author(self):
         work = self._work(authors=[], with_license_pool=True)
         work.presentation_edition.add_contributor(

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -222,7 +222,7 @@ class TestAnnotators(DatabaseTest):
             work.presentation_edition.primary_identifier)
         eq_(tag_string, etree.tostring(same_tag))
 
-    def test_verbose_annotator_mentions_every_author(self):
+    def test_all_annotators_mention_every_author(self):
         work = self._work(authors=[], with_license_pool=True)
         work.presentation_edition.add_contributor(
             self._contributor()[0], Contributor.PRIMARY_AUTHOR_ROLE)
@@ -230,6 +230,9 @@ class TestAnnotators(DatabaseTest):
             self._contributor()[0], Contributor.AUTHOR_ROLE)
         work.presentation_edition.add_contributor(
             self._contributor()[0], "Illustrator")
+        eq_(2, len(Annotator.authors(
+            work, work.license_pools[0], work.presentation_edition,
+            work.presentation_edition.primary_identifier)))
         eq_(2, len(VerboseAnnotator.authors(
             work, work.license_pools[0], work.presentation_edition,
             work.presentation_edition.primary_identifier)))

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -56,7 +56,6 @@ class AtomFeed(object):
 
     @classmethod
     def add_link_to_entry(cls, entry, children=None, **kwargs):
-        #links.append(E.link(rel=rel, href=url, type=image_type))
         link = cls.E.link(**kwargs)
         entry.append(link)
         if children:


### PR DESCRIPTION
This branch creates an author tags for each author, even in simple OPDS entries. This means that creating the  simple OPDS entry will take longer and require the database. It also reduces the need for `Edition.author`, which can potentially be removed at this point. We use it in a lot of places, though, I'm reluctant to make that change right now. (I'll make an issue for it if this PR is approved.)

The branch also allows Works and Editions created during testing to have a series set at the time of creation. This reduces the need to recalculate the presentation later on.

One change here that I'm not sure about is potentially adding authors by sort name if their display name is not available. I'm not sure if that possibility happens in practice, but it appears in tests quite often (due to how we create contributors on the Edition we use in tests).