### PR TITLE
Fix bibliographic coverage 2

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -585,4 +585,3 @@ class BibliographicParser(Axis360Parser):
             availability = None
 
         return bibliographic, availability
-

--- a/migration/20170803-drop-externalintegrationsettings.sql
+++ b/migration/20170803-drop-externalintegrationsettings.sql
@@ -1,0 +1,1 @@
+drop table if exists externalintegrationsettings;

--- a/oneclick.py
+++ b/oneclick.py
@@ -907,10 +907,3 @@ class OneClickBibliographicCoverageProvider(BibliographicCoverageProvider):
             return self.failure(identifier, e)
 
         return self.set_metadata(identifier, metadata)
-
-
-
-
-
-
-

--- a/overdrive.py
+++ b/overdrive.py
@@ -140,8 +140,11 @@ class OverdriveAPI(object):
         self.client_key = collection.external_integration.username.encode("utf8")
         self.client_secret = collection.external_integration.password.encode("utf8")
         self.website_id = collection.external_integration.setting(self.WEBSITE_ID).value.encode("utf8")
-        self.ils_name = collection.external_integration.setting(
-            self.ILS_NAME).value.encode("utf8")
+
+        self.ils_name = collection.external_integration.setting(self.ILS_NAME).value
+        if not self.ils_name:
+            self.ils_name = "default"
+        self.ils_name.encode("utf8")
 
         if (not self.client_key or not self.client_secret or not self.website_id
             or not self.library_id):
@@ -1038,7 +1041,8 @@ class OverdriveAdvantageAccount(object):
         # the library, just in case that name has changed.
         child.name = name
         return parent, child
-        
+
+
 class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
     """Fill in bibliographic metadata for Overdrive records.
 
@@ -1090,4 +1094,3 @@ class OverdriveBibliographicCoverageProvider(BibliographicCoverageProvider):
             return self.failure(identifier, e)
 
         return self.set_metadata(identifier, metadata)
-

--- a/testing.py
+++ b/testing.py
@@ -943,6 +943,12 @@ class BrokenCoverageProvider(InstrumentedCoverageProvider):
     def process_item(self, item):
         raise Exception("I'm too broken to even return a CoverageFailure.")
 
+
+class BrokenBibliographicCoverageProvider(
+        BrokenCoverageProvider, BibliographicCoverageProvider):
+    SERVICE_NAME = "Broken (bibliographic)"
+
+
 class TransientFailureCoverageProvider(InstrumentedCoverageProvider):
     SERVICE_NAME = "Never successful (transient)"
     def process_item(self, item):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -44,6 +44,7 @@ from oneclick import MockOneClickAPI
 
 from scripts import (
     AddClassificationScript,
+    BibliographicRefreshScript,
     CheckContributorNamesInDB, 
     CollectionInputScript,
     ConfigureCollectionScript,
@@ -69,6 +70,10 @@ from scripts import (
     ShowIntegrationsScript,
     ShowLibrariesScript,
     WorkProcessingScript,
+)
+from testing import(
+    AlwaysSuccessfulBibliographicCoverageProvider,
+    BrokenBibliographicCoverageProvider,
 )
 from monitor import (
     CollectionMonitor,
@@ -1793,7 +1798,83 @@ I would now expect you to be able to find 1 works.
 
         # The materialized view was refreshed.
         eq_(1, mw_query.count())
+
+
+class TestBibliographicRefreshScript(DatabaseTest):
+
+    def create_collection_for_data_source(self, data_source_name):
+        return self._collection(
+            protocol=data_source_name, data_source_name=data_source_name,
+            external_account_id=u'external_account', url=self._url,
+            username=u'username', password=u'password'
+        )
+
+    def test_providers_created_at_initialization(self):
+        sources = [
+            DataSource.AXIS_360,
+            DataSource.BIBLIOTHECA,
+            DataSource.ONECLICK,
+            DataSource.BIBLIOTHECA,
+        ]
+        collections = list()
+        for source in sources:
+            collections.append(self.create_collection_for_data_source(source))
+
+        script = BibliographicRefreshScript(_db=self._db)
+        # There is a provider for each Collection.
+        eq_(4, len(script.providers))
+        # None of the providers are OverdriveBibliographicCoverageProviders.
+        assert not filter(
+            lambda p: p.DATA_SOURCE_NAME == DataSource.OVERDRIVE,
+            script.providers
+        )
+
+    def test_replacement_policy_set_at_initialization(self):
+        collection = self.create_collection_for_data_source(DataSource.AXIS_360)
+        mirror = object()
+        script = BibliographicRefreshScript(
+            _db=self._db, link_content=True, mirror=mirror
+        )
+
+        [provider] = script.providers
+        eq_(True, provider.replacement_policy.link_content)
+        eq_(mirror, provider.replacement_policy.mirror)
+
+    def test_refresh_metadata(self):
+        script = BibliographicRefreshScript(_db=self._db)
+
+        # Override the BibliographicCoverageProvider creation process.
+        provider = AlwaysSuccessfulBibliographicCoverageProvider(
+            self._default_collection
+        )
+        script.providers = [provider]
+
+        # Without being part of a Collection, an identifier is not refreshed.
+        identifier = self._identifier()
+        eq_(False, script.refresh_metadata(identifier))
+
+        # As part of a Collection that is not covered by a provider, an
+        # identifier is not refreshed.
+        collection = self._collection(
+            protocol=ExternalIntegration.OPDS_IMPORT,
+            data_source_name=DataSource.GUTENBERG,
+        )
+        lp = self._licensepool(
+            None, data_source_name=DataSource.OVERDRIVE, collection=collection
+        )
+        identifier = lp.identifier
+        eq_(False, script.refresh_metadata(identifier))
+
+        # Now that the identifier is in a collection with a CoverageProvider,
+        # it's covered.
+        lp.collection = self._default_collection
+        eq_(True, script.refresh_metadata(identifier))
         
+        # Unless an error is raised!
+        provider = BrokenBibliographicCoverageProvider(self._default_collection)
+        script.providers = [provider]
+        eq_(False, script.refresh_metadata(identifier))
+
 
 class TestWorkConsolidationScript(object):
     """TODO"""
@@ -1821,11 +1902,6 @@ class TestCustomListManagementScript(object):
 
 
 class TestSubjectAssignmentScript(object):
-    """TODO"""
-    pass
-
-
-class TestBibliographicRefreshScript(object):
     """TODO"""
     pass
 


### PR DESCRIPTION
This merges some bug fixes from 1.x, mainly getting the BibliographicRefreshScript working again.

It also drops any extraneous `externalintegrationsettings` table and allows an optional OverdriveAPI setting to be empty.