### PR TITLE
Changed url, username, and password on ExternalIntegration to be properties using ConfigurationSettings.

### DIFF
--- a/migration/20170614-move-externalintegration-columns-to-settings.sql
+++ b/migration/20170614-move-externalintegration-columns-to-settings.sql
@@ -1,0 +1,21 @@
+-- Create a setting for each external integration url.
+INSERT INTO configurationsettings (external_integration_id, key, value)
+SELECT e.id, 'url', e.url
+FROM externalintegrations e
+WHERE e.url is not null;
+
+-- Create a setting for each external integration username.
+INSERT INTO configurationsettings (external_integration_id, key, value)
+SELECT e.id, 'username', e.username
+FROM externalintegrations e
+WHERE e.username is not null;
+
+-- Create a setting for each external integration password.
+INSERT INTO configurationsettings (external_integration_id, key, value)
+SELECT e.id, 'password', e.password
+FROM externalintegrations e
+WHERE e.password is not null;
+
+ALTER TABLE externalintegrations DROP COLUMN url;
+ALTER TABLE externalintegrations DROP COLUMN username;
+ALTER TABLE externalintegrations DROP COLUMN password;

--- a/model.py
+++ b/model.py
@@ -9030,6 +9030,19 @@ class ExternalIntegration(Base):
     # List of such ADMIN_AUTH_GOAL integrations
     ADMIN_AUTH_PROTOCOLS = [GOOGLE_OAUTH]
 
+    # Keys for common configuration settings
+
+    # If there is a special URL to use for access to this API,
+    # put it here.
+    URL = "url"
+
+    # If access requires authentication, these settings represent the
+    # username/password or key/secret combination necessary to
+    # authenticate. If there's a secret but no key, it's stored in
+    # 'password'.
+    USERNAME = "username"
+    PASSWORD = "password"
+
     __tablename__ = 'externalintegrations'
     id = Column(Integer, primary_key=True)
 
@@ -9040,17 +9053,6 @@ class ExternalIntegration(Base):
     # Basically, the protocol is the 'how' and the goal is the 'why'.
     protocol = Column(Unicode, nullable=False)
     goal = Column(Unicode, nullable=True)
-
-    # If there is a special URL to use for access to this API,
-    # put it here.
-    url = Column(Unicode, nullable=True)
-
-    # If access requires authentication, these fields represent the
-    # username/password or key/secret combination necessary to
-    # authenticate. If there's a secret but no key, it's stored in
-    # 'password'.
-    username = Column(Unicode, nullable=True)
-    password = Column(Unicode, nullable=True)
 
     # Any additional configuration information goes into
     # ConfigurationSettings.
@@ -9085,6 +9087,30 @@ class ExternalIntegration(Base):
             key, self
         )
 
+    @hybrid_property
+    def url(self):
+        return self.setting(self.URL).value
+
+    @url.setter
+    def set_url(self, new_url):
+        self.set_setting(self.URL, new_url)
+
+    @hybrid_property
+    def username(self):
+        return self.setting(self.USERNAME).value
+
+    @username.setter
+    def set_username(self, new_username):
+        self.set_setting(self.USERNAME, new_username)
+
+    @hybrid_property
+    def password(self):
+        return self.setting(self.PASSWORD).value
+
+    @password.setter
+    def set_password(self, new_password):
+        return self.set_setting(self.PASSWORD, new_password)
+
     def explain(self, include_password=False):
         """Create a series of human-readable strings to explain an
         ExternalIntegration's settings.
@@ -9096,14 +9122,9 @@ class ExternalIntegration(Base):
         """
         lines = []
         lines.append("Protocol/Goal: %s/%s" % (self.protocol, self.goal))
-        if self.url:
-            lines.append("URL: %s" % self.url)
-        if self.username:
-            lines.append("Username: %s" % self.username)
-        if self.password and include_password:
-            lines.append("Password: %s" % self.password)
         for setting in self.settings:
-            lines.append("%s=%s" % (setting.key, setting.value))
+            if (setting.key != self.PASSWORD) or include_password:
+                lines.append("%s=%s" % (setting.key, setting.value))
         return lines
 
 class ConfigurationSetting(Base):
@@ -9575,14 +9596,9 @@ class Collection(Base):
             lines.append('Used by library: "%s"' % library.short_name)
         if self.external_account_id:
             lines.append('External account ID: "%s"' % self.external_account_id)
-        if integration.url:
-            lines.append('URL: "%s"' % integration.url)
-        if integration.username:
-            lines.append('Username: "%s"' % integration.username)
-        if integration.password and include_password:
-            lines.append('Password: "%s"' % integration.password)
         for setting in integration.settings:
-            lines.append('Setting "%s": "%s"' % (setting.key, setting.value))
+            if (setting.key != ExternalIntegration.PASSWORD) or include_password:
+                lines.append('Setting "%s": "%s"' % (setting.key, setting.value))
         return lines
 
     def catalog_identifier(self, _db, identifier):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5552,7 +5552,7 @@ class TestLibrary(DatabaseTest):
         library.integrations.append(integration)
         
         data = library.explain()
-        eq_("""Library UUID: "uuid"
+        eq_(u"""Library UUID: "uuid"
 Name: "The Library"
 Short name: "Short"
 Short name (for library registry): "SHORT"
@@ -5560,8 +5560,8 @@ Short name (for library registry): "SHORT"
 External integrations:
 ----------------------
 Protocol/Goal: protocol/goal
-URL: http://url/
-Username: someuser
+url=http://url/
+username=someuser
 somesetting=somevalue
 """,
             "\n".join(data)
@@ -5569,7 +5569,7 @@ somesetting=somevalue
         
         with_secrets = library.explain(True)
         assert 'Shared secret (for library registry): "secret"' in with_secrets
-        assert 'Password: somepass' in with_secrets
+        assert 'password=somepass' in with_secrets
 
 
 class TestExternalIntegration(DatabaseTest):
@@ -5624,15 +5624,15 @@ class TestExternalIntegration(DatabaseTest):
         integration.setting("somesetting").value = "somevalue"
         
         data = integration.explain()
-        eq_("""Protocol/Goal: protocol/goal
-URL: http://url/
-Username: someuser
+        eq_(u"""Protocol/Goal: protocol/goal
+url=http://url/
+username=someuser
 somesetting=somevalue""",
             "\n".join(data)
         )
         
         with_secrets = integration.explain(True)
-        assert 'Password: somepass' in with_secrets
+        assert 'password=somepass' in with_secrets
 
 
 class TestConfigurationSetting(DatabaseTest):
@@ -5865,15 +5865,15 @@ class TestCollection(DatabaseTest):
              'Protocol: "Overdrive"',
              'Used by library: "The only library"',
              'External account ID: "id"',
-             'URL: "url"',
-             'Username: "username"',
+             'Setting "url": "url"',
+             'Setting "username": "username"',
              'Setting "setting": "value"'
         ],
             data
         )
 
         with_password = self.collection.explain(include_password=True)
-        assert 'Password: "password"' in with_password
+        assert 'Setting "password": "password"' in with_password
 
         # If the collection is the child of another collection,
         # its parent is mentioned.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1227,8 +1227,9 @@ class TestConfigureCollectionScript(DatabaseTest):
         eq_([collection], l2.collections)
         eq_([], l3.collections)
 
-        # One CollectionSetting was set on the collection.
-        [setting] = collection.external_integration.settings
+        # One CollectionSetting was set on the collection, in addition
+        # to url, username, and password.
+        setting = collection.external_integration.setting("library_id")
         eq_("library_id", setting.key)
         eq_("1234", setting.value)
 


### PR DESCRIPTION
This makes it easier to convert between settings and form values in the admin interface - everything can be accessed as a setting. I changed the explain methods to do this too. In other places, they can be used the same way as before.