### PR TITLE
Improved OPDS import collection scripts and setup from admin interface

### DIFF
--- a/opds_import.py
+++ b/opds_import.py
@@ -306,6 +306,10 @@ class OPDSImporter(object):
         {
             "key": Collection.EXTERNAL_ACCOUNT_ID_KEY,
             "label": _("URL"),
+        },
+        {
+            "key": Collection.DATA_SOURCE_NAME_SETTING,
+            "label": _("Data source name"),
         }
     ]
 

--- a/scripts.py
+++ b/scripts.py
@@ -1527,7 +1527,8 @@ class OPDSImportScript(CollectionInputScript):
     
     def do_run(self, cmd_args=None):
         parsed = self.parse_command_line(self._db, cmd_args=cmd_args)
-        for collection in parsed.collections:
+        collections = parsed.collections or Collection.by_protocol(self._db, ExternalIntegration.OPDS_IMPORT)
+        for collection in collections:
             self.run_monitor(collection, force=parsed.force)
 
     def run_monitor(self, collection, force=None):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1581,14 +1581,16 @@ class TestOPDSImportScript(DatabaseTest):
         script = MockOPDSImportScript(self._db)
         script.do_run([])
 
-        # Since we provided no collection, no MockOPDSImportMonitor
-        # was instantiated.
-        eq_([], MockOPDSImportMonitor.INSTANCES)
+        # Since we provided no collection, a MockOPDSImportMonitor
+        # was instantiated for each OPDS Import collection in the database.
+        monitor = MockOPDSImportMonitor.INSTANCES.pop()
+        eq_(self._default_collection, monitor.collection)
 
         args = ['--collection=%s' % self._default_collection.name]
         script.do_run(args)
 
-        # Now a monitor has been instantiated and run.
+        # If we provide the collection name, a MockOPDSImportMonitor is
+        # also instantiated.
         monitor = MockOPDSImportMonitor.INSTANCES.pop()
         eq_(self._default_collection, monitor.collection)
         eq_(True, monitor.was_run)


### PR DESCRIPTION
The OPDS importer requires the collection to have a data source name, but it was missing from the admin interface. I also changed the OPDS import monitor to run on all OPDS import collections if none are passed in. 