### PR TITLE
Make sure the integrationclients migration runs

### DIFF
--- a/migration/20170905-update-integrationclients-for-shared-secret.sql
+++ b/migration/20170905-update-integrationclients-for-shared-secret.sql
@@ -1,2 +1,5 @@
--- Start from scratch with a new integrationclients table
-drop table if exists integrationclients;
+-- Reset the integrationclients table.
+alter table integrationclients drop column _secret;
+alter table integrationclients rename column key to shared_secret;
+drop index if exists ix_integrationclients_key;
+delete from integrationclients;


### PR DESCRIPTION
When running migrations on circulation, I realized that the addition of the index on datasources made dropping the table impossible. This change to the migration allows it to run while still emptying the table if necessary.