### PR TITLE
Add ExternalIntegration.name.

### DIFF
--- a/migration/20170615-add-name-to-externalintegration.sql
+++ b/migration/20170615-add-name-to-externalintegration.sql
@@ -1,0 +1,2 @@
+alter table externalintegrations add column name character varying;
+create index "ix_externalintegrations_name" on externalintegrations (name);

--- a/model.py
+++ b/model.py
@@ -9067,6 +9067,10 @@ class ExternalIntegration(Base):
     protocol = Column(Unicode, nullable=False)
     goal = Column(Unicode, nullable=True)
 
+    # A unique name for this ExternalIntegration. This is primarily
+    # used to identify ExternalIntegrations from command-line scripts.
+    name = Column(Unicode, nullable=True, unique=True)
+    
     # Any additional configuration information goes into
     # ConfigurationSettings.
     settings = relationship(
@@ -9136,6 +9140,9 @@ class ExternalIntegration(Base):
         :return: A list of explanatory strings.
         """
         lines = []
+        lines.append("ID: %s" % self.id)
+        if self.name:
+            lines.append("Name: %s" % self.name)
         lines.append("Protocol/Goal: %s/%s" % (self.protocol, self.goal))
 
         def key(setting):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5569,12 +5569,13 @@ Short name (for library registry): "SHORT"
 
 External integrations:
 ----------------------
+ID: %s
 Protocol/Goal: protocol/goal
 library-specific='value for library1' (applies only to The Library)
 somesetting='somevalue'
 url='http://url/'
 username='someuser'
-"""
+""" % integration.id
         actual = library.explain()
         eq_(expect, "\n".join(actual))
         
@@ -5629,6 +5630,7 @@ class TestExternalIntegration(DatabaseTest):
         integration = self._external_integration(
             "protocol", "goal"
         )
+        integration.name = "The Integration"
         integration.url = "http://url/"
         integration.username = "someuser"
         integration.password = "somepass"
@@ -5652,12 +5654,14 @@ class TestExternalIntegration(DatabaseTest):
         # If we decline to pass in a library, we get information about how
         # each library in the system configures this integration.
 
-        expect = """Protocol/Goal: protocol/goal
+        expect = """ID: %s
+Name: The Integration
+Protocol/Goal: protocol/goal
 library-specific='value1' (applies only to First Library)
 library-specific='value2' (applies only to Second Library)
 somesetting='somevalue'
 url='http://url/'
-username='someuser'"""
+username='someuser'""" % integration.id
         actual = integration.explain()
         eq_(expect, "\n".join(actual))
 


### PR DESCRIPTION
This branch defines a `name` field on `ExternalIntegration`. The name may be null, but must be unique if provided. The name will make it easier to configure a server from the command line using a repeatable script.