### PR TITLE
Contributor lookups by VIAF or LC shouldn't crash on duplicates

### DIFF
--- a/model.py
+++ b/model.py
@@ -2310,7 +2310,9 @@ class Contributor(Base):
             if create_new:
                 contributor, new = get_one_or_create(
                     _db, Contributor, create_method_kwargs=create_method_kwargs,
-                    **query)
+                    on_multiple='interchangeable',
+                    **query
+                )
                 if contributor:
                     contributors = [contributor]
             else:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -804,6 +804,22 @@ class TestContributor(DatabaseTest):
 
         eq_((bob1, False), Contributor.lookup(self._db, lc="foo"))
 
+    def test_lookup_by_viaf_interchangeable(self):
+        # Two contributors with the same lc. This shouldn't happen, but 
+        # the reason it shouldn't happen is these two people are the same
+        # person, so lookup() should just pick one and go with it.
+        bob1, new = self._contributor(sort_name="Bob", lc="foo")
+        bob2, new = self._contributor()
+        bob2.sort_name = "Bob"
+        bob2.lc = "foo"
+        self._db.commit()
+        assert bob1 != bob2
+        [some_bob], new = Contributor.lookup(
+            self._db, sort_name="Bob", lc="foo"
+        )
+        eq_(False, new)
+        assert some_bob in (bob1, bob2)
+
     def test_lookup_by_name(self):
 
         # Two contributors named Bob.


### PR DESCRIPTION
In the metadata wrangler there are some duplicate contributors -- same LC and VIAF. This shouldn't happen, and this branch doesn't fix the problem. This branch fixes the _related_ problem that when it does happen, `Contributor.lookup` crashes. This stops the metadata wrangler from being able to resolve identifiers whose Contributors have the problem.

This branch makes Contributors interchangeable if they have the same LC or the same VIAF. At some point they'll all be consolidated and it won't matter which one we chose.