### PR TITLE
Support Metadata Wrangler integration

### DIFF
--- a/migration/20170908-change-metadata-wrangler-settings.py
+++ b/migration/20170908-change-metadata-wrangler-settings.py
@@ -24,11 +24,11 @@ try:
                 # A username (or client_id) is no longer required.
                 _db.delete(setting)
             if setting.key == 'password':
-                # All passwords (previous client_secrets) must be reset as
-                # shared_secrets.
+                # The password (previously client_secret) must be reset to
+                # register for a shared_secret.
                 setting.value = None
         _db.commit()
     _db.close()
 except Exception as e:
-    db.close()
+    _db.close()
     raise e

--- a/migration/20170908-change-metadata-wrangler-settings.py
+++ b/migration/20170908-change-metadata-wrangler-settings.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""Delete outdated ConfigurationSettings for the metadata wrangler."""
+import os
+import sys
+import logging
+from nose.tools import set_trace
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from model import (
+    production_session,
+    ExternalIntegration as EI,
+)
+
+_db = production_session()
+try:
+    integration = EI.lookup(_db, EI.METADATA_WRANGLER, EI.METADATA_GOAL)
+
+    if integration:
+        for setting in integration.settings:
+            if setting.key == 'username':
+                # A username (or client_id) is no longer required.
+                _db.delete(setting)
+            if setting.key == 'password':
+                # All passwords (previous client_secrets) must be reset as
+                # shared_secrets.
+                setting.value = None
+        _db.commit()
+    _db.close()
+except Exception as e:
+    db.close()
+    raise e

--- a/opds_import.py
+++ b/opds_import.py
@@ -125,8 +125,7 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup):
 
     SETTINGS = [
         { "key": ExternalIntegration.URL, "label": _("URL"), "default": "http://metadata.librarysimplified.org/" },
-        { "key": ExternalIntegration.USERNAME, "label": _("Client ID") },
-        { "key": ExternalIntegration.PASSWORD, "label": _("Client Secret") },
+        { "key": ExternalIntegration.PASSWORD, "label": _("Shared Secret") },
     ]
 
     SITEWIDE = True


### PR DESCRIPTION
This branch uses a shared secret bearer token (instead of basic auth) to access authenticated Collection goodies on the Metadata Wrangler.

Supports NYPL-Simplified/circulation#667.