### PR TITLE
Cache by ID

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -428,7 +428,7 @@ class Lane(object):
 
     @property
     def library(self):
-        return get_one(self._db, Library, id=self.library_id)
+        return Library.by_id(self._db, self.library_id)
     
     @property
     def url_name(self):

--- a/model.py
+++ b/model.py
@@ -8405,7 +8405,12 @@ class DeliveryMechanism(Base, HasFullTableCache):
 
     @classmethod
     def lookup(cls, _db, content_type, drm_scheme):
-        return cls.by_cache_key(_db, (content_type, drm_scheme), None)
+        def lookup_hook():
+            return get_one_or_create(
+                _db, DeliveryMechanism, content_type=content_type,
+                drm_scheme=drm_scheme
+            )
+        return cls.by_cache_key(_db, (content_type, drm_scheme), lookup_hook)
 
     @property
     def implicit_medium(self):

--- a/model.py
+++ b/model.py
@@ -10481,6 +10481,14 @@ def refresh_datasource_cache(mapper, connection, target):
     # the cache will be repopulated.
     DataSource.reset_cache()
 
+@event.listens_for(DeliveryMechanism, 'after_insert')
+@event.listens_for(DeliveryMechanism, 'after_delete')
+@event.listens_for(DeliveryMechanism, 'after_update')
+def refresh_datasource_cache(mapper, connection, target):
+    # The next time someone tries to access a DeliveryMechanism,
+    # the cache will be repopulated.
+    DeliveryMechanism.reset_cache()
+    
 @event.listens_for(ExternalIntegration, 'after_insert')
 @event.listens_for(ExternalIntegration, 'after_delete')
 @event.listens_for(ExternalIntegration, 'after_update')

--- a/model.py
+++ b/model.py
@@ -10092,7 +10092,7 @@ class Collection(Base, HasFullTableCache):
     def parents(self):
         if self.parent_id:
             _db = Session.object_session(self)
-            parent = get_one(_db, Collection, id=self.parent_id)
+            parent = Collection.for_id(_db, self.parent_id)
             yield parent
             for collection in parent.parents:
                 yield collection

--- a/model.py
+++ b/model.py
@@ -10092,7 +10092,7 @@ class Collection(Base, HasFullTableCache):
     def parents(self):
         if self.parent_id:
             _db = Session.object_session(self)
-            parent = Collection.for_id(_db, self.parent_id)
+            parent = Collection.by_id(_db, self.parent_id)
             yield parent
             for collection in parent.parents:
                 yield collection

--- a/model.py
+++ b/model.py
@@ -1074,6 +1074,7 @@ class DataSource(Base, HasFullTableCache):
     )
 
     _cache = HasFullTableCache.RESET
+    _id_cache = HasFullTableCache.RESET
     
     def __repr__(self):
         return '<DataSource: name="%s">' % (self.name)
@@ -5460,6 +5461,7 @@ class Genre(Base, HasFullTableCache):
                                cascade="all, delete, delete-orphan")
 
     _cache = HasFullTableCache.RESET
+    _id_cache = HasFullTableCache.RESET
     
     def __repr__(self):
         if classifier.genres.get(self.name):
@@ -8911,6 +8913,7 @@ class Library(Base, HasFullTableCache):
     )
 
     _cache = HasFullTableCache.RESET
+    _id_cache = HasFullTableCache.RESET
     
     def __repr__(self):
         return '<Library: name="%s", short name="%s", uuid="%s", library registry short name="%s">' % (
@@ -9575,7 +9578,8 @@ class ConfigurationSetting(Base, HasFullTableCache):
     )
 
     _cache = HasFullTableCache.RESET
-
+    _id_cache = HasFullTableCache.RESET
+    
     def __repr__(self):
         return u'<ConfigurationSetting: key=%s, ID=%d>' % (
             self.key, self.id)
@@ -9852,6 +9856,7 @@ class Collection(Base, HasFullTableCache):
     )
 
     _cache = HasFullTableCache.RESET
+    _id_cache = HasFullTableCache.RESET
     
     def __repr__(self):
         return (u'<Collection "%s"/"%s" ID=%d>' %

--- a/model.py
+++ b/model.py
@@ -1083,7 +1083,8 @@ class DataSource(Base, HasFullTableCache):
         return self.name
     
     @classmethod
-    def lookup(cls, _db, name, autocreate=False, offers_licenses=False):
+    def lookup(cls, _db, name, autocreate=False, offers_licenses=False,
+               primary_identifier_type=None):
         # Turn a deprecated name (e.g. "3M" into the current name
         # (e.g. "Bibliotheca").
         name = cls.DEPRECATED_NAMES.get(name, name)
@@ -1095,7 +1096,10 @@ class DataSource(Base, HasFullTableCache):
             if autocreate:
                 data_source, is_new = get_one_or_create(
                     _db, DataSource, name=name,
-                    create_method_kwargs=dict(offers_licenses=offers_licenses)
+                    create_method_kwargs=dict(
+                        offers_licenses=offers_licenses,
+                        primary_identifier_type=primary_identifier_type
+                    )
                 )
             else:
                 data_source = get_one(_db, DataSource, name=name)
@@ -1208,18 +1212,10 @@ class DataSource(Base, HasFullTableCache):
                 (cls.BIBBLIO, False, True, Identifier.BIBBLIO_CONTENT_ITEM_ID, None)
         ):
 
-            extra = dict()
-            if refresh_rate:
-                extra['circulation_refresh_rate_seconds'] = refresh_rate
-
-            obj, new = get_one_or_create(
-                _db, DataSource,
-                name=name,
-                create_method_kwargs=dict(
-                    offers_licenses=offers_licenses,
-                    primary_identifier_type=primary_identifier_type,
-                    extra=extra,
-                )
+            obj = DataSource.lookup(
+                _db, name, autocreate=True,
+                offers_licenses=offers_licenses,
+                primary_identifier_type = primary_identifier_type
             )
 
             if offers_metadata_lookup:

--- a/model.py
+++ b/model.py
@@ -9697,7 +9697,7 @@ class ConfigurationSetting(Base, HasFullTableCache):
     
     @value.setter
     def set_value(self, new_value):
-        self._value = new_value
+        self._value = unicode(new_value)
 
     @classmethod
     def _is_secret(self, key):

--- a/model.py
+++ b/model.py
@@ -9697,7 +9697,9 @@ class ConfigurationSetting(Base, HasFullTableCache):
     
     @value.setter
     def set_value(self, new_value):
-        self._value = unicode(new_value)
+        if new_value:
+            new_value = unicode(new_value)
+        self._value = new_value
 
     @classmethod
     def _is_secret(self, key):

--- a/testing.py
+++ b/testing.py
@@ -165,6 +165,7 @@ class DatabaseTest(object):
 
         # Remove any database objects cached in the model classes but
         # associated with the now-rolled-back session.
+        Collection.reset_cache()
         ConfigurationSetting.reset_cache()
         DataSource.reset_cache()
         Genre.reset_cache()

--- a/testing.py
+++ b/testing.py
@@ -168,6 +168,7 @@ class DatabaseTest(object):
         Collection.reset_cache()
         ConfigurationSetting.reset_cache()
         DataSource.reset_cache()
+        ExternalIntegration.reset_cache()
         Genre.reset_cache()
         Library.reset_cache()
         

--- a/testing.py
+++ b/testing.py
@@ -168,6 +168,7 @@ class DatabaseTest(object):
         Collection.reset_cache()
         ConfigurationSetting.reset_cache()
         DataSource.reset_cache()
+        DeliveryMechanism.reset_cache()
         ExternalIntegration.reset_cache()
         Genre.reset_cache()
         Library.reset_cache()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6791,7 +6791,7 @@ class TestHasFullTableCache(DatabaseTest):
         temp_id_cache = {}
         self.mock_class._cache_insert(self.mock, temp_cache, temp_id_cache)
         eq_({MockHasTableCache.KEY: self.mock}, temp_cache)
-        eq_({MockHasTableCache.ID: self.mock}, temp_cache, temp_id_cache)
+        eq_({MockHasTableCache.ID: self.mock}, temp_id_cache)
 
     # populate_cache(), _check_cache(), and by_id() are tested in
     # TestGenre since those methods must be backed by a real database

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -629,6 +629,7 @@ class TestGenre(DatabaseTest):
 
         # We start with an unusable object as the cache.
         eq_(Genre.RESET, Genre._cache)
+        eq_(Genre.RESET, Genre._id_cache)
 
         # When we call populate_cache()...
         Genre.populate_cache(self._db)
@@ -639,6 +640,27 @@ class TestGenre(DatabaseTest):
         eq_("Drama", drama.name)
         eq_(False, is_new)
 
+        # The ID of every genre is copied to the ID cache.
+        eq_(drama, Genre._id_cache[drama.id])
+        drama2 = Genre.by_id(self._db, drama.id)
+        eq_(drama2, drama)
+
+    def test_by_id(self):
+
+        # Get a genre to test with.
+        drama = get_one(self._db, Genre, name="Drama")
+        
+        # Since we went right to the database, that didn't change the
+        # fact that the ID cache is uninitialized.
+        eq_(Genre.RESET, Genre._id_cache)
+
+        # Look up the same genre using by_id...
+        eq_(drama, Genre.by_id(self._db, drama.id))
+
+        # ... and the ID cache is fully initialized.
+        eq_(drama, Genre._id_cache[drama.id])
+        assert len(Genre._id_cache) > 1
+        
     def test_check_cache_miss_triggers_create_function(self):
         _db = self._db
         class Factory(object):
@@ -653,6 +675,7 @@ class TestGenre(DatabaseTest):
                 
         factory = Factory()
         Genre._cache = {}
+        Genre._id_cache = {}
         genre, is_new = Genre._check_cache(self._db, "Drama", factory.call_me)
         eq_("Drama", genre.name)
         eq_(False, is_new)
@@ -661,6 +684,9 @@ class TestGenre(DatabaseTest):
         # The Genre object created in call_me has been associated with the
         # Genre's cache key in the table-wide cache.
         eq_(genre, Genre._cache[genre.cache_key()])
+
+        # The cache by ID has been similarly populated.
+        eq_(genre, Genre._id_cache[genre.id])
 
     def test_check_cache_miss_when_cache_is_reset_populates_cache(self):
         # The cache is not in a state to be used.
@@ -676,6 +702,7 @@ class TestGenre(DatabaseTest):
 
         # ... and the cache is repopulated
         assert drama.cache_key() in Genre._cache
+        assert drama.id in Genre._id_cache
 
     def test_check_cache_hit_returns_cached_object(self):
 
@@ -6731,8 +6758,14 @@ class MockHasTableCache(HasFullTableCache):
     """
     
     _cache = HasFullTableCache.RESET
+    _id_cache = HasFullTableCache.RESET
 
+    ID = "the only ID"
     KEY = "the only cache key"
+
+    @property
+    def id(self):
+        return self.ID
     
     def cache_key(self):
         return self.KEY
@@ -6748,17 +6781,21 @@ class TestHasFullTableCache(DatabaseTest):
 
     def test_reset_cache(self):
         self.mock_class._cache = object()
+        self.mock_class._id_cache = object()
         self.mock_class.reset_cache()
         eq_(HasFullTableCache.RESET, self.mock_class._cache)
+        eq_(HasFullTableCache.RESET, self.mock_class._id_cache)
 
     def test_cache_insert(self):
         temp_cache = {}
-        value = object()
-        self.mock_class._cache_insert(self.mock, temp_cache)
-        eq_({self.mock.KEY: self.mock}, temp_cache)
+        temp_id_cache = {}
+        self.mock_class._cache_insert(self.mock, temp_cache, temp_id_cache)
+        eq_({MockHasTableCache.KEY: self.mock}, temp_cache)
+        eq_({MockHasTableCache.ID: self.mock}, temp_cache, temp_id_cache)
 
-    # populate_cache() and _check_cache() are tested in TestGenre
-    # since those methods must be backed by a real database table.
+    # populate_cache(), _check_cache(), and by_id() are tested in
+    # TestGenre since those methods must be backed by a real database
+    # table.
 
 
     


### PR DESCRIPTION
This branch creates a second cache managed by HasFullTableCache. This one tracks the contents of a table by its database ID. I define a new method to pull things from this cache (`HasFullTableCache.by_id`) and rename `HasFullTableCache._check_cache` to `HasFullTableCache.by_cache_key`.

This isn't really used in core, but there are several places where I think it can save us database queries in circulation.

This branch is also a lot more careful about avoiding race conditions where a cache is invalidated while we're looking something up.

Here's the description for another branch which I just decided to put in with this one because it's more of the same:

This branch eliminates a lot of database hits by replacing many calls to `get_one()` with calls to HasFullTableCache.by_cache_key and (mainly) HasFullTableCache.by_id. The single biggest win here is the change in Lane.library(), which was causing hundreds of database hits when the circ manager was started up.

This branch adds the HasFullTableCache mixin to two more classes: DeliveryMechanism and ExternalIntegration. The ExternalIntegration implementation is a little ugly, but we only need the by_id implementation, so it works.