### PR TITLE
Migrations without config file

### DIFF
--- a/migration/20170713-17-move-externalintegration-columns-to-settings.sql
+++ b/migration/20170713-17-move-externalintegration-columns-to-settings.sql
@@ -37,3 +37,10 @@ UPDATE collections c
 SET external_integration_id = e.id
 FROM externalintegrations e
 WHERE e.protocol = 'OPDS Import' and c.external_integration_id is null;
+
+ALTER TABLE collections DROP COLUMN protocol;
+
+INSERT INTO configurationsettings (external_integration_id, key, value)
+SELECT eis.external_integration_id, eis.key, eis.value
+FROM externalintegrationsettings eis
+WHERE eis.value is not null;

--- a/migration/20170713-17-move-externalintegration-columns-to-settings.sql
+++ b/migration/20170713-17-move-externalintegration-columns-to-settings.sql
@@ -38,7 +38,7 @@ SET external_integration_id = e.id
 FROM externalintegrations e
 WHERE e.protocol = 'OPDS Import' and c.external_integration_id is null;
 
-ALTER TABLE collections DROP COLUMN protocol;
+ALTER TABLE collections DROP COLUMN IF EXISTS protocol;
 
 INSERT INTO configurationsettings (external_integration_id, key, value)
 SELECT eis.external_integration_id, eis.key, eis.value


### PR DESCRIPTION
This merges the `sys.exit()` changes from master. It also sweeps away some lingering columns and Collection data from 1.1.23.