### PR TITLE
"Default Blank" is not the name of a series; it indicates the absence of a series

### DIFF
--- a/oneclick.py
+++ b/oneclick.py
@@ -661,14 +661,18 @@ class OneClickRepresentationExtractor(object):
             # Sometimes, series position and total == 0, for many series items (ex: "seriesName": "EngLits").
             # Sometimes, seriesName is set to "Default Blank", meaning "not actually a series".
             series_name = book.get('seriesName', None)
-
-            series_position = book.get('seriesPosition', None)
-            if series_position:
-                try:
-                    series_position = int(series_position)
-                except ValueError:
-                    # not big enough deal to stop the whole process
-                    series_position = None
+            series_position = None
+            if series_name == 'Default Blank':
+                # This is not actually a series.
+                series_name = None
+            else:
+                series_position = book.get('seriesPosition', None)
+                if series_position:
+                    try:
+                        series_position = int(series_position)
+                    except ValueError:
+                        # not big enough deal to stop the whole process
+                        series_position = None
 
             # ignored for now
             series_total = book.get('seriesTotal', None)

--- a/tests/files/oneclick/response_isbn_found_no_series.json
+++ b/tests/files/oneclick/response_isbn_found_no_series.json
@@ -1,0 +1,7 @@
+{
+  "isbn": "9780307378101",
+  "seriesName": "Default Blank",
+  "seriesPosition": 10,
+  "seriesTotal": 17,
+  "title": "Tea Time for the Traditionally Built"
+}

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -181,6 +181,7 @@ class TestOneClickRepresentationExtractor(OneClickTest):
         eq_(None, metadata.subtitle)
         eq_(Edition.BOOK_MEDIUM, metadata.medium)
         eq_("No. 1 Ladies Detective Agency", metadata.series)
+        eq_(10, metadata.series_position)
         eq_("eng", metadata.language)
         eq_("Anchor", metadata.publisher)
         eq_(None, metadata.imprint)
@@ -256,6 +257,18 @@ class TestOneClickRepresentationExtractor(OneClickTest):
         eq_(Representation.EPUB_MEDIA_TYPE, epub.content_type)       
         eq_(DeliveryMechanism.ADOBE_DRM, epub.drm_scheme)      
 
+
+    def test_book_info_metadata_no_series(self):
+        """'Default Blank' is not a series -- it's a string representing
+        the absence of a series.
+        """
+
+        datastr, datadict = self.api.get_data("response_isbn_found_no_series.json")
+        metadata = OneClickRepresentationExtractor.isbn_info_to_metadata(datadict)
+
+        eq_("Tea Time for the Traditionally Built", metadata.title)
+        eq_(None, metadata.series)
+        eq_(None, metadata.series_position)
 
 
 class TestOneClickBibliographicCoverageProvider(OneClickTest):


### PR DESCRIPTION
When OneClick wants to say a book is not part of a series, it sets the series name to "Default Blank". We had a comment about this, but no code. This branch introduces the code that correctly handles the situation -- series name of "Default Blank" means the series should be None, not "Default Blank".