### PR TITLE
Lane has library

### DIFF
--- a/files/materialized_view_works.sql
+++ b/files/materialized_view_works.sql
@@ -29,7 +29,8 @@ as
     works.verbose_opds_entry,
     licensepools.id AS license_pool_id,
     licensepools.open_access_download_url,
-    licensepools.availability_time
+    licensepools.availability_time,
+    licensepools.collection_id
 
    FROM works
      JOIN editions ON editions.id = works.presentation_edition_id

--- a/lane.py
+++ b/lane.py
@@ -892,6 +892,8 @@ class Lane(object):
     @classmethod
     def from_description(cls, library, parent, description):
         genre = None
+        if not isinstance(library, Library):
+            raise ValueError("Expected library, got %r" % library)
         _db = Session.object_session(library)
         if isinstance(description, Lane):
             # The lane has already been created.

--- a/lane.py
+++ b/lane.py
@@ -36,8 +36,11 @@ from model import (
     DeliveryMechanism,
     Edition,
     Genre,
+    get_one,
+    Library,
     LicensePool,
     LicensePoolDeliveryMechanism,
+    Session,
     Work,
     WorkGenre,
 )
@@ -422,6 +425,10 @@ class Lane(object):
     MINIMUM_SAMPLE_SIZE = None
 
     @property
+    def library(self):
+        return get_one(self._db, Library, id=self.library_id)
+    
+    @property
     def url_name(self):
         """Return the name of this lane to be used in URLs.
 
@@ -496,7 +503,7 @@ class Lane(object):
             lane.debug(level+1)
 
     def __init__(self, 
-                 _db, 
+                 library,
                  full_name,
                  display_name=None,
 
@@ -531,10 +538,16 @@ class Lane(object):
                  searchable=False,
                  invisible=False,
                  ):
+        if not isinstance(library, Library):
+            raise ValueError("Expected Library in Lane constructor, got %r" % library)
         self.name = full_name
         self.display_name = display_name or self.name
         self.parent = parent
-        self._db = _db
+        self._db = Session.object_session(library)
+        self.library_id = library.id
+        self.collection_ids = [
+            collection.id for collection in library.collections
+        ]
         self.default_for_language = False
         self.searchable = searchable
         self.invisible = invisible
@@ -595,7 +608,7 @@ class Lane(object):
 
         # Best-seller and staff pick lanes go at the top.
         base_args = dict(
-            _db=self._db, parent=self, include_all=False, genres=genres,
+            library=self.library, parent=self, include_all=False, genres=genres,
             exclude_genres=exclude_genres, fiction=fiction, 
             audiences=audiences, age_range=age_range,
             appeals=appeals, languages=languages, 
@@ -766,7 +779,7 @@ class Lane(object):
                     if subgenre in full_exclude_genres:
                         continue
                     sublane = Lane(
-                            self._db, full_name=subgenre.name,
+                            self.library, full_name=subgenre.name,
                             parent=self, genres=[subgenre],
                             subgenre_behavior=self.IN_SUBLANES
                     )
@@ -784,10 +797,10 @@ class Lane(object):
                 self.sublanes.add(sl)
         elif sublanes:
             self.sublanes = LaneList.from_description(
-                _db, self, sublanes
+                self.library, self, sublanes
             )
         else:
-            self.sublanes = LaneList.from_description(_db, self, [])
+            self.sublanes = LaneList.from_description(self.library, self, [])
 
     def include_staff_picks(self, **base_args):
         """Includes a Staff Picks sublane to the base/top of this lane."""
@@ -877,8 +890,9 @@ class Lane(object):
         return audiences      
 
     @classmethod
-    def from_description(cls, _db, parent, description):
+    def from_description(cls, library, parent, description):
         genre = None
+        _db = Session.object_session(library)
         if isinstance(description, Lane):
             # The lane has already been created.
             description.parent = parent
@@ -887,11 +901,11 @@ class Lane(object):
             if description.get('suppress_lane'):
                 return None
             # Invoke the constructor
-            return Lane(_db, parent=parent, **description)
+            return Lane(library, parent=parent, **description)
         else:
             # This is a lane for a specific genre.
             genre, genredata = Lane.load_genre(_db, description)
-            return Lane(_db, genre.name, parent=parent, genres=genre)
+            return Lane(library, genre.name, parent=parent, genres=genre)
 
     @classmethod
     def load_genre(cls, _db, descriptor):
@@ -1027,7 +1041,8 @@ class Lane(object):
         * Have a delivery mechanism that can be rendered by the
           default client.
 
-        * Have an unsuppressed license pool.
+        * Have an unsuppressed license pool that belongs to one of the
+          available collections.
         """
 
         q = self._db.query(Work).join(Work.presentation_edition)
@@ -1206,12 +1221,12 @@ class Lane(object):
 
         return q
 
-    @classmethod
     def only_show_ready_deliverable_works(
-            cls, query, work_model, show_suppressed=False
+            self, query, work_model, show_suppressed=False
     ):
-        """Restrict a query to show only presentation-ready
-        works which the default client can fulfill.
+        """Restrict a query to show only presentation-ready works present in
+        an appropriate collection which the default client can
+        fulfill.
 
         Note that this assumes the query has an active join against
         LicensePool.
@@ -1242,6 +1257,11 @@ class Lane(object):
                 or_(LicensePool.licenses_owned > 0, LicensePool.open_access)
         )
 
+        # Only find books in an appropriate collection.
+        query = query.filter(
+            LicensePool.collection_id.in_(self.collection_ids)
+        )
+        
         # If we don't allow holds, hide any books with no available copies.
         hold_policy = Configuration.hold_policy()
         if hold_policy == Configuration.HOLD_POLICY_HIDE:
@@ -1537,11 +1557,11 @@ class LaneList(object):
         )       
 
     @classmethod
-    def from_description(cls, _db, parent_lane, description):
+    def from_description(cls, library, parent_lane, description):
         lanes = LaneList(parent_lane)
         description = description or []
         for lane_description in description:
-            lane = Lane.from_description(_db, parent_lane, lane_description)
+            lane = Lane.from_description(library, parent_lane, lane_description)
 
             def _add_recursively(l):
                 lanes.add(l)
@@ -1660,7 +1680,7 @@ class QueryGeneratedLane(Lane):
         """
         raise NotImplementedError()
 
-def make_lanes(_db, definitions=None):
+def make_lanes(library, definitions=None):
 
     definitions = definitions or Configuration.policy(
         Configuration.LANES_POLICY
@@ -1670,4 +1690,4 @@ def make_lanes(_db, definitions=None):
         return None
 
     lanes = [Lane(_db=_db, **definition) for definition in definitions]
-    return LaneList.from_description(_db, None, lanes)
+    return LaneList.from_description(library, None, lanes)

--- a/migration/20170609-recreate-materialized-views.sql
+++ b/migration/20170609-recreate-materialized-views.sql
@@ -1,3 +1,117 @@
+drop materialized view mv_works_editions_datasources_identifiers;
+create materialized view mv_works_editions_datasources_identifiers
+as
+ SELECT 
+    distinct works.id AS works_id,
+    editions.id AS editions_id,
+    editions.data_source_id,
+    editions.primary_identifier_id,
+    editions.sort_title,
+    editions.permanent_work_id,
+    editions.sort_author,
+    editions.medium,
+    editions.language,
+    editions.cover_full_url,
+    editions.cover_thumbnail_url,
+    editions.series,
+    editions.series_position,
+    datasources.name,
+    identifiers.type,
+    identifiers.identifier,
+    works.audience,
+    works.target_age,
+    works.fiction,
+    works.quality,
+    works.rating,
+    works.popularity,
+    works.random,
+    works.last_update_time,
+    works.simple_opds_entry,
+    works.verbose_opds_entry,
+    licensepools.id AS license_pool_id,
+    licensepools.open_access_download_url,
+    licensepools.availability_time,
+    licensepools.collection_id
+
+   FROM works
+     JOIN editions ON editions.id = works.presentation_edition_id
+     JOIN licensepools ON editions.id = licensepools.presentation_edition_id
+     JOIN datasources ON licensepools.data_source_id = datasources.id
+     JOIN identifiers on editions.primary_identifier_id = identifiers.id
+  WHERE works.presentation_ready = true
+    AND works.simple_opds_entry IS NOT NULL
+  
+  ORDER BY editions.sort_title, editions.sort_author, licensepools.availability_time;
+
+-- Create a unique index so that searches can look up books by work ID.
+
+create unique index mv_works_editions_work_id on mv_works_editions_datasources_identifiers (works_id);
+
+-- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
+
+create index mv_works_editions_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id);
+
+-- Similarly, an index on everything, sorted by descending update time.
+
+create index mv_works_editions_by_modification on mv_works_editions_datasources_identifiers (last_update_time DESC, sort_author, sort_title, works_id);
+
+-- We need three versions of each index:
+--- One that orders by sort_author, sort_title, and works_id
+--- One that orders by sort_title, sort_author, and works_id
+--- One that orders by availability_time (descending!), sort_title, sort_author, and works_id
+
+-- English adult fiction
+
+create index mv_works_editions_english_adult_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_editions_english_adult_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+create index mv_works_editions_english_adult_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language = 'eng';
+
+-- English adult nonfiction
+
+create index mv_works_editions_english_adult_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_editions_english_adult_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+create index mv_works_editions_english_adult_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language = 'eng';
+
+-- Nonenglish adult fiction
+--- These are also ordered by language
+
+create index mv_works_editions_nonenglish_adult_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = true AND language <> 'eng';
+
+-- Nonenglish adult nonfiction
+--- These are also ordered by language
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+create index mv_works_editions_nonenglish_adult_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, works_id, language) WHERE audience in ('Adult', 'Adults Only') AND fiction = false AND language <> 'eng';
+
+-- YA/Children's fiction, regardless of language
+
+create index mv_works_editions_ya_fiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_editions_ya_fiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+create index mv_works_editions_ya_fiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = true;
+
+-- YA/Children's nonfiction, regardless of language
+
+create index mv_works_editions_ya_nonfiction_by_author on mv_works_editions_datasources_identifiers (sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_editions_ya_nonfiction_by_title on mv_works_editions_datasources_identifiers (sort_title, sort_author, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+create index mv_works_editions_ya_nonfiction_by_availability on mv_works_editions_datasources_identifiers (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
+
+
+drop materialized view mv_works_editions_workgenres_datasources_identifiers;
 create materialized view mv_works_editions_workgenres_datasources_identifiers
 as
  SELECT 
@@ -32,8 +146,7 @@ as
     works.verbose_opds_entry,
     licensepools.id AS license_pool_id,
     licensepools.open_access_download_url,
-    licensepools.availability_time,
-    licensepools.collection_id
+    licensepools.availability_time
 
    FROM works
      JOIN editions ON editions.id = works.presentation_edition_id

--- a/tests/test_cachedfeed.py
+++ b/tests/test_cachedfeed.py
@@ -33,7 +33,7 @@ class TestCachedFeed(DatabaseTest):
     def test_lifecycle(self):
         facets = Facets.default()
         pagination = Pagination.default()
-        lane = Lane(self._db, u"My Lane", languages=['eng', 'chi'])
+        lane = Lane(self._default_library, u"My Lane", languages=['eng', 'chi'])
 
         # Fetch a cached feed from the database--it's empty.
         args = (self._db, lane, CachedFeed.PAGE_TYPE, facets, pagination, None)
@@ -66,7 +66,7 @@ class TestCachedFeed(DatabaseTest):
     def test_fetch_ignores_feeds_without_content(self):
         facets = Facets.default()
         pagination = Pagination.default()
-        lane = Lane(self._db, u"My Lane", languages=['eng', 'chi'])
+        lane = Lane(self._default_library, u"My Lane", languages=['eng', 'chi'])
 
         # Create a feed without content (i.e. don't update it)
         contentless_feed = get_one_or_create(
@@ -94,7 +94,7 @@ class TestCachedFeed(DatabaseTest):
         
         facets = Facets.default()
         pagination = Pagination.default()
-        lane = Lane(self._db, u"My Lane", languages=['eng', 'chi'])
+        lane = Lane(self._default_library, u"My Lane", languages=['eng', 'chi'])
 
         args = (self._db, lane, CachedFeed.PAGE_TYPE, facets,
                      pagination, None)

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -531,8 +531,8 @@ class TestExternalSearch(ExternalSearchTest):
 
         # Filters on media
 
-        book_lane = Lane(self._db, "Books", media=Edition.BOOK_MEDIUM)
-        audio_lane = Lane(self._db, "Audio", media=Edition.AUDIO_MEDIUM)
+        book_lane = Lane(self._default_library, "Books", media=Edition.BOOK_MEDIUM)
+        audio_lane = Lane(self._default_library, "Audio", media=Edition.AUDIO_MEDIUM)
 
         results = self.search.query_works("pride and prejudice", book_lane.media, None, None, None, None, None, None)
         hits = results["hits"]["hits"]
@@ -547,9 +547,9 @@ class TestExternalSearch(ExternalSearchTest):
 
         # Filters on languages
 
-        english_lane = Lane(self._db, "English", languages="en")
-        spanish_lane = Lane(self._db, "Spanish", languages="es")
-        both_lane = Lane(self._db, "Both", languages=["en", "es"])
+        english_lane = Lane(self._default_library, "English", languages="en")
+        spanish_lane = Lane(self._default_library, "Spanish", languages="es")
+        both_lane = Lane(self._default_library, "Both", languages=["en", "es"])
 
         results = self.search.query_works("sherlock", None, english_lane.languages, None, None, None, None, None)
         hits = results["hits"]["hits"]
@@ -568,9 +568,9 @@ class TestExternalSearch(ExternalSearchTest):
 
         # Filters on exclude languages
 
-        no_english_lane = Lane(self._db, "English", exclude_languages="en")
-        no_spanish_lane = Lane(self._db, "Spanish", exclude_languages="es")
-        neither_lane = Lane(self._db, "Both", exclude_languages=["en", "es"])
+        no_english_lane = Lane(self._default_library, "English", exclude_languages="en")
+        no_spanish_lane = Lane(self._default_library, "Spanish", exclude_languages="es")
+        neither_lane = Lane(self._default_library, "Both", exclude_languages=["en", "es"])
 
         results = self.search.query_works("sherlock", None, None, no_english_lane.exclude_languages, None, None, None, None)
         hits = results["hits"]["hits"]
@@ -589,9 +589,9 @@ class TestExternalSearch(ExternalSearchTest):
 
         # Filters on fiction
 
-        fiction_lane = Lane(self._db, "fiction", fiction=True)
-        nonfiction_lane = Lane(self._db, "nonfiction", fiction=False)
-        both_lane = Lane(self._db, "both", fiction=Lane.BOTH_FICTION_AND_NONFICTION)
+        fiction_lane = Lane(self._default_library, "fiction", fiction=True)
+        nonfiction_lane = Lane(self._default_library, "nonfiction", fiction=False)
+        both_lane = Lane(self._default_library, "both", fiction=Lane.BOTH_FICTION_AND_NONFICTION)
 
         results = self.search.query_works("moby dick", None, None, None, fiction_lane.fiction, None, None, None)
         hits = results["hits"]["hits"]
@@ -610,10 +610,10 @@ class TestExternalSearch(ExternalSearchTest):
 
         # Filters on audience
 
-        adult_lane = Lane(self._db, "Adult", audiences=Classifier.AUDIENCE_ADULT)
-        ya_lane = Lane(self._db, "YA", audiences=Classifier.AUDIENCE_YOUNG_ADULT)
-        children_lane = Lane(self._db, "Children", audiences=Classifier.AUDIENCE_CHILDREN)
-        ya_and_children_lane = Lane(self._db, "YA and Children", audiences=[Classifier.AUDIENCE_YOUNG_ADULT, Classifier.AUDIENCE_CHILDREN])
+        adult_lane = Lane(self._default_library, "Adult", audiences=Classifier.AUDIENCE_ADULT)
+        ya_lane = Lane(self._default_library, "YA", audiences=Classifier.AUDIENCE_YOUNG_ADULT)
+        children_lane = Lane(self._default_library, "Children", audiences=Classifier.AUDIENCE_CHILDREN)
+        ya_and_children_lane = Lane(self._default_library, "YA and Children", audiences=[Classifier.AUDIENCE_YOUNG_ADULT, Classifier.AUDIENCE_CHILDREN])
 
         results = self.search.query_works("alice", None, None, None, None, adult_lane.audiences, None, None)
         hits = results["hits"]["hits"]
@@ -640,10 +640,10 @@ class TestExternalSearch(ExternalSearchTest):
 
         # Filters on age range
 
-        age_8_lane = Lane(self._db, "Age 8", age_range=[8, 8])
-        age_5_8_lane = Lane(self._db, "Age 5-8", age_range=[5, 8])
-        age_5_10_lane = Lane(self._db, "Age 5-10", age_range=[5, 10])
-        age_8_10_lane = Lane(self._db, "Age 8-10", age_range=[8, 10])
+        age_8_lane = Lane(self._default_library, "Age 8", age_range=[8, 8])
+        age_5_8_lane = Lane(self._default_library, "Age 5-8", age_range=[5, 8])
+        age_5_10_lane = Lane(self._default_library, "Age 5-10", age_range=[5, 10])
+        age_8_10_lane = Lane(self._default_library, "Age 8-10", age_range=[8, 10])
 
         results = self.search.query_works("president", None, None, None, None, None, age_8_lane.age_range, None)
         hits = results["hits"]["hits"]
@@ -686,9 +686,9 @@ class TestExternalSearch(ExternalSearchTest):
 
         # Filters on genre
 
-        biography_lane = Lane(self._db, "Biography", genres=["Biography & Memoir"])
-        fantasy_lane = Lane(self._db, "Fantasy", genres=["Fantasy"])
-        both_lane = Lane(self._db, "Both", genres=["Biography & Memoir", "Fantasy"], fiction=Lane.BOTH_FICTION_AND_NONFICTION)
+        biography_lane = Lane(self._default_library, "Biography", genres=["Biography & Memoir"])
+        fantasy_lane = Lane(self._default_library, "Fantasy", genres=["Fantasy"])
+        both_lane = Lane(self._default_library, "Both", genres=["Biography & Memoir", "Fantasy"], fiction=Lane.BOTH_FICTION_AND_NONFICTION)
 
         results = self.search.query_works("lincoln", None, None, None, None, None, None, biography_lane.genre_ids)
         hits = results["hits"]["hits"]
@@ -865,7 +865,7 @@ class TestSearchFilterFromLane(DatabaseTest):
         search = DummyExternalSearchIndex()
 
         lane = Lane(
-            self._db, "For Ages 5-10", 
+            self._default_library, "For Ages 5-10", 
             age_range=[5,10]
         )
         filter = search.make_filter(
@@ -885,7 +885,7 @@ class TestSearchFilterFromLane(DatabaseTest):
         search = DummyExternalSearchIndex()
 
         lane = Lane(
-            self._db, "english or spanish", 
+            self._default_library, "english or spanish", 
             languages=set(['eng', 'spa']),
         )
         filter = search.make_filter(
@@ -904,7 +904,7 @@ class TestSearchFilterFromLane(DatabaseTest):
         search = DummyExternalSearchIndex()
 
         lane = Lane(
-            self._db, "Not english or spanish", 
+            self._default_library, "Not english or spanish", 
             exclude_languages=set(['eng', 'spa']),
         )
         filter = search.make_filter(

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -303,21 +303,21 @@ class TestFacetsApply(DatabaseTest):
 class TestLane(DatabaseTest):
 
     def test_depth(self):
-        child = Lane(self._db, "sublane")
-        parent = Lane(self._db, "parent", sublanes=[child])
+        child = Lane(self._default_library, "sublane")
+        parent = Lane(self._default_library, "parent", sublanes=[child])
         eq_(0, parent.depth)
         eq_(1, child.depth)
 
     def test_includes_language(self):
-        english_lane = Lane(self._db, self._str, languages=['eng'])
+        english_lane = Lane(self._default_library, self._str, languages=['eng'])
         eq_(True, english_lane.includes_language('eng'))
         eq_(False, english_lane.includes_language('fre'))
 
-        no_english_lane = Lane(self._db, self._str, exclude_languages=['eng'])
+        no_english_lane = Lane(self._default_library, self._str, exclude_languages=['eng'])
         eq_(False, no_english_lane.includes_language('eng'))
         eq_(True, no_english_lane.includes_language('fre'))
 
-        all_language_lane = Lane(self._db, self._str)
+        all_language_lane = Lane(self._default_library, self._str)
         eq_(True, all_language_lane.includes_language('eng'))
         eq_(True, all_language_lane.includes_language('fre'))
 
@@ -329,18 +329,18 @@ class TestLane(DatabaseTest):
 
         # Because this lane has no list-related information, the
         # RuntimeError shouldn't pop up at all.
-        lane = SetCustomListErrorLane(self._db, self._str)
+        lane = SetCustomListErrorLane(self._default_library, self._str)
 
         # The minute we put in some list information, it does!
         assert_raises(
-            RuntimeError, SetCustomListErrorLane, self._db, self._str,
-            list_data_source=DataSource.NYT
+            RuntimeError, SetCustomListErrorLane, self._default_library,
+            self._str, list_data_source=DataSource.NYT
         )
 
         # It can be a DataSource, or a CustomList identifier. World == oyster.
         assert_raises(
-            RuntimeError, SetCustomListErrorLane, self._db, self._str,
-            list_identifier=u"Staff Picks"
+            RuntimeError, SetCustomListErrorLane, self._default_library,
+            self._str, list_identifier=u"Staff Picks"
         )
 
 
@@ -359,7 +359,7 @@ class TestLanes(DatabaseTest):
 
     def test_nonexistent_list_raises_exception(self):
         assert_raises(
-            UndefinedLane, Lane, self._db, 
+            UndefinedLane, Lane, self._default_library, 
             u"This Will Fail", list_identifier=u"No Such List"
         )
 
@@ -375,7 +375,7 @@ class TestLanes(DatabaseTest):
             num_entries=0
         )
         lane = Lane(
-            self._db, "Everything", 
+            self._default_library, "Everything", 
             include_staff_picks=True, include_best_sellers=True
         )
 
@@ -408,7 +408,7 @@ class TestLanes(DatabaseTest):
         self._db.commit()
         SessionManager.refresh_materialized_views(self._db)
 
-        lane = Lane(self._db, u'My Lane', list_identifier=my_list.foreign_identifier)
+        lane = Lane(self._default_library, u'My Lane', list_identifier=my_list.foreign_identifier)
 
         result = lane.list_featured_works_query.all()
         eq_(sorted(featured_works), sorted(result))
@@ -522,7 +522,7 @@ class TestLanes(DatabaseTest):
     def test_subgenres_become_sublanes(self):
         fantasy, ig = Genre.lookup(self._db, classifier.Fantasy)
         lane = Lane(
-            self._db, "YA Fantasy", genres=fantasy, 
+            self._default_library, "YA Fantasy", genres=fantasy, 
             languages='eng',
             audiences=Lane.AUDIENCE_YOUNG_ADULT,
             age_range=[15,16],
@@ -541,7 +541,7 @@ class TestLanes(DatabaseTest):
     def test_get_search_target(self):
         fantasy, ig = Genre.lookup(self._db, classifier.Fantasy)
         lane = Lane(
-            self._db, "YA Fantasy", genres=fantasy, 
+            self._default_library, "YA Fantasy", genres=fantasy, 
             languages='eng',
             audiences=Lane.AUDIENCE_YOUNG_ADULT,
             age_range=[15,16],
@@ -569,10 +569,10 @@ class TestLanes(DatabaseTest):
         urban_fantasy, ig = Genre.lookup(self._db, classifier.Urban_Fantasy)
 
         urban_fantasy_lane = Lane(
-            self._db, "Urban Fantasy", genres=urban_fantasy)
+            self._default_library, "Urban Fantasy", genres=urban_fantasy)
 
         fantasy_lane = Lane(
-            self._db, "Fantasy", fantasy, 
+            self._default_library, "Fantasy", fantasy, 
             genres=fantasy,
             subgenre_behavior=Lane.IN_SAME_LANE,
             sublanes=[urban_fantasy_lane]
@@ -582,7 +582,7 @@ class TestLanes(DatabaseTest):
         # You can just give the name of a genre as a sublane and it
         # will work.
         fantasy_lane = Lane(
-            self._db, "Fantasy", fantasy, 
+            self._default_library, "Fantasy", fantasy, 
             genres=fantasy,
             subgenre_behavior=Lane.IN_SAME_LANE,
             sublanes="Urban Fantasy"
@@ -595,10 +595,10 @@ class TestLanes(DatabaseTest):
         urban_fantasy, ig = Genre.lookup(self._db, classifier.Urban_Fantasy)
 
         urban_fantasy_lane = Lane(
-            self._db, "Urban Fantasy", genres=urban_fantasy)
+            self._default_library, "Urban Fantasy", genres=urban_fantasy)
 
         assert_raises(UndefinedLane, Lane,
-            self._db, "Fantasy", fantasy, 
+            self._default_library, "Fantasy", fantasy, 
             genres=fantasy,
             audiences=Lane.AUDIENCE_YOUNG_ADULT,
             subgenre_behavior=Lane.IN_SUBLANES,
@@ -609,7 +609,7 @@ class TestLanes(DatabaseTest):
         """The appropriate opds entry is deferred during querying.
         """
         original_setting = Configuration.DEFAULT_OPDS_FORMAT
-        lane = Lane(self._db, "Everything")
+        lane = Lane(self._default_library, "Everything")
 
         # Verbose config doesn't query simple OPDS entries.
         Configuration.DEFAULT_OPDS_FORMAT = "verbose_opds_entry"
@@ -638,14 +638,14 @@ class TestLanes(DatabaseTest):
         urban_fantasy, ig = Genre.lookup(self._db, classifier.Urban_Fantasy)
 
         sublane = Lane(
-            self._db, "Urban Fantasy", genres=urban_fantasy)
+            self._default_library, "Urban Fantasy", genres=urban_fantasy)
 
         invisible_parent = Lane(
-            self._db, "Fantasy", invisible=True, genres=fantasy, 
+            self._default_library, "Fantasy", invisible=True, genres=fantasy, 
             sublanes=[sublane], subgenre_behavior=Lane.IN_SAME_LANE)
 
         visible_grandparent = Lane(
-            self._db, "English", sublanes=[invisible_parent],
+            self._default_library, "English", sublanes=[invisible_parent],
             subgenre_behavior=Lane.IN_SAME_LANE)
 
         eq_(sublane.visible_parent(), visible_grandparent)
@@ -657,18 +657,18 @@ class TestLanes(DatabaseTest):
         urban_fantasy, ig = Genre.lookup(self._db, classifier.Urban_Fantasy)
 
         lane = Lane(
-            self._db, "Urban Fantasy", genres=urban_fantasy)
+            self._default_library, "Urban Fantasy", genres=urban_fantasy)
 
         visible_parent = Lane(
-            self._db, "Fantasy", genres=fantasy,
+            self._default_library, "Fantasy", genres=fantasy,
             sublanes=[lane], subgenre_behavior=Lane.IN_SAME_LANE)
 
         invisible_grandparent = Lane(
-            self._db, "English", invisible=True, sublanes=[visible_parent],
+            self._default_library, "English", invisible=True, sublanes=[visible_parent],
             subgenre_behavior=Lane.IN_SAME_LANE)
 
         visible_ancestor = Lane(
-            self._db, "Books With Words", sublanes=[invisible_grandparent],
+            self._default_library, "Books With Words", sublanes=[invisible_grandparent],
             subgenre_behavior=Lane.IN_SAME_LANE)
 
         eq_(lane.visible_ancestors(), [visible_parent, visible_ancestor])
@@ -678,15 +678,15 @@ class TestLanes(DatabaseTest):
         urban_fantasy, ig = Genre.lookup(self._db, classifier.Urban_Fantasy)
 
         sublane = Lane(
-            self._db, "Urban Fantasy", genres=urban_fantasy,
+            self._default_library, "Urban Fantasy", genres=urban_fantasy,
             subgenre_behavior=Lane.IN_SAME_LANE)
 
         invisible_parent = Lane(
-            self._db, "Fantasy", invisible=True, genres=fantasy,
+            self._default_library, "Fantasy", invisible=True, genres=fantasy,
             sublanes=[sublane], subgenre_behavior=Lane.IN_SAME_LANE)
 
         visible_grandparent = Lane(
-            self._db, "English", sublanes=[invisible_parent],
+            self._default_library, "English", sublanes=[invisible_parent],
             subgenre_behavior=Lane.IN_SAME_LANE)
 
         eq_(False, visible_grandparent.has_visible_sublane())
@@ -698,17 +698,17 @@ class TestLanes(DatabaseTest):
         urban_fantasy, ig = Genre.lookup(self._db, classifier.Urban_Fantasy)
         humorous, ig = Genre.lookup(self._db, classifier.Humorous_Fiction)
 
-        visible_sublane = Lane(self._db, "Humorous Fiction", genres=humorous)
+        visible_sublane = Lane(self._default_library, "Humorous Fiction", genres=humorous)
 
         visible_grandchild = Lane(
-            self._db, "Urban Fantasy", genres=urban_fantasy)
+            self._default_library, "Urban Fantasy", genres=urban_fantasy)
 
         invisible_sublane = Lane(
-            self._db, "Fantasy", invisible=True, genres=fantasy,
+            self._default_library, "Fantasy", invisible=True, genres=fantasy,
             sublanes=[visible_grandchild], subgenre_behavior=Lane.IN_SAME_LANE)
 
         lane = Lane(
-            self._db, "English", sublanes=[visible_sublane, invisible_sublane],
+            self._default_library, "English", sublanes=[visible_sublane, invisible_sublane],
             subgenre_behavior=Lane.IN_SAME_LANE)
 
         eq_(2, len(lane.visible_sublanes))
@@ -848,24 +848,24 @@ class TestLanesQuery(DatabaseTest):
 
         # The 'everything' lane contains 18 works -- everything except
         # the music.
-        lane = Lane(self._db, "Everything")
+        lane = Lane(self._default_library, "Everything")
         w, mw = _assert_expectations(lane, 18, lambda x: True)
 
         # The 'Spanish' lane contains 1 book.
-        lane = Lane(self._db, "Spanish", languages='spa')
+        lane = Lane(self._default_library, "Spanish", languages='spa')
         eq_(['spa'], lane.languages)
         w, mw = _assert_expectations(lane, 1, lambda x: True)
         eq_([self.spanish], w)
 
         # The 'everything except English' lane contains that same book.
-        lane = Lane(self._db, "Not English", exclude_languages='eng')
+        lane = Lane(self._default_library, "Not English", exclude_languages='eng')
         eq_(None, lane.languages)
         eq_(['eng'], lane.exclude_languages)
         w, mw = _assert_expectations(lane, 1, lambda x: True)
         eq_([self.spanish], w)
 
         # The 'music' lane contains 1 work of music
-        lane = Lane(self._db, "Music", media=Edition.MUSIC_MEDIUM)
+        lane = Lane(self._default_library, "Music", media=Edition.MUSIC_MEDIUM)
         w, mw = _assert_expectations(
             lane, 1, 
             lambda x: x.presentation_edition.medium==Edition.MUSIC_MEDIUM,
@@ -873,14 +873,14 @@ class TestLanesQuery(DatabaseTest):
         )
         
         # The 'English fiction' lane contains ten fiction books.
-        lane = Lane(self._db, "English Fiction", fiction=True, languages='eng')
+        lane = Lane(self._default_library, "English Fiction", fiction=True, languages='eng')
         w, mw = _assert_expectations(
             lane, 10, lambda x: x.fiction
         )
 
         # The 'nonfiction' lane contains seven nonfiction books.
         # It does not contain the music.
-        lane = Lane(self._db, "Nonfiction", fiction=False)
+        lane = Lane(self._default_library, "Nonfiction", fiction=False)
         w, mw = _assert_expectations(
             lane, 7, 
             lambda x: x.presentation_edition.medium==Edition.BOOK_MEDIUM and not x.fiction,
@@ -888,7 +888,7 @@ class TestLanesQuery(DatabaseTest):
         )
 
         # The 'adults' lane contains five books for adults.
-        lane = Lane(self._db, "Adult English",
+        lane = Lane(self._default_library, "Adult English",
                     audiences=Lane.AUDIENCE_ADULT, languages='eng')
         w, mw = _assert_expectations(
             lane, 5, lambda x: x.audience==Lane.AUDIENCE_ADULT
@@ -897,7 +897,7 @@ class TestLanesQuery(DatabaseTest):
         # This lane contains those five books plus two adults-only
         # books.
         audiences = [Lane.AUDIENCE_ADULT, Lane.AUDIENCE_ADULTS_ONLY]
-        lane = Lane(self._db, "Adult + Adult Only",
+        lane = Lane(self._default_library, "Adult + Adult Only",
                     audiences=audiences, languages='eng'
         )
         w, mw = _assert_expectations(
@@ -907,7 +907,7 @@ class TestLanesQuery(DatabaseTest):
         eq_(2, len([x for x in mw if x.audience==Lane.AUDIENCE_ADULTS_ONLY]))
 
         # The 'Young Adults' lane contains five books.
-        lane = Lane(self._db, "Young Adults", 
+        lane = Lane(self._default_library, "Young Adults", 
                     audiences=Lane.AUDIENCE_YOUNG_ADULT)
         w, mw = _assert_expectations(
             lane, 5, lambda x: x.audience==Lane.AUDIENCE_YOUNG_ADULT
@@ -915,7 +915,7 @@ class TestLanesQuery(DatabaseTest):
 
         # There is one book suitable for seven-year-olds.
         lane = Lane(
-            self._db, "If You're Seven", audiences=Lane.AUDIENCE_CHILDREN,
+            self._default_library, "If You're Seven", audiences=Lane.AUDIENCE_CHILDREN,
             age_range=7
         )
         w, mw = _assert_expectations(
@@ -924,7 +924,7 @@ class TestLanesQuery(DatabaseTest):
 
         # There are four books suitable for ages 10-12.
         lane = Lane(
-            self._db, "10-12", audiences=Lane.AUDIENCE_CHILDREN,
+            self._default_library, "10-12", audiences=Lane.AUDIENCE_CHILDREN,
             age_range=(10,12)
         )
         w, mw = _assert_expectations(
@@ -938,7 +938,7 @@ class TestLanesQuery(DatabaseTest):
         # Here's an 'adult fantasy' lane, in which the subgenres of Fantasy
         # are kept in the same place as generic Fantasy.
         lane = Lane(
-            self._db, "Adult Fantasy",
+            self._default_library, "Adult Fantasy",
             genres=[self.fantasy], 
             subgenre_behavior=Lane.IN_SAME_LANE,
             fiction=Lane.FICTION_DEFAULT_FOR_GENRE,
@@ -955,7 +955,7 @@ class TestLanesQuery(DatabaseTest):
         # Here's a 'YA fantasy' lane in which urban fantasy is explicitly
         # excluded (maybe because it has its own separate lane).
         lane = Lane(
-            self._db, full_name="Adult Fantasy",
+            self._default_library, full_name="Adult Fantasy",
             genres=[self.fantasy], 
             exclude_genres=[self.urban_fantasy],
             subgenre_behavior=Lane.IN_SAME_LANE,
@@ -979,7 +979,7 @@ class TestLanesQuery(DatabaseTest):
 
         # Try a lane based on license source.
         overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
-        lane = Lane(self._db, full_name="Overdrive Books",
+        lane = Lane(self._default_library, full_name="Overdrive Books",
                     license_source=overdrive)
         w, mw = _assert_expectations(
             lane, 10, lambda x: True
@@ -1014,7 +1014,7 @@ class TestLanesQuery(DatabaseTest):
 
         # Create a lane for one specific list
         fiction_best_sellers = Lane(
-            self._db, full_name="Fiction Best Sellers",
+            self._default_library, full_name="Fiction Best Sellers",
             list_identifier=fic_name
         )
         w, mw = _assert_expectations(
@@ -1024,7 +1024,7 @@ class TestLanesQuery(DatabaseTest):
 
         # Create a lane for all best-sellers.
         all_best_sellers = Lane(
-            self._db, full_name="All Best Sellers",
+            self._default_library, full_name="All Best Sellers",
             list_data_source=best_seller_list_1.data_source.name
         )
         w, mw = _assert_expectations(
@@ -1036,7 +1036,7 @@ class TestLanesQuery(DatabaseTest):
 
         # Combine list membership with another criteria (nonfiction)
         all_nonfiction_best_sellers = Lane(
-            self._db, full_name="All Nonfiction Best Sellers",
+            self._default_library, full_name="All Nonfiction Best Sellers",
             fiction=False,
             list_data_source=best_seller_list_1.data_source.name
         )
@@ -1048,7 +1048,7 @@ class TestLanesQuery(DatabaseTest):
         # Apply a cutoff date to a best-seller list,
         # excluding the work that was last seen a year ago.
         best_sellers_past_week = Lane(
-            self._db, full_name="Best Sellers - The Past Week",
+            self._default_library, full_name="Best Sellers - The Past Week",
             list_data_source=best_seller_list_1.data_source.name,
             list_seen_in_previous_days=7
         )
@@ -1060,7 +1060,7 @@ class TestLanesQuery(DatabaseTest):
     def test_from_description(self):
         """Create a LaneList from a simple description."""
         lanes = LaneList.from_description(
-            self._db,
+            self._default_library,
             None,
             [dict(
                 full_name="Fiction",
@@ -1177,11 +1177,12 @@ class TestFilters(DatabaseTest):
         # only_show_ready_deliverable_works filters out everything but
         # w1 (owned licenses), w6 (open-access), w7 (available
         # licenses), and w8 (available licenses, weird delivery mechanism).
-        q = Lane.only_show_ready_deliverable_works(orig_q, Work)
+        lane = Lane(self._default_library, self._str)
+        q = lane.only_show_ready_deliverable_works(orig_q, Work)
         eq_(set([w1, w6, w7, w8]), set(q.all()))
 
         # If we decide to show suppressed works, w4 shows up as well.
-        q = Lane.only_show_ready_deliverable_works(
+        q = lane.only_show_ready_deliverable_works(
             orig_q, Work, show_suppressed=True
         )
         eq_(set([w1, w4, w6, w7, w8]), set(q.all()))
@@ -1199,7 +1200,7 @@ class TestFilters(DatabaseTest):
             # w6 still shows up because it's an open-access work.
             # w7 and w8 show up because we own licenses and copies are
             #  available.
-            q = Lane.only_show_ready_deliverable_works(orig_q, Work)
+            q = lane.only_show_ready_deliverable_works(orig_q, Work)
             eq_(set([w6, w7, w8]), set(q.all()))
 
     def test_lane_subclass_queries(self):
@@ -1227,7 +1228,7 @@ class TestFilters(DatabaseTest):
 
         # When the work is queried, both of the LicensePools are
         # available in the database session, despite the filtering.
-        subclass = LaneSubclass(self._db, "Lane Subclass")
+        subclass = LaneSubclass(self._default_library, "Lane Subclass")
         [subclass_work] = subclass.works().all()
         eq_(2, len(subclass_work.license_pools))
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -349,7 +349,7 @@ class TestOPDS(DatabaseTest):
         super(TestOPDS, self).setup()
 
         self.lanes = LaneList.from_description(
-            self._db,
+            self._default_library,
             None,
             [dict(full_name="Fiction",
                   fiction=True,
@@ -372,8 +372,8 @@ class TestOPDS(DatabaseTest):
         )
 
         mock_top_level = Lane(
-            self._db, '', display_name='', sublanes=self.lanes.lanes,
-            include_all=False, invisible=True
+            self._default_library, '', display_name='',
+            sublanes=self.lanes.lanes, include_all=False, invisible=True
         )
 
         class FakeConf(object):
@@ -452,7 +452,7 @@ class TestOPDS(DatabaseTest):
     def test_lane_feed_contains_facet_links(self):
         work = self._work(with_open_access_download=True)
 
-        lane = Lane(self._db, "lane")
+        lane = Lane(self._default_library, "lane")
         facets = Facets.default()
 
         cached_feed = AcquisitionFeed.page(self._db, "title", "http://the-url.com/",
@@ -942,7 +942,7 @@ class TestOPDS(DatabaseTest):
         feed has no books in the groups.
         """
         
-        test_lane = Lane(self._db, "Test Lane", genres=['Mystery'])
+        test_lane = Lane(self._default_library, "Test Lane", genres=['Mystery'])
 
         work1 = self._work(genre=Mystery, with_open_access_download=True)
         work1.quality = 0.75

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -10,9 +10,9 @@ from . import DatabaseTest
 class TestOpenSearchDocument(DatabaseTest):
 
     def test_search_info(self):
-        sublane = Lane(self._db, "Sublane")
+        sublane = Lane(self._default_library, "Sublane")
 
-        lane = Lane(self._db, "Lane", sublanes=[sublane])
+        lane = Lane(self._default_library, "Lane", sublanes=[sublane])
 
         # Neither lane is searchable yet.
 


### PR DESCRIPTION
This branch changes the Lane constructor and related factory functions to make it take a Library instead of a database connection.

This branch also changes the materialized views to add the `LicensePool.collection_id` field. We use this in `Lane.only_show_ready_deliverable_works` to restrict results to LicensePools that are in one of the library's Collections.

Without this code, if you were to have multiple libraries in a circ manager, each library would show the other's books in their OPDS feeds and search results.

This branch should also fix the search result problem (since `Lane.search` calls `Lane.only_show_ready_deliverable_works`) but for performance reasons I think we also need to start indexing `collection_id` as part of the search document, and applying the collection filter during the search step.