### PR TITLE
Fix materialized view ids

### DIFF
--- a/files/materialized_view_works.sql
+++ b/files/materialized_view_works.sql
@@ -3,8 +3,8 @@ as
  SELECT 
     distinct works.id AS works_id,
     editions.id AS editions_id,
-    editions.data_source_id,
-    editions.primary_identifier_id,
+    licensepools.data_source_id,
+    licensepools.identifier_id,
     editions.sort_title,
     editions.permanent_work_id,
     editions.sort_author,
@@ -36,7 +36,7 @@ as
      JOIN editions ON editions.id = works.presentation_edition_id
      JOIN licensepools ON editions.id = licensepools.presentation_edition_id
      JOIN datasources ON licensepools.data_source_id = datasources.id
-     JOIN identifiers on editions.primary_identifier_id = identifiers.id
+     JOIN identifiers on licensepools.identifier_id = identifiers.id
   WHERE works.presentation_ready = true
     AND works.simple_opds_entry IS NOT NULL
   

--- a/files/materialized_view_works_workgenres.sql
+++ b/files/materialized_view_works_workgenres.sql
@@ -3,8 +3,8 @@ as
  SELECT 
     works.id AS works_id,
     editions.id AS editions_id,
-    editions.data_source_id,
-    editions.primary_identifier_id,
+    licensepools.data_source_id,
+    licensepools.identifier_id,
     editions.sort_title,
     editions.permanent_work_id,
     editions.sort_author,
@@ -39,7 +39,7 @@ as
      JOIN editions ON editions.id = works.presentation_edition_id
      JOIN licensepools ON editions.id = licensepools.presentation_edition_id
      JOIN datasources ON licensepools.data_source_id = datasources.id
-     JOIN identifiers on editions.primary_identifier_id = identifiers.id
+     JOIN identifiers on licensepools.identifier_id = identifiers.id
      JOIN workgenres ON works.id = workgenres.work_id
   WHERE works.presentation_ready = true
     AND works.simple_opds_entry IS NOT NULL

--- a/migration/20170713-14-recreate-materialized-views.sql
+++ b/migration/20170713-14-recreate-materialized-views.sql
@@ -4,8 +4,8 @@ as
  SELECT 
     distinct works.id AS works_id,
     editions.id AS editions_id,
-    editions.data_source_id,
-    editions.primary_identifier_id,
+    licensepools.data_source_id,
+    licensepools.identifier_id,
     editions.sort_title,
     editions.permanent_work_id,
     editions.sort_author,
@@ -37,7 +37,7 @@ as
      JOIN editions ON editions.id = works.presentation_edition_id
      JOIN licensepools ON editions.id = licensepools.presentation_edition_id
      JOIN datasources ON licensepools.data_source_id = datasources.id
-     JOIN identifiers on editions.primary_identifier_id = identifiers.id
+     JOIN identifiers on licensepools.identifier_id = identifiers.id
   WHERE works.presentation_ready = true
     AND works.simple_opds_entry IS NOT NULL
   
@@ -117,8 +117,8 @@ as
  SELECT 
     works.id AS works_id,
     editions.id AS editions_id,
-    editions.data_source_id,
-    editions.primary_identifier_id,
+    licensepools.data_source_id,
+    licensepools.identifier_id,
     editions.sort_title,
     editions.permanent_work_id,
     editions.sort_author,
@@ -152,7 +152,7 @@ as
      JOIN editions ON editions.id = works.presentation_edition_id
      JOIN licensepools ON editions.id = licensepools.presentation_edition_id
      JOIN datasources ON licensepools.data_source_id = datasources.id
-     JOIN identifiers on editions.primary_identifier_id = identifiers.id
+     JOIN identifiers on licensepools.identifier_id = identifiers.id
      JOIN workgenres ON works.id = workgenres.work_id
   WHERE works.presentation_ready = true
     AND works.simple_opds_entry IS NOT NULL

--- a/scripts.py
+++ b/scripts.py
@@ -2358,7 +2358,7 @@ class FixInvisibleWorksScript(CollectionInputScript):
         mv_works = mv_works.filter(
             exists().where(
                 and_(MaterializedWork.data_source_id==LPDM.data_source_id,
-                     MaterializedWork.primary_identifier_id==LPDM.identifier_id)
+                     MaterializedWork.identifier_id==LPDM.identifier_id)
             )
         )
         if mv_works.count() == 0:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6548,10 +6548,10 @@ class TestMaterializedViews(DatabaseTest):
         eq_("staff chose this title", mw.sort_title)
 
         # And since the data_source_id is the ID of the data source
-        # associated with the presentation edition, we would expect it
-        # to be the data source ID of the presentation edition.
-        eq_(presentation_edition.data_source.id, mw.data_source_id)
-        eq_(presentation_edition.data_source.id, mwg.data_source_id)
+        # associated with the license pool, we would expect it to be
+        # the data source ID of the license pool.
+        eq_(pool.data_source.id, mw.data_source_id)
+        eq_(pool.data_source.id, mwg.data_source_id)
 
 
 class TestAdmin(DatabaseTest):


### PR DESCRIPTION
This branch fixes https://github.com/NYPL-Simplified/server_core/issues/598.

The data source ID seems to matter much more than the identifier ID. I changed the name of the identifier field (from primary_identifier_id to identifier_id) and it didn't break any tests or seem to matter at all. I don't see primary_identifier_id in opds.py or lane.py, the two places that do the most work with the materialized views.

I'm piggybacking off of the most recent "recreate materialized views" migration rather than creating a new one, since we don't have any production deployments that have already run that script.