### PR TITLE
Default library, not one library

### DIFF
--- a/migration/20170627-add-default-to-library.sql
+++ b/migration/20170627-add-default-to-library.sql
@@ -1,0 +1,8 @@
+-- Add library_id as a foreign key
+alter table libraries add column is_default boolean default false;
+
+create index "ix_libraries_default" on libraries (is_default);
+
+-- The first library in the system is set as the default.
+update libraries set is_default = False;
+update libraries set is_default = True where id in (select min(id) from libraries);

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5523,6 +5523,45 @@ class TestLibrary(DatabaseTest):
         # recommended, but it's not an error.
         library.library_registry_short_name = None
 
+    def test_default(self):
+        # We start off with no libraries.
+        eq_(None, Library.default(self._db))
+
+        # Let's make a couple libraries.
+        l1 = self._default_library
+        l2 = self._library()
+
+        # None of them are the default according to the database.
+        eq_(False, l1.is_default)
+        eq_(False, l2.is_default)
+
+        # If we call Library.default, the library with the lowest database
+        # ID is made the default.
+        eq_(l1, Library.default(self._db))
+        eq_(True, l1.is_default)
+        eq_(False, l2.is_default)
+
+        # We can set is_default to change the default library.
+        l2.is_default = True
+        eq_(False, l1.is_default)
+        eq_(True, l2.is_default)
+
+        # If ever there are multiple default libraries, calling default()
+        # will set the one with the lowest database ID to the default.
+        l1._is_default = True
+        l2._is_default = True
+        eq_(l1, Library.default(self._db))
+        eq_(True, l1.is_default)
+        eq_(False, l2.is_default)
+
+        def assign_false():
+            l1.is_default = False
+        assert_raises_regexp(
+            ValueError,
+            "You cannot stop a library from being the default library; you must designate a different library as the default.",
+            assign_false
+        )
+        
     def test_explain(self):
         """Test that Library.explain gives all relevant information
         about a Library.


### PR DESCRIPTION
This branch removes `Library.instance` and replaces it with the concept of the default library. One and only one library is supposed to be the default. This is stored in the new `libraries.is_default` field. I use a setter to make sure that if there are any libraries, one of them is always the default. If there should ever be more than one default library (e.g. due to a race condition), a winner is chosen.

I think we are almost never going to use the default library concept in a multi-library setting, which is why I'm okay with automatically detecting and correcting situations where the number of default libraries != 1.