### PR TITLE
Only look up default loan and reservation period if they're actually needed.

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -1106,21 +1106,21 @@ class AcquisitionFeed(OPDSFeed):
 
         if not license_pool:
             return
-        if license_pool.open_access:
-            default_loan_period = default_reservation_period = None
-        else:
-            collection = license_pool.collection
+        default_loan_period = default_reservation_period = None
+        collection = license_pool.collection
+        if (loan or hold) and not open_access:
             default_loan_period = datetime.timedelta(
                 collection.default_loan_period
-            )
-            default_reservation_period = datetime.timedelta(
-                collection.default_reservation_period
             )
         if loan:
             status = 'available'
             since = loan.start
             until = loan.until(default_loan_period)
         elif hold:
+            if not open_access:
+                default_reservation_period = datetime.timedelta(
+                    collection.default_reservation_period
+                )
             until = hold.until(default_loan_period, default_reservation_period)
             if hold.position == 0:
                 status = 'ready'


### PR DESCRIPTION
Collection.default_loan_period and Collection.default_reservation_period used to be configuration settings, and looking them up was basically free. Now they're database settings, and although looking them up once is not terribly expensive, looking them up for every single entry in an OPDS feed gets old quick. 

Fortunately, we only need to look these values up if there is an active loan or hold for the book we're building the OPDS entry for. Otherwise we can do without. This change improves feed generation performance by about 25%.

There are other ways of handling this which might improve things further, such as joining a Collection to its ConfigurationSettings in the initial database query, and I'll investigate those, but this is a tiny change that makes a big difference so I think it's worth merging.