### PR TITLE
Add explain() for sitewide configuration settings

### DIFF
--- a/model.py
+++ b/model.py
@@ -9184,7 +9184,26 @@ class ConfigurationSetting(Base):
             # Commit to get this in the database ASAP.
             _db.commit()
         return secret.value
-    
+
+    @classmethod
+    def explain(cls, _db, include_secrets=False):
+        """Explain all site-wide ConfigurationSettings."""
+        lines = []
+        site_wide_settings = []
+        
+        for setting in _db.query(ConfigurationSetting).filter(
+                ConfigurationSetting.library==None).filter(
+                    ConfigurationSetting.external_integration==None):
+            if not include_secrets and setting.key.endswith("_secret"):
+                continue
+            site_wide_settings.append(setting)
+        if site_wide_settings:
+            lines.append("Site-wide configuration settings:")
+            lines.append("---------------------------------")
+        for setting in sorted(site_wide_settings, key=lambda s: s.key):
+            lines.append("%s='%s'" % (setting.key, setting.value))
+        return lines
+
     @classmethod
     def sitewide(cls, _db, key):
         """Find or create a sitewide ConfigurationSetting."""

--- a/model.py
+++ b/model.py
@@ -8783,7 +8783,7 @@ class Library(Base):
                 )
             value = unicode(value)
         self._library_registry_short_name = value
-
+        
     def setting(self, key):
         """Find or create a ConfigurationSetting on this Library.
 
@@ -8901,13 +8901,25 @@ class Library(Base):
                 self.library_registry_shared_secret
             )
 
+        # Find all ConfigurationSettings that are set on the library
+        # itself and are not on the library + an external integration.
+        settings = [x for x in self.settings if not x.external_integration]
+        if settings:
+            lines.append("")
+            lines.append("Configuration settings:")
+            lines.append("-----------------------")
+        for setting in settings:
+            lines.append("%s='%s'" % (setting.key, setting.value))
+            
         integrations = list(self.integrations)
         if integrations:
             lines.append("")
             lines.append("External integrations:")
             lines.append("----------------------")
         for integration in integrations:
-            lines.extend(integration.explain(include_secrets))
+            lines.extend(
+                integration.explain(self, include_password=include_secrets)
+            )
             lines.append("")
         return lines
 
@@ -9085,10 +9097,12 @@ class ExternalIntegration(Base):
             key, self
         )
 
-    def explain(self, include_password=False):
+    def explain(self, library=None, include_password=False):
         """Create a series of human-readable strings to explain an
         ExternalIntegration's settings.
 
+        :param library: Include additional settings imposed upon this
+           ExternalIntegration by the given Library.
         :param include_password: For security reasons,
            the password (if any) is not displayed by default.
 
@@ -9102,8 +9116,22 @@ class ExternalIntegration(Base):
             lines.append("Username: %s" % self.username)
         if self.password and include_password:
             lines.append("Password: %s" % self.password)
-        for setting in self.settings:
-            lines.append("%s=%s" % (setting.key, setting.value))
+
+        def key(setting):
+            if setting.library:
+                return setting.key, setting.library.name
+            return (setting.key, None)
+        for setting in sorted(self.settings, key=key):
+            if library and setting.library and setting.library != library:
+                # This is a different library's specialization of
+                # this integration. Ignore it.
+                continue
+            explanation = "%s='%s'" % (setting.key, setting.value)
+            if setting.library:
+                explanation = "%s (applies only to %s)" % (
+                    explanation, setting.library.name
+                )
+            lines.append(explanation)
         return lines
 
 class ConfigurationSetting(Base):

--- a/scripts.py
+++ b/scripts.py
@@ -642,34 +642,8 @@ class ShowLibrariesScript(Script):
                     )
                 )
             )
-            output.write("\n")
-
-class ConfigureSiteScript(Script):
-    """View or change site-wide settings."""
-    name = "Change site-wide settings"
-
-    @classmethod
-    def arg_parser(cls, _db):
-        parser = argparse.ArgumentParser()
-        parser.add_argument(
-            '--setting',
-            help='Set a site-wide setting, such as default_ungrouped_feed_max_age. Format: --setting="default_ungrouped_feed_max_age=1200"',
-            action="append",
-        )
-
-    def do_run(self, _db=None, cmd_args=None, output=sys.stdout):
-        _db = _db or self._db
-        args = self.parse_command_line(_db, cmd_args=cmd_args)
-        if args.setting:
-            for setting in args.setting:
-                if not '=' in setting:
-                    raise ValueError(
-                        'Incorrect format for setting: "%s". Should be "key=value"'
-                        % setting
-                    )
-                key, value = setting.split('=', 1)
-                integration.setting(key).value = value
-
+            output.write("\n")            
+                    
 
 class ConfigureLibraryScript(Script):
     """Create a library or change its settings."""

--- a/scripts.py
+++ b/scripts.py
@@ -644,7 +644,33 @@ class ShowLibrariesScript(Script):
             )
             output.write("\n")
 
-        
+class ConfigureSiteScript(Script):
+    """View or change site-wide settings."""
+    name = "Change site-wide settings"
+
+    @classmethod
+    def arg_parser(cls, _db):
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            '--setting',
+            help='Set a site-wide setting, such as default_ungrouped_feed_max_age. Format: --setting="default_ungrouped_feed_max_age=1200"',
+            action="append",
+        )
+
+    def do_run(self, _db=None, cmd_args=None, output=sys.stdout):
+        _db = _db or self._db
+        args = self.parse_command_line(_db, cmd_args=cmd_args)
+        if args.setting:
+            for setting in args.setting:
+                if not '=' in setting:
+                    raise ValueError(
+                        'Incorrect format for setting: "%s". Should be "key=value"'
+                        % setting
+                    )
+                key, value = setting.split('=', 1)
+                integration.setting(key).value = value
+
+
 class ConfigureLibraryScript(Script):
     """Create a library or change its settings."""
     name = "Change a library's settings"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5656,8 +5656,8 @@ class TestExternalIntegration(DatabaseTest):
 library-specific='value1' (applies only to First Library)
 library-specific='value2' (applies only to Second Library)
 somesetting='somevalue'
-url=http://url/
-username=someuser"""
+url='http://url/'
+username='someuser'"""
         actual = integration.explain()
         eq_(expect, "\n".join(actual))
 
@@ -5669,7 +5669,7 @@ username=someuser"""
         
         # If we pass in True for include_password, we see the passwords.
         with_secrets = integration.explain(include_password=True)
-        assert 'password=somepass' in with_secrets
+        assert "password='somepass'" in with_secrets
         
 
 class TestConfigurationSetting(DatabaseTest):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5779,6 +5779,28 @@ class TestConfigurationSetting(DatabaseTest):
 
         jsondata.value = "tra la la"
         assert_raises(ValueError, lambda: jsondata.json_value)
+
+    def test_explain(self):
+        """Test that ConfigurationSetting.explain gives information
+        about all site-wide configuration settings.
+        """
+        ConfigurationSetting.sitewide(self._db, "a_secret").value = "1"
+        ConfigurationSetting.sitewide(self._db, "nonsecret_setting").value = "2"
+
+        integration = self._external_integration("a protocol", "a goal")
+        
+        actual = ConfigurationSetting.explain(self._db, include_secrets=True)
+        expect = """Site-wide configuration settings:
+---------------------------------
+a_secret='1'
+nonsecret_setting='2'"""
+        eq_(expect, "\n".join(actual))
+        
+        without_secrets = "\n".join(ConfigurationSetting.explain(
+            self._db, include_secrets=False
+        ))
+        assert 'a_secret' not in without_secrets
+        assert 'nonsecret_setting' in without_secrets
         
 class TestCollection(DatabaseTest):
 


### PR DESCRIPTION
This branch defines `ConfigurationSetting.explain()`, which works like `Library.explain()` and `Collection.explain()`, but which focuses on explaining site-wide configuration settings.

This branch also changes `ExternalIntegration.explain()` to take a `library` argument. If that argument is provided, it will include an explanation of additional settings imposed on the integration by that specific library.

This is part of a larger piece of work towards making it easy to configure the site via the command line, but this is all the work I can get done on this today so I figured I'd package it as a PR.