### PR TITLE
Cache ConfigurationSettings

### DIFF
--- a/model.py
+++ b/model.py
@@ -10323,6 +10323,7 @@ def configuration_relevant_collection_change(target, value, initiator):
 def configuration_relevant_lifecycle_event(mapper, connection, target):
     site_configuration_has_changed(target)
 
+@event.listens_for(ConfigurationSetting, 'after_insert')
 @event.listens_for(ConfigurationSetting, 'after_delete')
 @event.listens_for(ConfigurationSetting, 'after_update')
 def refresh_configuration_settings(mapper, connection, target):

--- a/model.py
+++ b/model.py
@@ -5368,7 +5368,7 @@ class Genre(Base):
                 if genre is None:
                     logging.getLogger().error('"%s" is not a recognized genre.', name)
                     return None, False
-            cls._cache_genre(cache, genre)
+            cls._cache_genre(cls._cache, genre)
             
         # Now we know the genre is in the cache. Retrieve it and associate
         # it with this database session.

--- a/model.py
+++ b/model.py
@@ -5321,7 +5321,6 @@ class Genre(Base):
     work_genres = relationship("WorkGenre", backref="genre", 
                                cascade="all, delete, delete-orphan")
 
-    # A dictionary of all known Genre objects by name.
     _cache = {}
     
     def __repr__(self):
@@ -9447,7 +9446,7 @@ class ConfigurationSetting(Base):
 
     @classmethod
     def reset_cache(cls):
-        cls._cache = RESET_ME
+        cls._cache = cls.RESET_ME
 
     def __repr__(self):
         return u'<ConfigurationSetting: key=%s, ID=%d>' % (
@@ -9564,6 +9563,13 @@ class ConfigurationSetting(Base):
                 library=library, external_integration=external_integration,
                 key=key
             )
+            if cls._cache == cls.RESET_ME:
+                # The cache is being reset while we're doing this,
+                # possibly because we just created a new
+                # ConfigurationSetting. Just return the setting object
+                # as-is and forget about updating the cache until
+                # things settle down.
+                return setting
             cls._cache_insert(setting, cls._cache)
         setting = cls._cache[cache_key]
         setting = _db.merge(setting, load=False)
@@ -10317,7 +10323,4 @@ def configuration_relevant_lifecycle_event(mapper, connection, target):
 def refresh_configuration_settings(mapper, connection, target):
     # The next time someone tries to access a configuration setting,
     # the cache will be repopulated.
-    for i in range(20):
-        print
-    print "CACHE RESET!!!!!!!!!!!!"
     ConfigurationSetting.reset_cache()

--- a/model.py
+++ b/model.py
@@ -9574,8 +9574,6 @@ class ConfigurationSetting(Base, HasFullTableCache):
         """Find or create a ConfigurationSetting associated with a Library
         and an ExternalIntegration.
         """
-        cache_key = self._cache_key(library, external_integration, key)
-
         def create():
             """Function called when a ConfigurationSetting is not found in cache
             and must be created.
@@ -9586,6 +9584,9 @@ class ConfigurationSetting(Base, HasFullTableCache):
                 key=key
             )
 
+        # ConfigurationSettings are stored in cache based on their library,
+        # external integration, and the name of the setting.
+        cache_key = cls._cache_key(library, external_integration, key)
         setting, ignore = cls._check_cache(_db, cache_key, create)
         return setting
         

--- a/model.py
+++ b/model.py
@@ -5333,7 +5333,7 @@ class Genre(Base):
             self.name, len(self.subjects), len(self.works), length)
 
     @classmethod
-    def _cache_genre(cls, genre):
+    def _cache_genre(cls, cache, genre):
         """Remove a Genre's association with the database session
         that created it, then cache it for later retrieval.
 
@@ -5341,15 +5341,15 @@ class Genre(Base):
         """
         make_transient(genre)
         make_transient_to_detached(genre)
-        cls._cache[genre.name] = genre
+        cache[genre.name] = genre
         return genre
     
     @classmethod
     def load_all(cls, _db):
-        cls._cache = {}
-        cache = cls._cache
+        cache = {}
         for genre in _db.query(Genre):
-            cls._cache_genre(genre)
+            cls._cache_genre(cache, genre)
+        cls._cache = cache
             
     @classmethod
     def lookup(cls, _db, name, autocreate=False):

--- a/model.py
+++ b/model.py
@@ -5368,7 +5368,7 @@ class Genre(Base):
                 if genre is None:
                     logging.getLogger().error('"%s" is not a recognized genre.', name)
                     return None, False
-            cls._cache_genre(genre)
+            cls._cache_genre(cache, genre)
             
         # Now we know the genre is in the cache. Retrieve it and associate
         # it with this database session.

--- a/model.py
+++ b/model.py
@@ -9509,14 +9509,11 @@ class ConfigurationSetting(Base):
 
     @classmethod
     def _cache_insert(cls, setting, cache):
-        """Remove a ConfigurationSetting's association with the database
-        session that created it, then cache it in `cache` for later
-        retrieval.
+        """Cache a ConfigurationSetting for later retrieval, probably by a
+        different database session.
 
-        :return: The ConfigurationSetting, in a detached state.
+        :return: The ConfigurationSetting.
         """
-        #make_transient(setting)
-        #make_transient_to_detached(setting)
         library_id = setting.library_id
         external_integration_id = setting.external_integration_id
         key = setting.key

--- a/model.py
+++ b/model.py
@@ -9515,8 +9515,8 @@ class ConfigurationSetting(Base):
 
         :return: The ConfigurationSetting, in a detached state.
         """
-        make_transient(setting)
-        make_transient_to_detached(setting)
+        #make_transient(setting)
+        #make_transient_to_detached(setting)
         library_id = setting.library_id
         external_integration_id = setting.external_integration_id
         key = setting.key
@@ -9578,7 +9578,7 @@ class ConfigurationSetting(Base):
                 return setting
             cls._cache_insert(setting, cls._cache)
         setting = cls._cache[cache_key]
-        if _db:
+        if _db and setting not in _db:
             setting = _db.merge(setting, load=False)
         return setting
 

--- a/model.py
+++ b/model.py
@@ -9578,7 +9578,8 @@ class ConfigurationSetting(Base):
                 return setting
             cls._cache_insert(setting, cls._cache)
         setting = cls._cache[cache_key]
-        setting = _db.merge(setting, load=False)
+        if _db:
+            setting = _db.merge(setting, load=False)
         return setting
 
     @hybrid_property

--- a/model.py
+++ b/model.py
@@ -9532,7 +9532,6 @@ class ConfigurationSetting(Base):
         need to be repopulated often. ConfigurationSettings are looked
         up many times on each request, so the cache will be used a lot.
         """
-        print "CACHE POPULATE"
         cache = {}
         for setting in _db.query(ConfigurationSetting):
             cls._cache_insert(setting, cache)

--- a/model.py
+++ b/model.py
@@ -5357,7 +5357,7 @@ class Genre(Base):
             name = name.name
 
         new = False
-        if name not in self._cache:
+        if name not in cls._cache:
             # This genre didn't exist when Genre.load_all() was called.
             # Maybe it exists now, or we can create it.
             args = (_db, Genre)

--- a/opds.py
+++ b/opds.py
@@ -1108,7 +1108,7 @@ class AcquisitionFeed(OPDSFeed):
             return
         default_loan_period = default_reservation_period = None
         collection = license_pool.collection
-        if (loan or hold) and not open_access:
+        if (loan or hold) and not license_pool.open_access:
             default_loan_period = datetime.timedelta(
                 collection.default_loan_period
             )
@@ -1117,7 +1117,7 @@ class AcquisitionFeed(OPDSFeed):
             since = loan.start
             until = loan.until(default_loan_period)
         elif hold:
-            if not open_access:
+            if not license_pool.open_access:
                 default_reservation_period = datetime.timedelta(
                     collection.default_reservation_period
                 )

--- a/testing.py
+++ b/testing.py
@@ -165,6 +165,7 @@ class DatabaseTest(object):
 
         # Remove any database objects cached in the model classes but
         # associated with the now-rolled-back session.
+        Genre.reset_cache()
         ConfigurationSetting.reset_cache()
         
         # Also roll back any record of those changes in the

--- a/testing.py
+++ b/testing.py
@@ -18,6 +18,7 @@ from model import (
     IntegrationClient,
     Collection,
     Complaint,
+    ConfigurationSetting,
     Contributor,
     CoverageRecord,
     Credential,
@@ -162,6 +163,10 @@ class DatabaseTest(object):
         # other session.
         self.transaction.rollback()
 
+        # Remove any database objects cached in the model classes but
+        # associated with the now-rolled-back session.
+        ConfigurationSetting.reset_cache()
+        
         # Also roll back any record of those changes in the
         # Configuration instance.
         for key in [

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5687,9 +5687,9 @@ class TestExternalIntegration(DatabaseTest):
         eq_("id1", setting.value)
 
         # Calling set() again updates the key-value pair.
-        eq_([setting], self.external_integration.settings)
+        eq_([setting.id], [x.id for x in self.external_integration.settings])
         setting2 = self.external_integration.set_setting("website_id", "id2")
-        eq_(setting, setting2)
+        eq_(setting.id, setting2.id)
         eq_("id2", setting2.value)
 
         eq_(setting2, self.external_integration.setting("website_id"))
@@ -5879,7 +5879,7 @@ class TestConfigurationSetting(DatabaseTest):
         setting2 = ConfigurationSetting.for_library_and_externalintegration(
             self._db, key, library, integration
         )
-        eq_(setting, setting2)
+        eq_(setting.id, setting2.id)
         assert_raises(
             IntegrityError,
             create, self._db, ConfigurationSetting,
@@ -5934,7 +5934,7 @@ class TestConfigurationSetting(DatabaseTest):
         # associated with the library.
         self._db.delete(integration)
         self._db.commit()
-        eq_([for_library], library.settings)
+        eq_([for_library.id], [x.id for x in library.settings])
 
     def test_int_value(self):
         number = ConfigurationSetting.sitewide(self._db, "number")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -663,6 +663,7 @@ class TestGenre(DatabaseTest):
         )
 
         # The object was already in the cache, so we just looked it up.
+        # No exception.
         eq_(drama, drama2)
         eq_(False, is_new)
         
@@ -674,9 +675,7 @@ class TestGenre(DatabaseTest):
 
         # Create a previously unknown genre.
         genre, ignore = Genre.lookup(
-            self._db
-
-        , "Some Weird Genre", autocreate=True
+            self._db, "Some Weird Genre", autocreate=True
         )
 
         # We don't know its default fiction status.


### PR DESCRIPTION
This branch creates a cache that contains the entire `configurationsettings` table. The lookup methods are changed to check this cache, with the database as a fallback.

This is similar to my earlier cache of the `genres` table, but a bit more complicated. Unlike `Genre`, we expect new `ConfigurationSetting` objects to be created and modified after the site starts up, so we need a mechanism for invalidating the cache. I use the same event monitoring system we use to keep an eye on the site configuration.

Since the cache can be invalidated, there's also the possibility that it gets invalidated while you're looking  up a `ConfigurationSetting`, leaving you with nowhere to cache the object.

I created a mix-in class for this "keep the whole table cached" strategy and adapted Genre to use it as well. In a future branch I'll apply this strategy to DataSource, Library, and Collection, which should save at least a couple database queries on every incoming request.

This branch has some known problems which are addressed in the follow-up: https://github.com/NYPL-Simplified/server_core/pull/610

I don't know whether it'd be easier for you to review that branch and do all this code at once, or review the basic stuff and then the branch I think completes the work.