### PR TITLE
Overdrive ils name

### DIFF
--- a/overdrive.py
+++ b/overdrive.py
@@ -111,7 +111,12 @@ class OverdriveAPI(object):
 
     WEBSITE_ID = "website_id"
 
-   
+    # When setting up Patron authentication for an Overdrive account,
+    # it's necessary to specify an "ILS name" obtained from
+    # Overdrive. Components that don't authenticate patrons (such as
+    # the metadata wrangler) don't need to set this value.
+    ILS_NAME = "ils_name"
+    
     def __init__(self, collection):
         if collection.protocol != ExternalIntegration.OVERDRIVE:
             raise ValueError(
@@ -135,6 +140,10 @@ class OverdriveAPI(object):
         self.client_key = collection.external_integration.username.encode("utf8")
         self.client_secret = collection.external_integration.password.encode("utf8")
         self.website_id = collection.external_integration.setting(self.WEBSITE_ID).value.encode("utf8")
+        # 'default' works as an ILS name for many libraries, but not all.
+        ils_name = collection.external_integration.setting(
+            self.ILS_NAME).value or "default"
+        self.ils_name = ils_name.encode("utf8")
 
         if (not self.client_key or not self.client_secret or not self.website_id
             or not self.library_id):

--- a/overdrive.py
+++ b/overdrive.py
@@ -140,10 +140,8 @@ class OverdriveAPI(object):
         self.client_key = collection.external_integration.username.encode("utf8")
         self.client_secret = collection.external_integration.password.encode("utf8")
         self.website_id = collection.external_integration.setting(self.WEBSITE_ID).value.encode("utf8")
-        # 'default' works as an ILS name for many libraries, but not all.
-        ils_name = collection.external_integration.setting(
-            self.ILS_NAME).value or "default"
-        self.ils_name = ils_name.encode("utf8")
+        self.ils_name = collection.external_integration.setting(
+            self.ILS_NAME).value.encode("utf8")
 
         if (not self.client_key or not self.client_secret or not self.website_id
             or not self.library_id):

--- a/overdrive.py
+++ b/overdrive.py
@@ -428,6 +428,7 @@ class MockOverdriveAPI(OverdriveAPI):
         integration.username = u'a'
         integration.password = u'b'
         integration.set_setting('website_id', 'd')
+        integration.set_setting(OverdriveAPI.ILS_NAME, 'e')
         library.collections.append(collection)
         return collection
     

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -75,6 +75,19 @@ class OverdriveTestWithAPI(OverdriveTest):
 
 class TestOverdriveAPI(OverdriveTestWithAPI):
 
+    def test_default_ils_name(self):
+
+        # MockOverdriveAPI doesn't specify an ils_name, so we use
+        # the default, which is the literal string 'default'.
+        eq_("default", self.api.ils_name)
+
+        # If we specify a different ils_name, that's the one that gets
+        # used.
+        self.collection.external_integration.setting(
+            OverdriveAPI.ILS_NAME).value="Not the default"
+        api = MockOverdriveAPI(self.collection)
+        eq_("Not the default", api.ils_name)
+        
     def test_make_link_safe(self):
         eq_("http://foo.com?q=%2B%3A%7B%7D",
             OverdriveAPI.make_link_safe("http://foo.com?q=+:{}"))

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -76,18 +76,10 @@ class OverdriveTestWithAPI(OverdriveTest):
 class TestOverdriveAPI(OverdriveTestWithAPI):
 
     def test_default_ils_name(self):
-
         # The 'ils_name' setting (defined in
         # MockOverdriveAPI.mock_collection) becomes
         # OverdriveAPI.ils_name.
         eq_("e", self.api.ils_name)
-
-        # If we remove the value for the ils_name setting, the literal
-        # string 'default' is used.  used.
-        self.collection.external_integration.setting(
-            OverdriveAPI.ILS_NAME).value = None
-        api = MockOverdriveAPI(self.collection)
-        eq_("default", api.ils_name)
         
     def test_make_link_safe(self):
         eq_("http://foo.com?q=%2B%3A%7B%7D",

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -211,6 +211,7 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         main.external_integration.username = "user"
         main.external_integration.password = "password"
         main.external_integration.setting('website_id').value = '100'
+        main.external_integration.setting('ils_name').value = 'default'
 
         # Here's an Overdrive API client for that collection.
         overdrive_main = MockOverdriveAPI(main)

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -77,16 +77,17 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
 
     def test_default_ils_name(self):
 
-        # MockOverdriveAPI doesn't specify an ils_name, so we use
-        # the default, which is the literal string 'default'.
-        eq_("default", self.api.ils_name)
+        # The 'ils_name' setting (defined in
+        # MockOverdriveAPI.mock_collection) becomes
+        # OverdriveAPI.ils_name.
+        eq_("e", self.api.ils_name)
 
-        # If we specify a different ils_name, that's the one that gets
-        # used.
+        # If we remove the value for the ils_name setting, the literal
+        # string 'default' is used.  used.
         self.collection.external_integration.setting(
-            OverdriveAPI.ILS_NAME).value="Not the default"
+            OverdriveAPI.ILS_NAME).value = None
         api = MockOverdriveAPI(self.collection)
-        eq_("Not the default", api.ils_name)
+        eq_("default", api.ils_name)
         
     def test_make_link_safe(self):
         eq_("http://foo.com?q=%2B%3A%7B%7D",


### PR DESCRIPTION
This branch stores the Overdrive `ils_name` variable as a configuration setting. Previously there was (in circulation) an assumption that this value was always "default", which turns out to be often true but not always true.

This fixes https://github.com/NYPL-Simplified/circulation/issues/610