### PR TITLE
Fix scripts

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -174,8 +174,6 @@ class RunMonitorScript(Script):
             RunCollectionMonitorScript(
                 self.collection_monitor, self._db, **self.collection_monitor_kwargs
             ).run()
-        else:
-            self.monitor.run()
 
 
 class RunCollectionMonitorScript(Script):

--- a/scripts.py
+++ b/scripts.py
@@ -1174,8 +1174,7 @@ class CollectionInputScript(Script):
     """A script that takes collection names as command line inputs."""
 
     @classmethod
-    def parse_command_line(cls, _db=None, cmd_args=None, stdin=sys.stdin, 
-                           *args, **kwargs):
+    def parse_command_line(cls, _db=None, cmd_args=None, *args, **kwargs):
         parser = cls.arg_parser()
         parsed = parser.parse_args(cmd_args)
         return cls.look_up_collections(_db, parsed, *args, **kwargs)

--- a/scripts.py
+++ b/scripts.py
@@ -1217,7 +1217,7 @@ class CollectionInputScript(Script):
             '--collection', 
             help='Collection to use',
             dest='collection_names',            
-            metavar='NAME', nargs='+', default=[]
+            metavar='NAME', action='append', default=[]
         )
         return parser
     

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1290,7 +1290,7 @@ class TestCollectionInputScript(DatabaseTest):
         # on the command line.
         c2 = self._collection()
         expect = [c2, self._default_collection]
-        actual = collections(["--collection=" + c.name for x in expect])
+        actual = collections(["--collection=" + c.name for c in expect])
         eq_(expect, found)
 
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1291,7 +1291,7 @@ class TestCollectionInputScript(DatabaseTest):
         c2 = self._collection()
         expect = [c2, self._default_collection]
         actual = collections(["--collection=" + c.name for c in expect])
-        eq_(expect, found)
+        eq_(expect, actual)
 
 
 # Mock classes used by TestOPDSImportScript

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -56,6 +56,7 @@ from scripts import (
     PatronInputScript,
     RunCollectionMonitorScript,
     RunCoverageProviderScript,
+    RunMonitorScript,
     Script,
     ShowCollectionsScript,
     ShowLibrariesScript,
@@ -219,20 +220,39 @@ class TestIdentifierInputScript(DatabaseTest):
         eq_(DataSource.STANDARD_EBOOKS, parsed.identifier_data_source)
 
 
+class OPDSCollectionMonitor(CollectionMonitor):
+    """Mock Monitor for use in tests of Run*MonitorScript."""
+    SERVICE_NAME = "Test Monitor"
+    PROTOCOL = ExternalIntegration.OPDS_IMPORT
+
+    def __init__(self, _db, test_argument=None, **kwargs):
+        self.test_argument = test_argument
+        super(OPDSCollectionMonitor, self).__init__(_db, **kwargs)
+
+    def run_once(self, start, cutoff):
+        self.collection.ran_with_argument = self.test_argument
+
+        
+class TestRunMonitorScript(DatabaseTest):
+
+    def test_run_with_collection_monitor(self):
+        """It's not ideal, but you can run a CollectionMonitor script from
+        RunMonitorScript. This will run the monitor on every
+        appropriate Collection.
+        """
+        c1 = self._collection()
+        c2 = self._collection()
+        script = RunMonitorScript(
+            OPDSCollectionMonitor, self._db, test_argument="test value"
+        )
+        script.run()
+        for c in [c1, c2]:
+            eq_("test value", c.ran_with_argument)
+        
+        
 class TestRunCollectionMonitorScript(DatabaseTest):
 
     def test_all(self):
-        class OPDSCollectionMonitor(CollectionMonitor):
-            SERVICE_NAME = "Test Monitor"
-            PROTOCOL = ExternalIntegration.OPDS_IMPORT
-
-            def __init__(self, _db, test_argument=None, **kwargs):
-                self.test_argument = test_argument
-                super(OPDSCollectionMonitor, self).__init__(_db, **kwargs)
-
-            def run_once(self, start, cutoff):
-                self.collection.ran_with_argument = self.test_argument
-
         # Here we have three OPDS import Collections...
         o1 = self._collection()
         o2 = self._collection()
@@ -1334,3 +1354,53 @@ class TestOPDSImportScript(DatabaseTest):
         monitor = MockOPDSImportMonitor.INSTANCES.pop()
         eq_(self._default_collection, monitor.collection)
         eq_(True, monitor.kwargs['force_reimport'])
+
+
+class TestWorkConsolidationScript(object):
+    """TODO"""
+    pass
+
+
+class TestWorkPresentationScript(object):
+    """TODO"""
+    pass
+
+
+class TestWorkClassificationScript(object):
+    """TODO"""
+    pass
+
+
+class TestWorkOPDSScript(object):
+    """TODO"""
+    pass
+
+
+class TestCustomListManagementScript(object):
+    """TODO"""
+    pass
+
+
+class TestSubjectAssignmentScript(object):
+    """TODO"""
+    pass
+
+
+class TestBibliographicRefreshScript(object):
+    """TODO"""
+    pass
+
+        
+class TestNYTBestSellerListsScript(object):
+    """TODO"""
+    pass
+
+
+class TestRefreshMaterializedViewsScript(object):
+    """TODO"""
+    pass
+
+
+class TestExplain(object):
+    """TODO"""
+    pass

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1290,7 +1290,8 @@ class TestCollectionInputScript(DatabaseTest):
         # on the command line.
         c2 = self._collection()
         expect = [c2, self._default_collection]
-        actual = collections(["--collection=" + c.name for c in expect])
+        args = ["--collection=" + c.name for c in expect]
+        actual = collections(args)
         eq_(expect, actual)
 
 


### PR DESCRIPTION
This branch creates the `CollectionInputScript`, which allows you to name specific collections on the command line, and parses them into Collection objects.

The `OPDSImportScript` is now a `CollectionInputScript`, and it has some tests. `RunCollectionMonitorScript` does not subclass this class, but it should in the future.

This branch handles a now-common problem where a `CollectionMonitor` is passed in to `RunMonitorScript` when it should be passed in to `RunCollectionMonitorScript`. `RunMonitorScript` now complains and runs the monitor through `RunCollectionMonitorScript` instead.