### PR TITLE
Changed lane to include the parent collection when a library is associated with a child collection.

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -550,6 +550,8 @@ class Lane(object):
         self.library_id = library.id
         self.collection_ids = [
             collection.id for collection in library.collections
+        ] + [
+            collection.parent_id for collection in library.collections if collection.parent_id
         ]
         self.default_for_language = False
         self.searchable = searchable

--- a/lane.py
+++ b/lane.py
@@ -549,9 +549,7 @@ class Lane(object):
         self._db = _db
         self.library_id = library.id
         self.collection_ids = [
-            collection.id for collection in library.collections
-        ] + [
-            collection.parent_id for collection in library.collections if collection.parent_id
+            collection.id for collection in library.all_collections
         ]
         self.default_for_language = False
         self.searchable = searchable

--- a/model.py
+++ b/model.py
@@ -8850,6 +8850,13 @@ class Library(Base):
             key, self
         )
 
+    @property
+    def all_collections(self):
+        for collection in self.collections:
+            yield collection
+            for parent in collection.parents:
+                yield parent
+
     # Some specific per-library configuration settings.
 
     # The name of the per-library regular expression used to derive a patron's
@@ -8939,7 +8946,7 @@ class Library(Base):
         :param collection_ids: Only include titles in the given
         collections.
         """
-        collection_ids = collection_ids or [x.id for x in self.collections]
+        collection_ids = collection_ids or [x.id for x in self.all_collections]
         # Only find presentation-ready works.
         #
         # Such works are automatically filtered out of 
@@ -9875,6 +9882,15 @@ class Collection(Base):
             data_source = DataSource.lookup(_db, name, autocreate=True)
         return data_source
     
+    @property
+    def parents(self):
+        if self.parent_id:
+            _db = Session.object_session(self)
+            parent = get_one(_db, Collection, id=self.parent_id)
+            yield parent
+            for collection in parent.parents:
+                yield collection
+
     @property
     def metadata_identifier(self):
         """Identifier based on collection details that uniquely represents

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5557,6 +5557,16 @@ class TestLibrary(DatabaseTest):
             assign_false
         )
 
+    def test_all_collections(self):
+        library = self._default_library
+
+        parent = self._collection()
+        self._default_collection.parent_id = parent.id
+
+        eq_([self._default_collection], library.collections)
+        eq_(set([self._default_collection, parent]),
+            set(library.all_collections))
+
     def test_estimated_holdings_by_language(self):
         library = self._default_library
         
@@ -6162,6 +6172,19 @@ class TestCollection(DatabaseTest):
         overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
         eq_(set([c2]),
             set(Collection.by_datasource(self._db, overdrive).all()))
+
+    def test_parents(self):
+        # Collections can return all their parents recursively.
+        c1 = self._collection()
+        eq_([], list(c1.parents))
+
+        c2 = self._collection()
+        c2.parent_id = c1.id
+        eq_([c1], list(c2.parents))
+
+        c3 = self._collection()
+        c3.parent_id = c2.id
+        eq_([c2, c1], list(c3.parents))
 
     def test_create_external_integration(self):
         # A newly created Collection has no associated ExternalIntegration.


### PR DESCRIPTION
When I tried setting up an Overdrive Advantage collection, I expected that I would be able to add the Overdrive Advantage collection to a library and have that library's feeds also contain the books from the parent consortium collection. Without this change, I'd have to separately add the consortium collection to the library.

The downside is that now there's no way to get a feed that has the Overdrive Advantage books without the consortium's books.