### PR TITLE
If no args are provided, don't try string interpolation.

### DIFF
--- a/log.py
+++ b/log.py
@@ -18,13 +18,12 @@ class JSONFormatter(logging.Formatter):
     if len(fqdn) > len(hostname):
         hostname = fqdn
     def format(self, record):
-        try:
-            message = record.msg % record.args
-        except TypeError, e:
-            if record.args:
+        message = record.msg
+        if record.args:
+            try:
+                message = record.msg % record.args
+            except TypeError, e:
                 raise e
-            else:
-                message = record.msg
         data = dict(
             host=self.hostname,
             app="simplified",


### PR DESCRIPTION
This branch fixes a problem where `"Axis%20360%20ID" % ()` was turned into "Axis[20360 space characters]%20ID", which made logs very hard to read.

I think this problem can still happen if args are provided, but this solves the most common case.