### PR TITLE
Don't try to drop an index that doesn't exist.

### DIFF
--- a/migration/20170713-6-add-library-to-patron.sql
+++ b/migration/20170713-6-add-library-to-patron.sql
@@ -3,9 +3,9 @@
 -- each had to be unique. Now, the *combination* of each of those fields
 -- with patrons.library_id must be unique.
 
-DROP INDEX ix_patrons_authorization_identifier;
-DROP INDEX ix_patrons_external_identifier;
-DROP INDEX ix_patrons_username;
+DROP INDEX IF EXISTS ix_patrons_authorization_identifier;
+DROP INDEX IF EXISTS ix_patrons_external_identifier;
+DROP INDEX IF EXISTS ix_patrons_username;
 
 ALTER TABLE patrons ADD COLUMN library_id integer;
 ALTER TABLE patrons ADD CONSTRAINT patrons_library_id_fkey FOREIGN KEY (library_id) REFERENCES libraries(id);


### PR DESCRIPTION
This branch evades a problem I found when migrating the content server; an index that's not important to the content server was never added, so an attempt to drop it failed.