### PR TITLE
All API classes now implement collection() by looking up the collection in the full-table cache.

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -106,8 +106,8 @@ class Axis360API(object):
 
     @property
     def collection(self):
-        return get_one(self._db, Collection, id=self.collection_id)
-    
+        return Collection.by_id(self._db, id=self.collection_id)
+
     @property
     def source(self):
         return DataSource.lookup(self._db, DataSource.AXIS_360)

--- a/bibliotheca.py
+++ b/bibliotheca.py
@@ -103,7 +103,7 @@ class BibliothecaAPI(object):
 
     @property
     def collection(self):
-        return get_one(self._db, Collection, id=self.collection_id)
+        return Collection.by_id(self._db, id=self.collection_id)
         
     @property
     def source(self):

--- a/oneclick.py
+++ b/oneclick.py
@@ -121,7 +121,7 @@ class OneClickAPI(object):
 
     @property
     def collection(self):
-        return get_one(self._db, Collection, id=self.collection_id)
+        return Collection.by_id(self._db, id=self.collection_id)
 
     @property
     def authorization_headers(self):

--- a/overdrive.py
+++ b/overdrive.py
@@ -170,7 +170,7 @@ class OverdriveAPI(object):
 
     @property
     def collection(self):
-        return get_one(self._db, Collection, id=self.collection_id)
+        return Collection.by_id(self._db, id=self.collection_id)
         
     @property
     def source(self):


### PR DESCRIPTION
When a patron retrieves the loans feed, this eliminates one database request for every loan or hold they have.