### PR TITLE
Remove default license-offering from INTERNAL_PROCESSING DataSource

### DIFF
--- a/migration/20170626-no-internal-processing-licenses-by-default.sql
+++ b/migration/20170626-no-internal-processing-licenses-by-default.sql
@@ -1,0 +1,3 @@
+update datasources
+set offers_licenses = 'f'
+where name = 'Library Simplified Internal Process';

--- a/model.py
+++ b/model.py
@@ -1004,7 +1004,7 @@ class DataSource(Base):
                 (cls.OA_CONTENT_SERVER, True, False, None, None),
                 (cls.NOVELIST, False, True, Identifier.NOVELIST_ID, None),
                 (cls.PRESENTATION_EDITION, False, False, None, None),
-                (cls.INTERNAL_PROCESSING, True, False, None, None),
+                (cls.INTERNAL_PROCESSING, False, False, None, None),
                 (cls.FEEDBOOKS, True, False, Identifier.URI, None),
                 (cls.BIBBLIO, False, True, Identifier.BIBBLIO_CONTENT_ITEM_ID, None)
         ):


### PR DESCRIPTION
I noticed that the INTERNAL_PROCESSING DataSource was set to offer licenses by default when it shouldn't be. Only the Metadata Wrangler currently needs this DataSource to offer up (fake) licenses.