### PR TITLE
Support content in multi-tenant

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,7 +8,6 @@ import copy
 from util import LanguageCodes
 from flask.ext.babel import lazy_gettext as _
 
-from s3 import S3Uploader
 from facets import FacetConstants
 
 class CannotLoadConfiguration(Exception):

--- a/config.py
+++ b/config.py
@@ -85,7 +85,7 @@ class Configuration(object):
     OVERDRIVE_INTEGRATION = "Overdrive"
     THREEM_INTEGRATION = "3M"
 
-    # ConfigurationSEtting key for a CDN's mirror domain
+    # ConfigurationSetting key for a CDN's mirror domain
     CDN_MIRRORED_DOMAIN_KEY = u'mirrored_domain'
 
     UNINITIALIZED_CDNS = object()
@@ -384,9 +384,12 @@ class Configuration(object):
             )
         cls.instance = configuration
 
-        if _db:               
+        if _db:
             cls.load_cdns(_db)
             cls.instance[cls.LOADED_FROM_DATABASE] = True
+            for parent in cls.__bases__:
+                if parent.__name__.endswith('Configuration'):
+                    parent.load(_db)
         else:
             if not cls.integration('CDN'):
                 cls.instance[cls.INTEGRATIONS]['CDN'] = cls.UNINITIALIZED_CDNS

--- a/migration/20170616-1-move-third-party-config-to-external-integrations.py
+++ b/migration/20170616-1-move-third-party-config-to-external-integrations.py
@@ -15,8 +15,6 @@ from config import Configuration
 from external_search import ExternalSearchIndex
 from model import (
     ExternalIntegration as EI,
-    Library,
-    get_one_or_create,
     production_session,
 )
 
@@ -30,7 +28,6 @@ def log_import(integration_or_setting):
 try:
     Configuration.load()
     _db = production_session()
-    LIBRARIES = _db.query(Library).all()
 
     # Import CDN configuration.
     cdn_conf = Configuration.integration(u'CDN')

--- a/migration/20170616-1-move-third-party-config-to-external-integrations.py
+++ b/migration/20170616-1-move-third-party-config-to-external-integrations.py
@@ -77,7 +77,6 @@ try:
         S3_SETTINGS = [
             S3Uploader.BOOK_COVERS_BUCKET_KEY,
             S3Uploader.OA_CONTENT_BUCKET_KEY,
-            S3Uploader.STATIC_OPDS_FEED_BUCKET_KEY,
         ]
         for k, v in s3_conf.items():
             if not k in S3_SETTINGS:

--- a/model.py
+++ b/model.py
@@ -9599,6 +9599,7 @@ class Collection(Base):
 
     @classmethod
     def by_datasource(cls, _db, data_source):
+        """Query collections that are associated with the given DataSource."""
         if isinstance(data_source, DataSource):
             data_source = data_source.name
 

--- a/model.py
+++ b/model.py
@@ -9544,6 +9544,18 @@ class Collection(Base):
             ).filter(ExternalIntegration.protocol==protocol)
         return qu
 
+    @classmethod
+    def by_datasource(cls, _db, data_source):
+        if isinstance(data_source, DataSource):
+            data_source = data_source.name
+
+        qu = _db.query(cls).join(ExternalIntegration,
+                cls.external_integration_id==ExternalIntegration.id)\
+            .join(ExternalIntegration.settings)\
+            .filter(ConfigurationSetting.key==Collection.DATA_SOURCE_NAME_SETTING)\
+            .filter(ConfigurationSetting.value==data_source)
+        return qu
+
     @hybrid_property
     def protocol(self):
         """What protocol do we need to use to get licenses for this 

--- a/model.py
+++ b/model.py
@@ -9038,12 +9038,16 @@ class ExternalIntegration(Base):
     AXIS_360 = DataSource.AXIS_360
     ONE_CLICK = DataSource.ONECLICK
 
-    # These protocols are only used on the Content Server.
+    # These protocols are only used on the Content Server when mirroring
+    # content from a given directory or directly from Project
+    # Gutenberg, respectively. These protocols aren't intended for use
+    # with LicensePools on the Circulation Manager.
+    DIRECTORY_IMPORT = u'Directory Import'
     GUTENBERG = DataSource.GUTENBERG
 
     LICENSE_PROTOCOLS = [
         OPDS_IMPORT, OVERDRIVE, BIBLIOTHECA, AXIS_360, ONE_CLICK,
-        GUTENBERG,
+        DIRECTORY_IMPORT, GUTENBERG,
     ]
 
     # Some integrations with LICENSE_GOAL imply that the data and

--- a/model.py
+++ b/model.py
@@ -9032,8 +9032,12 @@ class ExternalIntegration(Base):
     AXIS_360 = DataSource.AXIS_360
     ONE_CLICK = DataSource.ONECLICK
 
+    # These protocols are only used on the Content Server.
+    GUTENBERG = DataSource.GUTENBERG
+
     LICENSE_PROTOCOLS = [
-        OPDS_IMPORT, OVERDRIVE, BIBLIOTHECA, AXIS_360, ONE_CLICK
+        OPDS_IMPORT, OVERDRIVE, BIBLIOTHECA, AXIS_360, ONE_CLICK,
+        GUTENBERG,
     ]
 
     # Some integrations with LICENSE_GOAL imply that the data and

--- a/opds_import.py
+++ b/opds_import.py
@@ -1519,10 +1519,10 @@ class OPDSImportMonitor(CollectionMonitor):
 class OPDSImporterWithS3Mirror(OPDSImporter):
     """OPDS Importer that mirrors content to S3."""
 
-    def __init__(self, _db, default_data_source, **kwargs):
+    def __init__(self, _db, collection, **kwargs):
         kwargs = dict(kwargs)
         if 'mirror' not in kwargs:
             kwargs['mirror'] = S3Uploader.from_config(_db)
         super(OPDSImporterWithS3Mirror, self).__init__(
-            _db, default_data_source, **kwargs
+            _db, collection, **kwargs
         )

--- a/s3.py
+++ b/s3.py
@@ -1,12 +1,13 @@
-import tinys3
+import logging
 import os
+import tinys3
 import urllib
 from nose.tools import set_trace
 from sqlalchemy.orm.session import Session
 from urlparse import urlsplit
 from util.mirror import MirrorUploader
 
-import logging
+from config import CannotLoadConfiguration
 from requests.exceptions import (
     ConnectionError,
     HTTPError,
@@ -17,7 +18,6 @@ class S3Uploader(MirrorUploader):
 
     BOOK_COVERS_BUCKET_KEY = u'book_covers_bucket'
     OA_CONTENT_BUCKET_KEY = u'open_access_content_bucket'
-    STATIC_OPDS_FEED_BUCKET_KEY = u'static_feed_bucket'
 
     S3_HOSTNAME = "s3.amazonaws.com"
     S3_BASE = "http://%s/" % S3_HOSTNAME
@@ -92,7 +92,7 @@ class S3Uploader(MirrorUploader):
 
     @classmethod
     def get_bucket(cls, bucket_key, sessioned_object=None):
-        from config import CannotLoadConfiguration
+        """Gets the bucket for a particular use based on the given key"""
         if cls.__buckets__ == cls.UNINITIALIZED_BUCKETS:
             if not sessioned_object:
                 raise CannotLoadConfiguration(

--- a/scripts.py
+++ b/scripts.py
@@ -1542,11 +1542,14 @@ class OPDSImportScript(CollectionInputScript):
     def do_run(self, cmd_args=None):
         parsed = self.parse_command_line(self._db, cmd_args=cmd_args)
         for collection in parsed.collections:
-            monitor = self.MONITOR_CLASS(
-                self._db, collection, import_class=self.IMPORTER_CLASS,
-                force_reimport=parsed.force
-            )
-            monitor.run()
+            self.run_monitor(collection, force=parsed.force)
+
+    def run_monitor(self, collection, force=None):
+        monitor = self.MONITOR_CLASS(
+            self._db, collection, import_class=self.IMPORTER_CLASS,
+            force_reimport=force
+        )
+        monitor.run()
 
 
 class RefreshMaterializedViewsScript(Script):

--- a/testing.py
+++ b/testing.py
@@ -723,7 +723,7 @@ class DatabaseTest(object):
     
     def _collection(self, name=None, protocol=ExternalIntegration.OPDS_IMPORT,
                     external_account_id=None, url=None, username=None,
-                    password=None):
+                    password=None, data_source_name=None):
         name = name or self._str
         collection, ignore = get_one_or_create(
             self._db, Collection, name=name
@@ -733,6 +733,11 @@ class DatabaseTest(object):
         integration.url = url
         integration.username = username
         integration.password = password
+
+        if data_source_name:
+            integration.set_setting(
+                Collection.DATA_SOURCE_NAME_SETTING, data_source_name
+            )
         return collection
         
     @property

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6009,6 +6009,20 @@ class TestCollection(DatabaseTest):
         eq_(set([self.collection, c1, c2]),
             set(Collection.by_protocol(self._db, None).all()))
 
+    def test_by_datasource(self):
+        """Collections can be found by their associated DataSource"""
+        c1 = self._collection(data_source_name=DataSource.GUTENBERG)
+        c2 = self._collection(data_source_name=DataSource.OVERDRIVE)
+
+        # Using the DataSource name
+        eq_(set([c1]),
+            set(Collection.by_datasource(self._db, DataSource.GUTENBERG).all()))
+
+        # Using the DataSource itself
+        overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
+        eq_(set([c2]),
+            set(Collection.by_datasource(self._db, overdrive).all()))
+
     def test_create_external_integration(self):
         # A newly created Collection has no associated ExternalIntegration.
         collection, ignore = get_one_or_create(

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -99,7 +99,7 @@ class TestS3URLGeneration(DatabaseTest):
         # an error ir raised.
         assert_raises_regexp(
             CannotLoadConfiguration, 'No S3 bucket found', S3Uploader.get_bucket,
-            S3Uploader.STATIC_OPDS_FEED_BUCKET_KEY
+            'nonexistent_bucket_key'
         )
 
     def test_content_root(self):


### PR DESCRIPTION
A couple changes to support bringing the content server over to multi-tenancy, including:

- Loading Configuration from the database for both the current Configuration class and any of its parent Configuration classes (otherwise errors occur in core/opds.py)
- Adding Gutenberg as a LICENSE_GOAL protocol
- Removing the 'static_feed_bucket' from S3 (Since it's only used in a couple configurable scripts on the content server, this'll be fine.)
- Slightly altering the `OPDSImportScript` for a new subclass