### PR TITLE
Avoid a crash if the supposed search alias exists as an index

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -80,13 +80,30 @@ class ExternalSearchIndex(object):
         """Finds or creates the works_index and works_alias based on
         provided configuration.
         """
-        index_details = self.indices.get_alias(name=current_alias, ignore=[404])
-        found = not (index_details.get('status')==404 or 'error' in index_details)
+        try:
+            index_details = self.indices.get(current_alias)
+            found_index = True
+        except Exception, e:
+            found_index = False
 
+        if found_index:
+            # The alias exists as an index. This isn't supposed to happen,
+            # but we can avoid a meltdown now by doing nothing.
+            self.log.error(
+                'Supposed alias "%s" already exists, as an index.',
+                current_alias
+            )
+            return
+
+        # If the alias doesn't exist at all, create it.
+        alias_details = self.indices.get_alias(name=current_alias, ignore=[404])
+        found_alias = not (alias_details.get('status')==404 or 'error' in alias_details)
+        found = found_index or found_alias
+        
         def _set_works_index(name):
             self.works_index = self.__client.works_index = name
-
-        if found:
+            
+        if found_alias:
             # We found an index for the alias in configuration. Assume
             # there is only one.
             _set_works_index(index_details.keys()[0])


### PR DESCRIPTION
I'm not sure if this is the right fix for https://github.com/NYPL-Simplified/server_core/issues/579, but it works and I figure it's a good place to start.