### PR TITLE
Remove API encoding errors

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -79,9 +79,9 @@ class Axis360API(object):
                 collection.protocol
             )
         self._db = Session.object_session(collection)
-        self.library_id = collection.external_account_id.encode("utf8")
-        self.username = collection.external_integration.username.encode("utf8")
-        self.password = collection.external_integration.password.encode("utf8")
+        self.library_id = collection.external_account_id
+        self.username = collection.external_integration.username
+        self.password = collection.external_integration.password
 
         # Convert the nickname for a server into an actual URL.
         base_url = collection.external_integration.url or self.PRODUCTION_BASE_URL
@@ -94,7 +94,13 @@ class Axis360API(object):
             raise CannotLoadConfiguration(
                 "Axis 360 configuration is incomplete."
             )
-            
+
+        # Use utf8 instead of unicode encoding
+        settings = [self.library_id, self.username, self.password]
+        self.library_id, self.username, self.password = (
+            setting.encode('utf8') for setting in settings
+        )
+
         self.token = None
         self.collection_id = collection.id
 

--- a/bibliotheca.py
+++ b/bibliotheca.py
@@ -82,15 +82,21 @@ class BibliothecaAPI(object):
         self.version = (
             collection.external_integration.setting('version').value or self.DEFAULT_VERSION
         )
-        self.account_id = collection.external_integration.username.encode("utf8")
-        self.account_key = collection.external_integration.password.encode("utf8")
-        self.library_id = collection.external_account_id.encode("utf8")
+        self.account_id = collection.external_integration.username
+        self.account_key = collection.external_integration.password
+        self.library_id = collection.external_account_id
         self.base_url = collection.external_integration.url or self.DEFAULT_BASE_URL
         
         if not self.account_id or not self.account_key or not self.library_id:
             raise CannotLoadConfiguration(
                 "Bibliotheca configuration is incomplete."
             )
+
+        # Use utf8 instead of unicode encoding
+        settings = [self.account_id, self.account_key, self.library_id]
+        self.account_id, self.account_key, self.library_id = (
+            setting.encode('utf8') for setting in settings
+        )
 
         self.item_list_parser = ItemListParser()
         self.collection_id = collection.id

--- a/oneclick.py
+++ b/oneclick.py
@@ -10,7 +10,8 @@ import re
 from sqlalchemy.orm.session import Session
 
 from config import (
-    Configuration, 
+    CannotLoadConfiguration,
+    Configuration,
     temp_config,
 )
 
@@ -82,8 +83,17 @@ class OneClickAPI(object):
             )
         self._db = Session.object_session(collection)
         self.collection_id = collection.id
-        self.library_id = collection.external_account_id.encode("utf8")
-        self.token = collection.external_integration.password.encode("utf8")
+        self.library_id = collection.external_account_id
+        self.token = collection.external_integration.password
+
+        if not (self.library_id and self.token):
+            raise CannotLoadConfiguration(
+                "OneClick configuration is incomplete."
+            )
+
+        # Use utf8 instead of unicode encoding
+        self.library_id = self.library_id.encode('utf8')
+        self.token = self.token.encode('utf8')
 
         # Convert the nickname for a server into an actual URL.
         base_url = collection.external_integration.url or self.PRODUCTION_BASE_URL

--- a/overdrive.py
+++ b/overdrive.py
@@ -137,20 +137,24 @@ class OverdriveAPI(object):
         else:
             self.parent_library_id = None
 
-        self.client_key = collection.external_integration.username.encode("utf8")
-        self.client_secret = collection.external_integration.password.encode("utf8")
-        self.website_id = collection.external_integration.setting(self.WEBSITE_ID).value.encode("utf8")
-
+        self.client_key = collection.external_integration.username
+        self.client_secret = collection.external_integration.password
+        self.website_id = collection.external_integration.setting(self.WEBSITE_ID).value
         self.ils_name = collection.external_integration.setting(self.ILS_NAME).value
         if not self.ils_name:
             self.ils_name = "default"
-        self.ils_name.encode("utf8")
 
         if (not self.client_key or not self.client_secret or not self.website_id
             or not self.library_id):
             raise CannotLoadConfiguration(
                 "Overdrive configuration is incomplete."
             )
+
+        # Use utf8 instead of unicode encoding
+        settings = [self.client_key, self.client_secret, self.website_id, self.ils_name]
+        self.client_key, self.client_secret, self.website_id, self.ils_name = (
+            setting.encode('utf8') for setting in settings
+        )
 
         # Get set up with up-to-date credentials from the API.
         self.check_creds()


### PR DESCRIPTION
When a third-party wasn't configured, attempts to encode configuration settings raised errors at startup.