### PR TITLE
Add a script for configuring site-wide settings

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -684,7 +684,7 @@ class ConfigureSiteScript(Script):
             ).order_by(ConfigurationSetting.key)
         output.write("Current site-wide settings:\n")
         for setting in settings:
-            if args.show_secrets or not self.is_secret(setting.key):
+            if args.show_secrets or not setting.is_secret:
                 output.write("%s='%s'\n" % (setting.key, setting.value))
             
             

--- a/scripts.py
+++ b/scripts.py
@@ -646,25 +646,7 @@ class ShowLibrariesScript(Script):
             output.write("\n")            
                     
 
-class ConfigurationScript(Script):
-
-    @classmethod
-    def is_secret(self, key):
-        """Does this configuration key look like its value is a secret?
-
-        This will have to do in the absence of programmatic ways of
-        saying that a certain setting should be treated as secret.
-        """
-        return any(
-            key == x or
-            key.startswith('%s_' % x) or
-            key.endswith('_%s' % x) or
-            ("_%s_" %x) in key
-            for x in ('secret', 'password')
-        )
-
-            
-class ConfigureSiteScript(ConfigurationScript):
+class ConfigureSiteScript(Script):
     """View or update site-wide configuration."""
     @classmethod
     def arg_parser(cls):
@@ -803,8 +785,8 @@ class ShowCollectionsScript(Script):
             help='Only display information for the collection with the given name',
         )
         parser.add_argument(
-            '--show-password',
-            help='Display collection passwords.',
+            '--show-secrets',
+            help='Display secret values such as passwords.',
             action='store_true'
         )
         return parser
@@ -822,7 +804,7 @@ class ShowCollectionsScript(Script):
         for collection in collections:
             output.write(
                 "\n".join(
-                    collection.explain(include_password=args.show_password)
+                    collection.explain(include_secrets=args.show_secrets)
                 )
             )
             output.write("\n")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5667,8 +5667,8 @@ username='someuser'"""
         assert "applies only to First Library" not in for_library_2
         assert "applies only to Second Library" in for_library_2
         
-        # If we pass in True for include_password, we see the passwords.
-        with_secrets = integration.explain(include_password=True)
+        # If we pass in True for include_secrets, we see the passwords.
+        with_secrets = integration.explain(include_secrets=True)
         assert "password='somepass'" in with_secrets
         
 
@@ -5949,7 +5949,7 @@ class TestCollection(DatabaseTest):
             data
         )
 
-        with_password = self.collection.explain(include_password=True)
+        with_password = self.collection.explain(include_secrets=True)
         assert 'Setting "password": "password"' in with_password
 
         # If the collection is the child of another collection,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5674,6 +5674,24 @@ username='someuser'"""
 
 class TestConfigurationSetting(DatabaseTest):
 
+    def test_is_secret(self):
+        """Some configuration settings are considered secrets, 
+        and some are not.
+        """
+        m = ConfigurationSetting._is_secret
+        eq_(True, m('secret'))
+        eq_(True, m('password'))
+        eq_(True, m('its_a_secret_to_everybody'))
+        eq_(True, m('the_password'))
+        eq_(True, m('password_for_the_account'))
+        eq_(False, m('public_information'))
+
+        eq_(True,
+            ConfigurationSetting.sitewide(self._db, "secret_key").is_secret)
+        eq_(False,
+            ConfigurationSetting.sitewide(self._db, "public_key").is_secret)
+
+        
     def test_duplicate(self):
         """You can't have two ConfigurationSettings for the same key,
         library, and external integration.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1155,8 +1155,8 @@ class TestShowCollectionsScript(DatabaseTest):
         # on both collections.
         output = StringIO()
         ShowCollectionsScript().do_run(self._db, output=output)
-        expect_1 = "\n".join(c1.explain(include_password=False))
-        expect_2 = "\n".join(c2.explain(include_password=False))
+        expect_1 = "\n".join(c1.explain(include_secrets=False))
+        expect_2 = "\n".join(c2.explain(include_secrets=False))
         
         eq_(expect_1 + "\n" + expect_2 + "\n", output.getvalue())
 
@@ -1174,11 +1174,11 @@ class TestShowCollectionsScript(DatabaseTest):
         output = StringIO()
         ShowCollectionsScript().do_run(
             self._db,
-            cmd_args=["--show-password"],
+            cmd_args=["--show-secrets"],
             output=output
         )
-        expect_1 = "\n".join(c1.explain(include_password=True))
-        expect_2 = "\n".join(c2.explain(include_password=True))
+        expect_1 = "\n".join(c1.explain(include_secrets=True))
+        expect_2 = "\n".join(c2.explain(include_secrets=True))
         eq_(expect_1 + "\n" + expect_2 + "\n", output.getvalue())
 
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -45,6 +45,7 @@ from scripts import (
     CollectionInputScript,
     ConfigureCollectionScript,
     ConfigureLibraryScript,
+    ConfigureSiteScript,
     CustomListManagementScript,
     DatabaseMigrationInitializationScript,
     DatabaseMigrationScript,
@@ -1014,6 +1015,39 @@ class TestShowLibrariesScript(DatabaseTest):
         expect_1 = "\n".join(l1.explain(include_secrets=True))
         expect_2 = "\n".join(l2.explain(include_secrets=True))
         eq_(expect_1 + "\n" + expect_2 + "\n", output.getvalue())
+
+
+class TestConfigureSiteScript(DatabaseTest):
+
+    def test_settings(self):
+        script = ConfigureSiteScript()
+        output = StringIO()
+        script.do_run(
+            self._db, [
+                "--setting=setting1=value1",
+                "--setting=setting2=[1,2,\"3\"]",
+                "--setting=secret_setting=secretvalue",
+            ],
+            output
+        )
+        # The secret was set, but is not shown.
+        eq_("""Current site-wide settings:
+setting1='value1'
+setting2='[1,2,"3"]'
+""",
+            output.getvalue()
+        )
+
+        # If we run again with --show-secrets, the secret is shown.
+        output = StringIO()
+        script.do_run(self._db, ["--show-secrets"], output)
+        eq_("""Current site-wide settings:
+secret_setting='secretvalue'
+setting1='value1'
+setting2='[1,2,"3"]'
+""",
+            output.getvalue()
+        )
 
 
 class TestConfigureLibraryScript(DatabaseTest):


### PR DESCRIPTION
This branch introduces the `ConfigureSiteScript`, for setting and viewing site-wide settings.

This branch also introduces `ConfigurationSetting.is_secret`, which uses heuristics to determine whether a configuration setting contains a 'secret'. The scripts that have an option for showing a "password" have been changed to use this setting to determine whether a setting should be treated as secret, rather than only hiding a setting called "password".