### PR TITLE
Change API constructors to take database session

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -72,13 +72,13 @@ class Axis360API(object):
 
     log = logging.getLogger("Axis 360 API")
 
-    def __init__(self, collection):
+    def __init__(self, _db, collection):
         if collection.protocol != ExternalIntegration.AXIS_360:
             raise ValueError(
                 "Collection protocol is %s, but passed into Axis360API!" %
                 collection.protocol
             )
-        self._db = Session.object_session(collection)
+        self._db = _db
         self.library_id = collection.external_account_id
         self.username = collection.external_integration.username
         self.password = collection.external_integration.password
@@ -221,7 +221,7 @@ class MockAxis360API(Axis360API):
         library.collections.append(collection)
         return collection
 
-    def __init__(self, collection, with_token=True, **kwargs):
+    def __init__(self, _db, collection, with_token=True, **kwargs):
         """Constructor.
 
         :param collection: Get Axis 360 credentials from this
@@ -231,7 +231,7 @@ class MockAxis360API(Axis360API):
             it already has a valid token, and will not go through
             the motions of negotiating one with the mock server.
         """
-        super(MockAxis360API, self).__init__(collection, **kwargs)
+        super(MockAxis360API, self).__init__(_db, collection, **kwargs)
         if with_token:
             self.token = "mock token"
         self.responses = []
@@ -282,6 +282,9 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
             # We were given a specific Axis360API instance to use.
             self.api = api_class
         else:
+            # A web application should not use this option because it
+            # will put a non-scoped session in the mix.
+            _db = Session.object_session(collection)
             self.api = api_class(collection)
         self.parser = BibliographicParser()
 

--- a/axis.py
+++ b/axis.py
@@ -285,7 +285,7 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
             # A web application should not use this option because it
             # will put a non-scoped session in the mix.
             _db = Session.object_session(collection)
-            self.api = api_class(collection)
+            self.api = api_class(_db, collection)
         self.parser = BibliographicParser()
 
     def process_batch(self, identifiers):

--- a/bibliotheca.py
+++ b/bibliotheca.py
@@ -459,8 +459,8 @@ class BibliothecaBibliographicCoverageProvider(BibliographicCoverageProvider):
         else:
             # A web application should not use this option because it
             # will put a non-scoped session in the mix.
-            _db = Session.object_session(Collection)
-            self.api = api_class(collection)
+            _db = Session.object_session(collection)
+            self.api = api_class(_db, collection)
         
     def process_item(self, identifier):
         # We don't accept a representation from the cache because

--- a/bibliotheca.py
+++ b/bibliotheca.py
@@ -70,7 +70,7 @@ class BibliothecaAPI(object):
     DEFAULT_VERSION = "2.0"
     DEFAULT_BASE_URL = "https://partner.yourcloudlibrary.com/"
     
-    def __init__(self, collection):
+    def __init__(self, _db, collection):
         
         if collection.protocol != ExternalIntegration.BIBLIOTHECA:
             raise ValueError(
@@ -78,7 +78,7 @@ class BibliothecaAPI(object):
                 collection.protocol
             )
 
-        self._db = Session.object_session(collection)
+        self._db = _db
         self.version = (
             collection.external_integration.setting('version').value or self.DEFAULT_VERSION
         )
@@ -226,10 +226,12 @@ class MockBibliothecaAPI(BibliothecaAPI):
         library.collections.append(collection)
         return collection
         
-    def __init__(self, collection, *args, **kwargs):
+    def __init__(self, _db, collection, *args, **kwargs):
         self.responses = []
         self.requests = []
-        super(MockBibliothecaAPI, self).__init__(collection, *args, **kwargs)
+        super(MockBibliothecaAPI, self).__init__(
+            _db, collection, *args, **kwargs
+        )
 
     def now(self):
         """Return an unvarying time in the format Bibliotheca expects."""
@@ -455,6 +457,9 @@ class BibliothecaBibliographicCoverageProvider(BibliographicCoverageProvider):
             # instead of creating a new one.
             self.api = api_class
         else:
+            # A web application should not use this option because it
+            # will put a non-scoped session in the mix.
+            _db = Session.object_session(Collection)
             self.api = api_class(collection)
         
     def process_item(self, identifier):

--- a/model.py
+++ b/model.py
@@ -8972,7 +8972,7 @@ class Library(Base):
             Edition.language, func.count(Work.id).label("work_count")
         ).select_from(Work).join(Work.license_pools).join(
             Work.presentation_edition
-        ).group_by(Edition.language)
+        ).filter(Edition.language != None).group_by(Edition.language)
         qu = self.restrict_to_ready_deliverable_works(qu, Work)
         if not include_open_access:
             qu = qu.filter(LicensePool.open_access==False)

--- a/oneclick.py
+++ b/oneclick.py
@@ -75,13 +75,13 @@ class OneClickAPI(object):
    
     log = logging.getLogger("OneClick API")
 
-    def __init__(self, collection):
+    def __init__(self, _db, collection):
         if collection.protocol != ExternalIntegration.ONE_CLICK:
             raise ValueError(
                 "Collection protocol is %s, but passed into OneClickAPI!" %
                 collection.protocol
             )
-        self._db = Session.object_session(collection)
+        self._db = _db
         self.collection_id = collection.id
         self.library_id = collection.external_account_id
         self.token = collection.external_integration.password
@@ -538,13 +538,13 @@ class MockOneClickAPI(OneClickAPI):
         library.collections.append(collection)
         return collection
     
-    def __init__(self, collection, base_path=None, **kwargs):
+    def __init__(self, _db, collection, base_path=None, **kwargs):
         self._collection = collection
         self.responses = []
         self.requests = []
         base_path = base_path or os.path.split(__file__)[0]
         self.resource_path = os.path.join(base_path, "files", "oneclick")
-        return super(MockOneClickAPI, self).__init__(collection, **kwargs)
+        return super(MockOneClickAPI, self).__init__(_db, collection, **kwargs)
 
     @property
     def collection(self):
@@ -858,7 +858,10 @@ class OneClickBibliographicCoverageProvider(BibliographicCoverageProvider):
             else:
                 self.api = api_class
         else:
-            self.api = api_class(collection, **api_class_kwargs)
+            # A web application should not use this option because it
+            # will put a non-scoped session in the mix.
+            _db = Session.object.session(collection)
+            self.api = api_class(_db, collection, **api_class_kwargs)
 
     def process_item(self, identifier):
         """ OneClick availability information is served separately from 

--- a/oneclick.py
+++ b/oneclick.py
@@ -860,7 +860,7 @@ class OneClickBibliographicCoverageProvider(BibliographicCoverageProvider):
         else:
             # A web application should not use this option because it
             # will put a non-scoped session in the mix.
-            _db = Session.object.session(collection)
+            _db = Session.object_session(collection)
             self.api = api_class(_db, collection, **api_class_kwargs)
 
     def process_item(self, identifier):

--- a/scripts.py
+++ b/scripts.py
@@ -1486,7 +1486,7 @@ class OneClickImportScript(Script):
                  **api_class_kwargs):
         _db = Session.object_session(collection)
         super(OneClickImportScript, self).__init__(_db=_db)
-        self.api = api_class(collection, **api_class_kwargs)
+        self.api = api_class(_db, collection, **api_class_kwargs)
 
     def do_run(self):
         self.log.info("OneClickImportScript.do_run().")

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -52,7 +52,7 @@ class AxisTestWithAPI(AxisTest):
     """Test against a mock Axis 360 Collection using a MockAxis360API."""
     def setup(self):
         super(AxisTestWithAPI, self).setup()
-        self.api = MockAxis360API(self.collection)
+        self.api = MockAxis360API(self._db, self.collection)
 
 
 class TestAxis360API(AxisTestWithAPI):
@@ -86,7 +86,7 @@ class TestAxis360API(AxisTestWithAPI):
         """Raise an exception if we don't get a 200 status code when
         refreshing the bearer token.
         """
-        api = MockAxis360API(self.collection, with_token=False)
+        api = MockAxis360API(self._db, self.collection, with_token=False)
         api.queue_response(412)
         assert_raises_regexp(
             RemoteIntegrationException, "Bad response from http://axis.test/accesstoken: Got status code 412 from external server, but can only continue on: 200.", 

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -41,7 +41,7 @@ class TestBibliothecaAPI(DatabaseTest, BaseBibliothecaTest):
     def setup(self):
         super(TestBibliothecaAPI, self).setup()
         self.collection = MockBibliothecaAPI.mock_collection(self._db)
-        self.api = MockBibliothecaAPI(self.collection)
+        self.api = MockBibliothecaAPI(self._db, self.collection)
 
     def test_full_path(self):
         id = self.api.library_id

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5577,9 +5577,13 @@ class TestLibrary(DatabaseTest):
         tagalog = self._work(language="tgl", with_license_pool=True)
         [pool] = tagalog.license_pools
         self._add_generic_delivery_mechanism(pool)
+
+        # Here's an open-access book that improperly has no language set.
+        no_language = self._work(with_open_access_download=True)
+        no_language.presentation_edition.language = None
         
         # estimated_holdings_by_language counts the English and the
-        # Tagalog works.
+        # Tagalog works. The work with no language is ignored.
         estimate = library.estimated_holdings_by_language()
         eq_(dict(eng=1, tgl=1), estimate)
         

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -49,7 +49,9 @@ class OneClickTest(DatabaseTest):
         super(OneClickTest, self).setup()
         base_path = os.path.split(__file__)[0]
         self.collection = MockOneClickAPI.mock_collection(self._db)
-        self.api = MockOneClickAPI(self.collection, base_path=base_path)
+        self.api = MockOneClickAPI(
+            self._db, self.collection, base_path=base_path
+        )
 
 
 class TestOneClickAPI(OneClickTest):

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -70,7 +70,7 @@ class OverdriveTestWithAPI(OverdriveTest):
     """
     def setup(self):
         super(OverdriveTestWithAPI, self).setup()
-        self.api = MockOverdriveAPI(self.collection)
+        self.api = MockOverdriveAPI(self._db, self.collection)
 
 
 class TestOverdriveAPI(OverdriveTestWithAPI):
@@ -124,6 +124,7 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
             CannotLoadConfiguration,
             "Overdrive credentials are valid but could not fetch library: Some message.",
             MisconfiguredOverdriveAPI,
+            self._db,
             self.collection
         )
         
@@ -214,7 +215,7 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         main.external_integration.setting('ils_name').value = 'default'
 
         # Here's an Overdrive API client for that collection.
-        overdrive_main = MockOverdriveAPI(main)
+        overdrive_main = MockOverdriveAPI(self._db, main)
         eq_("https://api.overdrive.com/v1/libraries/1",
             overdrive_main._library_endpoint)
 
@@ -224,7 +225,7 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
             protocol=ExternalIntegration.OVERDRIVE, external_account_id="2",
         )
         child.parent = main
-        overdrive_child = MockOverdriveAPI(child)
+        overdrive_child = MockOverdriveAPI(self._db, child)
         eq_(
             'https://api.overdrive.com/v1/libraries/1/advantageAccounts/2',
             overdrive_child._library_endpoint


### PR DESCRIPTION
This branch makes all the API constructors take a database session. This is necessary because within a web app, the database connection you get by calling `Session.object_session` on the `Collection` can't be used beyond the current request.

This branch also changes `Library.estimated_holdings_by_language` to ignore books that have no `Edition.language` property set. The old code was treating `None` as a language when setting the library's language settings. Since `None` isn't a language, this made it impossible to load a site that had any books with the language property unset.