### PR TITLE
Dont use ORM when migrating database

### DIFF
--- a/model.py
+++ b/model.py
@@ -406,13 +406,14 @@ class SessionManager(object):
             _db.commit()
 
     @classmethod
-    def session(cls, url):
+    def session(cls, url, initialize_data=True):
         engine = connection = 0
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=sa_exc.SAWarning)
             engine, connection = cls.initialize(url)
         session = Session(connection)
-        session = cls.initialize_data(session)
+        if initialize_data:
+            session = cls.initialize_data(session)
         return session
 
     @classmethod

--- a/scripts.py
+++ b/scripts.py
@@ -1698,8 +1698,8 @@ class DatabaseMigrationScript(Script):
         # the database before the ExternalIntegration has been uploaded.
         Configuration.load(None)
 
-    def run(self, test=False):
-        parsed = self.parse_command_line()
+    def run(self, test=False, cmd_args=None):
+        parsed = self.parse_command_line(cmd_args=cmd_args)
         last_run_date = parsed.last_run_date
         last_run_counter = parsed.last_run_counter
         timestamp = None

--- a/scripts.py
+++ b/scripts.py
@@ -1565,7 +1565,7 @@ class RefreshMaterializedViewsScript(Script):
         )
         return parser
 
-    def do_run(self, test=False):
+    def do_run(self):
         args = self.parse_command_line()
         if args.blocking_refresh:
             concurrently = ''
@@ -1592,7 +1592,7 @@ class RefreshMaterializedViewsScript(Script):
         # time) wraps everything in a big transaction, but VACUUM
         # can't be executed within a transaction block. So create a
         # separate connection that uses autocommit.
-        url = Configuration.database_url(test=test)
+        url = Configuration.database_url()
         engine = create_engine(url, isolation_level="AUTOCOMMIT")
         engine.autocommit = True
         a = time.time()
@@ -1698,7 +1698,7 @@ class DatabaseMigrationScript(Script):
         # the database before the ExternalIntegration has been uploaded.
         Configuration.load(None)
 
-    def run(self):
+    def run(self, test=False):
         parsed = self.parse_command_line()
         last_run_date = parsed.last_run_date
         last_run_counter = parsed.last_run_counter
@@ -1709,7 +1709,7 @@ class DatabaseMigrationScript(Script):
         # Create a special database session that doesn't initialize
         # the ORM. As long as we only execute SQL and don't try to use
         # any ORM objects, we'll be fine.
-        url = Configuration.database_url()
+        url = Configuration.database_url(test=test)
         self._session = SessionManager.session(url, initialize_data=False)
 
         # Try to find an existing timestamp representing the last migration

--- a/scripts.py
+++ b/scripts.py
@@ -1565,7 +1565,7 @@ class RefreshMaterializedViewsScript(Script):
         )
         return parser
 
-    def do_run(self):
+    def do_run(self, test=False):
         args = self.parse_command_line()
         if args.blocking_refresh:
             concurrently = ''
@@ -1592,7 +1592,7 @@ class RefreshMaterializedViewsScript(Script):
         # time) wraps everything in a big transaction, but VACUUM
         # can't be executed within a transaction block. So create a
         # separate connection that uses autocommit.
-        url = Configuration.database_url()
+        url = Configuration.database_url(test=test)
         engine = create_engine(url, isolation_level="AUTOCOMMIT")
         engine.autocommit = True
         a = time.time()

--- a/scripts.py
+++ b/scripts.py
@@ -26,6 +26,7 @@ from sqlalchemy import (
     exists,
     and_,
     or_,
+    text,
 )
 from sqlalchemy.sql.functions import func
 from sqlalchemy.orm.exc import (
@@ -1601,10 +1602,25 @@ class RefreshMaterializedViewsScript(Script):
 
 
 class DatabaseMigrationScript(Script):
-    """Runs new migrations"""
+    """Runs new migrations.
+
+    This script needs to execute without ever loading an ORM object,
+    because the database might be in a state that's not compatible
+    with the current ORM version.
+    """
 
     name = "Database Migration"
     MIGRATION_WITH_COUNTER = re.compile("\d{8}-(\d+)-(.)+\.(py|sql)")
+
+    class TimestampInfo(object):
+        """Act like a ORM Timestamp object, but with no database connection."""
+        def __init__(self, timestamp, counter):
+            if isinstance(timestamp, basestring):
+                timestamp = Script.parse_time(timestamp)
+            self.timestamp = timestamp
+            if isinstance(counter, basestring):
+                counter = int(counter)
+            self.counter = counter
 
     @classmethod
     def arg_parser(cls):
@@ -1682,39 +1698,46 @@ class DatabaseMigrationScript(Script):
         # the database before the ExternalIntegration has been uploaded.
         Configuration.load(None)
 
-    def do_run(self):
+    def run(self):
         parsed = self.parse_command_line()
         last_run_date = parsed.last_run_date
         last_run_counter = parsed.last_run_counter
-
-        existing_timestamp = get_one(self._db, Timestamp, service=self.name)
+        timestamp = None
         if last_run_date:
-            last_run_datetime = self.parse_time(last_run_date)
-            if existing_timestamp:
-                existing_timestamp.timestamp = last_run_datetime
-                if last_run_counter:
-                    existing_timestamp.counter = last_run_counter
-            else:
-                existing_timestamp, ignore = get_one_or_create(
-                    self._db, Timestamp,
-                    service=self.name,
-                    timestamp=last_run_datetime
-                )
+            timestamp = self.TimestampInfo(last_run_date, last_run_counter)
 
-        if existing_timestamp:
+        # Create a special database session that doesn't initialize
+        # the ORM. As long as we only execute SQL and don't try to use
+        # any ORM objects, we'll be fine.
+        url = Configuration.database_url()
+        self._session = SessionManager.session(url, initialize_data=False)
+
+        # Try to find an existing timestamp representing the last migration
+        # script that was run.
+        sql = "SELECT timestamp, counter FROM timestamps WHERE service=:service AND collection_id IS NULL LIMIT 1;"
+        results = list(self._db.execute(text(sql), dict(service=self.name)))
+        if results:
+            [(date, counter)] = results
+            current_timestamp = self.TimestampInfo(date, counter)
+            if not timestamp:
+                timestamp = current_timestamp
+        else:
+            # Make sure there's a "Database Migration" row in the
+            # timestamps table so that we can update the row later.
+            sql = "INSERT INTO timestamps (service) values (:service);"
+            self._db.execute(text(sql), dict(service=self.name))
+
+        if timestamp:
             migrations, migrations_by_dir = self.fetch_migration_files()
 
-            new_migrations = self.get_new_migrations(
-                existing_timestamp, migrations
-            )
+            new_migrations = self.get_new_migrations(timestamp, migrations)
             if new_migrations:
                 # Log the new migrations.
                 print "%d new migrations found." % len(new_migrations)
                 for migration in new_migrations:
                     print "  - %s" % migration
-
                 self.run_migrations(
-                    new_migrations, migrations_by_dir, existing_timestamp
+                    new_migrations, migrations_by_dir, timestamp
                 )
             else:
                 print "No new migrations found. Your database is up-to-date."
@@ -1874,6 +1897,10 @@ class DatabaseMigrationScript(Script):
         match = self.MIGRATION_WITH_COUNTER.search(migration_file)
         if match:
             timestamp.counter = int(match.groups()[0])
+        sql = "UPDATE timestamps SET timestamp=:timestamp, counter=:counter where service=:service AND collection_id IS NULL"
+        self._db.execute(text(sql), dict(timestamp=timestamp.timestamp,
+                                         counter=timestamp.counter,
+                                         service=self.name))
         self._db.commit()
 
         print "New timestamp created at %s for %s" % (

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -793,7 +793,7 @@ class TestDatabaseMigrationScript(DatabaseTest):
         eq_(self.timestamp.counter, 3)
 
     def test_all_migration_files_are_run(self):
-        self.script.run()
+        self.script.run(test=True)
 
         # There are two test timestamps in the database, confirming that
         # the test SQL files created by self._create_test_migration_files()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import os
+import shutil
 import tempfile
 from StringIO import StringIO
 
@@ -532,7 +533,7 @@ class TestDatabaseMigrationScript(DatabaseTest):
         for migration_dir in directories:
             if not os.path.isdir(migration_dir):
                 temp_migration_dir = tempfile.mkdtemp()
-                os.rename(temp_migration_dir, migration_dir)
+                shutil.move(temp_migration_dir, migration_dir)
 
         # Put a file of each migratable type in both directories.
         self._create_test_migration_file(self.core_migration_dir, 'CORE', 'sql')

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -794,7 +794,7 @@ class TestDatabaseMigrationScript(DatabaseTest):
         eq_(self.timestamp.counter, 3)
 
     def test_all_migration_files_are_run(self):
-        self.script.run(test=True)
+        self.script.run(test=True, cmd_args=["--last-run-date", "2010-01-01"])
 
         # There are two test timestamps in the database, confirming that
         # the test SQL files created by self._create_test_migration_files()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -793,7 +793,7 @@ class TestDatabaseMigrationScript(DatabaseTest):
         eq_(self.timestamp.counter, 3)
 
     def test_all_migration_files_are_run(self):
-        self.script.do_run()
+        self.script.run()
 
         # There are two test timestamps in the database, confirming that
         # the test SQL files created by self._create_test_migration_files()


### PR DESCRIPTION
This branch changes `DatabaseMigrationScript` so that it never loads the database model. Loading the database model for version N can cause a crash if the actual database schema still reflects version N-1. This is the situation `DatabaseMigrationScript` is supposed to address, and this script has been using `Timestamp` from the start, so I don't understand why this ever worked.

I have manually tested this using the `20170831-add-data-source-integration-client-id.sql` script, with and without a migration row in the `timestamps` table.