### PR TITLE
OneClick monitors

### DIFF
--- a/oneclick.py
+++ b/oneclick.py
@@ -917,3 +917,34 @@ class OneClickBibliographicCoverageProvider(BibliographicCoverageProvider):
             return self.failure(identifier, e)
 
         return self.set_metadata(identifier, metadata)
+
+
+class OneClickMonitor(CollectionMonitor):
+
+    def __init__(self, _db, collection, api_class=OverdriveAPI,
+                 **api_class_kwargs):
+        """Constructor."""
+        super(OverdriveCirculationMonitor, self).__init__(_db, collection)
+        self.api = api_class(collection, **api_class_kwargs)
+
+    def run_once(self, start, cutoff):
+        items_transmitted, items_created = self.populate()
+        self._db.commit()
+        result_string = "%s items transmitted, %s items saved to DB" % (items_transmitted, items_created)
+        self.log.info(result_string)
+        
+    def populate(self):
+        raise NotImplementedError()
+
+
+class OneClickImportMonitor(OneClickMonitor):
+
+    def populate(self):
+        return self.api.populate_all_catalog()
+
+
+class OneClickDeltaMonitor(CollectionMonitor):
+
+    def populate(self):
+        return self.api.populate_delta()
+

--- a/scripts.py
+++ b/scripts.py
@@ -1478,32 +1478,6 @@ class CustomListManagementScript(Script):
         self._db.commit()
 
 
-class OneClickImportScript(Script):
-    """Import all books from a OneClick-subscribed library catalog."""
-
-    def __init__(self, collection=None, api_class=OneClickAPI,
-                 **api_class_kwargs):
-        _db = Session.object_session(collection)
-        super(OneClickImportScript, self).__init__(_db=_db)
-        self.api = api_class(collection, **api_class_kwargs)
-
-    def do_run(self):
-        self.log.info("OneClickImportScript.do_run().")
-        items_transmitted, items_created = self.api.populate_all_catalog()
-        result_string = "OneClickImportScript: %s items transmitted, %s items saved to DB" % (items_transmitted, items_created)
-        self.log.info(result_string)
-
-
-class OneClickDeltaScript(OneClickImportScript):
-    """Import book deletions, additions, and metadata changes for a 
-    OneClick-subscribed library catalog.
-    """
-
-    def do_run(self):
-        self.log.info("OneClickDeltaScript.do_run().")
-        items_transmitted, items_updated = self.api.populate_delta()
-
-
 class CollectionInputScript(Script):
     """A script that takes collection names as command line inputs."""
 

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -21,8 +21,10 @@ from model import (
     Edition,
     Identifier,
     Hyperlink,
+    LicensePool,
     Representation,
     Subject,
+    Work,
 )
 
 from oneclick import (
@@ -30,6 +32,8 @@ from oneclick import (
     MockOneClickAPI,
     OneClickBibliographicCoverageProvider,
     OneClickRepresentationExtractor,
+    OneClickDeltaMonitor,
+    OneClickImportMonitor,
 )
 
 from util.http import (
@@ -325,5 +329,118 @@ class TestOneClickBibliographicCoverageProvider(OneClickTest):
         eq_(True, pool.work.presentation_ready)
        
 
+class TestOneClickSyncMonitor(DatabaseTest):
 
+    # TODO: This shouldn't test anything except that the monitors can
+    # be instantiated and run by RunCollectionMonitorScript, and that
+    # when they are run they call the appropriate method on their .api
+    # object.
+    #
+    # However, removing this code requires ensuring that
+    # populate_all_catalog() and populate_delta() are tested somewhere
+    # else.
 
+    def setup(self):
+        super(TestOneClickSyncMonitor, self).setup()
+        self.base_path = os.path.split(__file__)[0]
+        self.resource_path = os.path.join(self.base_path, "files", "oneclick")
+        self.collection = MockOneClickAPI.mock_collection(self._db)
+    
+    def get_data(self, filename):
+        # returns contents of sample file as string and as dict
+        path = os.path.join(self.resource_path, filename)
+        data = open(path).read()
+        return data, json.loads(data)
+
+    def test_import(self):
+
+        # Create a OneClickImportMonitor, which will take the current
+        # state of a OneClick collection and mirror the whole thing to
+        # a local database.
+        monitor = OneClickImportMonitor(
+            self._db, self.collection, api_class=MockOneClickAPI,
+            api_class_kwargs=dict(base_path=self.base_path)
+        )
+        datastr, datadict = self.get_data("response_catalog_all_sample.json")
+        monitor.api.queue_response(status_code=200, content=datastr)
+        monitor.run()
+
+        # verify that we created Works, Editions, LicensePools
+        works = self._db.query(Work).all()
+        work_titles = [work.title for work in works]
+        expected_titles = ["Tricks", "Emperor Mage: The Immortals", 
+            "In-Flight Russian", "Road, The", "Private Patient, The", 
+            "Year of Magical Thinking, The", "Junkyard Bot: Robots Rule, Book 1, The", 
+            "Challenger Deep"]
+        eq_(set(expected_titles), set(work_titles))
+
+        # make sure we created some Editions
+        edition = Edition.for_foreign_id(self._db, DataSource.ONECLICK, Identifier.ONECLICK_ID, "9780062231727", create_if_not_exists=False)
+        assert(edition is not None)
+        edition = Edition.for_foreign_id(self._db, DataSource.ONECLICK, Identifier.ONECLICK_ID, "9781615730186", create_if_not_exists=False)
+        assert(edition is not None)
+
+        # make sure we created some LicensePools
+        pool, made_new = LicensePool.for_foreign_id(
+            self._db, DataSource.ONECLICK, Identifier.ONECLICK_ID,
+            "9780062231727", collection=self.collection
+        )
+        eq_(False, made_new)
+        pool, made_new = LicensePool.for_foreign_id(
+            self._db, DataSource.ONECLICK, Identifier.ONECLICK_ID,
+            "9781615730186", collection=self.collection
+        )
+        eq_(False, made_new)
+
+        # make sure there are 8 LicensePools
+        pools = self._db.query(LicensePool).all()
+        eq_(8, len(pools))
+
+        # Now we're going to run the delta monitor to change things
+        # around a bit.
+        
+        # set license numbers on test pool to match what's in the
+        # delta document.
+        pool, made_new = LicensePool.for_foreign_id(
+            self._db, DataSource.ONECLICK, Identifier.ONECLICK_ID,
+            "9781615730186", collection=self.collection
+        )
+        eq_(False, made_new)
+        pool.licenses_owned = 10
+        pool.licenses_available = 9
+        pool.licenses_reserved = 2
+        pool.patrons_in_hold_queue = 1
+
+        # now update that library with a sample delta            
+        delta_monitor = OneClickDeltaMonitor(
+            self._db, self.collection, api_class=MockOneClickAPI,
+            api_class_kwargs=dict(base_path=self.base_path)
+        )
+        datastr, datadict = self.get_data("response_catalog_delta.json")
+        delta_monitor.api.queue_response(status_code=200, content=datastr)
+        delta_monitor.run()
+
+        # "Tricks" did not get deleted, but did get its pools set to "nope".
+        # "Emperor Mage: The Immortals" got new metadata.
+        works = self._db.query(Work).all()
+        work_titles = [work.title for work in works]
+        expected_titles = ["Tricks", "Emperor Mage: The Immortals", 
+            "In-Flight Russian", "Road, The", "Private Patient, The", 
+            "Year of Magical Thinking, The", "Junkyard Bot: Robots Rule, Book 1, The", 
+            "Challenger Deep"]
+        eq_(set(expected_titles), set(work_titles))
+
+        eq_("Tricks", pool.presentation_edition.title)
+        eq_(0, pool.licenses_owned)
+        eq_(0, pool.licenses_available)
+        eq_(0, pool.licenses_reserved)
+        eq_(0, pool.patrons_in_hold_queue)
+        assert (datetime.datetime.utcnow() - pool.last_checked) < datetime.timedelta(seconds=20)
+
+        # make sure we updated fields
+        edition = Edition.for_foreign_id(self._db, DataSource.ONECLICK, Identifier.ONECLICK_ID, "9781934180723", create_if_not_exists=False)
+        eq_("Recorded Books, Inc.", edition.publisher)
+
+        # make sure there are still 8 LicensePools
+        pools = self._db.query(LicensePool).all()
+        eq_(8, len(pools))

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -331,14 +331,14 @@ class TestOneClickBibliographicCoverageProvider(OneClickTest):
 
 class TestOneClickSyncMonitor(DatabaseTest):
 
-    # TODO: This shouldn't test anything except that the monitors can
-    # be instantiated and run by RunCollectionMonitorScript, and that
-    # when they are run they call the appropriate method on their .api
-    # object.
+    # TODO: The only thing this should test is that the monitors can
+    # be instantiated using the constructor arguments used by
+    # RunCollectionMonitorScript, and that calling run_once() results
+    # in a call to the appropriate OneClickAPI method.
     #
-    # However, removing this code requires ensuring that
-    # populate_all_catalog() and populate_delta() are tested somewhere
-    # else.
+    # However, there's no other code that tests populate_all_catalog()
+    # or populate_delta(), so we can't just remove the code; we need to
+    # refactor the tests.
 
     def setup(self):
         super(TestOneClickSyncMonitor, self).setup()
@@ -396,8 +396,10 @@ class TestOneClickSyncMonitor(DatabaseTest):
         pools = self._db.query(LicensePool).all()
         eq_(8, len(pools))
 
+        #
         # Now we're going to run the delta monitor to change things
         # around a bit.
+        #
         
         # set license numbers on test pool to match what's in the
         # delta document.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -58,8 +58,6 @@ from scripts import (
     FixInvisibleWorksScript,
     LibraryInputScript,
     MockStdin,
-    OneClickDeltaScript,
-    OneClickImportScript, 
     OPDSImportScript,
     PatronInputScript,
     RunCollectionMonitorScript,
@@ -939,127 +937,6 @@ class TestAddClassificationScript(DatabaseTest):
         [classification] = identifier.classifications
         subject = classification.subject
         eq_("some random tag", subject.identifier)
-
-
-class TestOneClickImportScript(DatabaseTest):
-
-    def get_data(self, filename):
-        base_path = os.path.split(__file__)[0]
-        self.resource_path = os.path.join(base_path, "files", "oneclick")
-
-        # returns contents of sample file as string and as dict
-        path = os.path.join(self.resource_path, filename)
-        data = open(path).read()
-        return data, json.loads(data)
-
-    def test_import(self):
-        base_path = os.path.split(__file__)[0]
-        collection = MockOneClickAPI.mock_collection(self._db)
-        importer = OneClickImportScript(
-            collection, api_class=MockOneClickAPI, base_path=base_path
-        )
-        datastr, datadict = self.get_data("response_catalog_all_sample.json")
-        importer.api.queue_response(status_code=200, content=datastr)
-        importer.run()
-
-        # verify that we created Works, Editions, LicensePools
-        works = self._db.query(Work).all()
-        work_titles = [work.title for work in works]
-        expected_titles = ["Tricks", "Emperor Mage: The Immortals", 
-            "In-Flight Russian", "Road, The", "Private Patient, The", 
-            "Year of Magical Thinking, The", "Junkyard Bot: Robots Rule, Book 1, The", 
-            "Challenger Deep"]
-        eq_(set(expected_titles), set(work_titles))
-
-        # make sure we created some Editions
-        edition = Edition.for_foreign_id(self._db, DataSource.ONECLICK, Identifier.ONECLICK_ID, "9780062231727", create_if_not_exists=False)
-        assert(edition is not None)
-        edition = Edition.for_foreign_id(self._db, DataSource.ONECLICK, Identifier.ONECLICK_ID, "9781615730186", create_if_not_exists=False)
-        assert(edition is not None)
-
-        # make sure we created some LicensePools
-        pool, made_new = LicensePool.for_foreign_id(
-            self._db, DataSource.ONECLICK, Identifier.ONECLICK_ID,
-            "9780062231727", collection=collection
-        )
-        eq_(False, made_new)
-        pool, made_new = LicensePool.for_foreign_id(
-            self._db, DataSource.ONECLICK, Identifier.ONECLICK_ID,
-            "9781615730186", collection=collection
-        )
-        eq_(False, made_new)
-
-        # make sure there are 8 LicensePools
-        pools = self._db.query(LicensePool).all()
-        eq_(8, len(pools))
-
-
-class TestOneClickDeltaScript(DatabaseTest):
-
-    def get_data(self, filename):
-        base_path = os.path.split(__file__)[0]
-        self.resource_path = os.path.join(base_path, "files", "oneclick")
-
-        # returns contents of sample file as string and as dict
-        path = os.path.join(self.resource_path, filename)
-        data = open(path).read()
-        return data, json.loads(data)
-
-
-    def test_delta(self):
-        # First, load a collection.
-        base_path = os.path.split(__file__)[0]
-        collection = MockOneClickAPI.mock_collection(self._db)
-        importer = OneClickImportScript(
-            collection, api_class=MockOneClickAPI, base_path=base_path
-        )
-        datastr, datadict = self.get_data("response_catalog_all_sample.json")
-        importer.api.queue_response(status_code=200, content=datastr)
-        importer.run()
-
-        # set license numbers on test pool
-        pool, made_new = LicensePool.for_foreign_id(
-            self._db, DataSource.ONECLICK, Identifier.ONECLICK_ID,
-            "9781615730186", collection=collection
-        )
-        eq_(False, made_new)
-        pool.licenses_owned = 10
-        pool.licenses_available = 9
-        pool.licenses_reserved = 2
-        pool.patrons_in_hold_queue = 1
-
-        # now update that library with a sample delta            
-        delta_runner = OneClickDeltaScript(
-            collection, api_class=MockOneClickAPI, base_path=base_path
-        )
-        datastr, datadict = self.get_data("response_catalog_delta.json")
-        delta_runner.api.queue_response(status_code=200, content=datastr)
-        delta_runner.run()
-
-        # "Tricks" did not get deleted, but did get its pools set to "nope".
-        # "Emperor Mage: The Immortals" got new metadata.
-        works = self._db.query(Work).all()
-        work_titles = [work.title for work in works]
-        expected_titles = ["Tricks", "Emperor Mage: The Immortals", 
-            "In-Flight Russian", "Road, The", "Private Patient, The", 
-            "Year of Magical Thinking, The", "Junkyard Bot: Robots Rule, Book 1, The", 
-            "Challenger Deep"]
-        eq_(set(expected_titles), set(work_titles))
-
-        eq_("Tricks", pool.presentation_edition.title)
-        eq_(0, pool.licenses_owned)
-        eq_(0, pool.licenses_available)
-        eq_(0, pool.licenses_reserved)
-        eq_(0, pool.patrons_in_hold_queue)
-        assert (datetime.datetime.utcnow() - pool.last_checked) < datetime.timedelta(seconds=20)
-
-        # make sure we updated fields
-        edition = Edition.for_foreign_id(self._db, DataSource.ONECLICK, Identifier.ONECLICK_ID, "9781934180723", create_if_not_exists=False)
-        eq_("Recorded Books, Inc.", edition.publisher)
-
-        # make sure there are still 8 LicensePools
-        pools = self._db.query(LicensePool).all()
-        eq_(8, len(pools))
 
 
 class TestShowLibrariesScript(DatabaseTest):


### PR DESCRIPTION
This branch makes it possible to run the OneClick import and delta scripts in a multi-collection environment. This works by creating `CollectionMonitor` classes that can be invoked with the standard `RunCollectionMonitorScript`.

Prior to this branch, invoking one of these scripts would cause an error, because nothing in the script invocation specified the Collection to use. With `RunCollectionMonitorScript` each relevant Collection is processed in turn.

If necessary, we can improve `RunCollectionMonitorScript` later on to give more precise control over specifying a Collection from the command line, and all the `RunCollectionMonitorScript`s will benefit from the work.