### PR TITLE
Corrected constant.

### DIFF
--- a/model.py
+++ b/model.py
@@ -8882,7 +8882,7 @@ class ExternalIntegration(Base):
 
     @classmethod
     def admin_authentication(cls, _db):
-        admin_auth = get_one(_db, cls, type=cls.ADMIN_AUTH_TYPE)
+        admin_auth = get_one(_db, cls, goal=cls.ADMIN_AUTH_GOAL)
         return admin_auth
 
     def set_setting(self, key, value):


### PR DESCRIPTION
This branch corrects the usage of a constant in a method that's only used in the circulation manager, which is why I didn't catch it before.