### PR TITLE
Heavy cache usage

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -428,7 +428,7 @@ class Lane(object):
 
     @property
     def library(self):
-        return get_one(self._db, Library, id=self.library_id)
+        return Library.by_id(self._db, self.library_id)
     
     @property
     def url_name(self):

--- a/model.py
+++ b/model.py
@@ -8405,7 +8405,12 @@ class DeliveryMechanism(Base, HasFullTableCache):
 
     @classmethod
     def lookup(cls, _db, content_type, drm_scheme):
-        return cls.by_cache_key(_db, (content_type, drm_scheme), None)
+        def lookup_hook():
+            return get_one_or_create(
+                _db, DeliveryMechanism, content_type=content_type,
+                drm_scheme=drm_scheme
+            )
+        return cls.by_cache_key(_db, (content_type, drm_scheme), lookup_hook)
 
     @property
     def implicit_medium(self):

--- a/model.py
+++ b/model.py
@@ -10323,6 +10323,7 @@ def configuration_relevant_collection_change(target, value, initiator):
 def configuration_relevant_lifecycle_event(mapper, connection, target):
     site_configuration_has_changed(target)
 
+@event.listens_for(ConfigurationSetting, 'after_insert')
 @event.listens_for(ConfigurationSetting, 'after_delete')
 @event.listens_for(ConfigurationSetting, 'after_update')
 def refresh_configuration_settings(mapper, connection, target):

--- a/model.py
+++ b/model.py
@@ -10092,7 +10092,7 @@ class Collection(Base, HasFullTableCache):
     def parents(self):
         if self.parent_id:
             _db = Session.object_session(self)
-            parent = get_one(_db, Collection, id=self.parent_id)
+            parent = Collection.for_id(_db, self.parent_id)
             yield parent
             for collection in parent.parents:
                 yield collection

--- a/model.py
+++ b/model.py
@@ -5321,7 +5321,6 @@ class Genre(Base):
     work_genres = relationship("WorkGenre", backref="genre", 
                                cascade="all, delete, delete-orphan")
 
-    # A dictionary of all known Genre objects by name.
     _cache = {}
     
     def __repr__(self):
@@ -9447,7 +9446,7 @@ class ConfigurationSetting(Base):
 
     @classmethod
     def reset_cache(cls):
-        cls._cache = RESET_ME
+        cls._cache = cls.RESET_ME
 
     def __repr__(self):
         return u'<ConfigurationSetting: key=%s, ID=%d>' % (
@@ -9564,6 +9563,13 @@ class ConfigurationSetting(Base):
                 library=library, external_integration=external_integration,
                 key=key
             )
+            if cls._cache == cls.RESET_ME:
+                # The cache is being reset while we're doing this,
+                # possibly because we just created a new
+                # ConfigurationSetting. Just return the setting object
+                # as-is and forget about updating the cache until
+                # things settle down.
+                return setting
             cls._cache_insert(setting, cls._cache)
         setting = cls._cache[cache_key]
         setting = _db.merge(setting, load=False)
@@ -10317,7 +10323,4 @@ def configuration_relevant_lifecycle_event(mapper, connection, target):
 def refresh_configuration_settings(mapper, connection, target):
     # The next time someone tries to access a configuration setting,
     # the cache will be repopulated.
-    for i in range(20):
-        print
-    print "CACHE RESET!!!!!!!!!!!!"
     ConfigurationSetting.reset_cache()

--- a/model.py
+++ b/model.py
@@ -10092,7 +10092,7 @@ class Collection(Base, HasFullTableCache):
     def parents(self):
         if self.parent_id:
             _db = Session.object_session(self)
-            parent = Collection.for_id(_db, self.parent_id)
+            parent = Collection.by_id(_db, self.parent_id)
             yield parent
             for collection in parent.parents:
                 yield collection

--- a/model.py
+++ b/model.py
@@ -9574,8 +9574,6 @@ class ConfigurationSetting(Base, HasFullTableCache):
         """Find or create a ConfigurationSetting associated with a Library
         and an ExternalIntegration.
         """
-        cache_key = self._cache_key(library, external_integration, key)
-
         def create():
             """Function called when a ConfigurationSetting is not found in cache
             and must be created.
@@ -9586,6 +9584,9 @@ class ConfigurationSetting(Base, HasFullTableCache):
                 key=key
             )
 
+        # ConfigurationSettings are stored in cache based on their library,
+        # external integration, and the name of the setting.
+        cache_key = cls._cache_key(library, external_integration, key)
         setting, ignore = cls._check_cache(_db, cache_key, create)
         return setting
         

--- a/model.py
+++ b/model.py
@@ -1074,6 +1074,7 @@ class DataSource(Base, HasFullTableCache):
     )
 
     _cache = HasFullTableCache.RESET
+    _id_cache = HasFullTableCache.RESET
     
     def __repr__(self):
         return '<DataSource: name="%s">' % (self.name)
@@ -5460,6 +5461,7 @@ class Genre(Base, HasFullTableCache):
                                cascade="all, delete, delete-orphan")
 
     _cache = HasFullTableCache.RESET
+    _id_cache = HasFullTableCache.RESET
     
     def __repr__(self):
         if classifier.genres.get(self.name):
@@ -8911,6 +8913,7 @@ class Library(Base, HasFullTableCache):
     )
 
     _cache = HasFullTableCache.RESET
+    _id_cache = HasFullTableCache.RESET
     
     def __repr__(self):
         return '<Library: name="%s", short name="%s", uuid="%s", library registry short name="%s">' % (
@@ -9575,7 +9578,8 @@ class ConfigurationSetting(Base, HasFullTableCache):
     )
 
     _cache = HasFullTableCache.RESET
-
+    _id_cache = HasFullTableCache.RESET
+    
     def __repr__(self):
         return u'<ConfigurationSetting: key=%s, ID=%d>' % (
             self.key, self.id)
@@ -9852,6 +9856,7 @@ class Collection(Base, HasFullTableCache):
     )
 
     _cache = HasFullTableCache.RESET
+    _id_cache = HasFullTableCache.RESET
     
     def __repr__(self):
         return (u'<Collection "%s"/"%s" ID=%d>' %

--- a/model.py
+++ b/model.py
@@ -9509,14 +9509,11 @@ class ConfigurationSetting(Base):
 
     @classmethod
     def _cache_insert(cls, setting, cache):
-        """Remove a ConfigurationSetting's association with the database
-        session that created it, then cache it in `cache` for later
-        retrieval.
+        """Cache a ConfigurationSetting for later retrieval, probably by a
+        different database session.
 
-        :return: The ConfigurationSetting, in a detached state.
+        :return: The ConfigurationSetting.
         """
-        #make_transient(setting)
-        #make_transient_to_detached(setting)
         library_id = setting.library_id
         external_integration_id = setting.external_integration_id
         key = setting.key

--- a/model.py
+++ b/model.py
@@ -1083,7 +1083,8 @@ class DataSource(Base, HasFullTableCache):
         return self.name
     
     @classmethod
-    def lookup(cls, _db, name, autocreate=False, offers_licenses=False):
+    def lookup(cls, _db, name, autocreate=False, offers_licenses=False,
+               primary_identifier_type=None):
         # Turn a deprecated name (e.g. "3M" into the current name
         # (e.g. "Bibliotheca").
         name = cls.DEPRECATED_NAMES.get(name, name)
@@ -1095,7 +1096,10 @@ class DataSource(Base, HasFullTableCache):
             if autocreate:
                 data_source, is_new = get_one_or_create(
                     _db, DataSource, name=name,
-                    create_method_kwargs=dict(offers_licenses=offers_licenses)
+                    create_method_kwargs=dict(
+                        offers_licenses=offers_licenses,
+                        primary_identifier_type=primary_identifier_type
+                    )
                 )
             else:
                 data_source = get_one(_db, DataSource, name=name)
@@ -1208,18 +1212,10 @@ class DataSource(Base, HasFullTableCache):
                 (cls.BIBBLIO, False, True, Identifier.BIBBLIO_CONTENT_ITEM_ID, None)
         ):
 
-            extra = dict()
-            if refresh_rate:
-                extra['circulation_refresh_rate_seconds'] = refresh_rate
-
-            obj, new = get_one_or_create(
-                _db, DataSource,
-                name=name,
-                create_method_kwargs=dict(
-                    offers_licenses=offers_licenses,
-                    primary_identifier_type=primary_identifier_type,
-                    extra=extra,
-                )
+            obj = DataSource.lookup(
+                _db, name, autocreate=True,
+                offers_licenses=offers_licenses,
+                primary_identifier_type = primary_identifier_type
             )
 
             if offers_metadata_lookup:

--- a/model.py
+++ b/model.py
@@ -9515,8 +9515,8 @@ class ConfigurationSetting(Base):
 
         :return: The ConfigurationSetting, in a detached state.
         """
-        make_transient(setting)
-        make_transient_to_detached(setting)
+        #make_transient(setting)
+        #make_transient_to_detached(setting)
         library_id = setting.library_id
         external_integration_id = setting.external_integration_id
         key = setting.key
@@ -9578,7 +9578,7 @@ class ConfigurationSetting(Base):
                 return setting
             cls._cache_insert(setting, cls._cache)
         setting = cls._cache[cache_key]
-        if _db:
+        if _db and setting not in _db:
             setting = _db.merge(setting, load=False)
         return setting
 

--- a/model.py
+++ b/model.py
@@ -9578,7 +9578,8 @@ class ConfigurationSetting(Base):
                 return setting
             cls._cache_insert(setting, cls._cache)
         setting = cls._cache[cache_key]
-        setting = _db.merge(setting, load=False)
+        if _db:
+            setting = _db.merge(setting, load=False)
         return setting
 
     @hybrid_property

--- a/model.py
+++ b/model.py
@@ -9532,7 +9532,6 @@ class ConfigurationSetting(Base):
         need to be repopulated often. ConfigurationSettings are looked
         up many times on each request, so the cache will be used a lot.
         """
-        print "CACHE POPULATE"
         cache = {}
         for setting in _db.query(ConfigurationSetting):
             cls._cache_insert(setting, cache)

--- a/model.py
+++ b/model.py
@@ -9697,7 +9697,7 @@ class ConfigurationSetting(Base, HasFullTableCache):
     
     @value.setter
     def set_value(self, new_value):
-        self._value = new_value
+        self._value = unicode(new_value)
 
     @classmethod
     def _is_secret(self, key):

--- a/model.py
+++ b/model.py
@@ -9697,7 +9697,9 @@ class ConfigurationSetting(Base, HasFullTableCache):
     
     @value.setter
     def set_value(self, new_value):
-        self._value = unicode(new_value)
+        if new_value:
+            new_value = unicode(new_value)
+        self._value = new_value
 
     @classmethod
     def _is_secret(self, key):

--- a/opds.py
+++ b/opds.py
@@ -1108,7 +1108,7 @@ class AcquisitionFeed(OPDSFeed):
             return
         default_loan_period = default_reservation_period = None
         collection = license_pool.collection
-        if (loan or hold) and not open_access:
+        if (loan or hold) and not license_pool.open_access:
             default_loan_period = datetime.timedelta(
                 collection.default_loan_period
             )
@@ -1117,7 +1117,7 @@ class AcquisitionFeed(OPDSFeed):
             since = loan.start
             until = loan.until(default_loan_period)
         elif hold:
-            if not open_access:
+            if not license_pool.open_access:
                 default_reservation_period = datetime.timedelta(
                     collection.default_reservation_period
                 )

--- a/testing.py
+++ b/testing.py
@@ -165,8 +165,9 @@ class DatabaseTest(object):
 
         # Remove any database objects cached in the model classes but
         # associated with the now-rolled-back session.
-        Genre.reset_cache()
         ConfigurationSetting.reset_cache()
+        DataSource.reset_cache()
+        Genre.reset_cache()
         Library.reset_cache()
         
         # Also roll back any record of those changes in the

--- a/testing.py
+++ b/testing.py
@@ -165,6 +165,7 @@ class DatabaseTest(object):
 
         # Remove any database objects cached in the model classes but
         # associated with the now-rolled-back session.
+        Genre.reset_cache()
         ConfigurationSetting.reset_cache()
         
         # Also roll back any record of those changes in the

--- a/testing.py
+++ b/testing.py
@@ -18,6 +18,7 @@ from model import (
     IntegrationClient,
     Collection,
     Complaint,
+    ConfigurationSetting,
     Contributor,
     CoverageRecord,
     Credential,
@@ -162,6 +163,10 @@ class DatabaseTest(object):
         # other session.
         self.transaction.rollback()
 
+        # Remove any database objects cached in the model classes but
+        # associated with the now-rolled-back session.
+        ConfigurationSetting.reset_cache()
+        
         # Also roll back any record of those changes in the
         # Configuration instance.
         for key in [

--- a/testing.py
+++ b/testing.py
@@ -167,6 +167,7 @@ class DatabaseTest(object):
         # associated with the now-rolled-back session.
         Genre.reset_cache()
         ConfigurationSetting.reset_cache()
+        Library.reset_cache()
         
         # Also roll back any record of those changes in the
         # Configuration instance.

--- a/testing.py
+++ b/testing.py
@@ -165,6 +165,7 @@ class DatabaseTest(object):
 
         # Remove any database objects cached in the model classes but
         # associated with the now-rolled-back session.
+        Collection.reset_cache()
         ConfigurationSetting.reset_cache()
         DataSource.reset_cache()
         Genre.reset_cache()

--- a/testing.py
+++ b/testing.py
@@ -168,6 +168,7 @@ class DatabaseTest(object):
         Collection.reset_cache()
         ConfigurationSetting.reset_cache()
         DataSource.reset_cache()
+        ExternalIntegration.reset_cache()
         Genre.reset_cache()
         Library.reset_cache()
         

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6791,7 +6791,7 @@ class TestHasFullTableCache(DatabaseTest):
         temp_id_cache = {}
         self.mock_class._cache_insert(self.mock, temp_cache, temp_id_cache)
         eq_({MockHasTableCache.KEY: self.mock}, temp_cache)
-        eq_({MockHasTableCache.ID: self.mock}, temp_cache, temp_id_cache)
+        eq_({MockHasTableCache.ID: self.mock}, temp_id_cache)
 
     # populate_cache(), _check_cache(), and by_id() are tested in
     # TestGenre since those methods must be backed by a real database

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5687,9 +5687,9 @@ class TestExternalIntegration(DatabaseTest):
         eq_("id1", setting.value)
 
         # Calling set() again updates the key-value pair.
-        eq_([setting], self.external_integration.settings)
+        eq_([setting.id], [x.id for x in self.external_integration.settings])
         setting2 = self.external_integration.set_setting("website_id", "id2")
-        eq_(setting, setting2)
+        eq_(setting.id, setting2.id)
         eq_("id2", setting2.value)
 
         eq_(setting2, self.external_integration.setting("website_id"))
@@ -5879,7 +5879,7 @@ class TestConfigurationSetting(DatabaseTest):
         setting2 = ConfigurationSetting.for_library_and_externalintegration(
             self._db, key, library, integration
         )
-        eq_(setting, setting2)
+        eq_(setting.id, setting2.id)
         assert_raises(
             IntegrityError,
             create, self._db, ConfigurationSetting,
@@ -5934,7 +5934,7 @@ class TestConfigurationSetting(DatabaseTest):
         # associated with the library.
         self._db.delete(integration)
         self._db.commit()
-        eq_([for_library], library.settings)
+        eq_([for_library.id], [x.id for x in library.settings])
 
     def test_int_value(self):
         number = ConfigurationSetting.sitewide(self._db, "number")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -663,6 +663,7 @@ class TestGenre(DatabaseTest):
         )
 
         # The object was already in the cache, so we just looked it up.
+        # No exception.
         eq_(drama, drama2)
         eq_(False, is_new)
         
@@ -674,9 +675,7 @@ class TestGenre(DatabaseTest):
 
         # Create a previously unknown genre.
         genre, ignore = Genre.lookup(
-            self._db
-
-        , "Some Weird Genre", autocreate=True
+            self._db, "Some Weird Genre", autocreate=True
         )
 
         # We don't know its default fiction status.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5593,6 +5593,18 @@ class TestLibrary(DatabaseTest):
         # recommended, but it's not an error.
         library.library_registry_short_name = None
 
+    def test_lookup(self):
+        library = self._default_library
+        name = library.short_name
+        eq_(name, library.cache_key())
+        # Cache is empty.
+        eq_(None, Library._check_cache(_db, name, None))
+
+        eq_(library, Library.lookup(self._db, name))
+
+        # Cache is populated.
+        eq_(library, Library._check_cache(_db, name, None))
+            
     def test_default(self):
         # We start off with no libraries.
         eq_(None, Library.default(self._db))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5746,7 +5746,7 @@ class TestExternalIntegration(DatabaseTest):
         self.external_integration, ignore = create(
             self._db, ExternalIntegration, goal=self._str, protocol=self._str
         )
-
+        
     def test_data_source(self):
         # For most collections, the protocol determines the
         # data source.
@@ -6213,20 +6213,29 @@ class TestCollection(DatabaseTest):
         )
 
     def test_by_name_and_protocol(self):
-        # You'll get an exception if you look up an existing name
-        # but the protocol doesn't match.
         name = "A name"
+        protocol = ExternalIntegration.OVERDRIVE
+        key = (name, protocol)
+        
+        # Cache is empty.
+        eq_(None, Collection._check_cache(_db, name, key))
+        
         collection1, is_new = Collection.by_name_and_protocol(
             self._db, name, ExternalIntegration.OVERDRIVE
         )
         eq_(True, is_new)
 
+        # Cache is populated.
+        eq_(collection1, Collection._check_cache(_db, name, key))
+        
         collection2, is_new = Collection.by_name_and_protocol(
             self._db, name, ExternalIntegration.OVERDRIVE
         )
         eq_(collection1, collection2)
         eq_(False, is_new)
 
+        # You'll get an exception if you look up an existing name
+        # but the protocol doesn't match.
         assert_raises_regexp(
             ValueError,
             'Collection "A name" does not use protocol "Bibliotheca".',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -629,6 +629,7 @@ class TestGenre(DatabaseTest):
 
         # We start with an unusable object as the cache.
         eq_(Genre.RESET, Genre._cache)
+        eq_(Genre.RESET, Genre._id_cache)
 
         # When we call populate_cache()...
         Genre.populate_cache(self._db)
@@ -639,6 +640,27 @@ class TestGenre(DatabaseTest):
         eq_("Drama", drama.name)
         eq_(False, is_new)
 
+        # The ID of every genre is copied to the ID cache.
+        eq_(drama, Genre._id_cache[drama.id])
+        drama2 = Genre.by_id(self._db, drama.id)
+        eq_(drama2, drama)
+
+    def test_by_id(self):
+
+        # Get a genre to test with.
+        drama = get_one(self._db, Genre, name="Drama")
+        
+        # Since we went right to the database, that didn't change the
+        # fact that the ID cache is uninitialized.
+        eq_(Genre.RESET, Genre._id_cache)
+
+        # Look up the same genre using by_id...
+        eq_(drama, Genre.by_id(self._db, drama.id))
+
+        # ... and the ID cache is fully initialized.
+        eq_(drama, Genre._id_cache[drama.id])
+        assert len(Genre._id_cache) > 1
+        
     def test_check_cache_miss_triggers_create_function(self):
         _db = self._db
         class Factory(object):
@@ -653,6 +675,7 @@ class TestGenre(DatabaseTest):
                 
         factory = Factory()
         Genre._cache = {}
+        Genre._id_cache = {}
         genre, is_new = Genre._check_cache(self._db, "Drama", factory.call_me)
         eq_("Drama", genre.name)
         eq_(False, is_new)
@@ -661,6 +684,9 @@ class TestGenre(DatabaseTest):
         # The Genre object created in call_me has been associated with the
         # Genre's cache key in the table-wide cache.
         eq_(genre, Genre._cache[genre.cache_key()])
+
+        # The cache by ID has been similarly populated.
+        eq_(genre, Genre._id_cache[genre.id])
 
     def test_check_cache_miss_when_cache_is_reset_populates_cache(self):
         # The cache is not in a state to be used.
@@ -676,6 +702,7 @@ class TestGenre(DatabaseTest):
 
         # ... and the cache is repopulated
         assert drama.cache_key() in Genre._cache
+        assert drama.id in Genre._id_cache
 
     def test_check_cache_hit_returns_cached_object(self):
 
@@ -6731,8 +6758,14 @@ class MockHasTableCache(HasFullTableCache):
     """
     
     _cache = HasFullTableCache.RESET
+    _id_cache = HasFullTableCache.RESET
 
+    ID = "the only ID"
     KEY = "the only cache key"
+
+    @property
+    def id(self):
+        return self.ID
     
     def cache_key(self):
         return self.KEY
@@ -6748,17 +6781,21 @@ class TestHasFullTableCache(DatabaseTest):
 
     def test_reset_cache(self):
         self.mock_class._cache = object()
+        self.mock_class._id_cache = object()
         self.mock_class.reset_cache()
         eq_(HasFullTableCache.RESET, self.mock_class._cache)
+        eq_(HasFullTableCache.RESET, self.mock_class._id_cache)
 
     def test_cache_insert(self):
         temp_cache = {}
-        value = object()
-        self.mock_class._cache_insert(self.mock, temp_cache)
-        eq_({self.mock.KEY: self.mock}, temp_cache)
+        temp_id_cache = {}
+        self.mock_class._cache_insert(self.mock, temp_cache, temp_id_cache)
+        eq_({MockHasTableCache.KEY: self.mock}, temp_cache)
+        eq_({MockHasTableCache.ID: self.mock}, temp_cache, temp_id_cache)
 
-    # populate_cache() and _check_cache() are tested in TestGenre
-    # since those methods must be backed by a real database table.
+    # populate_cache(), _check_cache(), and by_id() are tested in
+    # TestGenre since those methods must be backed by a real database
+    # table.
 
 
     


### PR DESCRIPTION
This branch eliminates a lot of database hits by replacing many calls to `get_one()` with calls to HasFullTableCache.by_cache_key and (mainly) HasFullTableCache.by_id. The single biggest win here is the change in Lane.library(), which was causing hundreds of database hits when the circ manager was started up.

This branch adds the HasFullTableCache mixin to two more classes: DeliveryMechanism and ExternalIntegration. The ExternalIntegration implementation is a little ugly, but we only need the by_id implementation, so it works.