### PR TITLE
Flexible configuration

### DIFF
--- a/model.py
+++ b/model.py
@@ -8981,7 +8981,7 @@ class ConfigurationSetting(Base):
       is a patron of, is associated with both a Library and an
       ExternalIntegration.
     """
-    __tablename__ = 'externalintegrationsettings'
+    __tablename__ = 'configurationsettings'
     id = Column(Integer, primary_key=True)
     external_integration_id = Column(
         Integer, ForeignKey('externalintegrations.id'), index=True

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5606,6 +5606,32 @@ class TestExternalIntegration(DatabaseTest):
 
 class TestConfigurationSetting(DatabaseTest):
 
+    def test_duplicate(self):
+        """You can't have two ConfigurationSettings for the same key,
+        library, and external integration.
+
+        (test_relationships shows that you can have two settings for the same
+        key as long as library or integration is different.)
+        """
+        key = self._str
+        integration, ignore = create(
+            self._db, ExternalIntegration, goal=self._str, protocol=self._str
+        )
+        library = self._default_library
+        setting = ConfigurationSetting.for_library_and_externalintegration(
+            self._db, key, library, integration
+        )
+        setting2 = ConfigurationSetting.for_library_and_externalintegration(
+            self._db, key, library, integration
+        )
+        eq_(setting, setting2)
+        assert_raises(
+            IntegrityError,
+            create, self._db, ConfigurationSetting,
+            key=key,
+            library=library, external_integration=integration
+        )
+    
     def test_relationships(self):
         integration, ignore = create(
             self._db, ExternalIntegration, goal=self._str, protocol=self._str


### PR DESCRIPTION
This branch replaces ExternalIntegrationSetting with the more general ConfigurationSetting, which can be used to configure the site as a whole, an ExternalIntegration, a Library, or the combination of a Library and an ExternalIntegration.

This will radically simplify the move of authentication mechanisms from JSON into the database, and give a place for other things (especially library-specific links like terms-of-use) to go into the database as well.