### PR TITLE
Move lane configuration out of Configuration and into Library ConfigurationSettings

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -92,7 +92,11 @@ def _make_response(content, content_type, cache_for):
                                         "Cache-Control": cache_control})
 
 def load_facets_from_request():
-    """Figure out which Facets object this request is asking for."""
+    """Figure out which Facets object this request is asking for.
+
+    The active request must have the `library` member set to a Library
+    object.
+    """
     arg = flask.request.args.get
     library = flask.request.library
     

--- a/app_server.py
+++ b/app_server.py
@@ -123,7 +123,7 @@ def load_facets(library, order, availability, collection):
             _("I don't know how to order a feed by '%(order)s'", order=order),
             400
         )
-    availability_facets = config.enabled_facets(
+    availability_facets = library.enabled_facets(
         Facets.AVAILABILITY_FACET_GROUP_NAME
     )
     if availability and not availability in availability_facets:

--- a/app_server.py
+++ b/app_server.py
@@ -97,7 +97,7 @@ def load_facets_from_request(facet_config=None):
     The active request must have the `library` member set to a Library
     object.
 
-    :param config: An object to use instead of the request Library
+    :param facet_config: An object to use instead of the request Library
     when deciding which facets are enabled.
     """
     arg = flask.request.args.get

--- a/config.py
+++ b/config.py
@@ -93,9 +93,6 @@ class Configuration(object):
     OVERDRIVE_INTEGRATION = "Overdrive"
     THREEM_INTEGRATION = "3M"
 
-    MINIMUM_FEATURED_QUALITY = "minimum_featured_quality"
-    FEATURED_LANE_SIZE = "featured_lane_size"
-
     S3_INTEGRATION = u"S3"
     S3_ACCESS_KEY = u"access_key"
     S3_SECRET_KEY = u"secret_key"
@@ -189,18 +186,6 @@ class Configuration(object):
     def logging_policy(cls):
         default_logging = {}
         return cls.get(cls.LOGGING, default_logging)
-
-    # TODO: Needs to be a per-library ConfigurationSetting once
-    # lanes are configured in database.
-    @classmethod
-    def minimum_featured_quality(cls):
-        return float(cls.policy(cls.MINIMUM_FEATURED_QUALITY, 0.65))
-
-    # TODO: Needs to be a per-library ConfigurationSetting once
-    # lanes are configured in database.
-    @classmethod
-    def featured_lane_size(cls):
-        return int(cls.policy(cls.FEATURED_LANE_SIZE, 15))
 
     @classmethod
     def localization_languages(cls):

--- a/config.py
+++ b/config.py
@@ -5,7 +5,6 @@ import os
 import json
 import logging
 import copy
-from facets import FacetConstants as Facets
 from util import LanguageCodes
 
 class CannotLoadConfiguration(Exception):
@@ -51,42 +50,11 @@ class Configuration(object):
     LOG_DATA_FORMAT = "format"
 
     DATA_DIRECTORY = "data_directory"
-
+    
     # Policies, mostly circulation specific
     POLICIES = "policies"
-
-    # TODO: These policies should be converted to per-library
-    # ConfigurationSettings. Since they affect how feeds are
-    # generated, this can only happen once lane configuration happens
-    # in the database.
-    HOLD_POLICY = "holds"
-    HOLD_POLICY_ALLOW = "allow"
-    HOLD_POLICY_HIDE = "hide"
-    
+   
     LANES_POLICY = "lanes"
-
-    # Facet policies
-    FACET_POLICY = 'facets'
-    ENABLED_FACETS_KEY = 'enabled'
-    DEFAULT_FACET_KEY = 'default'
-
-    DEFAULT_ENABLED_FACETS = {
-        Facets.ORDER_FACET_GROUP_NAME : [
-            Facets.ORDER_AUTHOR, Facets.ORDER_TITLE, Facets.ORDER_ADDED_TO_COLLECTION
-        ],
-        Facets.AVAILABILITY_FACET_GROUP_NAME : [
-            Facets.AVAILABLE_ALL, Facets.AVAILABLE_NOW, Facets.AVAILABLE_OPEN_ACCESS
-        ],
-        Facets.COLLECTION_FACET_GROUP_NAME : [
-            Facets.COLLECTION_FULL, Facets.COLLECTION_MAIN, Facets.COLLECTION_FEATURED
-        ]
-    }
-
-    DEFAULT_FACET = {
-        Facets.ORDER_FACET_GROUP_NAME : Facets.ORDER_AUTHOR,
-        Facets.AVAILABILITY_FACET_GROUP_NAME : Facets.AVAILABLE_ALL,
-        Facets.COLLECTION_FACET_GROUP_NAME : Facets.COLLECTION_MAIN,
-    }
 
     # Lane policies
     DEFAULT_OPDS_FORMAT = "verbose_opds_entry"
@@ -138,7 +106,7 @@ class Configuration(object):
 
     BASE_OPDS_AUTHENTICATION_DOCUMENT = "base_opds_authentication_document"
     SHOW_STAFF_PICKS_ON_TOP_LEVEL = "show_staff_picks_on_top_level"
-
+    
     # General getters
 
     @classmethod
@@ -213,29 +181,6 @@ class Configuration(object):
     @classmethod
     def data_directory(cls):
         return cls.get(cls.DATA_DIRECTORY)
-
-    # TODO: This needs to be turned into a per-Library
-    # ConfigurationSetting, but it's not practical to do so until lane
-    # configuration is moved into the database.
-    @classmethod
-    def hold_policy(cls):
-        return cls.policy(cls.HOLD_POLICY, cls.HOLD_POLICY_ALLOW)
-
-    @classmethod
-    def enabled_facets(cls, group_name):
-        """Look up the enabled facets for a given facet group."""
-        policy = cls.policy(cls.FACET_POLICY)
-        if not policy or not cls.ENABLED_FACETS_KEY in policy:
-            return cls.DEFAULT_ENABLED_FACETS[group_name]
-        return policy[cls.ENABLED_FACETS_KEY][group_name]
-
-    @classmethod
-    def default_facet(cls, group_name):
-        """Look up the default facet for a given facet group."""
-        policy = cls.policy(cls.FACET_POLICY)
-        if not policy or not cls.DEFAULT_FACET_KEY in policy:
-            return cls.DEFAULT_FACET[group_name]
-        return policy[cls.DEFAULT_FACET_KEY][group_name]
 
     @classmethod
     def base_opds_authentication_document(cls):

--- a/config.py
+++ b/config.py
@@ -105,7 +105,6 @@ class Configuration(object):
     CDN_INTEGRATION = u"CDN"
 
     BASE_OPDS_AUTHENTICATION_DOCUMENT = "base_opds_authentication_document"
-    SHOW_STAFF_PICKS_ON_TOP_LEVEL = "show_staff_picks_on_top_level"
     
     # General getters
 
@@ -202,12 +201,6 @@ class Configuration(object):
     @classmethod
     def featured_lane_size(cls):
         return int(cls.policy(cls.FEATURED_LANE_SIZE, 15))
-
-    # TODO: Needs to be a per-library ConfigurationSetting once
-    # lanes are configured in database.
-    @classmethod
-    def show_staff_picks_on_top_level(cls):
-        return cls.policy(cls.SHOW_STAFF_PICKS_ON_TOP_LEVEL, default=True)
 
     @classmethod
     def localization_languages(cls):

--- a/facets.py
+++ b/facets.py
@@ -48,3 +48,25 @@ class FacetConstants(object):
         COLLECTION_MAIN : "Main Collection",
         COLLECTION_FEATURED : "Popular Books",
     }
+
+    # Unless a library offers an alternate configuration, patrons will
+    # see these facet groups.
+    DEFAULT_ENABLED_FACETS = {
+        ORDER_FACET_GROUP_NAME : [
+            ORDER_AUTHOR, ORDER_TITLE, ORDER_ADDED_TO_COLLECTION
+        ],
+        AVAILABILITY_FACET_GROUP_NAME : [
+            AVAILABLE_ALL, AVAILABLE_NOW, AVAILABLE_OPEN_ACCESS
+        ],
+        COLLECTION_FACET_GROUP_NAME : [
+            COLLECTION_FULL, COLLECTION_MAIN, COLLECTION_FEATURED
+        ]
+    }
+
+    # Unless a library offers an alternate configuration, these
+    # facets will be the default selection for the facet groups.
+    DEFAULT_FACET = {
+        ORDER_FACET_GROUP_NAME : ORDER_AUTHOR,
+        AVAILABILITY_FACET_GROUP_NAME : AVAILABLE_ALL,
+        COLLECTION_FACET_GROUP_NAME : COLLECTION_MAIN,
+    }

--- a/facets.py
+++ b/facets.py
@@ -70,3 +70,46 @@ class FacetConstants(object):
         AVAILABILITY_FACET_GROUP_NAME : AVAILABLE_ALL,
         COLLECTION_FACET_GROUP_NAME : COLLECTION_MAIN,
     }
+
+
+class FacetConfig(object):
+    """A class that implements the facet-related methods of
+    Library, and allows modifications to the enabled
+    and default facets. For use when a controller needs to
+    use a facet configuration different from the site-wide
+    facets. 
+    """
+    @classmethod
+    def from_library(cls, library):
+
+        enabled_facets = dict()
+        for group in FacetConstants.DEFAULT_ENABLED_FACETS.keys():
+            enabled_facets[group] = library.enabled_facets(group)
+
+        default_facets = dict()
+        for group in FacetConstants.DEFAULT_FACET.keys():
+            default_facets[group] = library.default_facet(group)
+        
+        return FacetConfig(enabled_facets, default_facets)
+
+    def __init__(self, enabled_facets, default_facets):
+        self._enabled_facets = enabled_facets
+        self._default_facets = default_facets
+
+    def enabled_facets(self, group_name):
+        return self._enabled_facets.get(group_name)
+
+    def default_facet(self, group_name):
+        return self._default_facets.get(group_name)
+
+    def enable_facet(self, group_name, facet):
+        self._enabled_facets.setdefault(group_name, [])
+        if facet not in self._enabled_facets[group_name]:
+            self._enabled_facets[group_name] += [facet]
+
+    def set_default_facet(self, group_name, facet):
+        """Add `facet` to the list of possible values for `group_name`, even
+        if the library does not have that facet configured.
+        """
+        self.enable_facet(group_name, facet)
+        self._default_facets[group_name] = facet

--- a/facets.py
+++ b/facets.py
@@ -93,8 +93,8 @@ class FacetConfig(object):
         return FacetConfig(enabled_facets, default_facets)
 
     def __init__(self, enabled_facets, default_facets):
-        self._enabled_facets = enabled_facets
-        self._default_facets = default_facets
+        self._enabled_facets = dict(enabled_facets)
+        self._default_facets = dict(default_facets)
 
     def enabled_facets(self, group_name):
         return self._enabled_facets.get(group_name)

--- a/lane.py
+++ b/lane.py
@@ -1674,7 +1674,7 @@ class QueryGeneratedLane(Lane):
         if not query:
             return []
 
-        target_size = Configuration.featured_lane_size()
+        target_size = self.library.featured_lane_size
         return self.randomized_sample_works(
             query, target_size=target_size, use_min_size=True
         )

--- a/lane.py
+++ b/lane.py
@@ -286,10 +286,10 @@ class Facets(FacetConstants):
             )
             q = q.filter(or_clause)
         elif self.collection == self.COLLECTION_FEATURED:
-            # Exclude books with a quality of less than
-            # MINIMUM_FEATURED_QUALITY.
+            # Exclude books with a quality of less than the library's
+            # minimum featured quality.
             q = q.filter(
-                work_model.quality >= Configuration.minimum_featured_quality()
+                work_model.quality >= self.library.minimum_featured_quality
             )
 
         # Set the ORDER BY clause.
@@ -1413,7 +1413,7 @@ class Lane(object):
         """
         books = []
         featured_subquery = None
-        target_size = Configuration.featured_lane_size()
+        target_size = self.library.featured_lane_size
         # If this lane (or its ancestors) is a CustomList, look for any
         # featured works that were set on the list itself.
         list_books, work_id_column = self.list_featured_works(
@@ -1475,7 +1475,7 @@ class Lane(object):
         """Returns the featured books for a lane descended from CustomList(s)"""
         books = list()
         work_id_column = None
-        target_size = target_size or Configuration.featured_lane_size()
+        target_size = target_size or self.library.featured_lane_size
 
         if self.list_featured_works_query:
             subquery = self.list_featured_works_query.with_labels().subquery()

--- a/migration/20170612-add-library-id-to-cachedfeed.sql
+++ b/migration/20170612-add-library-id-to-cachedfeed.sql
@@ -6,7 +6,7 @@ alter table cachedfeeds add column library_id integer;
 alter table cachedfeeds add constraint coveragerecords_collection_id_fkey
     foreign key (library_id) references libraries(id);
 
-create unique index "ix_cachedfeeds_library_id_lane_name_type_facets_pagination"
+create index "ix_cachedfeeds_library_id_lane_name_type_facets_pagination"
     on cachedfeeds (library_id, lane_name, type, facets, pagination);
 
 -- Set library_id to the default library for all existing cachedfeeds.

--- a/migration/20170612-add-library-id-to-cachedfeed.sql
+++ b/migration/20170612-add-library-id-to-cachedfeed.sql
@@ -3,7 +3,7 @@ drop index if exists ix_cachedfeeds_lane_name_type_facets_pagination;
 
 -- Add library_id as a foreign key
 alter table cachedfeeds add column library_id integer;
-alter table cachedfeeds add constraint coveragerecords_collection_id_fkey
+alter table cachedfeeds add constraint cachedfeeds_library_id_fkey
     foreign key (library_id) references libraries(id);
 
 create index "ix_cachedfeeds_library_id_lane_name_type_facets_pagination"

--- a/migration/20170612-add-library-id-to-cachedfeed.sql
+++ b/migration/20170612-add-library-id-to-cachedfeed.sql
@@ -1,0 +1,13 @@
+-- Remove the existing index from cachedfeeds
+drop index if exists ix_cachedfeeds_lane_name_type_facets_pagination;
+
+-- Add library_id as a foreign key
+alter table cachedfeeds add column library_id integer;
+alter table cachedfeeds add constraint coveragerecords_collection_id_fkey
+    foreign key (library_id) references libraries(id);
+
+create unique index "ix_cachedfeeds_library_id_lane_name_type_facets_pagination"
+    on cachedfeeds (library_id, lane_name, type, facets, pagination);
+
+-- Set library_id to the default library for all existing cachedfeeds.
+update cachedfeeds set library_id = (select id from libraries limit 1);

--- a/model.py
+++ b/model.py
@@ -6469,9 +6469,8 @@ class LicensePool(Base):
 
     def on_hold_to(self, patron, start=None, end=None, position=None):
         _db = Session.object_session(patron)
-        if (Configuration.hold_policy() 
-            != Configuration.HOLD_POLICY_ALLOW):
-            raise PolicyException("Holds are disabled on this system.")
+        if not patron.library.allow_holds:
+            raise PolicyException("Holds are disabled for this library.")
         start = start or datetime.datetime.utcnow()
         hold, new = get_one_or_create(
             _db, Hold, patron=patron, license_pool=self)

--- a/model.py
+++ b/model.py
@@ -8791,6 +8791,14 @@ class Library(Base):
     ENABLED_FACETS_KEY_PREFIX = "facets_enabled_"
     DEFAULT_FACET_KEY_PREFIX = "facets_default_"
 
+    # Each library may set a minimum quality for the books that show
+    # up in the 'featured' lanes that show up on the front page.
+    MINIMUM_FEATURED_QUALITY = "minimum_featured_quality"
+
+    # Each library may configure the maximum number of books in the
+    # 'featured' lanes.
+    FEATURED_LANE_SIZE = "featured_lane_size"
+    
     @property
     def allow_holds(self):
         """Does this library allow patrons to put items on hold?"""
@@ -8800,7 +8808,23 @@ class Library(Base):
             # holds are allowed.
             value = True
         return value
-    
+
+    @property
+    def minimum_featured_quality(self):
+        """The minimum quality a book must have to be 'featured'."""
+        value = self.setting(self.MINIMUM_FEATURED_QUALITY).float_value
+        if value is None:
+            value = 0.65
+        return value
+            
+    @property
+    def featured_lane_size(self):
+        """The minimum quality a book must have to be 'featured'."""
+        value = self.setting(self.FEATURED_LANE_SIZE).int_value
+        if value is None:
+            value = 15
+        return value
+        
     def enabled_facets(self, group_name):
         """Look up the enabled facets for a given facet group."""
         setting = self.enabled_facets_setting(group_name)
@@ -9172,6 +9196,18 @@ class ConfigurationSetting(Base):
             return int(self.value)
         return None
 
+    @property
+    def float_value(self):
+        """Turn the value into an float if possible.
+
+        :return: A float, or None if there is no value.
+
+        :raise ValueError: If the value cannot be converted to a float.
+        """
+        if self.value:
+            return float(self.value)
+        return None
+    
     @property
     def json_value(self):
         """Interpret the value as JSON if possible.

--- a/model.py
+++ b/model.py
@@ -6104,15 +6104,21 @@ class LicensePool(Base):
         )
 
     @classmethod
-    def with_complaint(cls, _db, resolved=False):
+    def with_complaint(cls, library, resolved=False):
         """Return query for LicensePools that have at least one Complaint."""
+        _db = Session.object_session(library)
         subquery = _db.query(
                 LicensePool.id,
                 func.count(LicensePool.id).label("complaint_count")
-            ).\
-            select_from(LicensePool).\
-            join(LicensePool.complaints).\
-            group_by(LicensePool.id)
+            ).select_from(LicensePool).join(
+                LicensePool.collection).join(
+                    Collection.libraries).filter(
+                        Library.id==library.id
+                    ).join(
+                        LicensePool.complaints
+                    ).group_by(
+                        LicensePool.id
+                    )
 
         if resolved == False:
             subquery = subquery.filter(Complaint.resolved == None)

--- a/model.py
+++ b/model.py
@@ -8853,7 +8853,9 @@ class Library(Base):
             logging.error("Invalid list of enabled facets for %s: %s",
                           group_name, setting.value)
         if value is None:
-            value = FacetConstants.DEFAULT_ENABLED_FACETS.get(group_name, [])
+            value = list(
+                FacetConstants.DEFAULT_ENABLED_FACETS.get(group_name, [])
+            )
         return value
 
     def enabled_facets_setting(self, group_name):

--- a/model.py
+++ b/model.py
@@ -5812,6 +5812,11 @@ class CachedFeed(Base):
     # The content of the feed.
     content = Column(Unicode, nullable=True)
 
+    # Every feed is associated with a Library.
+    library_id = Column(
+        Integer, ForeignKey('libraries.id'), index=True
+    )
+    
     # A feed may be associated with a Work.
     work_id = Column(Integer, ForeignKey('works.id'),
         nullable=True, index=True)
@@ -5867,6 +5872,7 @@ class CachedFeed(Base):
             on_multiple='interchangeable',
             constraint=constraint_clause,
             lane_name=lane_name,
+            library=lane.library,
             work=work,
             type=type,
             languages=languages_key,
@@ -5929,7 +5935,8 @@ class CachedFeed(Base):
 
 
 Index(
-    "ix_cachedfeeds_lane_name_type_facets_pagination", CachedFeed.lane_name, CachedFeed.type,
+    "ix_cachedfeeds_library_id_lane_name_type_facets_pagination",
+    CachedFeed.library_id, CachedFeed.lane_name, CachedFeed.type,
     CachedFeed.facets, CachedFeed.pagination
 )
 
@@ -8725,6 +8732,12 @@ class Library(Base):
         'Patron', backref='library', cascade="all, delete, delete-orphan"
     )
 
+    # A Library may have many CachedFeeds.
+    cachedfeeds = relationship(
+        "CachedFeed", backref="library",
+        cascade="save-update, merge, delete, delete-orphan",
+    )
+    
     # A Library may have many ExternalIntegrations.
     integrations = relationship(
         "ExternalIntegration", secondary=lambda: externalintegrations_libraries,

--- a/model.py
+++ b/model.py
@@ -8821,7 +8821,7 @@ class Library(Base):
         """Look up the default facet for a given facet group."""
         value = self.default_facet_setting(group_name).value
         if not value:
-            value = FacetConstants.DEFAULT_ENABLED_FACETS.get(group_name)
+            value = FacetConstants.DEFAULT_FACET.get(group_name)
         return value
 
     def default_facet_setting(self, group_name):

--- a/model.py
+++ b/model.py
@@ -109,6 +109,7 @@ from classifier import (
     GenreData,
     WorkClassifier,
 )
+from facets import FacetConstants
 from user_profile import ProfileStorage
 from util import (
     LanguageCodes,
@@ -8780,7 +8781,38 @@ class Library(Base):
     # The name of the per-library regular expression used to derive a patron's
     # external_type from their authorization_identifier.
     EXTERNAL_TYPE_REGULAR_EXPRESSION = 'external_type_regular_expression'
-        
+
+    # The name of the per-library configuration policy that controls whether
+    # books may be put on hold.
+    ALLOW_HOLDS = "allow_holds"
+    
+    # Each facet group has two associated per-library keys: one
+    # configuring which facets are enabled for that facet group, and
+    # one configuring which facet is the default.
+    ENABLED_FACETS_KEY_PREFIX = "facets_enabled_"
+    DEFAULT_FACET_KEY_PREFIX = "facets_default_"
+
+    @property
+    def allow_holds(self):
+        """Does this library allow patrons to put items on hold?"""
+        return self.setting(self.ALLOW_HOLDS).bool_value
+    
+    def enabled_facets(self, group_name):
+        """Look up the enabled facets for a given facet group."""
+        key = self.ENABLED_FACETS_KEY_PREFIX + group_name
+        value = library.setting(key).json_value
+        if value is None:
+            value = FacetConstants.DEFAULT_ENABLED_FACETS.get(group_name, [])
+        return value
+
+    def default_facet(self, group_name):
+        """Look up the default facet for a given facet group."""
+        key = self.DEFAULT_FACET_KEY_PREFIX + group_name
+        value = self.setting(key).value
+        if not value:
+            value = FacetConstants.DEFAULT_ENABLED_FACETS.get(group_name)
+        return value
+    
     def explain(self, include_secrets=False):
         """Create a series of human-readable strings to explain a library's
         settings.

--- a/opds.py
+++ b/opds.py
@@ -532,7 +532,7 @@ class AcquisitionFeed(OPDSFeed):
 
         :return: CachedFeed (if use_cache is True) or unicode
         """
-        facets = facets or Facets.default(self.library)
+        facets = facets or Facets.default(lane.library)
         pagination = pagination or Pagination.default()
 
         cached = None

--- a/opds.py
+++ b/opds.py
@@ -532,7 +532,7 @@ class AcquisitionFeed(OPDSFeed):
 
         :return: CachedFeed (if use_cache is True) or unicode
         """
-        facets = facets or Facets.default()
+        facets = facets or Facets.default(self.library)
         pagination = pagination or Pagination.default()
 
         cached = None

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -1,4 +1,5 @@
 import json
+import flask
 from flask import Flask
 from flask_babel import (
     Babel,

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -205,15 +205,18 @@ class TestComplaintController(DatabaseTest):
         eq_("foo", complaint.source)
         eq_("bar", complaint.detail)
 
-class TestLoadMethods(object):
+
+class TestLoadMethods(DatabaseTest):
 
     def setup(self):
+        super(TestLoadMethods, self).setup()
         self.app = Flask(__name__)
         Babel(self.app)
 
 
     def test_load_facets_from_request(self):
         with self.app.test_request_context('/?order=%s' % Facets.ORDER_TITLE):
+            flask.request.library = self._default_library
             facets = load_facets_from_request()
             eq_(Facets.ORDER_TITLE, facets.order)
             # Enabled facets are passed in to the newly created Facets,
@@ -221,6 +224,7 @@ class TestLoadMethods(object):
             assert facets.facets_enabled_at_init != None
 
         with self.app.test_request_context('/?order=bad_facet'):
+            flask.request.library = self._default_library
             problemdetail = load_facets_from_request()
             eq_(INVALID_INPUT.uri, problemdetail.uri)
 

--- a/tests/test_cachedfeed.py
+++ b/tests/test_cachedfeed.py
@@ -31,7 +31,7 @@ from . import (
 class TestCachedFeed(DatabaseTest):
 
     def test_lifecycle(self):
-        facets = Facets.default()
+        facets = Facets.default(self._default_library)
         pagination = Pagination.default()
         lane = Lane(self._default_library, u"My Lane", languages=['eng', 'chi'])
 
@@ -64,7 +64,7 @@ class TestCachedFeed(DatabaseTest):
         eq_(True, fresh)
 
     def test_fetch_ignores_feeds_without_content(self):
-        facets = Facets.default()
+        facets = Facets.default(self._default_library)
         pagination = Pagination.default()
         lane = Lane(self._default_library, u"My Lane", languages=['eng', 'chi'])
 
@@ -92,7 +92,7 @@ class TestCachedFeed(DatabaseTest):
 
     def test_refusal_to_create_expensive_feed(self):
         
-        facets = Facets.default()
+        facets = Facets.default(self._default_library)
         pagination = Pagination.default()
         lane = Lane(self._default_library, u"My Lane", languages=['eng', 'chi'])
 

--- a/tests/test_cachedfeed.py
+++ b/tests/test_cachedfeed.py
@@ -98,7 +98,7 @@ class TestCachedFeed(DatabaseTest):
 
         args = (self._db, lane, CachedFeed.PAGE_TYPE, facets,
                      pagination, None)
-        
+
         # If we ask for a group feed that will be cached forever, and it's
         # not around, we'll get a page feed instead.
         feed, fresh = CachedFeed.fetch(

--- a/tests/test_facets.py
+++ b/tests/test_facets.py
@@ -20,6 +20,7 @@ class TestFacetConfig(DatabaseTest):
         # enabled_facets() and default_facet() the same as the Library
         # does.
         config = FacetConfig.from_library(library)
+        assert Facets.ORDER_RANDOM not in config.enabled_facets(order_by)
         for group in Facets.DEFAULT_FACET.keys():
             eq_(config.enabled_facets(group),
                 library.enabled_facets(group))

--- a/tests/test_facets.py
+++ b/tests/test_facets.py
@@ -1,0 +1,43 @@
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+
+from . import DatabaseTest
+
+from facets import (
+    FacetConstants as Facets,
+    FacetConfig,
+)
+
+class TestFacetConfig(DatabaseTest):
+   
+    def test_from_library(self):
+        library = self._default_library
+        order_by = Facets.ORDER_FACET_GROUP_NAME
+    
+        # When you create a FacetConfig from a Library it implements
+        # enabled_facets() and default_facet() the same as the Library
+        # does.
+        config = FacetConfig.from_library(library)
+        for group in Facets.DEFAULT_FACET.keys():
+            eq_(config.enabled_facets(group),
+                library.enabled_facets(group))
+            eq_(config.default_facet(group),
+                library.default_facet(group))
+            
+        # If you then modify the FacetConfig, it deviates from what
+        # the Library would do.
+        config.set_default_facet(order_by, Facets.ORDER_RANDOM)
+        eq_(Facets.ORDER_RANDOM, config.default_facet(order_by))
+        assert library.default_facet(order_by) != Facets.ORDER_RANDOM
+        assert Facets.ORDER_RANDOM in config.enabled_facets(order_by)
+
+    def test_enable_facet(self):
+        # You can enable a facet without making it the default for its
+        # facet group.
+        order_by = Facets.ORDER_FACET_GROUP_NAME
+        config = FacetConfig.from_library(self._default_library)
+        config.enable_facet(order_by, Facets.ORDER_RANDOM)
+        assert Facets.ORDER_RANDOM in config.enabled_facets(order_by)
+        assert config.default_facet(order_by) != Facets.ORDER_RANDOM

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -421,12 +421,10 @@ class TestLanes(DatabaseTest):
                                    sampled_works=None):
             featured_works = None
             featured_materialized_works = None
-            with temp_config() as config:
-                config[Configuration.POLICIES] = {
-                    Configuration.FEATURED_LANE_SIZE : size
-                }
-                featured_works = lane.featured_works(use_materialized_works=False)
-                featured_materialized_works = lane.featured_works()
+            library = self._default_library
+            library.setting(library.FEATURED_LANE_SIZE).value = size
+            featured_works = lane.featured_works(use_materialized_works=False)
+            featured_materialized_works = lane.featured_works()
 
             expected_length = expected_length
             if expected_length == None:

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 from nose.tools import (
     eq_,
@@ -36,6 +37,7 @@ from model import (
     Edition,
     Genre,
     Identifier,
+    Library,
     LicensePool,
     SessionManager,
     Work,
@@ -43,11 +45,19 @@ from model import (
 )
 
 
-class TestFacets(object):
+class TestFacets(DatabaseTest):
 
+    def _configure_facets(self, library, enabled, default):
+        """Set facet configuration for the given Library."""
+        for key, values in enabled.items():
+            library.enabled_facets_setting(key).value = json.dumps(values)
+        for key, value in default.items():
+            library.default_facet_setting(key).value = value
+    
     def test_facet_groups(self):
 
         facets = Facets(
+            self._default_library,
             Facets.COLLECTION_MAIN, Facets.AVAILABLE_ALL, Facets.ORDER_TITLE
         )
         all_groups = list(facets.facet_groups)
@@ -63,34 +73,33 @@ class TestFacets(object):
             selected
         )
 
-        test_facet_policy = {
-            "enabled" : {
+        test_enabled_facets = {
                 Facets.ORDER_FACET_GROUP_NAME : [
                     Facets.ORDER_WORK_ID, Facets.ORDER_TITLE
                 ],
                 Facets.COLLECTION_FACET_GROUP_NAME : [Facets.COLLECTION_FULL],
                 Facets.AVAILABILITY_FACET_GROUP_NAME : [Facets.AVAILABLE_ALL],
-            },
-            "default" : {
-                Facets.ORDER_FACET_GROUP_NAME : Facets.ORDER_TITLE,
-                Facets.COLLECTION_FACET_GROUP_NAME : Facets.COLLECTION_FULL,
-                Facets.AVAILABILITY_FACET_GROUP_NAME : Facets.AVAILABLE_ALL,
-            }
         }
-        with temp_config() as config:
-            config['policies'] = {
-                Configuration.FACET_POLICY : test_facet_policy
-            }
-            facets = Facets(None, None, Facets.ORDER_TITLE)
-            all_groups = list(facets.facet_groups)
-
-            # We have disabled almost all the facets, so the list of
-            # facet transitions includes only two items.
-            #
-            # 'Sort by title' was selected, and it shows up as the selected
-            # item in this facet group.
-            expect = [['order', 'title', True], ['order', 'work_id', False]]
-            eq_(expect, sorted([list(x[:2]) + [x[-1]] for x in all_groups]))
+        test_default_facets = {
+            Facets.ORDER_FACET_GROUP_NAME : Facets.ORDER_TITLE,
+            Facets.COLLECTION_FACET_GROUP_NAME : Facets.COLLECTION_FULL,
+            Facets.AVAILABILITY_FACET_GROUP_NAME : Facets.AVAILABLE_ALL,
+        }
+        library = self._default_library
+        self._configure_facets(
+            library, test_enabled_facets, test_default_facets
+        )
+            
+        facets = Facets(self._default_library,
+                        None, None, Facets.ORDER_TITLE)
+        all_groups = list(facets.facet_groups)
+        # We have disabled almost all the facets, so the list of
+        # facet transitions includes only two items.
+        #
+        # 'Sort by title' was selected, and it shows up as the selected
+        # item in this facet group.
+        expect = [['order', 'title', True], ['order', 'work_id', False]]
+        eq_(expect, sorted([list(x[:2]) + [x[-1]] for x in all_groups]))
 
     def test_facets_can_be_enabled_at_initialization(self):
         enabled_facets = {
@@ -100,10 +109,13 @@ class TestFacets(object):
             Facets.COLLECTION_FACET_GROUP_NAME : [Facets.COLLECTION_MAIN],
             Facets.AVAILABILITY_FACET_GROUP_NAME : [Facets.AVAILABLE_OPEN_ACCESS]
         }
-
+        library = self._default_library
+        self._configure_facets(library, enabled_facets, {})
+        
         # Create a new Facets object with these facets enabled,
         # no matter the Configuration.
         facets = Facets(
+            self._default_library,
             Facets.COLLECTION_MAIN, Facets.AVAILABLE_OPEN_ACCESS,
             Facets.ORDER_TITLE, enabled_facets=enabled_facets
         )
@@ -155,6 +167,7 @@ class TestFacets(object):
 
         def order(facet, work, edition, ascending=None):
             f = Facets(
+                self._default_library,
                 collection=Facets.COLLECTION_FULL, 
                 availability=Facets.AVAILABLE_ALL,
                 order=facet,
@@ -239,65 +252,56 @@ class TestFacetsApply(DatabaseTest):
                      available=Facets.AVAILABLE_ALL,
                      order=Facets.ORDER_TITLE
         ):
-            f = Facets(collection, available, order)
+            f = Facets(self._default_library, collection, available, order)
             return f.apply(self._db, qu)
 
         # When holds are allowed, we can find all works by asking
         # for everything.
-        with temp_config() as config:
-            config['policies'] = {
-                Configuration.HOLD_POLICY : Configuration.HOLD_POLICY_ALLOW
-            }
-
-            everything = facetify()
-            eq_(4, everything.count())
+        library = self._default_library
+        library.setting(Library.ALLOW_HOLDS).value = "True"
+        everything = facetify()
+        eq_(4, everything.count())
 
         # If we disallow holds, we lose one book even when we ask for
         # everything.
-        with temp_config() as config:
-            config['policies'] = {
-                Configuration.HOLD_POLICY : Configuration.HOLD_POLICY_HIDE
-            }
-            everything = facetify()
-            eq_(3, everything.count())
-            assert licensed_high not in everything
+        library.setting(Library.ALLOW_HOLDS).value = "False"
+        everything = facetify()
+        eq_(3, everything.count())
+        assert licensed_high not in everything
 
-        with temp_config() as config:
-            config['policies'] = {
-                Configuration.HOLD_POLICY : Configuration.HOLD_POLICY_ALLOW
-            }
-            # Even when holds are allowed, if we restrict to books
-            # currently available we lose the unavailable book.
-            available_now = facetify(available=Facets.AVAILABLE_NOW)
-            eq_(3, available_now.count())
-            assert licensed_high not in available_now
+        library.setting(Library.ALLOW_HOLDS).value = "True"
+        # Even when holds are allowed, if we restrict to books
+        # currently available we lose the unavailable book.
+        available_now = facetify(available=Facets.AVAILABLE_NOW)
+        eq_(3, available_now.count())
+        assert licensed_high not in available_now
 
-            # If we restrict to open-access books we lose two books.
-            open_access = facetify(available=Facets.AVAILABLE_OPEN_ACCESS)
-            eq_(2, open_access.count())
-            assert licensed_high not in open_access
-            assert licensed_low not in open_access
+        # If we restrict to open-access books we lose two books.
+        open_access = facetify(available=Facets.AVAILABLE_OPEN_ACCESS)
+        eq_(2, open_access.count())
+        assert licensed_high not in open_access
+        assert licensed_low not in open_access
 
-            # If we restrict to the main collection we lose the low-quality
-            # open-access book.
-            main_collection = facetify(collection=Facets.COLLECTION_MAIN)
-            eq_(3, main_collection.count())
-            assert open_access_low not in main_collection
+        # If we restrict to the main collection we lose the low-quality
+        # open-access book.
+        main_collection = facetify(collection=Facets.COLLECTION_MAIN)
+        eq_(3, main_collection.count())
+        assert open_access_low not in main_collection
 
-            # If we restrict to the featured collection we lose both
-            # low-quality books.
-            featured_collection = facetify(collection=Facets.COLLECTION_FEATURED)
-            eq_(2, featured_collection.count())
-            assert open_access_low not in featured_collection
-            assert licensed_low not in featured_collection
+        # If we restrict to the featured collection we lose both
+        # low-quality books.
+        featured_collection = facetify(collection=Facets.COLLECTION_FEATURED)
+        eq_(2, featured_collection.count())
+        assert open_access_low not in featured_collection
+        assert licensed_low not in featured_collection
 
-            title_order = facetify(order=Facets.ORDER_TITLE)
-            eq_([open_access_high, open_access_low, licensed_high, licensed_low],
-                title_order.all())
+        title_order = facetify(order=Facets.ORDER_TITLE)
+        eq_([open_access_high, open_access_low, licensed_high, licensed_low],
+            title_order.all())
 
-            random_order = facetify(order=Facets.ORDER_RANDOM)
-            eq_([licensed_low, open_access_high, licensed_high, open_access_low],
-                random_order.all())
+        random_order = facetify(order=Facets.ORDER_RANDOM)
+        eq_([licensed_low, open_access_high, licensed_high, open_access_low],
+            random_order.all())
 
 
 class TestLane(DatabaseTest):
@@ -1183,7 +1187,8 @@ class TestFilters(DatabaseTest):
         # only_show_ready_deliverable_works filters out everything but
         # w1 (owned licenses), w6 (open-access), w7 (available
         # licenses), and w8 (available licenses, weird delivery mechanism).
-        lane = Lane(self._default_library, self._str)
+        library = self._default_library
+        lane = Lane(library, self._str)
         q = lane.only_show_ready_deliverable_works(orig_q, Work)
         eq_(set([w1, w6, w7, w8]), set(q.all()))
 
@@ -1194,27 +1199,24 @@ class TestFilters(DatabaseTest):
         eq_(set([w1, w4, w6, w7, w8]), set(q.all()))
 
         # Change site policy to hide books that can't be borrowed.
-        with temp_config() as config:
-            config['policies'] = {
-                Configuration.HOLD_POLICY : Configuration.HOLD_POLICY_HIDE
-            }
-
-            # w1 no longer shows up, because although we own licenses, 
-            #  no copies are available.
-            # w4 is open-access but it's suppressed, so it still doesn't 
-            #  show up.
-            # w6 still shows up because it's an open-access work.
-            # w7 and w8 show up because we own licenses and copies are
-            #  available.
-            q = lane.only_show_ready_deliverable_works(orig_q, Work)
-            eq_(set([w6, w7, w8]), set(q.all()))
+        library.setting(Library.ALLOW_HOLDS).value = "False"
+        # w1 no longer shows up, because although we own licenses, 
+        #  no copies are available.
+        # w4 is open-access but it's suppressed, so it still doesn't 
+        #  show up.
+        # w6 still shows up because it's an open-access work.
+        # w7 and w8 show up because we own licenses and copies are
+        #  available.
+        q = lane.only_show_ready_deliverable_works(orig_q, Work)
+        eq_(set([w6, w7, w8]), set(q.all()))
 
         # If we add the second collection to the library, its works
         # start showing up. (But we have to recreate the Lane object
         # because it only looks at the library's collections during
         # construction.)
-        self._default_library.collections.append(collection2)
-        lane = Lane(self._default_library, self._str)
+        library.setting(Library.ALLOW_HOLDS).value = "True"
+        library.collections.append(collection2)
+        lane = Lane(library, self._str)
         q = lane.only_show_ready_deliverable_works(orig_q, Work)
         eq_(set([w1, w6, w7, w8, w9]), set(q.all()))
         

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5722,6 +5722,16 @@ class TestConfigurationSetting(DatabaseTest):
         number.value = "tra la la"
         assert_raises(ValueError, lambda: number.int_value)
 
+    def test_float_value(self):
+        number = ConfigurationSetting.sitewide(self._db, "number")
+        eq_(None, number.int_value)
+        
+        number.value = "1234.5"
+        eq_(1234.5, number.float_value)
+
+        number.value = "tra la la"
+        assert_raises(ValueError, lambda: number.float_value)
+        
     def test_json_value(self):
         jsondata = ConfigurationSetting.sitewide(self._db, "json")
         eq_(None, jsondata.int_value)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3665,40 +3665,33 @@ class TestHold(DatabaseTest):
         patron = self._patron()
         edition = self._edition()
         pool = self._licensepool(edition)
-        with temp_config() as config:
-            config['policies'] = {
-                Configuration.HOLD_POLICY : Configuration.HOLD_POLICY_ALLOW
-            }
-            hold, is_new = pool.on_hold_to(patron, now, later, 4)
-            eq_(True, is_new)
-            eq_(now, hold.start)
-            eq_(None, hold.end)
-            eq_(4, hold.position)
+        self._default_library.setting(Library.ALLOW_HOLDS).value = True
+        hold, is_new = pool.on_hold_to(patron, now, later, 4)
+        eq_(True, is_new)
+        eq_(now, hold.start)
+        eq_(None, hold.end)
+        eq_(4, hold.position)
 
-            # Now update the position to 0. It's the patron's turn
-            # to check out the book.
-            hold, is_new = pool.on_hold_to(patron, now, later, 0)
-            eq_(False, is_new)
-            eq_(now, hold.start)
-            # The patron has until `hold.end` to actually check out the book.
-            eq_(later, hold.end)
-            eq_(0, hold.position)
+        # Now update the position to 0. It's the patron's turn
+        # to check out the book.
+        hold, is_new = pool.on_hold_to(patron, now, later, 0)
+        eq_(False, is_new)
+        eq_(now, hold.start)
+        # The patron has until `hold.end` to actually check out the book.
+        eq_(later, hold.end)
+        eq_(0, hold.position)
 
     def test_holds_not_allowed(self):
         patron = self._patron()
         edition = self._edition()
         pool = self._licensepool(edition)
 
-        with temp_config() as config:
-            config['policies'] = {
-                Configuration.HOLD_POLICY : Configuration.HOLD_POLICY_HIDE
-            }
-        
-            assert_raises_regexp(
-                PolicyException,
-                "Holds are disabled on this system.",
-                pool.on_hold_to, patron, datetime.datetime.now(), 4
-            )
+        self._default_library.setting(Library.ALLOW_HOLDS).value = False
+        assert_raises_regexp(
+            PolicyException,
+            "Holds are disabled for this library.",
+            pool.on_hold_to, patron, datetime.datetime.now(), 4
+        )
         
     def test_work(self):
         # We don't need to test the functionality--that's tested in

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -453,7 +453,7 @@ class TestOPDS(DatabaseTest):
         work = self._work(with_open_access_download=True)
 
         lane = Lane(self._default_library, "lane")
-        facets = Facets.default()
+        facets = Facets.default(self._default_library)
 
         cached_feed = AcquisitionFeed.page(self._db, "title", "http://the-url.com/",
                                     lane, TestAnnotator, facets=facets)
@@ -797,7 +797,7 @@ class TestOPDS(DatabaseTest):
         work1 = self._work(genre=Epic_Fantasy, with_open_access_download=True)
         work2 = self._work(genre=Epic_Fantasy, with_open_access_download=True)
 
-        facets = Facets.default()
+        facets = Facets.default(self._default_library)
         pagination = Pagination(size=1)
 
         def make_page(pagination):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -466,20 +466,21 @@ class TestOPDS(DatabaseTest):
         eq_("http://the-url.com/", self_link['href'])
         facet_links = self.links(by_title, AcquisitionFeed.FACET_REL)
         
-        order_facets = Configuration.enabled_facets(
+        library = self._default_library
+        order_facets = library.enabled_facets(
             Facets.ORDER_FACET_GROUP_NAME
         )
-        availability_facets = Configuration.enabled_facets(
+        availability_facets = library.enabled_facets(
             Facets.AVAILABILITY_FACET_GROUP_NAME
         )
-        collection_facets = Configuration.enabled_facets(
+        collection_facets = library.enabled_facets(
             Facets.COLLECTION_FACET_GROUP_NAME
         )        
 
         def link_for_facets(facets):
             return [x for x in facet_links if facets.query_string in x['href']]
 
-        facets = Facets(None, None, None)
+        facets = Facets(library, None, None, None)
         for i1, i2, new_facets, selected in facets.facet_groups:            
             links = link_for_facets(new_facets)
             if selected:

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -941,35 +941,33 @@ class TestOPDS(DatabaseTest):
         """Test that a page feed is returned when the requested groups
         feed has no books in the groups.
         """
-        
-        test_lane = Lane(self._default_library, "Test Lane", genres=['Mystery'])
+        library = self._default_library
+        test_lane = Lane(library, "Test Lane", genres=['Mystery'])
 
         work1 = self._work(genre=Mystery, with_open_access_download=True)
         work1.quality = 0.75
         work2 = self._work(genre=Mystery, with_open_access_download=True)
         work2.quality = 0.75
 
-        with temp_config() as config:
-            config['policies'] = {}
-            config['policies'][Configuration.FEATURED_LANE_SIZE] = 2
-            annotator = TestAnnotator()
+        library.setting(library.FEATURED_LANE_SIZE).value = 2
+        annotator = TestAnnotator()
 
-            feed = AcquisitionFeed.groups(
-                self._db, "test", self._url, test_lane, annotator,
-                force_refresh=True, use_materialized_works=False
-            )
+        feed = AcquisitionFeed.groups(
+            self._db, "test", self._url, test_lane, annotator,
+            force_refresh=True, use_materialized_works=False
+        )
 
-            # The feed is filed as a groups feed, even though in
-            # form it is a page feed.
-            eq_(CachedFeed.GROUPS_TYPE, feed.type)
+        # The feed is filed as a groups feed, even though in
+        # form it is a page feed.
+        eq_(CachedFeed.GROUPS_TYPE, feed.type)
 
-            parsed = feedparser.parse(feed.content)
+        parsed = feedparser.parse(feed.content)
 
-            # There are two entries, one for each work.
-            e1, e2 = parsed['entries']
+        # There are two entries, one for each work.
+        e1, e2 = parsed['entries']
 
-            # The entries have no links (no collection links).
-            assert all('links' not in entry for entry in [e1, e2])
+        # The entries have no links (no collection links).
+        assert all('links' not in entry for entry in [e1, e2])
 
     def test_search_feed(self):
         """Test the ability to create a paginated feed of works for a given


### PR DESCRIPTION
This branch changes Lane to take a Library in its constructor. This Library is the source for various items of configuration that were previously stored in the JSON configuration:

* For each facet group, which facets are enabled.
* Of the enabled facets in a facet group, which is the default.
* Whether the library allows patrons to put items on hold.
* The size of the 'featured' lanes used for the home page.
* The minimum quality a book must have to show up in a 'featured' lane.

I moved the `FacetConfig` class in from circulation. This class lets a controller override the Library's facet configuration for controller-specific purposes. (e.g. by default, the 'books in this series' feed orders books by series position, which is not a normally available ordering).

I changed the `cachedfeeds` table so that each feed keeps track of the library for which it is a feed.

I changed `LicensePool.with_complaint` to get LicensePools available through a specific Library, not all LicensePools on the system that have a complaint.