### PR TITLE
Cache Genre objects in a big dictionary

### DIFF
--- a/model.py
+++ b/model.py
@@ -5368,7 +5368,7 @@ class Genre(Base):
                 if genre is None:
                     logging.getLogger().error('"%s" is not a recognized genre.', name)
                     return None, False
-            cls._cache_genre(cache, genre)
+            cls._cache_genre(cls._cache, genre)
             
         # Now we know the genre is in the cache. Retrieve it and associate
         # it with this database session.

--- a/model.py
+++ b/model.py
@@ -5333,7 +5333,7 @@ class Genre(Base):
             self.name, len(self.subjects), len(self.works), length)
 
     @classmethod
-    def _cache_genre(cls, genre):
+    def _cache_genre(cls, cache, genre):
         """Remove a Genre's association with the database session
         that created it, then cache it for later retrieval.
 
@@ -5341,15 +5341,15 @@ class Genre(Base):
         """
         make_transient(genre)
         make_transient_to_detached(genre)
-        cls._cache[genre.name] = genre
+        cache[genre.name] = genre
         return genre
     
     @classmethod
     def load_all(cls, _db):
-        cls._cache = {}
-        cache = cls._cache
+        cache = {}
         for genre in _db.query(Genre):
-            cls._cache_genre(genre)
+            cls._cache_genre(cache, genre)
+        cls._cache = cache
             
     @classmethod
     def lookup(cls, _db, name, autocreate=False):

--- a/model.py
+++ b/model.py
@@ -5333,37 +5333,48 @@ class Genre(Base):
             self.name, len(self.subjects), len(self.works), length)
 
     @classmethod
+    def _cache_genre(cls, genre):
+        """Remove a Genre's association with the database session
+        that created it, then cache it for later retrieval.
+
+        :return: The Genre, in a detached state.
+        """
+        make_transient(genre)
+        make_transient_to_detached(genre)
+        cls._cache[genre.name] = genre
+        return genre
+    
+    @classmethod
     def load_all(cls, _db):
         cls._cache = {}
         cache = cls._cache
         for genre in _db.query(Genre):
-            # Remove the Genre object's association with the
-            # database session that created it.
-            make_transient(genre)
-            make_transient_to_detached(genre)
-            cache[genre.name] = genre
-    
+            cls._cache_genre(genre)
+            
     @classmethod
     def lookup(cls, _db, name, autocreate=False):
         if isinstance(name, GenreData):
             name = name.name
-        if name in cls._cache:
-            genre = cls._cache[name]
-            genre = _db.merge(genre, load=False)
-            return genre, False
 
-        # This genre didn't exist when Genre.load_all() was called.
-        # We may be able to create it; otherwise something weird is
-        # going on.
-        args = (_db, Genre)
-        if autocreate:
-            result, new = get_one_or_create(*args, name=name)
-        else:
-            result = get_one(*args, name=name)
-            new = False
-        if result is None:
-            logging.getLogger().error('"%s" is not a recognized genre.', name)
-        return result, new
+        new = False
+        if name not in self._cache:
+            # This genre didn't exist when Genre.load_all() was called.
+            # Maybe it exists now, or we can create it.
+            args = (_db, Genre)
+            if autocreate:
+                genre, new = get_one_or_create(*args, name=name)
+            else:
+                genre = get_one(*args, name=name)
+                if genre is None:
+                    logging.getLogger().error('"%s" is not a recognized genre.', name)
+                    return None, False
+            cls._cache_genre(genre)
+            
+        # Now we know the genre is in the cache. Retrieve it and associate
+        # it with this database session.
+        genre = cls._cache[name]
+        genre = _db.merge(genre, load=False)
+        return genre, new
 
     @property
     def genredata(self):

--- a/model.py
+++ b/model.py
@@ -5368,7 +5368,7 @@ class Genre(Base):
                 if genre is None:
                     logging.getLogger().error('"%s" is not a recognized genre.', name)
                     return None, False
-            cls._cache_genre(genre)
+            cls._cache_genre(cache, genre)
             
         # Now we know the genre is in the cache. Retrieve it and associate
         # it with this database session.

--- a/model.py
+++ b/model.py
@@ -5357,7 +5357,7 @@ class Genre(Base):
             name = name.name
 
         new = False
-        if name not in self._cache:
+        if name not in cls._cache:
             # This genre didn't exist when Genre.load_all() was called.
             # Maybe it exists now, or we can create it.
             args = (_db, Genre)


### PR DESCRIPTION
This branch caches all the Genre objects in a dictionary ahead of time. The Genres are detached from the database session that created them, and then when they're looked up they're attached with the database session that wants to do the lookup. This gives the appearance of a Genre individually looked up and fresh from the database, even though all the genres are loaded from the database in a single query.