### PR TITLE
Small changes to support OPDS for distributors.

### DIFF
--- a/model.py
+++ b/model.py
@@ -1557,6 +1557,7 @@ class Identifier(Base):
     GUTENBERG_URN_SCHEME_PREFIX = "http://www.gutenberg.org/ebooks/"
     GUTENBERG_URN_SCHEME_RE = re.compile(
         GUTENBERG_URN_SCHEME_PREFIX + "([0-9]+)")
+    OTHER_URN_SCHEME_PREFIX = "urn:"
 
     __tablename__ = 'identifiers'
     id = Column(Integer, primary_key=True)
@@ -1766,6 +1767,8 @@ class Identifier(Base):
                 raise ValueError("%s is not a valid ISBN." % identifier_string)
             if isbnlib.is_isbn10(identifier_string):
                 identifier_string = isbnlib.to_isbn13(identifier_string)
+        elif identifier_string.startswith(Identifier.OTHER_URN_SCHEME_PREFIX):
+            type = Identifier.URI
         else:
             raise ValueError(
                 "Could not turn %s into a recognized identifier." %
@@ -5096,7 +5099,7 @@ class Hyperlink(Base):
     # TODO: Is this the appropriate relation?
     DRM_ENCRYPTED_DOWNLOAD = u"http://opds-spec.org/acquisition/"
 
-    CIRCULATION_ALLOWED = [OPEN_ACCESS_DOWNLOAD, DRM_ENCRYPTED_DOWNLOAD]
+    CIRCULATION_ALLOWED = [OPEN_ACCESS_DOWNLOAD, DRM_ENCRYPTED_DOWNLOAD, GENERIC_OPDS_ACQUISITION]
     METADATA_ALLOWED = [CANONICAL, IMAGE, THUMBNAIL_IMAGE, ILLUSTRATION, REVIEW, 
         DESCRIPTION, SHORT_DESCRIPTION, AUTHOR, ALTERNATE, SAMPLE]
     MIRRORED = [OPEN_ACCESS_DOWNLOAD, IMAGE]

--- a/scripts.py
+++ b/scripts.py
@@ -1516,6 +1516,7 @@ class OPDSImportScript(CollectionInputScript):
 
     IMPORTER_CLASS = OPDSImporter
     MONITOR_CLASS = OPDSImportMonitor
+    PROTOCOL = ExternalIntegration.OPDS_IMPORT
     
     @classmethod
     def arg_parser(cls):
@@ -1529,7 +1530,7 @@ class OPDSImportScript(CollectionInputScript):
     
     def do_run(self, cmd_args=None):
         parsed = self.parse_command_line(self._db, cmd_args=cmd_args)
-        collections = parsed.collections or Collection.by_protocol(self._db, ExternalIntegration.OPDS_IMPORT)
+        collections = parsed.collections or Collection.by_protocol(self._db, self.PROTOCOL)
         for collection in collections:
             self.run_monitor(collection, force=parsed.force)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -358,6 +358,12 @@ class TestIdentifier(DatabaseTest):
         eq_(Identifier.URI, https_identifier.type)
         eq_("https://example.com", https_identifier.identifier)
 
+        # We can parse UUIDs.
+        uuid_identifier, ignore = Identifier.parse_urn(
+            self._db, "urn:uuid:04377e87-ab69-41c8-a2a4-812d55dc0952")
+        eq_(Identifier.URI, uuid_identifier.type)
+        eq_("urn:uuid:04377e87-ab69-41c8-a2a4-812d55dc0952", uuid_identifier.identifier)
+
         # A URN we can't handle raises an exception.
         ftp_urn = "ftp://example.com"
         assert_raises(ValueError, Identifier.parse_urn, self._db, ftp_urn)

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -457,7 +457,7 @@ class TestOPDSImporter(OPDSImporterTest):
             )
 
         # If the URN is invalid we can't create a CoverageFailure.
-        invalid_urn = f("urn:blah", "500", "description")
+        invalid_urn = f("urnblah", "500", "description")
         eq_(invalid_urn, None)
 
         identifier = self._identifier()
@@ -1304,7 +1304,7 @@ class TestOPDSImportMonitor(OPDSImporterTest):
         self._default_collection.external_integration.protocol = ExternalIntegration.OVERDRIVE
         assert_raises_regexp(
             ValueError,
-            "Collection .* is configured for protocol Overdrive, not OPDS import.",
+            "Collection .* is configured for protocol Overdrive, not OPDS Import.",
             OPDSImportMonitor,
             self._db,
             self._default_collection,


### PR DESCRIPTION
Biblioboard uses "urn:uuid:.." identifiers, and the OPDS importer needed to allow additional protocols and provide a hook for adding non-open-access formats.