### PR TITLE
Remove edition license pool

### DIFF
--- a/config.py
+++ b/config.py
@@ -388,10 +388,6 @@ class Configuration(object):
             and last_check and (now - last_check).total_seconds() < timeout):
             # We went to the database less than [timeout] seconds ago.
             # Assume there has been no change.
-            logging.error("Assuming that %s is still valid.", cls._site_configuration_last_update())
-            logging.error("Known value: %s", known_value)
-            logging.error("Last check: %.2f sec ago.", (now-last_check).total_seconds())
-            logging.error("Timeout: %s", timeout)
             return cls._site_configuration_last_update()
         
         # Ask the database when was the last time the site

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1339,10 +1339,11 @@ class Metadata(MetaToModelUtility):
     def _run_query(self, qu, potentials, confidence):
         success = False
         for i in qu:
-            lp = i.license_pool
-            if lp and lp.deliverable and potentials.get(lp, 0) < confidence:
-                potentials[lp] = confidence
-                success = True
+            pools = i.license_pools
+            for lp in pools:
+                if lp and lp.deliverable and potentials.get(lp, 0) < confidence:
+                    potentials[lp] = confidence
+                    success = True
         return success
 
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -500,19 +500,19 @@ class MetaToModelUtility(object):
         original_url = link.href
 
         self.log.info("About to mirror %s" % original_url)
-        pool = None
+        pools = []
         edition = None
         title = None
         identifier = None
         if model_object:
             if isinstance(model_object, LicensePool):
-                pool = model_object
+                pools = [model_object]
                 identifier = model_object.identifier
 
                 if (identifier and identifier.primarily_identifies and identifier.primarily_identifies[0]): 
                     edition = identifier.primarily_identifies[0]
             elif isinstance(model_object, Edition):
-                pool = model_object.license_pool
+                pools = model_object.license_pools
                 identifier = model_object.primary_identifier
                 edition = model_object
         if edition and edition.title:
@@ -550,10 +550,11 @@ class MetaToModelUtility(object):
         # The license pool to suppress will be either the passed-in model_object (if it's of type pool), 
         # or the license pool associated with the passed-in model object (if it's of type edition).
         if representation.fetch_exception:
-            if pool and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
-                pool.suppressed = True
-                pool.license_exception = "Fetch exception: %s" % representation.fetch_exception
-                self.log.error(pool.license_exception)
+            if pools and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
+                for pool in pools:
+                    pool.suppressed = True
+                    pool.license_exception = "Fetch exception: %s" % representation.fetch_exception
+                    self.log.error(pool.license_exception)
             return
 
         # If we fetched the representation and it hasn't changed,
@@ -607,10 +608,11 @@ class MetaToModelUtility(object):
         # If we couldn't mirror an open access link representation, suppress
         # the license pool until someone fixes it manually.
         if representation.mirror_exception: 
-            if pool and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
-                pool.suppressed = True
-                pool.license_exception = "Mirror exception: %s" % representation.mirror_exception
-                self.log.error(pool.license_exception)
+            if pools and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
+                for pool in pools:
+                    pool.suppressed = True
+                    pool.license_exception = "Mirror exception: %s" % representation.mirror_exception
+                    self.log.error(pool.license_exception)
 
         if link_obj.rel == Hyperlink.IMAGE:
             # Create and mirror a thumbnail.

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -500,19 +500,19 @@ class MetaToModelUtility(object):
         original_url = link.href
 
         self.log.info("About to mirror %s" % original_url)
-        pool = None
+        pools = []
         edition = None
         title = None
         identifier = None
         if model_object:
             if isinstance(model_object, LicensePool):
-                pool = model_object
+                pools = [model_object]
                 identifier = model_object.identifier
 
                 if (identifier and identifier.primarily_identifies and identifier.primarily_identifies[0]): 
                     edition = identifier.primarily_identifies[0]
             elif isinstance(model_object, Edition):
-                pool = model_object.license_pool
+                pools = model_object.license_pools
                 identifier = model_object.primary_identifier
                 edition = model_object
         if edition and edition.title:
@@ -550,10 +550,11 @@ class MetaToModelUtility(object):
         # The license pool to suppress will be either the passed-in model_object (if it's of type pool), 
         # or the license pool associated with the passed-in model object (if it's of type edition).
         if representation.fetch_exception:
-            if pool and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
-                pool.suppressed = True
-                pool.license_exception = "Fetch exception: %s" % representation.fetch_exception
-                self.log.error(pool.license_exception)
+            if pools and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
+                for pool in pools:
+                    pool.suppressed = True
+                    pool.license_exception = "Fetch exception: %s" % representation.fetch_exception
+                    self.log.error(pool.license_exception)
             return
 
         # If we fetched the representation and it hasn't changed,
@@ -607,10 +608,11 @@ class MetaToModelUtility(object):
         # If we couldn't mirror an open access link representation, suppress
         # the license pool until someone fixes it manually.
         if representation.mirror_exception: 
-            if pool and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
-                pool.suppressed = True
-                pool.license_exception = "Mirror exception: %s" % representation.mirror_exception
-                self.log.error(pool.license_exception)
+            if pools and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
+                for pool in pools:
+                    pool.suppressed = True
+                    pool.license_exception = "Mirror exception: %s" % representation.mirror_exception
+                    self.log.error(pool.license_exception)
 
         if link_obj.rel == Hyperlink.IMAGE:
             # Create and mirror a thumbnail.
@@ -1337,10 +1339,11 @@ class Metadata(MetaToModelUtility):
     def _run_query(self, qu, potentials, confidence):
         success = False
         for i in qu:
-            lp = i.license_pool
-            if lp and lp.deliverable and potentials.get(lp, 0) < confidence:
-                potentials[lp] = confidence
-                success = True
+            pools = i.license_pools
+            for lp in pools:
+                if lp and lp.deliverable and potentials.get(lp, 0) < confidence:
+                    potentials[lp] = confidence
+                    success = True
         return success
 
 

--- a/model.py
+++ b/model.py
@@ -2805,13 +2805,14 @@ class Edition(Base):
         return r
 
     @property
-    def license_pool(self):
-        """The Edition's corresponding LicensePool, if any.
+    def license_pools(self):
+        """The LicensePools that provide access to the book described
+        by this Edition.
         """
         _db = Session.object_session(self)
-        return get_one(_db, LicensePool,
-                       data_source=self.data_source,
-                       identifier=self.primary_identifier)
+        return _db.query(LicensePool).filter(
+            LicensePool.data_source==self.data_source,
+            LicensePool.identifier==self.primary_identifier).all()
 
     def equivalent_identifiers(self, levels=3, threshold=0.5, type=None):
         """All Identifiers equivalent to this

--- a/model.py
+++ b/model.py
@@ -2807,13 +2807,14 @@ class Edition(Base):
         return r
 
     @property
-    def license_pool(self):
-        """The Edition's corresponding LicensePool, if any.
+    def license_pools(self):
+        """The LicensePools that provide access to the book described
+        by this Edition.
         """
         _db = Session.object_session(self)
-        return get_one(_db, LicensePool,
-                       data_source=self.data_source,
-                       identifier=self.primary_identifier)
+        return _db.query(LicensePool).filter(
+            LicensePool.data_source==self.data_source,
+            LicensePool.identifier==self.primary_identifier).all()
 
     def equivalent_identifiers(self, levels=3, threshold=0.5, type=None):
         """All Identifiers equivalent to this

--- a/scripts.py
+++ b/scripts.py
@@ -99,6 +99,18 @@ class Script(object):
         return self._session
 
     @property
+    def timestamp_name(self):
+        """The name of this script as seen in its Timestamp."""
+
+        class_name = type(self).__name__
+
+        # Some scripts like RunMonitorScript 
+        specific_name = getattr(self, 'name')
+        if specific_name:
+            return "%s: %s" % (class_name, specific_name)
+
+
+    @property
     def log(self):
         if not hasattr(self, '_log'):
             logger_name = getattr(self, 'name', None)
@@ -266,8 +278,16 @@ class RunCollectionCoverageProviderScript(RunCoverageProvidersScript):
         _db = _db or self._db
         providers = providers or list()
         if provider_class:
+            # Give each provider class its own Timestamp when run
+            # through this script.
+            self.name = provider_class.__name__
             providers += self.get_providers(_db, provider_class, **kwargs)
-
+        else:
+            # Give this combination of providers a unique Timestamp
+            # when run through this script.
+            self.name = ", ".join(
+                sorted([provider.SERVICE_NAME for provider in providers])
+            )
         super(RunCollectionCoverageProviderScript, self).__init__(providers)
 
     def get_providers(self, _db, provider_class, **kwargs):

--- a/scripts.py
+++ b/scripts.py
@@ -99,18 +99,6 @@ class Script(object):
         return self._session
 
     @property
-    def timestamp_name(self):
-        """The name of this script as seen in its Timestamp."""
-
-        class_name = type(self).__name__
-
-        # Some scripts like RunMonitorScript 
-        specific_name = getattr(self, 'name')
-        if specific_name:
-            return "%s: %s" % (class_name, specific_name)
-
-
-    @property
     def log(self):
         if not hasattr(self, '_log'):
             logger_name = getattr(self, 'name', None)
@@ -278,16 +266,7 @@ class RunCollectionCoverageProviderScript(RunCoverageProvidersScript):
         _db = _db or self._db
         providers = providers or list()
         if provider_class:
-            # Give each provider class its own Timestamp when run
-            # through this script.
-            self.name = provider_class.__name__
             providers += self.get_providers(_db, provider_class, **kwargs)
-        else:
-            # Give this combination of providers a unique Timestamp
-            # when run through this script.
-            self.name = ", ".join(
-                sorted([provider.SERVICE_NAME for provider in providers])
-            )
         super(RunCollectionCoverageProviderScript, self).__init__(providers)
 
     def get_providers(self, _db, provider_class, **kwargs):

--- a/testing.py
+++ b/testing.py
@@ -301,7 +301,9 @@ class DatabaseTest(object):
             if with_license_pool:
                 presentation_edition, pool = presentation_edition
         else:
-            pool = presentation_edition.license_pool
+            # Just pick one -- there's probably only one and if
+            # there's any confusion it's the fault of the caller.
+            pool = presentation_edition.license_pools[0]
         if new_edition:
             presentation_edition.calculate_presentation()
         work, ignore = get_one_or_create(

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -156,7 +156,7 @@ class TestCirculationData(DatabaseTest):
 
         [epub, pdf] = sorted(pool.delivery_mechanisms, 
                              key=lambda x: x.delivery_mechanism.content_type)
-        eq_(epub.resource, edition.license_pool.best_open_access_resource)
+        eq_(epub.resource, pool.best_open_access_resource)
 
         eq_(Representation.PDF_MEDIA_TYPE, pdf.delivery_mechanism.content_type)
         eq_(DeliveryMechanism.ADOBE_DRM, pdf.delivery_mechanism.drm_scheme)
@@ -611,7 +611,7 @@ class TestMetaToModelUtility(DatabaseTest):
         assert book.mirror_url.endswith(expect)
 
         # make sure the mirrored link is safely on edition
-        sorted_edition_links = sorted(edition.license_pool.identifier.links, key=lambda x: x.rel)
+        sorted_edition_links = sorted(pool.identifier.links, key=lambda x: x.rel)
         unmirrored_representation, mirrored_representation = [edlink.resource.representation for edlink in sorted_edition_links]
         assert mirrored_representation.mirror_url.startswith('http://s3.amazonaws.com/test.content.bucket/')
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -971,6 +971,20 @@ class TestContributor(DatabaseTest):
 
 class TestEdition(DatabaseTest):
 
+    def test_license_pools(self):
+        # Here are two collections that provide access to the same book.
+        c1 = self._collection()
+        c2 = self._collection()
+        
+        edition, lp1 = self._edition(with_license_pool=True)
+        lp2 = self._licensepool(edition=edition, collection=c2)
+
+        # Two LicensePools for the same work.
+        eq_(lp1.identifier, lp2.identifier)
+        
+        # Edition.license_pools contains both.
+        eq_([lp1, lp2], edition.license_pools)        
+
     def test_author_contributors(self):
         data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)
         id = self._str

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -983,7 +983,7 @@ class TestEdition(DatabaseTest):
         eq_(lp1.identifier, lp2.identifier)
         
         # Edition.license_pools contains both.
-        eq_([lp1, lp2], edition.license_pools)        
+        eq_(set([lp1, lp2]), set(edition.license_pools))
 
     def test_author_contributors(self):
         data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2934,23 +2934,25 @@ class TestWorkConsolidation(DatabaseTest):
             with_license_pool=True
         )
 
-        # For purposes of this test, let's pretend these books are
+        # For purposes of this test, let's pretend all these books are
         # open-access.
-        edition1.license_pool.open_access = True
-        edition2.license_pool.open_access = True
+        for e in [edition1, edition2]:
+            for license_pool in e.license_pools:
+                license_pool.open_access = True
         
         # Calling calculate_work() on the first edition creates a Work.
-        work1, created = edition1.license_pool.calculate_work()
+        work1, created = edition1.license_pools[0].calculate_work()
         eq_(created, True)
 
         # Calling calculate_work() on the second edition associated
         # the second edition's pool with the first work.
-        work2, created = edition2.license_pool.calculate_work()
+        work2, created = edition2.license_pools[0].calculate_work()
         eq_(created, False)
 
         eq_(work1, work2)
 
-        eq_(set([edition1.license_pool, edition2.license_pool]), set(work1.license_pools))
+        expect = edition1.license_pools + edition2.license_pools
+        eq_(set(expect), set(work1.license_pools))
 
 
     def test_calculate_work_for_licensepool_creates_new_work(self):
@@ -6627,7 +6629,7 @@ class TestMaterializedViews(DatabaseTest):
         [pool1] = work.license_pools
         edition2, pool2 = self._edition(with_license_pool=True)
         work.license_pools.append(pool1)
-        eq_(pool1, work.presentation_edition.license_pool)
+        eq_([pool1], work.presentation_edition.license_pools)
         work.presentation_ready = True
         work.simple_opds_entry = '<entry>'
         work.assign_genres_from_weights({classifier.Fantasy : 1})

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -441,10 +441,10 @@ class TestCustomListEntrySweepMonitor(DatabaseTest):
         
         # Two Collections, each with one book from one of the lists.
         c1 = self._collection()
-        c1.licensepools.append(edition1.license_pool)
+        c1.licensepools.extend(edition1.license_pools)
         
         c2 = self._collection()
-        c2.licensepools.append(edition2.license_pool)
+        c2.licensepools.extend(edition2.license_pools)
 
         # If we don't pass in a Collection to
         # CustomListEntrySweepMonitor, we get all three
@@ -472,10 +472,10 @@ class TestEditionSweepMonitor(DatabaseTest):
 
         # Two Collections, each with one book.
         c1 = self._collection()
-        c1.licensepools.append(e1.license_pool)
+        c1.licensepools.extend(e1.license_pools)
         
         c2 = self._collection()
-        c2.licensepools.append(e2.license_pool)
+        c2.licensepools.extend(e2.license_pools)
         
         # If we don't pass in a Collection to EditionSweepMonitor, we
         # get all three Editions, in their order of creation.

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -543,7 +543,7 @@ class TestOPDSImporter(OPDSImporterTest):
         # metadata wrangler. No Work has been created.
         eq_(DataSource.METADATA_WRANGLER, crow.data_source.name)
         eq_(None, crow.work)
-        eq_(None, crow.license_pool)
+        eq_([], crow.license_pools)
         eq_(Edition.BOOK_MEDIUM, crow.medium)
 
         # not even the 'mouse'
@@ -728,10 +728,10 @@ class TestOPDSImporter(OPDSImporterTest):
             DataSource.OVERDRIVE, Identifier.OVERDRIVE_ID,
             with_license_pool=True
         )
-        edition.license_pool.calculate_work()
-        work = edition.license_pool.work
+        [old_license_pool] = edition.license_pools
+        old_license_pool.calculate_work()
+        work = old_license_pool.work
 
-        old_license_pool = edition.license_pool
         feed = feed.replace("{OVERDRIVE ID}", edition.primary_identifier.identifier)
 
         self._default_collection.external_integration.setting('data_source').value = (
@@ -751,7 +751,7 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(DataSource.OVERDRIVE, new_edition.data_source.name)
         
         # But the license pools have not changed.
-        eq_(edition.license_pool, old_license_pool)
+        eq_(edition.license_pools, [old_license_pool])
         eq_(work.license_pools, [old_license_pool])
 
 

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -543,7 +543,7 @@ class TestOPDSImporter(OPDSImporterTest):
         # metadata wrangler. No Work has been created.
         eq_(DataSource.METADATA_WRANGLER, crow.data_source.name)
         eq_(None, crow.work)
-        eq_(None, crow.license_pool)
+        eq_([], crow.license_pools)
         eq_(Edition.BOOK_MEDIUM, crow.medium)
 
         # not even the 'mouse'
@@ -728,10 +728,10 @@ class TestOPDSImporter(OPDSImporterTest):
             DataSource.OVERDRIVE, Identifier.OVERDRIVE_ID,
             with_license_pool=True
         )
-        edition.license_pool.calculate_work()
-        work = edition.license_pool.work
+        [pool] = edition.license_pools
+        pool.calculate_work()
+        work = pool.work
 
-        old_license_pool = edition.license_pool
         feed = feed.replace("{OVERDRIVE ID}", edition.primary_identifier.identifier)
 
         self._default_collection.external_integration.setting('data_source').value = (
@@ -751,8 +751,8 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(DataSource.OVERDRIVE, new_edition.data_source.name)
         
         # But the license pools have not changed.
-        eq_(edition.license_pool, old_license_pool)
-        eq_(work.license_pools, [old_license_pool])
+        eq_(edition.license_pools, [pool])
+        eq_(work.license_pools, [pool])
 
 
     def test_import_from_license_source(self):


### PR DESCRIPTION
This branch replaces `Edition.license_pool` with `Edition.license_pools`. This code should have been changed in the 2.0 release, but everything appears to work, until you get two collections that provide LicensePools for the same Identifier and DataSource, a case we hadn't tested.

I'll be checking all three components and doing branches for them if they use `Edition.license_pool`.

Update:

content: https://github.com/NYPL-Simplified/content_server/pull/139
circulation: https://github.com/NYPL-Simplified/circulation/pull/659
metadata (just a submodule update): https://github.com/NYPL-Simplified/metadata_wrangler/pull/122