### PR TITLE
Consolidate s3 integrations

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,6 +8,8 @@ import copy
 from util import LanguageCodes
 from flask.ext.babel import lazy_gettext as _
 
+from s3 import S3Uploader
+
 class CannotLoadConfiguration(Exception):
     pass
 
@@ -262,6 +264,7 @@ class Configuration(object):
 
         if _db:
             cls.load_cdns(_db)
+            S3Uploader.initialize_buckets(_db)
         else:
             if not cls.integration('CDN'):
                 cls.instance[cls.INTEGRATIONS]['CDN'] = cls.UNINITIALIZED_CDNS

--- a/config.py
+++ b/config.py
@@ -263,8 +263,8 @@ class Configuration(object):
         cls.instance = configuration
 
         if _db:
-            cls.load_cdns(_db)
             S3Uploader.initialize_buckets(_db)
+            cls.load_cdns(_db)
         else:
             if not cls.integration('CDN'):
                 cls.instance[cls.INTEGRATIONS]['CDN'] = cls.UNINITIALIZED_CDNS

--- a/model.py
+++ b/model.py
@@ -8999,15 +8999,7 @@ class ExternalIntegration(Base):
 
     # These integrations are associated with external services such as
     # S3 that provide access to book covers.
-    BOOK_COVERS_GOAL = u'book_covers'
-
-    # These integrations are associated with external services such as
-    # S3 that provide access to static or cached OPDS feeds.
-    OPDS_FEED_GOAL = u'opds_feeds'
-
-    # These integrations are associated with external services such as
-    # S3 that provide access to open access content.
-    OA_CONTENT_GOAL = u'open_access_books'
+    STORAGE_GOAL = u'storage'
 
     # These integrations are associated with external services like
     # Cloudfront or other CDNs that mirror and/or cache certain domains.
@@ -9054,8 +9046,7 @@ class ExternalIntegration(Base):
     METADATA_WRANGLER = u'Metadata Wrangler'
     CONTENT_SERVER = u'Content Server'
 
-    # Integrations for storage or cache with BOOK_COVERS_GOAL,
-    # OPDS_GOAL, or OA_CONTENT_GOAL
+    # Integrations with STORAGE_GOAL
     S3 = u'S3'
 
     # Integrations with CDN_GOAL

--- a/opds_import.py
+++ b/opds_import.py
@@ -1511,7 +1511,7 @@ class OPDSImporterWithS3Mirror(OPDSImporter):
     def __init__(self, _db, default_data_source, **kwargs):
         kwargs = dict(kwargs)
         if 'mirror' not in kwargs:
-            kwargs['mirror'] = S3Uploader(_db)
+            kwargs['mirror'] = S3Uploader.from_config(_db)
         super(OPDSImporterWithS3Mirror, self).__init__(
             _db, default_data_source, **kwargs
         )

--- a/s3.py
+++ b/s3.py
@@ -242,22 +242,16 @@ class S3Uploader(MirrorUploader):
 
 class DummyS3Uploader(S3Uploader):
     """A dummy uploader for use in tests."""
+
+    __buckets__ = {
+       S3Uploader.BOOK_COVERS_BUCKET_KEY : 'test.cover.bucket',
+       S3Uploader.OA_CONTENT_BUCKET_KEY : 'test.content.bucket',
+    }
+
     def __init__(self, fail=False, *args, **kwargs):
         self.uploaded = []
         self.content = []
         self.fail = fail
-
-    @classmethod
-    def cover_image_root(cls, data_source, scaled_size=None):
-        return S3Uploader.cover_image_root(
-            'test.cover.bucket', data_source, scaled_size)
-
-    @classmethod
-    def content_root(cls, open_access=True):
-        """The root URL to the S3 location of hosted content of
-        the given type.
-        """
-        return S3Uploader.content_root('test.content.bucket', open_access)
 
     def mirror_batch(self, representations):
         self.uploaded.extend(representations)


### PR DESCRIPTION
This changes the setup for the `S3Uploader` to resemble CDNs more closely. S3 has a single ExternalIntegration with a goal of 'storage', and all of its buckets and their respective URLs are loaded from the database by `Configuration.load`. When `S3Uploader` is accessed, these buckets are available on the class itself.

Fixes #534.