### PR TITLE
Remove reference to collection_id, which may not be present in the database we're trying to migrate.

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -1714,7 +1714,7 @@ class DatabaseMigrationScript(Script):
 
         # Try to find an existing timestamp representing the last migration
         # script that was run.
-        sql = "SELECT timestamp, counter FROM timestamps WHERE service=:service AND collection_id IS NULL LIMIT 1;"
+        sql = "SELECT timestamp, counter FROM timestamps WHERE service=:service LIMIT 1;"
         results = list(self._db.execute(text(sql), dict(service=self.name)))
         if results:
             [(date, counter)] = results
@@ -1897,7 +1897,7 @@ class DatabaseMigrationScript(Script):
         match = self.MIGRATION_WITH_COUNTER.search(migration_file)
         if match:
             timestamp.counter = int(match.groups()[0])
-        sql = "UPDATE timestamps SET timestamp=:timestamp, counter=:counter where service=:service AND collection_id IS NULL"
+        sql = "UPDATE timestamps SET timestamp=:timestamp, counter=:counter where service=:service"
         self._db.execute(text(sql), dict(timestamp=timestamp.timestamp,
                                          counter=timestamp.counter,
                                          service=self.name))


### PR DESCRIPTION
When migrating a site to 2.0, the migration script won't run (among others) the script that creates `Timestamp.collection_id` because it assumes `Timestamp.collection_id` already exists.

Removing the reference doesn't affect things in the real world, since there are currently no collection-specific "Database Migration" tasks (and hopefully there will never be). We can always add this back later after migrating everything to 2.0.