### PR TITLE
Don't create a Library without a name

### DIFF
--- a/model.py
+++ b/model.py
@@ -8464,7 +8464,9 @@ class Library(Base):
         """Find the one and only library."""
         library, is_new = get_one_or_create(
             _db, Library, create_method_kwargs=dict(
-                uuid=str(uuid.uuid4())
+                uuid=str(uuid.uuid4()),
+                name=u'Default Library',
+                short_name=u'default',
             )
         )
         return library

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5391,6 +5391,7 @@ class TestCollection(DatabaseTest):
         """
         library = Library.instance(self._db)
         library.name = "The only library"
+        library.short_name = "only one"
         library.collections.append(self.collection)
         
         self.collection.external_account_id = "id"
@@ -5402,7 +5403,7 @@ class TestCollection(DatabaseTest):
         data = self.collection.explain()
         eq_(['Name: "test collection"',
              'Protocol: "Overdrive"',
-             'Used by library: "The only library"',
+             'Used by library: "only one"',
              'External account ID: "id"',
              'URL: "url"',
              'Username: "username"',


### PR DESCRIPTION
Alas, `Library.instance`, I knew it well.