### PR TITLE
Where are my books?

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -2268,7 +2268,7 @@ class FixInvisibleWorksScript(Script):
                 "Attempting to make %d works presentation-ready based on their metadata.\n" % (unready_count)
             )
             for work in unready:
-                work.set_presentation_ready_based_on_content(search)
+                work.set_presentation_ready_based_on_content(self.search)
             self.output.write(
                 "%d works are now presentation-ready.\n" % ready.count()
             )

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1633,7 +1633,7 @@ class TestFixInvisibleWorksScript(DatabaseTest):
         output = StringIO()
         search = DummyExternalSearchIndex()
 
-        FixInvisibleWorksScript(self._db, output).run()
+        FixInvisibleWorksScript(self._db, output, search=search).run()
         eq_("""0 presentation-ready works.
 0 works not presentation-ready.
 Here's your problem: there are no presentation-ready works.
@@ -1647,7 +1647,7 @@ Here's your problem: there are no presentation-ready works.
         # LicensePools, and will not show up in the materialized view.
         work = self._work(with_license_pool=False)
         work.presentation_ready=True
-        FixInvisibleWorksScript(self._db, output).run()
+        FixInvisibleWorksScript(self._db, output, search=search).run()
         eq_("""1 presentation-ready works.
 0 works not presentation-ready.
 0 works in materialized view.
@@ -1674,7 +1674,7 @@ Here's your problem: your presentation-ready works are not making it into the ma
         feed = create(self._db, CachedFeed, type=CachedFeed.PAGE_TYPE,
                       pagination="")
         
-        FixInvisibleWorksScript(self._db, output).run()
+        FixInvisibleWorksScript(self._db, output, search=search).run()
         eq_("""0 presentation-ready works.
 1 works not presentation-ready.
 Attempting to make 1 works presentation-ready based on their metadata.


### PR DESCRIPTION
This branch fixes https://github.com/NYPL-Simplified/server_core/issues/553. It creates a script that automatically solves these issues, all of which result in someone not seeing in the app server books that they imported:

* Your works are not marked presentation-ready even though they totally are. (This happened due to a misconfigured search index.)
* You added works to your database but didn't refresh the materialized views.
* You refreshed the materialized views but old `CachedFeed` objects are preventing you from seeing the new feeds.

It diagnoses, but does not solve, these issues:

* You have no presentation-ready works.
* Your works are presentation-ready but don't show up in the materialized view because there's something else wrong with them (like no LicensePools).

This might be a branch that could be merged into master instead of multi-tenant.