### PR TITLE
Support sending info from the circulation manager to the metadata wrangler

### DIFF
--- a/migration/20170831-add-data-source-integration-client-id.sql
+++ b/migration/20170831-add-data-source-integration-client-id.sql
@@ -1,0 +1,6 @@
+alter table datasources add column integration_client_id integer unique;
+alter table datasources add constraint datasources_integration_client_id_fkey
+    foreign key (integration_client_id) references integrationclients(id);
+
+create index "ix_datasources_integration_client"
+    on datasources (integration_client_id);

--- a/model.py
+++ b/model.py
@@ -1035,6 +1035,12 @@ class DataSource(Base, HasFullTableCache):
     primary_identifier_type = Column(String, index=True)
     extra = Column(MutableDict.as_mutable(JSON), default={})
 
+    # One DataSource can have one IntegrationClient.
+    integration_client_id = Column(
+        Integer, ForeignKey('integrationclients.id'),
+        unique=True, index=True, nullable=True)
+    integration_client = relationship("IntegrationClient", backref=backref("data_source", uselist=False))
+
     # One DataSource can generate many Editions.
     editions = relationship("Edition", backref="data_source")
 
@@ -9386,6 +9392,7 @@ class ExternalIntegration(Base, HasFullTableCache):
     BIBLIOTHECA = DataSource.BIBLIOTHECA
     AXIS_360 = DataSource.AXIS_360
     ONE_CLICK = DataSource.ONECLICK
+    OPDS_FOR_DISTRIBUTORS = u'OPDS for Distributors'
 
     # These protocols are only used on the Content Server when mirroring
     # content from a given directory or directly from Project

--- a/opds_import.py
+++ b/opds_import.py
@@ -132,6 +132,7 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup):
     SITEWIDE = True
 
     ADD_ENDPOINT = 'add'
+    ADD_WITH_METADATA_ENDPOINT = 'add_with_metadata'
     REMOVE_ENDPOINT = 'remove'
     UPDATES_ENDPOINT = 'updates'
     CANONICALIZE_ENDPOINT = 'canonical-author-name'
@@ -180,14 +181,14 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup):
             kwargs['auth'] = (self.client_id, self.client_secret)
         return super(MetadataWranglerOPDSLookup, self)._get(url, **kwargs)
 
-    def _post(self, url, **kwargs):
+    def _post(self, url, data="", **kwargs):
         """Make an HTTP request. This method is overridden in the mock class."""
         if self.authenticated:
             kwargs['auth'] = (self.client_id, self.client_secret)
         kwargs['timeout'] = kwargs.get('timeout', 120)
         kwargs['allowed_response_codes'] = kwargs.get('allowed_response_codes', [])
         kwargs['allowed_response_codes'] += ['2xx', '3xx']
-        return HTTP.post_with_timeout(url, "", **kwargs)
+        return HTTP.post_with_timeout(url, data, **kwargs)
 
     def get_collection_url(self, endpoint):
         if not self.authenticated:
@@ -204,6 +205,11 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup):
 
         logging.info("Metadata Wrangler Collection Addition URL: %s", url)
         return self._post(url)
+
+    def add_with_metadata(self, feed):
+        """Add a feed of items with metadata to an authenticated Metadata Wrangler Collection."""
+        add_with_metadata_url = self.get_collection_url(self.ADD_WITH_METADATA_ENDPOINT)
+        return self._post(add_with_metadata_url, unicode(feed))
 
     def remove(self, identifiers):
         """Remove items from an authenticated Metadata Wrangler Collection"""


### PR DESCRIPTION
This branch adds a relationship between DataSources and IntegrationClients, so the metadata wrangler can keep track of which Circulation Manager gave it some metadata. It also adds a constant for OPDS for distributors so the wrangler can use it, and adds a method to MetadataWranglerOPDSLookup to post a metadata feed.