### PR TITLE
More full table caches

### DIFF
--- a/testing.py
+++ b/testing.py
@@ -165,8 +165,9 @@ class DatabaseTest(object):
 
         # Remove any database objects cached in the model classes but
         # associated with the now-rolled-back session.
-        Genre.reset_cache()
         ConfigurationSetting.reset_cache()
+        DataSource.reset_cache()
+        Genre.reset_cache()
         Library.reset_cache()
         
         # Also roll back any record of those changes in the

--- a/testing.py
+++ b/testing.py
@@ -167,6 +167,7 @@ class DatabaseTest(object):
         # associated with the now-rolled-back session.
         Genre.reset_cache()
         ConfigurationSetting.reset_cache()
+        Library.reset_cache()
         
         # Also roll back any record of those changes in the
         # Configuration instance.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5593,6 +5593,18 @@ class TestLibrary(DatabaseTest):
         # recommended, but it's not an error.
         library.library_registry_short_name = None
 
+    def test_lookup(self):
+        library = self._default_library
+        name = library.short_name
+        eq_(name, library.cache_key())
+        # Cache is empty.
+        eq_(None, Library._check_cache(_db, name, None))
+
+        eq_(library, Library.lookup(self._db, name))
+
+        # Cache is populated.
+        eq_(library, Library._check_cache(_db, name, None))
+            
     def test_default(self):
         # We start off with no libraries.
         eq_(None, Library.default(self._db))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5746,7 +5746,7 @@ class TestExternalIntegration(DatabaseTest):
         self.external_integration, ignore = create(
             self._db, ExternalIntegration, goal=self._str, protocol=self._str
         )
-
+        
     def test_data_source(self):
         # For most collections, the protocol determines the
         # data source.
@@ -6213,20 +6213,29 @@ class TestCollection(DatabaseTest):
         )
 
     def test_by_name_and_protocol(self):
-        # You'll get an exception if you look up an existing name
-        # but the protocol doesn't match.
         name = "A name"
+        protocol = ExternalIntegration.OVERDRIVE
+        key = (name, protocol)
+        
+        # Cache is empty.
+        eq_(None, Collection._check_cache(_db, name, key))
+        
         collection1, is_new = Collection.by_name_and_protocol(
             self._db, name, ExternalIntegration.OVERDRIVE
         )
         eq_(True, is_new)
 
+        # Cache is populated.
+        eq_(collection1, Collection._check_cache(_db, name, key))
+        
         collection2, is_new = Collection.by_name_and_protocol(
             self._db, name, ExternalIntegration.OVERDRIVE
         )
         eq_(collection1, collection2)
         eq_(False, is_new)
 
+        # You'll get an exception if you look up an existing name
+        # but the protocol doesn't match.
         assert_raises_regexp(
             ValueError,
             'Collection "A name" does not use protocol "Bibliotheca".',


### PR DESCRIPTION
This branch expands on my earlier branch by adding full-table caches for DataSource,  Collection, and Library. The first two can be used as-is because they're tied into existing lookup methods. For Library I defined a new `lookup` method and made a change in my circulation branch to have `library_for_request` use that new method instead of going direct to the database.

The DataSource change is the big winner here; I think it will save seven database queries on an average  request for an OPDS feed. The Library change will save one query on every single request, once my circulation change is made. I don't think the Collection change will save us any queries in current typical usage, but I have an idea for future improvements.

If we could do this for ExternalIntegration we could save another four queries on an average request, but ExternalIntegration.lookup is complicated enough that it might not be possible.

This branch also changes HasFullTableCache._check_cache to repopulate the entire cache if it notices the cache has been reset. Previously this method was proceeding with an individual lookup once the cache was reset, which meant that although all the tests passed the cache was never actually being populated. This branch includes tests that actually look inside the internal cache to make sure it's been populated.