### PR TITLE
Integration config script

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -649,7 +649,7 @@ class ShowLibrariesScript(Script):
 class ConfigurationSettingScript(Script):
 
     @classmethod
-    def _parse_setting(self, value):
+    def _parse_setting(self, setting):
         """Parse a command-line setting option into a key-value pair."""
         if not '=' in setting:
             raise ValueError(
@@ -658,6 +658,7 @@ class ConfigurationSettingScript(Script):
             )
         return setting.split('=', 1)
 
+    @classmethod
     def add_setting_argument(self, parser, help):
         """Modify an ArgumentParser to indicate that the script takes 
         command-line settings.
@@ -694,7 +695,7 @@ class ConfigureSiteScript(ConfigurationSettingScript):
             default=False
         )
     
-        self.add_setting_argument(
+        cls.add_setting_argument(
             parser,
             'Set a site-wide setting, such as default_nongrouped_feed_max_age. Format: --setting="default_nongrouped_feed_max_age=1200"'
         )
@@ -759,7 +760,7 @@ class ConfigureLibraryScript(ConfigurationSettingScript):
             help='Set the library registry shared secret to a random value.',
             action='store_true',
         )
-        self.add_setting_argument(
+        cls.add_setting_argument(
             parser,
             'Set a per-library setting, such as terms-of-service. Format: --setting="terms-of-service=https://example.library/tos"',
         )
@@ -951,7 +952,8 @@ class ConfigureCollectionScript(ConfigurationSettingScript):
             '--password',
             help='Use this password to authenticate with the license protocol. Sometimes called a "secret".',
         )
-        self.add_setting_argument(
+        cls.add_setting_argument(
+            parser,
             'Set a protocol-specific setting on the collection, such as Overdrive\'s "website_id". Format: --setting="website_id=89"',
         )
         library_names = cls._library_names(_db)
@@ -1051,7 +1053,8 @@ class ConfigureIntegrationScript(ConfigurationSettingScript):
         parser.add_argument(
             '--goal', help='Goal of the integration',
         )
-        self.add_setting_argument(
+        cls.add_setting_argument(
+            parser,
             'Set a configuration value on the integration. Format: --setting="key=value"'
         )        
         return parser

--- a/scripts.py
+++ b/scripts.py
@@ -1068,17 +1068,15 @@ class ConfigureIntegrationScript(ConfigurationSettingScript):
             )
         integration = None
         if id:
-            integration = get_one(
-                _db, ExternalIntegration, ExternalIntegration.id==id
-            )
+            integration = get_one(_db, ExternalIntegration, id==id)
         if not integration and name:
-            integration = get_one(
-                _db, ExternalIntegration, ExternalIntegration.name==name
-            )
+            integration = get_one(_db, ExternalIntegration, name=name)
         if not integration and (protocol and goal):
             integration, is_new = get_one_or_create(
                 _db, ExternalIntegration, protocol=protocol, goal=goal
             )
+        if name:
+            integration.name = name
         return integration
         
     def do_run(self, _db=None, cmd_args=None, output=sys.stdout):

--- a/scripts.py
+++ b/scripts.py
@@ -646,7 +646,36 @@ class ShowLibrariesScript(Script):
             output.write("\n")            
                     
 
-class ConfigureSiteScript(Script):
+class ConfigurationSettingScript(Script):
+
+    @classmethod
+    def _parse_setting(self, value):
+        """Parse a command-line setting option into a key-value pair."""
+        if not '=' in setting:
+            raise ValueError(
+                'Incorrect format for setting: "%s". Should be "key=value"'
+                % setting
+            )
+        return setting.split('=', 1)
+
+    def add_setting_argument(self, parser, help):
+        """Modify an ArgumentParser to indicate that the script takes 
+        command-line settings.
+        """
+        parser.add_argument('--setting', help=help, action="append")
+    
+    def apply_settings(self, settings, obj):
+        """Treat `settings` as a list of command-line argument settings,
+        and apply each one to `obj`.
+        """
+        if not settings:
+            return None
+        for setting in settings:
+            key, value = self._parse_setting(setting)
+            obj.setting(key).value = value
+        
+            
+class ConfigureSiteScript(ConfigurationSettingScript):
     """View or update site-wide configuration."""
 
     def __init__(self, _db=None, config=Configuration):
@@ -665,10 +694,9 @@ class ConfigureSiteScript(Script):
             default=False
         )
     
-        parser.add_argument(
-            '--setting',
-            help='Set a site-wide setting, such as default_nongrouped_feed_max_age. Format: --setting="default_nongrouped_feed_max_age=1200"',
-            action="append",
+        self.add_setting_argument(
+            parser,
+            'Set a site-wide setting, such as default_nongrouped_feed_max_age. Format: --setting="default_nongrouped_feed_max_age=1200"'
         )
 
         parser.add_argument(
@@ -684,12 +712,7 @@ class ConfigureSiteScript(Script):
         args = self.parse_command_line(_db, cmd_args=cmd_args)
         if args.setting:
             for setting in args.setting:
-                if not '=' in setting:
-                    raise ValueError(
-                        'Incorrect format for setting: "%s". Should be "key=value"'
-                        % setting
-                    )
-                key, value = setting.split('=', 1)
+                key, value = self._parse_setting(setting)
                 if not args.force and not key in [s.get("key") for s in self.config.SITEWIDE_SETTINGS]:
                     raise ValueError(
                         "'%s' is not a known site-wide setting. Use --force to set it anyway."
@@ -708,7 +731,7 @@ class ConfigureSiteScript(Script):
                 output.write("%s='%s'\n" % (setting.key, setting.value))
             
             
-class ConfigureLibraryScript(Script):
+class ConfigureLibraryScript(ConfigurationSettingScript):
     """Create a library or change its settings."""
     name = "Change a library's settings"
 
@@ -735,6 +758,10 @@ class ConfigureLibraryScript(Script):
             '--random-library-registry-shared-secret',
             help='Set the library registry shared secret to a random value.',
             action='store_true',
+        )
+        self.add_setting_argument(
+            parser,
+            'Set a per-library setting, such as terms-of-service. Format: --setting="terms-of-service=https://example.library/tos"',
         )
         return parser
 
@@ -787,6 +814,7 @@ class ConfigureLibraryScript(Script):
             library.library_registry_short_name = args.library_registry_short_name
         if args.library_registry_shared_secret:
             library.library_registry_shared_secret = args.library_registry_shared_secret
+        self.apply_settings(args.setting, library)
         _db.commit()
         output.write("Configuration settings stored.\n")
         output.write("\n".join(library.explain()))
@@ -815,8 +843,15 @@ class ShowCollectionsScript(Script):
         _db = _db or self._db
         args = self.parse_command_line(_db, cmd_args=cmd_args)
         if args.name:
-            collection = get_one(_db, Collection, name=args.name)
-            collections = [collection]
+            name = args.name
+            collection = get_one(_db, Collection, name=name)
+            if collection:
+                collections = [collection]
+            else:
+                output.write(
+                    "Could not locate collection by name: %s" % name
+                )
+                collections = []
         else:
             collections = _db.query(Collection).order_by(Collection.name).all()
         if not collections:
@@ -830,7 +865,54 @@ class ShowCollectionsScript(Script):
             output.write("\n")
 
 
-class ConfigureCollectionScript(Script):
+class ShowIntegrationsScript(Script):
+    """Show information about the external integrations on a server."""
+    
+    name = "List the external integrations on this server."
+    @classmethod
+    def arg_parser(cls):
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            '--name',
+            help='Only display information for the integration with the given name or ID',
+        )
+        parser.add_argument(
+            '--show-secrets',
+            help='Display secret values such as passwords.',
+            action='store_true'
+        )
+        return parser
+    
+    def do_run(self, _db=None, cmd_args=None, output=sys.stdout):
+        _db = _db or self._db
+        args = self.parse_command_line(_db, cmd_args=cmd_args)
+        if args.name:
+            name = args.name
+            integration = get_one(_db, ExternalIntegration, name=name)
+            if not integration:
+                integration = get_one(_db, ExternalIntegration, id=name)
+            if integration:
+                integrations = [integration]
+            else:
+                output.write(
+                    "Could not locate integration by name or ID: %s\n" % args
+                )
+                integrations = []
+        else:
+            integrations = _db.query(ExternalIntegration).order_by(
+                ExternalIntegration.name, ExternalIntegration.id).all()
+        if not integrations:
+            output.write("No integrations found.\n")
+        for integration in integrations:
+            output.write(
+                "\n".join(
+                    integration.explain(include_secrets=args.show_secrets)
+                )
+            )
+            output.write("\n")
+
+
+class ConfigureCollectionScript(ConfigurationSettingScript):
     """Create a collection or change its settings."""
     name = "Change a collection's settings"
 
@@ -869,10 +951,8 @@ class ConfigureCollectionScript(Script):
             '--password',
             help='Use this password to authenticate with the license protocol. Sometimes called a "secret".',
         )
-        parser.add_argument(
-            '--setting',
-            help='Set a protocol-specific setting on the collection, such as Overdrive\'s "website_id". Format: --setting="website_id=89"',
-            action="append",
+        self.add_setting_argument(
+            'Set a protocol-specific setting on the collection, such as Overdrive\'s "website_id". Format: --setting="website_id=89"',
         )
         library_names = cls._library_names(_db)
         if library_names:
@@ -926,15 +1006,7 @@ class ConfigureCollectionScript(Script):
             integration.username = args.username
         if args.password:
             integration.password = args.password
-        if args.setting:
-            for setting in args.setting:
-                if not '=' in setting:
-                    raise ValueError(
-                        'Incorrect format for setting: "%s". Should be "key=value"'
-                        % setting
-                    )
-                key, value = setting.split('=', 1)
-                integration.setting(key).value = value
+        self.apply_settings(args.setting, integration)
 
         if hasattr(args, 'library'):
             for name in args.library:
@@ -953,6 +1025,72 @@ class ConfigureCollectionScript(Script):
         output.write("\n")
 
 
+class ConfigureIntegrationScript(ConfigurationSettingScript):
+    """Create a integration or change its settings."""
+    name = "Create a site-wide integration or change an integration's settings"
+
+    @classmethod
+    def parse_command_line(cls, _db=None, cmd_args=None):
+        parser = cls.arg_parser(_db)
+        return parser.parse_known_args(cmd_args)[0]
+    
+    @classmethod
+    def arg_parser(cls, _db):
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            '--name',
+            help='Name of the integration',
+        )
+        parser.add_argument(
+            '--id',
+            help='ID of the integration, if it has no name',
+        )
+        parser.add_argument(
+            '--protocol', help='Protocol used by the integration.',
+        )
+        parser.add_argument(
+            '--goal', help='Goal of the integration',
+        )
+        self.add_setting_argument(
+            'Set a configuration value on the integration. Format: --setting="key=value"'
+        )        
+        return parser
+    
+    def do_run(self, _db=None, cmd_args=None, output=sys.stdout):
+        _db = _db or self._db
+        args = self.parse_command_line(_db, cmd_args=cmd_args)
+
+        # Find or create the integration
+        protocol = None
+        id = args.id
+        name = args.name
+        protocol = args.protocol
+        goal = args.goal
+
+        if not id and not name and not (protocol and goal):
+            raise ValueError(
+                "An integration must by identified by either ID, name, or the combination of protocol and goal."
+            )
+        if id:
+            integration = get_one(
+                _db, ExternalIntegration, ExternalIntegration.id==id
+            )
+        if not integration and name:
+            integration = get_one(
+                _db, ExternalIntegration, ExternalIntegration.name==name
+            )
+        if not integration and (protocol and goal):
+            integration, is_new = get_one_or_create(
+                _db, ExternalIntegration, protocol=protocol, goal=goal
+            )
+        self.apply_settings(args.setting, integration)
+
+        _db.commit()
+        output.write("Configuration settings stored.\n")
+        output.write("\n".join(integration.explain()))
+        output.write("\n")
+
+        
 class AddClassificationScript(IdentifierInputScript):
     name = "Add a classification to an identifier"
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1418,10 +1418,11 @@ class TestConfigureIntegrationScript(DatabaseTest):
         )
 
         # An integration may be created given a protocol and goal.
-        integration2 = m(self._db, None, None, "Protocol", "Goal2")
+        integration2 = m(self._db, None, "I exist now", "Protocol", "Goal2")
         assert integration2 != integration
         eq_("Protocol", integration2.protocol)
         eq_("Goal2", integration2.goal)
+        eq_("I exist now", integration2.name)
         
     def test_add_settings(self):
         script = ConfigureIntegrationScript()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1124,6 +1124,7 @@ class TestConfigureLibraryScript(DatabaseTest):
                 "--name=Library 1",
                 "--library-registry-shared-secret=foo",
                 "--library-registry-short-name=nyl1",
+                '--setting=customkey=value',
             ],
             output
         )
@@ -1134,6 +1135,7 @@ class TestConfigureLibraryScript(DatabaseTest):
         eq_("L1", library.short_name)
         eq_("foo", library.library_registry_shared_secret)
         eq_("NYL1", library.library_registry_short_name)
+        eq_("value", library.setting("customkey").value)
         expect_output = "Configuration settings stored.\n" + "\n".join(library.explain()) + "\n"
         eq_(expect_output, output.getvalue())
 


### PR DESCRIPTION
This branch does some refactoring of scripts that set `ConfigurationSetting`s. It changes `ConfigureLibraryScript` so that you can set `ConfigurationSetting`s on a Library.

It also introduces two new scripts for managing `ExternalIntegration`s. `ShowIntegrationsScript` lists all the integrations and `ConfigureIntegrationScript`lets you create an `ExternalIntegration`, or set `ConfigurationSetting`s on an existing `ExternalIntegration`.

You can't use the command line to associate an `ExternalIntegration` with a Library, or to set a `ConfigurationSetting` on the combination of an integration and a library -- for that we decided the admin interface is good enough.