### PR TITLE
No new database sessions

### DIFF
--- a/config.py
+++ b/config.py
@@ -334,6 +334,10 @@ class Configuration(object):
             and last_check and (now - last_check).total_seconds() < timeout):
             # We went to the database less than [timeout] seconds ago.
             # Assume there has been no change.
+            logging.error("Assuming that %s is still valid.", cls._site_configuration_last_update())
+            logging.error("Known value: %s", known_value)
+            logging.error("Last check: %.2f sec ago.", (now-last_check).total_seconds())
+            logging.error("Timeout: %s", timeout)
             return cls._site_configuration_last_update()
         
         # Ask the database when was the last time the site
@@ -345,13 +349,14 @@ class Configuration(object):
             known_value = Timestamp.value(
                 _db, cls.SITE_CONFIGURATION_CHANGED, None
             )
-            print "Retrieved known value %s from database."
+            logging.error("Retrieved known value %s from database.", known_value)
         if not known_value:
             # The site configuration has never changed.
             last_update = None
         else:
             last_update = known_value
 
+        logging.error("Updating Configuration last update time to %s", last_update)
         # Update the Configuration object's record of the last update time.
         cls.instance[cls.SITE_CONFIGURATION_LAST_UPDATE] = last_update
         

--- a/config.py
+++ b/config.py
@@ -345,6 +345,7 @@ class Configuration(object):
             known_value = Timestamp.value(
                 _db, cls.SITE_CONFIGURATION_CHANGED, None
             )
+            print "Retrieved known value %s from database."
         if not known_value:
             # The site configuration has never changed.
             last_update = None

--- a/model.py
+++ b/model.py
@@ -79,7 +79,6 @@ from sqlalchemy.sql.expression import (
 )
 from sqlalchemy.exc import (
     IntegrityError,
-    InvalidRequestError,
 )
 from sqlalchemy import (
     create_engine,
@@ -332,7 +331,7 @@ class SessionManager(object):
                 session, content_type, drm_scheme
             )
             mechanism.default_client_can_fulfill = True
-
+        site_configuration_has_changed(session)
         session.commit()
 
 def get_one(db, model, on_multiple='error', constraint=None, **kwargs):
@@ -397,11 +396,7 @@ def create(db, model, create_method='',
     kwargs.update(create_method_kwargs or {})
     created = getattr(model, create_method, model)(**kwargs)
     db.add(created)
-    try:
-        db.flush()
-    except InvalidRequestError, e:
-        if e.message != 'Session is already flushing':
-            raise e
+    db.flush()
     return created, True
 
 Base = declarative_base()

--- a/model.py
+++ b/model.py
@@ -9976,12 +9976,14 @@ def site_configuration_has_changed(_db, timeout=1):
         # Update the timestamp.
         now = datetime.datetime.utcnow()
         sql = "UPDATE timestamps SET timestamp=:timestamp WHERE service=:service AND collection_id IS NULL;"
+        print "Updated timestamp to %s" % now
         _db.execute(
             text(sql),
             dict(service=Configuration.SITE_CONFIGURATION_CHANGED,
                  timestamp=now)
         )
-
+        sql = "SELECT timestamp from timestamps WHERE service=:service AND collection_id IS NULL;"
+        
         # Update the Configuration's record of when the configuration
         # was updated. This will update our local record immediately
         # without requiring a trip to the database.

--- a/model.py
+++ b/model.py
@@ -78,7 +78,8 @@ from sqlalchemy.sql.expression import (
     table,
 )
 from sqlalchemy.exc import (
-    IntegrityError
+    IntegrityError,
+    InvalidRequestError,
 )
 from sqlalchemy import (
     create_engine,
@@ -396,7 +397,11 @@ def create(db, model, create_method='',
     kwargs.update(create_method_kwargs or {})
     created = getattr(model, create_method, model)(**kwargs)
     db.add(created)
-    db.flush()
+    try:
+        db.flush()
+    except InvalidRequestError, e:
+        if e.message != 'Session is already flushing':
+            raise e
     return created, True
 
 Base = declarative_base()

--- a/model.py
+++ b/model.py
@@ -78,7 +78,7 @@ from sqlalchemy.sql.expression import (
     table,
 )
 from sqlalchemy.exc import (
-    IntegrityError,
+    IntegrityError
 )
 from sqlalchemy import (
     create_engine,

--- a/model.py
+++ b/model.py
@@ -7301,9 +7301,7 @@ class Timestamp(Base):
         """
         stamp = get_one(_db, Timestamp, service=service, collection=collection)
         if not stamp:
-            logging.error("No timestamp value for %s", service)
             return None
-        logging.error("Timestamp value for %s: %s", service, stamp.timestamp)
         return stamp.timestamp
     
     @classmethod
@@ -9978,18 +9976,15 @@ def site_configuration_has_changed(_db, timeout=1):
         # Update the timestamp.
         now = datetime.datetime.utcnow()
         sql = "UPDATE timestamps SET timestamp=:timestamp WHERE service=:service AND collection_id IS NULL;"
-        logging.error("Updated timestamp to %s", now)
         _db.execute(
             text(sql),
             dict(service=Configuration.SITE_CONFIGURATION_CHANGED,
                  timestamp=now)
         )
-        sql = "SELECT timestamp from timestamps WHERE service=:service AND collection_id IS NULL;"
         
         # Update the Configuration's record of when the configuration
         # was updated. This will update our local record immediately
         # without requiring a trip to the database.
-        logging.error("Calling site_configuration_last_update with %s", now)
         Configuration.site_configuration_last_update(
             _db, known_value=now
         )

--- a/model.py
+++ b/model.py
@@ -9972,7 +9972,6 @@ def site_configuration_has_changed(_db, timeout=1):
         sql = "UPDATE timestamps SET timestamp=now() at time zone 'utc' WHERE service='%s' AND collection_id IS NULL;" % (
             Configuration.SITE_CONFIGURATION_CHANGED
         )
-        print sql
         _db.execute(sql)
 
         # Update the Configuration's record of when the configuration

--- a/model.py
+++ b/model.py
@@ -7301,7 +7301,9 @@ class Timestamp(Base):
         """
         stamp = get_one(_db, Timestamp, service=service, collection=collection)
         if not stamp:
+            logging.error("No timestamp value for %s", service)
             return None
+        logging.error("Timestamp value for %s: %s", service, stamp.timestamp)
         return stamp.timestamp
     
     @classmethod
@@ -9976,7 +9978,7 @@ def site_configuration_has_changed(_db, timeout=1):
         # Update the timestamp.
         now = datetime.datetime.utcnow()
         sql = "UPDATE timestamps SET timestamp=:timestamp WHERE service=:service AND collection_id IS NULL;"
-        print "Updated timestamp to %s" % now
+        logging.error("Updated timestamp to %s", now)
         _db.execute(
             text(sql),
             dict(service=Configuration.SITE_CONFIGURATION_CHANGED,
@@ -9987,6 +9989,7 @@ def site_configuration_has_changed(_db, timeout=1):
         # Update the Configuration's record of when the configuration
         # was updated. This will update our local record immediately
         # without requiring a trip to the database.
+        logging.error("Calling site_configuration_last_update with %s", now)
         Configuration.site_configuration_last_update(
             _db, known_value=now
         )

--- a/model.py
+++ b/model.py
@@ -9949,12 +9949,11 @@ def site_configuration_has_changed(_db, timeout=1):
     of what you consider "site configuration", just to be safe.
 
     :param _db: Either a Session or (to save time in a common case) an
-    object that can be associated with or turned into a Session.
+    ORM object that can turned into a Session.
 
     :param timeout: Nothing will happen if it's been fewer than this
     number of seconds since the last site configuration change was
     recorded.
-
     """
     now = datetime.datetime.utcnow()
     last_update = Configuration._site_configuration_last_update()
@@ -9962,7 +9961,7 @@ def site_configuration_has_changed(_db, timeout=1):
         # The configuration last changed more than `timeout` ago, which
         # means it's time to reset the Timestamp that says when the
         # configuration last changed.
-        needs_commit = False
+
         # Convert something that might not be a Connection object into
         # a Connection object.
         if isinstance(_db, Base):

--- a/model.py
+++ b/model.py
@@ -9967,10 +9967,7 @@ def site_configuration_has_changed(_db, timeout=1):
         # a Connection object.
         if isinstance(_db, Base):
             _db = Session.object_session(_db)
-        elif isinstance(_db, Connection):
-            _db = Session(_db)
-            needs_commit = True
-            
+
         # Update the timestamp.
         timestamp = Timestamp.stamp(
             _db, Configuration.SITE_CONFIGURATION_CHANGED, collection=None
@@ -9982,10 +9979,6 @@ def site_configuration_has_changed(_db, timeout=1):
         Configuration.site_configuration_last_update(
             _db, known_value=timestamp.timestamp
         )
-
-        if needs_commit:
-            # We had to create a new database session. Commit it now.
-            _db.commit()
 
             
 # Most of the time, we can know whether a change to the database is
@@ -10007,7 +10000,7 @@ def site_configuration_has_changed(_db, timeout=1):
 @event.listens_for(Library.integrations, 'remove')
 @event.listens_for(Library.settings, 'append')
 @event.listens_for(Library.settings, 'remove')
-def configuration_relevant_collection_change(target, value,  initiator):
+def configuration_relevant_collection_change(target, value, initiator):
     site_configuration_has_changed(target)
 
 @event.listens_for(Library, 'after_insert')
@@ -10023,4 +10016,4 @@ def configuration_relevant_collection_change(target, value,  initiator):
 @event.listens_for(ConfigurationSetting, 'after_delete')
 @event.listens_for(ConfigurationSetting, 'after_update')
 def configuration_relevant_lifecycle_event(mapper, connection, target):
-    site_configuration_has_changed(connection)
+    site_configuration_has_changed(target)

--- a/model.py
+++ b/model.py
@@ -9969,15 +9969,20 @@ def site_configuration_has_changed(_db, timeout=1):
             _db = Session.object_session(_db)
 
         # Update the timestamp.
-        timestamp = Timestamp.stamp(
-            _db, Configuration.SITE_CONFIGURATION_CHANGED, collection=None
+        sql = "UPDATE timestamps SET timestamp=now() at time zone 'utc' WHERE service='%s' AND collection_id IS NULL;" % (
+            Configuration.SITE_CONFIGURATION_CHANGED
         )
+        print sql
+        _db.execute(sql)
 
         # Update the Configuration's record of when the configuration
         # was updated. This will update our local record immediately
-        # without requiring a trip to the database.
+        # without requiring a trip to the database. This time won't be
+        # exactly the same as the time in the database, but they'll be close
+        # enough.
+        now = datetime.datetime.utcnow()
         Configuration.site_configuration_last_update(
-            _db, known_value=timestamp.timestamp
+            _db, known_value=now
         )
 
             

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -197,17 +197,18 @@ class TestBaseCoverageProvider(CoverageProviderTest):
             def run_once(self, offset, count_as_covered=None):
                 self.run_once_calls.append(count_as_covered)
             
-        # We start with no timestamps.
-        eq_([], self._db.query(Timestamp).all())
+        # We start with no timestamp value.
+        service_name = "I do nothing"
+        eq_(None, Timestamp.value(self._db, service_name, collection=None))
         
         # Instantiate the Provider, and call
         # run_once_and_update_timestamp.
         provider = MockProvider(self._db)
         provider.run_once_and_update_timestamp()
 
-        # The timestamp is now set.
-        [timestamp] = self._db.query(Timestamp).all()
-        eq_("I do nothing", timestamp.service)
+        # The timestamp is now set to a recent value.
+        value = Timestamp.value(self._db, service_name, collection=None)
+        assert (datetime.datetime.utcnow() - value).total_seconds() < 1
 
         # run_once was called twice: once to exclude items that have
         # any coverage record whatsoever (ALL_STATUSES), and again to
@@ -496,7 +497,9 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
 
         # The coverage provider's timestamp was not updated, because
         # we're using ensure_coverage on a single record.
-        eq_([], self._db.query(Timestamp).all())
+        eq_(None,
+            Timestamp.value(self._db, provider.service_name, collection=None)
+        )
 
     def test_ensure_coverage_works_on_edition(self):
         """Verify that ensure_coverage() works on an Edition by covering
@@ -551,7 +554,11 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
 
         # The coverage provider's timestamp was not updated, because
         # we're using ensure_coverage.
-        eq_([], self._db.query(Timestamp).all())
+        # The coverage provider's timestamp was not updated, because
+        # we're using ensure_coverage on a single record.
+        eq_(None,
+            Timestamp.value(self._db, provider.service_name, collection=None)
+        )
 
     def test_ensure_coverage_transient_coverage_failure(self):
 
@@ -562,7 +569,9 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
         eq_("Oops!", failure.exception)
 
         # Timestamp was not updated.
-        eq_([], self._db.query(Timestamp).all())
+        eq_(None,
+            Timestamp.value(self._db, provider.service_name, collection=None)
+        )
         
     def test_ensure_coverage_changes_status(self):
         """Verify that processing an item that has a preexisting 
@@ -753,12 +762,15 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
         """Verify that NeverSuccessfulCoverageProvider works the
         way we'd expect.
         """
+
+        provider = NeverSuccessfulCoverageProvider(self._db)
         
         # We start with no CoverageRecords and no Timestamp.
         eq_([], self._db.query(CoverageRecord).all())
-        eq_([], self._db.query(Timestamp).all())
+        eq_(None,
+            Timestamp.value(self._db, provider.service_name, collection=None)
+        )
 
-        provider = NeverSuccessfulCoverageProvider(self._db)
         provider.run()
 
         # We have a CoverageRecord that signifies failure.
@@ -767,9 +779,10 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
         eq_(record.data_source, provider.data_source)
         eq_("What did you expect?", record.exception)
 
-        # But the coverage provider did run, and the timestamp is now set.
-        [timestamp] = self._db.query(Timestamp).all()
-        eq_("Never successful", timestamp.service)
+        # But the coverage provider did run, and the timestamp is now set to
+        # a recent value.
+        value = Timestamp.value(self._db, provider.service_name, collection=None)
+        assert (datetime.datetime.utcnow() - value).total_seconds() < 1
 
     def test_run_transient_failure(self):
         """Verify that TransientFailureCoverageProvider works the
@@ -1343,10 +1356,10 @@ class TestWorkCoverageProvider(DatabaseTest):
                      x.operation==provider.operation]
         eq_(CoverageRecord.TRANSIENT_FAILURE, failure.status)
 
-        # The timestamp is now set.
-        [timestamp] = self._db.query(Timestamp).all()
-        eq_("Never successful (transient, works) (the_operation)",
-            timestamp.service)
+        # The timestamp is now set to a recent value.
+        service_name = "Never successful (transient, works) (the_operation)"
+        value = Timestamp.value(self._db, service_name, collection=None)
+        assert (datetime.datetime.now()-value).total_seconds() < 2
 
     def test_persistent_failure(self):
         class MockProvider(NeverSuccessfulWorkCoverageProvider):
@@ -1366,9 +1379,10 @@ class TestWorkCoverageProvider(DatabaseTest):
         eq_(self.work, record.work)
         eq_("What did you expect?", record.exception)
 
-        # The timestamp is now set.
-        [timestamp] = self._db.query(Timestamp).all()
-        eq_("Never successful (works) (the_operation)", timestamp.service)
+        # The timestamp is now set to a recent value.
+        service_name = "Never successful (works) (the_operation)"
+        value = Timestamp.value(self._db, service_name, collection=None)
+        assert (datetime.datetime.now()-value).total_seconds() < 2
 
     def test_items_that_need_coverage(self):
         # Here's a WorkCoverageProvider.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5883,15 +5883,21 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         eq_(timestamp_value, last_update)
         
         # Now let's call site_configuration_has_changed().
-        now = datetime.datetime.utcnow()
+        time_of_update = datetime.datetime.utcnow()
         site_configuration_has_changed(self._db)
+
+        # The Timestamp has changed in the database.
+        new_timestamp_value = Timestamp.value(
+            self._db, Configuration.SITE_CONFIGURATION_CHANGED, None
+        )
+        assert new_timestamp_value > timestamp_value
         
-        # The last update value has been updated.
-        last_update_2 = Configuration.site_configuration_last_update(
+        # The locally-stored last update value has been updated.
+        new_last_update_time = Configuration.site_configuration_last_update(
             self._db, timeout=0
         )
-        assert last_update_2 > last_update
-        assert abs((last_update_2 - now).total_seconds()) < 1
+        assert new_last_update_time > last_update
+        assert (new_last_update_time - time_of_update).total_seconds() < 1
                 
         # Let's be sneaky and update the timestamp directly,
         # without calling site_configuration_has_changed(). This

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5884,14 +5884,12 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         
         # Now let's call site_configuration_has_changed().
         time_of_update = datetime.datetime.utcnow()
-        site_configuration_has_changed(self._db)
-        logging.error("I WOULD NOW EXPECT TIMESTAMP TO BE DIFFERENT")
+        site_configuration_has_changed(self._db, timeout=0)
         
         # The Timestamp has changed in the database.
         new_timestamp_value = Timestamp.value(
             self._db, Configuration.SITE_CONFIGURATION_CHANGED, None
         )
-        logging.error("ACTUAL NEW TIMESTAMP VALUE: %s")
         assert new_timestamp_value > timestamp_value
         
         # The locally-stored last update value has been updated.
@@ -5909,12 +5907,13 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         timestamp = Timestamp.stamp(
             self._db, Configuration.SITE_CONFIGURATION_CHANGED, None
         )
-        new_last_update = timestamp.timestamp
+        last_update_after_sneaky_change = timestamp.timestamp
 
         # Calling Configuration.check_for_site_configuration_update
         # doesn't detect the change because by default we only go to
         # the database once a minute.
-        eq_(last_update, Configuration.site_configuration_last_update(self._db))
+        eq_(new_last_update_time,
+            Configuration.site_configuration_last_update(self._db))
 
         # Passing in a different timeout value forces the method to go
         # to the database and find the correct answer.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5877,11 +5877,10 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         last_update = Configuration.site_configuration_last_update(self._db)
         assert (datetime.datetime.now()-last_update).total_seconds() < 1
         
-        # That value came from a Timestamp.
         timestamp_value = Timestamp.value(
             self._db, Configuration.SITE_CONFIGURATION_CHANGED, None
         )
-        eq_(last_update, timestamp_value)
+        eq_(timestamp_value, last_update)
         
         # Now let's call site_configuration_has_changed().
         now = datetime.datetime.utcnow()
@@ -5892,7 +5891,7 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
             self._db, timeout=0
         )
         assert last_update_2 > last_update
-        assert abs((last_update2 - now).total_seconds()) < 1
+        assert abs((last_update_2 - now).total_seconds()) < 1
                 
         # Let's be sneaky and update the timestamp directly,
         # without calling site_configuration_has_changed(). This

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5885,11 +5885,13 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         # Now let's call site_configuration_has_changed().
         time_of_update = datetime.datetime.utcnow()
         site_configuration_has_changed(self._db)
-
+        logging.error("I WOULD NOW EXPECT TIMESTAMP TO BE DIFFERENT")
+        
         # The Timestamp has changed in the database.
         new_timestamp_value = Timestamp.value(
             self._db, Configuration.SITE_CONFIGURATION_CHANGED, None
         )
+        logging.error("ACTUAL NEW TIMESTAMP VALUE: %s")
         assert new_timestamp_value > timestamp_value
         
         # The locally-stored last update value has been updated.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5873,9 +5873,8 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         """
         # The database configuration timestamp is initialized as part
         # of the default data. In that case, it happened during the
-        # setup() method.
+        # package_setup() for this test run.
         last_update = Configuration.site_configuration_last_update(self._db)
-        assert (datetime.datetime.now()-last_update).total_seconds() < 1
         
         timestamp_value = Timestamp.value(
             self._db, Configuration.SITE_CONFIGURATION_CHANGED, None

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -795,8 +795,7 @@ class TestDatabaseMigrationInitializationScript(DatabaseTest):
         eq_(self.timestamp.timestamp.strftime('%Y%m%d'), last_migration_date)
 
     def test_accurate_timestamp_created(self):
-        timestamps = self._db.query(Timestamp).all()
-        eq_(timestamps, [])
+        eq_(None, Timestamp.value(self._db, self.script.name, collection=None))
 
         self.script.do_run()
         self.assert_matches_latest_migration()


### PR DESCRIPTION
This branch fixes a couple problems I found when using the code that checks for changes to ConfigurationSettings.

First, the code that passed in a database connection (instead of a session) to site_configuration_has_changed was a bad idea. In an environment with a scoped session (like our  applications) you can't go creating new, non-scoped sessions on the same connection. Fortunately, it was easy to change `configuration_relevant_lifecycle_event` to pass in the target object instead. I didn't do this initially because I didn't really notice that that function took `target` as an argument.

Once that's fixed, there's another problem. The very first time `configuration_relevant_lifecycle_event` is ever called, it calls `create` to create the `Timestamp` that stores the last update time. `create` calls `flush`, but `configuration_relevant_lifecycle_event` is called when we're already in the middle of a flush, which raises the exception.

Ignoring the "you're already in the middle of a flush" exception seems to work, but I also noticed that the SQLAlchemy docs (http://docs.sqlalchemy.org/en/latest/orm/session_events.html#session-persistence-mapper) put restrictions on the things you can do from within a mapper-level event such as `before_insert`. In particular, you're not supposed to call `Session.add()`, which is what `create` does immediately before calling the `flush()` that causes us the problem.

I briefly tried using validators instead (http://docs.sqlalchemy.org/en/latest/orm/mapped_attributes.html#simple-validators), but validators seem to fall down even earlier: when you try to make a database query inside them.

I'm not sure what the solution is -- maybe making sure the last update time is present in the database immediately upon startup, so that we can guarantee  `configuration_relevant_lifecycle_event` never needs to call create().