### PR TITLE
Convert a value to a string even if the value is the number zero.

### DIFF
--- a/model.py
+++ b/model.py
@@ -9721,7 +9721,7 @@ class ConfigurationSetting(Base, HasFullTableCache):
     
     @value.setter
     def set_value(self, new_value):
-        if new_value:
+        if new_value is not None:
             new_value = unicode(new_value)
         self._value = new_value
 


### PR DESCRIPTION
This branch fixes a problem I'm having in circulation where setting a ConfigurationSetting value to the number zero doesn't trigger the code that's supposed to convert non-string values to Unicode.