### PR TITLE
Monitor for configuration changes

### DIFF
--- a/config.py
+++ b/config.py
@@ -289,34 +289,34 @@ class Configuration(object):
         return [LanguageCodes.three_to_two[l] for l in languages]
 
     # The last time the database configuration is known to have changed.
-    DATABASE_CONFIGURATION_LAST_UPDATE = "database_configuration_last_update"
+    SITE_CONFIGURATION_LAST_UPDATE = "site_configuration_last_update"
 
     # The last time we *checked* whether the database configuration had
     # changed.
-    LAST_CHECKED_FOR_DATABASE_CONFIGURATION_UPDATE = "last_checked_for_database_configuration_update"
+    LAST_CHECKED_FOR_SITE_CONFIGURATION_UPDATE = "last_checked_for_site_configuration_update"
     
     @classmethod
-    def database_configuration_last_update(cls):
+    def site_configuration_last_update(cls):
         """As far as we know, when is the last time the database configuration
         was updated?
         """
-        return cls.instance.get(cls.DATABASE_CONFIGURATION_LAST_UPDATE, None)
+        return cls.instance.get(cls.SITE_CONFIGURATION_LAST_UPDATE, None)
         
     @classmethod
-    def last_checked_for_database_configuration_update(cls):
+    def last_checked_for_site_configuration_update(cls):
         """When was the last time we actually checked when the database
         was updated?
         """
         return cls.instance.get(
-            cls.LAST_CHECKED_FOR_DATABASE_CONFIGURATION_UPDATE, None
+            cls.LAST_CHECKED_FOR_SITE_CONFIGURATION_UPDATE, None
         )
 
     @classmethod
-    def check_for_database_configuration_update(cls, _db, known_value=None):
+    def check_for_site_configuration_update(cls, _db, known_value=None):
         """Check whether the database configuration has been updated.
 
         If it has, updates
-        cls.instance[DATABASE_CONFIGURATION_LAST_UPDATE]. It's the
+        cls.instance[SITE_CONFIGURATION_LAST_UPDATE]. It's the
         application's responsibility to periodically check this value
         and reload the configuration if appropriate.
 
@@ -334,7 +334,7 @@ class Configuration(object):
         if not known_value:
             from core.model import Timestamp
             known_value = Timestamp.value(
-                _db, cls.DATABASE_CONFIGURATION_CHANGED, None
+                _db, cls.SITE_CONFIGURATION_CHANGED, None
             )
         if not known_value:
             # The database configuration has never changed.
@@ -343,12 +343,12 @@ class Configuration(object):
             last_update = known_value
 
         # Update the Configuration object's record of the last update time.
-        old_value = cls.instance.get(cls.DATABASE_CONFIGURATION_LAST_UPDATE)
-        cls.instance[cls.DATABASE_CONFIGURATION_LAST_UPDATE] = last_update
+        old_value = cls.instance.get(cls.SITE_CONFIGURATION_LAST_UPDATE)
+        cls.instance[cls.SITE_CONFIGURATION_LAST_UPDATE] = last_update
         
         # Whether that record changed or not, the time at which we
         # _checked_ is going to be set to the current time.
-        cls.instance[cls.LAST_CHECKED_FOR_DATABASE_CONFIGURATION_UPDATE] = now
+        cls.instance[cls.LAST_CHECKED_FOR_SITE_CONFIGURATION_UPDATE] = now
 
         return old_value != last_update
         

--- a/config.py
+++ b/config.py
@@ -39,10 +39,6 @@ class Configuration(object):
     log = logging.getLogger("Configuration file loader")
 
     instance = None
-
-    # The service associated with a Timestamp that tracks the last time
-    # a ConfigurationSetting's value changed in the database.
-    DATABASE_CONFIGURATION_CHANGED = "Database Configuration Changed"
     
     # Logging stuff
     LOGGING_LEVEL = "level"
@@ -294,6 +290,10 @@ class Configuration(object):
     # The last time we *checked* whether the database configuration had
     # changed.
     LAST_CHECKED_FOR_SITE_CONFIGURATION_UPDATE = "last_checked_for_site_configuration_update"
+
+    # The name of the service associated with a Timestamp that tracks
+    # the last time the site's configuration changed in the database.
+    SITE_CONFIGURATION_CHANGED = "Site Configuration Changed"
     
     @classmethod
     def site_configuration_last_update(cls):

--- a/config.py
+++ b/config.py
@@ -311,12 +311,6 @@ class Configuration(object):
             cls.LAST_CHECKED_FOR_DATABASE_CONFIGURATION_UPDATE, None
         )
 
-    EPOCH = datetime.datetime.utcfromtimestamp(0)
-    @classmethod
-    def seconds_since_epoch(cls, dt):
-        """Convert a datetime object into seconds since epoch."""
-        return (dt - cls.EPOCH).total_seconds()
-
     @classmethod
     def check_for_database_configuration_update(cls, _db, known_value=None):
         """Check whether the database configuration has been updated.
@@ -332,12 +326,13 @@ class Configuration(object):
         :return: True if the database configuration has been updated
         since the last time we checked; False if not.
         """
-        now = cls.seconds_since_epoch(datetime.datetime.utcnow())
+        now = datetime.datetime.utcnow()
 
         # Ask the database when was the last time the configuration
         # changed. Specifically, this is the last time the
         # configuration_changed() listener (defined in model.py) ran.
         if not known_value:
+            from core.model import Timestamp
             known_value = Timestamp.value(
                 _db, cls.DATABASE_CONFIGURATION_CHANGED, None
             )
@@ -345,7 +340,7 @@ class Configuration(object):
             # The database configuration has never changed.
             last_update = None
         else:
-            last_update = cls.seconds_since_epoch(known_value)
+            last_update = known_value
 
         # Update the Configuration object's record of the last update time.
         old_value = cls.instance.get(cls.DATABASE_CONFIGURATION_LAST_UPDATE)

--- a/config.py
+++ b/config.py
@@ -348,7 +348,7 @@ class Configuration(object):
         # site_configuration_was_changed() (defined in model.py) was
         # called.
         if not known_value:
-            from core.model import Timestamp
+            from model import Timestamp
             known_value = Timestamp.value(
                 _db, cls.SITE_CONFIGURATION_CHANGED, None
             )

--- a/config.py
+++ b/config.py
@@ -297,7 +297,7 @@ class Configuration(object):
     
     @classmethod
     def site_configuration_last_update(cls):
-        """As far as we know, when is the last time the database configuration
+        """As far as we know, when is the last time the site configuration
         was updated?
         """
         return cls.instance.get(cls.SITE_CONFIGURATION_LAST_UPDATE, None)
@@ -313,7 +313,7 @@ class Configuration(object):
 
     @classmethod
     def check_for_site_configuration_update(cls, _db, known_value=None):
-        """Check whether the database configuration has been updated.
+        """Check whether the site configuration has been updated.
 
         If it has, updates
         cls.instance[SITE_CONFIGURATION_LAST_UPDATE]. It's the
@@ -323,21 +323,22 @@ class Configuration(object):
         :param known_value: Use the given timestamp instead of checking
         with the database.
 
-        :return: True if the database configuration has been updated
+        :return: True if the site configuration was updated
         since the last time we checked; False if not.
         """
         now = datetime.datetime.utcnow()
 
-        # Ask the database when was the last time the configuration
-        # changed. Specifically, this is the last time the
-        # configuration_changed() listener (defined in model.py) ran.
+        # Ask the database when was the last time the site
+        # configuration changed. Specifically, this is the last time
+        # site_configuration_was_changed() (defined in model.py) was
+        # called.
         if not known_value:
             from core.model import Timestamp
             known_value = Timestamp.value(
                 _db, cls.SITE_CONFIGURATION_CHANGED, None
             )
         if not known_value:
-            # The database configuration has never changed.
+            # The site configuration has never changed.
             last_update = None
         else:
             last_update = known_value

--- a/model.py
+++ b/model.py
@@ -9940,10 +9940,14 @@ def tuple_to_numericrange(t):
     return NumericRange(t[0], t[1], '[]')
         
 @event.listens_for(ConfigurationSetting.value, 'set')
-def configuration_changed(target, value, oldvalue, initiator):
-    now = Configuration.seconds_since_epoch(datetime.datetime.utcnow())
+def configuration_setting_changed(target, value, oldvalue, initiator, timeout=1):
+    """When a new value for ConfigurationSetting.value is set,
+    modify the Timestamp that keeps track of the last time the site's
+    configuration changed.
+    """
+    now = datetime.datetime.utcnow()
     last_update = Configuration.database_configuration_last_update()
-    if not last_update or last_update > now:
+    if not last_update or (now - last_update).total_seconds() > timeout:
         # The configuration last changed more than a second ago, which
         # means it's time to reset the Timestamp that says when the
         # configuration last changed.

--- a/model.py
+++ b/model.py
@@ -9973,15 +9973,7 @@ def site_configuration_has_changed(_db, timeout=1):
         timestamp = Timestamp.stamp(
             _db, Configuration.SITE_CONFIGURATION_CHANGED, collection=None
         )
-
-        # We know the value just changed, so we can update our own
-        # local record of when the value changed. This will stop this
-        # code from running again if there's a second change to
-        # ConfigurationSetting.value immediately after this one.
-        Configuration.check_for_site_configuration_update(
-            _db, known_value=timestamp.timestamp
-        )
-
+        
 # Most of the time, we can know whether a change to the database is
 # likely to require that the application reload the portion of the
 # configuration it gets from the database. These hooks will call

--- a/model.py
+++ b/model.py
@@ -9956,7 +9956,7 @@ def site_configuration_has_changed(_db, timeout=1):
     recorded.
     """
     now = datetime.datetime.utcnow()
-    last_update = Configuration.database_configuration_last_update()
+    last_update = Configuration.site_configuration_last_update()
     if not last_update or (now - last_update).total_seconds() > timeout:
         # The configuration last changed more than a second ago, which
         # means it's time to reset the Timestamp that says when the
@@ -9970,14 +9970,14 @@ def site_configuration_has_changed(_db, timeout=1):
             _db = Session(_db)
 
         timestamp = Timestamp.stamp(
-            _db, Configuration.DATABASE_CONFIGURATION_CHANGED, collection=None
+            _db, Configuration.SITE_CONFIGURATION_CHANGED, collection=None
         )
 
         # We know the value just changed, so we can update our own
         # local record of when the value changed. This will stop this
         # code from running again if there's a second change to
         # ConfigurationSetting.value immediately after this one.
-        Configuration.check_for_database_configuration_update(
+        Configuration.check_for_site_configuration_update(
             _db, known_value=timestamp.timestamp
         )
 

--- a/model.py
+++ b/model.py
@@ -10016,7 +10016,3 @@ def configuration_relevant_collection_change(target, value,  initiator):
 @event.listens_for(ConfigurationSetting, 'after_update')
 def configuration_relevant_lifecycle_event(mapper, connection, target):
     site_configuration_has_changed(connection)
-
-@event.listens_for(ConfigurationSetting.value, 'set')
-def configuration_setting_modified_event(target, value, oldvalue, initiator):
-    site_configuration_has_changed(target)

--- a/model.py
+++ b/model.py
@@ -9957,7 +9957,7 @@ def site_configuration_has_changed(_db, timeout=1):
 
     """
     now = datetime.datetime.utcnow()
-    last_update = Configuration.site_configuration_last_update()
+    last_update = Configuration._site_configuration_last_update()
     if not last_update or (now - last_update).total_seconds() > timeout:
         # The configuration last changed more than `timeout` ago, which
         # means it's time to reset the Timestamp that says when the
@@ -9976,10 +9976,18 @@ def site_configuration_has_changed(_db, timeout=1):
             _db, Configuration.SITE_CONFIGURATION_CHANGED, collection=None
         )
 
+        # Update the Configuration's record of when the configuration
+        # was updated. This will update our local record immediately
+        # without requiring a trip to the database.
+        Configuration.site_configuration_last_update(
+            _db, known_value=timestamp.timestamp
+        )
+
         if needs_commit:
             # We had to create a new database session. Commit it now.
             _db.commit()
-        
+
+            
 # Most of the time, we can know whether a change to the database is
 # likely to require that the application reload the portion of the
 # configuration it gets from the database. These hooks will call

--- a/model.py
+++ b/model.py
@@ -10015,5 +10015,5 @@ def configuration_relevant_collection_change(target, value,  initiator):
 @event.listens_for(ConfigurationSetting, 'after_insert')
 @event.listens_for(ConfigurationSetting, 'after_delete')
 @event.listens_for(ConfigurationSetting, 'after_update')
-def configuration_object_lifecycle(mapper, connection, target):
+def configuration_relevant_lifecycle_event(mapper, connection, target):
     site_configuration_has_changed(connection)

--- a/model.py
+++ b/model.py
@@ -9944,9 +9944,9 @@ def site_configuration_has_changed(_db, timeout=1):
     """Call this whenever you want to indicate that the site configuration
     has changed and needs to be reloaded.
 
-    This is automatically triggered whenever a new value is set for
-    ConfigurationSetting.value, but you should call it whenever you
-    change an aspect of what you consider "site configuration".
+    This is automatically triggered on relevant changes to the data
+    model, but you also should call it whenever you change an aspect
+    of what you consider "site configuration", just to be safe.
 
     :param _db: Either a Session or (to save time in a common case) an
     object that can be associated with or turned into a Session.
@@ -9954,6 +9954,7 @@ def site_configuration_has_changed(_db, timeout=1):
     :param timeout: Nothing will happen if it's been fewer than this
     number of seconds since the last site configuration change was
     recorded.
+
     """
     now = datetime.datetime.utcnow()
     last_update = Configuration.site_configuration_last_update()

--- a/scripts.py
+++ b/scripts.py
@@ -757,7 +757,7 @@ class ConfigurationSettingScript(Script):
         for setting in settings:
             key, value = self._parse_setting(setting)
             obj.setting(key).value = value
-        
+            
             
 class ConfigureSiteScript(ConfigurationSettingScript):
     """View or update site-wide configuration."""
@@ -804,7 +804,6 @@ class ConfigureSiteScript(ConfigurationSettingScript):
                     )
                 else:
                     ConfigurationSetting.sitewide(_db, key).value = value
-            _db.commit()
         settings = _db.query(ConfigurationSetting).filter(
             ConfigurationSetting.library==None).filter(
                 ConfigurationSetting.external_integration==None
@@ -813,8 +812,9 @@ class ConfigureSiteScript(ConfigurationSettingScript):
         for setting in settings:
             if args.show_secrets or not setting.is_secret:
                 output.write("%s='%s'\n" % (setting.key, setting.value))
-            
-            
+        site_configuration_has_changed(_db)
+        _db.commit()
+        
 class ConfigureLibraryScript(ConfigurationSettingScript):
     """Create a library or change its settings."""
     name = "Change a library's settings"
@@ -899,6 +899,7 @@ class ConfigureLibraryScript(ConfigurationSettingScript):
         if args.library_registry_shared_secret:
             library.library_registry_shared_secret = args.library_registry_shared_secret
         self.apply_settings(args.setting, library)
+        site_configuration_has_changed(_db)
         _db.commit()
         output.write("Configuration settings stored.\n")
         output.write("\n".join(library.explain()))
@@ -1104,6 +1105,7 @@ class ConfigureCollectionScript(ConfigurationSettingScript):
                     raise ValueError(message)
                 if collection not in library.collections:
                     library.collections.append(collection)
+        site_configuration_has_changed(_db)
         _db.commit()
         output.write("Configuration settings stored.\n")
         output.write("\n".join(collection.explain()))
@@ -1182,7 +1184,7 @@ class ConfigureIntegrationScript(ConfigurationSettingScript):
         goal = args.goal
         integration = self._integration(_db, id, name, protocol, goal)
         self.apply_settings(args.setting, integration)
-
+        site_configuration_has_changed(_db)
         _db.commit()
         output.write("Configuration settings stored.\n")
         output.write("\n".join(integration.explain()))

--- a/scripts.py
+++ b/scripts.py
@@ -55,6 +55,7 @@ from model import (
     Work,
     WorkCoverageRecord,
     WorkGenre,
+    site_configuration_has_changed,
 )
 from monitor import SubjectAssignmentMonitor
 from monitor import CollectionMonitor

--- a/testing.py
+++ b/testing.py
@@ -136,7 +136,7 @@ class DatabaseTest(object):
         self.isbns = ["9780674368279", "0636920028468", "9781936460236"]
         self.search_mock = mock.patch(model.__name__ + ".ExternalSearchIndex", DummyExternalSearchIndex)
         self.search_mock.start()
-
+        
         # TODO:  keeping this for now, but need to fix it bc it hits _isbn, 
         # which pops an isbn off the list and messes tests up.  so exclude 
         # _ functions from participating.
@@ -154,6 +154,16 @@ class DatabaseTest(object):
         # test, whether in the session that was just closed or some
         # other session.
         self.transaction.rollback()
+
+        # Also roll back any record of those changes in the
+        # Configuration instance.
+        for key in [
+                Configuration.DATABASE_CONFIGURATION_LAST_UPDATE,
+                Configuration.LAST_CHECKED_FOR_DATABASE_CONFIGURATION_UPDATE
+        ]:
+            if key in Configuration.instance:
+                del(Configuration.instance[key])
+
         self.search_mock.stop()
 
     def shortDescription(self):

--- a/testing.py
+++ b/testing.py
@@ -158,8 +158,8 @@ class DatabaseTest(object):
         # Also roll back any record of those changes in the
         # Configuration instance.
         for key in [
-                Configuration.DATABASE_CONFIGURATION_LAST_UPDATE,
-                Configuration.LAST_CHECKED_FOR_DATABASE_CONFIGURATION_UPDATE
+                Configuration.SITE_CONFIGURATION_LAST_UPDATE,
+                Configuration.LAST_CHECKED_FOR_SITE_CONFIGURATION_UPDATE
         ]:
             if key in Configuration.instance:
                 del(Configuration.instance[key])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5875,13 +5875,13 @@ class TestConfigurationSetting(DatabaseTest):
         # If ConfigurationSettings are updated twice within the
         # timeout period (default 1 second), the last update time is
         # only set once, to avoid spamming the Timestamp with updates.
-        from model import configuration_setting_changed
-
+        from model import site_configuration_has_changed
+        
         # The high value for 'timeout' saves this code. If we decided
-        # that the timeout had expired and tried to modify the
-        # timestamp, the code would crash because we're not passing
-        # the right arguments in.
-        configuration_setting_changed(None, None, None, None, timeout=100)
+        # that the timeout had expired and tried to check the
+        # Timestamp, the code would crash because we're not passing
+        # a database connection in.
+        site_configuration_has_changed(None, timeout=100)
 
         # In fact, nothing has changed.
         eq_(new_last_update, Configuration.database_configuration_last_update())
@@ -6033,9 +6033,9 @@ class TestCollection(DatabaseTest):
              'Protocol: "Overdrive"',
              'Used by library: "The only library"',
              'External account ID: "id"',
+             'Setting "setting": "value"',
              'Setting "url": "url"',
              'Setting "username": "username"',
-             'Setting "setting": "value"'
         ],
             data
         )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5842,15 +5842,15 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         """
         # Starting out, the database configuration has never been updated
         # and we have never even checked whether it has been updated.
-        eq_(None, Configuration.database_configuration_last_update())
+        eq_(None, Configuration.site_configuration_last_update())
         eq_(None,
-            Configuration.last_checked_for_database_configuration_update()
+            Configuration.last_checked_for_site_configuration_update()
         )
 
         # The Timestamp tracking when the ConfigurationSettings last changed
         # is unset.
         timestamp_value = Timestamp.value(
-            self._db, Configuration.DATABASE_CONFIGURATION_CHANGED, None
+            self._db, Configuration.SITE_CONFIGURATION_CHANGED, None
         )
         eq_(None, timestamp_value)
         
@@ -5860,8 +5860,8 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
 
         # The last update time has been modified, as has the time we
         # checked on the last update time.
-        last_update = Configuration.database_configuration_last_update()
-        last_update_check = Configuration.last_checked_for_database_configuration_update()
+        last_update = Configuration.site_configuration_last_update()
+        last_update_check = Configuration.last_checked_for_site_configuration_update()
     
         assert abs((last_update - now).total_seconds()) < 1
         assert abs((last_update_check - now).total_seconds()) < 1
@@ -5872,10 +5872,10 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         assert last_update_check > last_update
 
         # Absent another call to site_configuration_has_changed(),
-        # calling Configuration.check_for_database_configuration_update
+        # calling Configuration.check_for_site_configuration_update
         # will return False.
         eq_(False,
-            Configuration.check_for_database_configuration_update(self._db))
+            Configuration.check_for_site_configuration_update(self._db))
 
         # But let's be sneaky and update the timestamp directly,
         # without calling site_configuration_has_changed(). This
@@ -5883,19 +5883,19 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         # site_cnofiguration_has_changed() -- they will know about the
         # change but we won't be informed.
         timestamp = Timestamp.stamp(
-            self._db, Configuration.DATABASE_CONFIGURATION_CHANGED, None
+            self._db, Configuration.SITE_CONFIGURATION_CHANGED, None
         )
         new_last_update = timestamp.timestamp
 
-        # Calling Configuration.check_for_database_configuration_update
+        # Calling Configuration.check_for_site_configuration_update
         # detects the change and returns True.
-        eq_(True, Configuration.check_for_database_configuration_update(
+        eq_(True, Configuration.check_for_site_configuration_update(
             self._db))
 
         # We ran another check, which set the last update time to the
         # time in the timestamp.
-        eq_(new_last_update, Configuration.database_configuration_last_update())
-        new_check_time = Configuration.last_checked_for_database_configuration_update()
+        eq_(new_last_update, Configuration.site_configuration_last_update())
+        new_check_time = Configuration.last_checked_for_site_configuration_update()
         assert new_check_time > last_update_check
 
         # If ConfigurationSettings are updated twice within the
@@ -5910,31 +5910,31 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
 
         # Nothing has changed -- how could it, with no database connection
         # to modify anything?
-        eq_(new_last_update, Configuration.database_configuration_last_update())
+        eq_(new_last_update, Configuration.site_configuration_last_update())
         eq_(new_check_time,
-            Configuration.last_checked_for_database_configuration_update())
+            Configuration.last_checked_for_site_configuration_update())
 
     # We don't test every event listener, but we do test one of each type.
     def test_configuration_relevant_lifecycle_event_updates_configuration(self):
         """When you modify a """
-        eq_(None, Configuration.database_configuration_last_update())
+        eq_(None, Configuration.site_configuration_last_update())
         eq_(None,
-            Configuration.last_checked_for_database_configuration_update()
+            Configuration.last_checked_for_site_configuration_update()
         )
 
         # Create a ConfigurationSetting and
         # site_configuration_has_changed is called.
         ConfigurationSetting.sitewide(self._db, "setting").value = "value"
-        update2 = Configuration.database_configuration_last_update()
-        check2 = Configuration.last_checked_for_database_configuration_update()
+        update2 = Configuration.site_configuration_last_update()
+        check2 = Configuration.last_checked_for_site_configuration_update()
         assert(update2 is not None)
         assert(check2 is not None)
 
         # Get around the site_configuration_has_changed() timeout by
         # destroying the evidence that it was just called.
         for key in [
-                Configuration.DATABASE_CONFIGURATION_LAST_UPDATE,
-                Configuration.LAST_CHECKED_FOR_DATABASE_CONFIGURATION_UPDATE
+                Configuration.SITE_CONFIGURATION_LAST_UPDATE,
+                Configuration.LAST_CHECKED_FOR_SITE_CONFIGURATION_UPDATE
         ]:
             if key in Configuration.instance:
                 del(Configuration.instance[key])
@@ -5942,27 +5942,27 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         # Modify an existing ConfigurationSetting and
         # site_configuration_has_changed() is called again.
         ConfigurationSetting.sitewide(self._db, "setting").value = "value2"
-        update3 = Configuration.database_configuration_last_update()
-        check3 = Configuration.last_checked_for_database_configuration_update()
+        update3 = Configuration.site_configuration_last_update()
+        check3 = Configuration.last_checked_for_site_configuration_update()
         assert(update3 > update2)
         assert(check3 > check2)
 
     def test_configuration_relevant_collection_change_updates_configuration(self):
-        eq_(None, Configuration.database_configuration_last_update())
+        eq_(None, Configuration.site_configuration_last_update())
         eq_(None,
-            Configuration.last_checked_for_database_configuration_update()
+            Configuration.last_checked_for_site_configuration_update()
         )
         # Create a library.
         library = self._default_library
-        assert Configuration.database_configuration_last_update() is not None
-        assert Configuration.last_checked_for_database_configuration_update() is not None
+        assert Configuration.site_configuration_last_update() is not None
+        assert Configuration.last_checked_for_site_configuration_update() is not None
         collection = self._collection()
         
         # Get around the site_configuration_has_changed() timeout by
         # destroying the evidence that it was just called.
         for key in [
-                Configuration.DATABASE_CONFIGURATION_LAST_UPDATE,
-                Configuration.LAST_CHECKED_FOR_DATABASE_CONFIGURATION_UPDATE
+                Configuration.SITE_CONFIGURATION_LAST_UPDATE,
+                Configuration.LAST_CHECKED_FOR_SITE_CONFIGURATION_UPDATE
         ]:
             if key in Configuration.instance:
                 del(Configuration.instance[key])
@@ -5971,8 +5971,8 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         # site_configuration_has_changed() is called again.
         library.collections.append(collection)
 
-        update2 = Configuration.database_configuration_last_update()
-        check2 = Configuration.last_checked_for_database_configuration_update()
+        update2 = Configuration.site_configuration_last_update()
+        check2 = Configuration.last_checked_for_site_configuration_update()
         assert(update2 is not None)
         assert(check2 is not None)
         

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5810,6 +5810,35 @@ class TestConfigurationSetting(DatabaseTest):
         jsondata.value = "tra la la"
         assert_raises(ValueError, lambda: jsondata.json_value)
 
+    def test_configuration_update(self):
+        ci = Configuration.instance
+
+        # Starting out, the database configuration has never been updated
+        # and we have never even checked whether it has been updated.
+        eq_(None, Configuration.database_configuration_last_update())
+        eq_(None,
+            Configuration.last_checked_for_database_configuration_update()
+        )
+
+        # Now let's set a setting.
+        now = Configuration.seconds_since_epoch(datetime.datetime.now())
+        ConfigurationSetting.sitewide(self._db, "setting").value = "value"
+
+        last_update = Configuration.database_configuration_last_update()
+        last_update_check = Configuration.last_checked_for_database_configuration_update()
+
+        set_trace()
+        assert abs(last_update - now) < 1
+        assert abs(last_update_check - now) < 1
+        
+        # The last update check time is before the last update time,
+        # even though this doesn't make sense temporally. We set it this way
+        # to reduce the risk of missed updates.
+        assert last_update_check > last_update
+        
+        set_trace()
+        pass
+        
     def test_explain(self):
         """Test that ConfigurationSetting.explain gives information
         about all site-wide configuration settings.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5888,10 +5888,16 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         new_last_update = timestamp.timestamp
 
         # Calling Configuration.check_for_site_configuration_update
-        # detects the change and returns True.
-        eq_(True, Configuration.check_for_site_configuration_update(
+        # doesn't detect the change because by default we only go to
+        # the database once a minute.
+        eq_(False, Configuration.check_for_site_configuration_update(
             self._db))
 
+        # Passing in a different timeout value forces the method to go
+        # to the database and find the correct answer.
+        eq_(True, Configuration.check_for_site_configuration_update(
+            self._db, timeout=0))
+        
         # We ran another check, which set the last update time to the
         # time in the timestamp.
         eq_(new_last_update, Configuration.site_configuration_last_update())
@@ -5916,7 +5922,9 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
 
     # We don't test every event listener, but we do test one of each type.
     def test_configuration_relevant_lifecycle_event_updates_configuration(self):
-        """When you modify a """
+        """When you create or modify a relevant item such as a
+        ConfigurationSetting.
+        """
         eq_(None, Configuration.site_configuration_last_update())
         eq_(None,
             Configuration.last_checked_for_site_configuration_update()


### PR DESCRIPTION
This branch gives you a method you can call to see if the site configuration has changed while you weren't looking: `Configuration.check_for_site_configuration_update()`.

It also gives you a method you can call if you yourself have changed the site configuration: `site_configuration_has_changed` in model.py.

I've added listeners for every database event I can think of that implies a change to what we generally consider "the site configuration". I've also changed the scripts that modify the configuration so that they explicitly call `site_configuration_has_changed` just before committing.

The goal is to use this within the circulation manager to detect when site configuration has changed and automatically reload the `CirculationManager` configuration.