### PR TITLE
Removed ExternalIntegration.SHORT_CLIENT_TOKEN constant.

### DIFF
--- a/model.py
+++ b/model.py
@@ -9188,7 +9188,6 @@ class ExternalIntegration(Base):
 
     # Integrations with DRM_GOAL
     ADOBE_VENDOR_ID = u'Adobe Vendor ID'
-    SHORT_CLIENT_TOKEN = u'Short Client Token'
 
     # Integrations with DISCOVERY_GOAL
     OPDS_REGISTRATION = u'OPDS Registration'


### PR DESCRIPTION
This constant is no longer needed as of https://github.com/NYPL-Simplified/circulation/pull/608.

DRM_GOAL is still used, but only by NYPL since it has an adobe vendor id integration.