### PR TITLE
Change a LicensePool based on a CirculationEvent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
       - postgresql-contrib-9.3
 
 env:
-  - ES_VERSION=1.7.0 ES_DOWNLOAD_ONE=https://download.elastic.co/elasticsearch/elasticsearch/ ES_DOWNLOAD_TWO=elasticsearch-${ES_VERSION}.tar.gz
+  - ES_VERSION=1.7.0 ES_DOWNLOAD="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz"
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
       - postgresql-contrib-9.3
 
 env:
-  - ES_VERSION=1.7.0 ES_DOWNLOAD="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz"
+  - ES_VERSION="1.7.0" ES_DOWNLOAD="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz"
 
 services:
   - postgresql
@@ -34,7 +34,7 @@ install:
   - python -m textblob.download_corpora
   - cp config.json.sample config.json
   - export SIMPLIFIED_CONFIGURATION_FILE="$TRAVIS_BUILD_DIR/config.json"
-  - wget ${ES_DOWNLOAD_ONE}${ES_DOWNLOAD_TWO}
+  - wget ${ES_DOWNLOAD}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
       - postgresql-contrib-9.3
 
 env:
-  - ES_VERSION=1.7.0 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+  - ES_VERSION=1.7.0 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.0.tar.gz
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
       - postgresql-contrib-9.3
 
 env:
-  - ES_VERSION=1.7.0 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.0.tar.gz
+  - ES_VERSION=1.7.0 ES_DOWNLOAD_ONE=https://download.elastic.co/elasticsearch/elasticsearch/ ES_DOWNLOAD_TWO=elasticsearch-${ES_VERSION}.tar.gz
 
 services:
   - postgresql
@@ -34,7 +34,7 @@ install:
   - python -m textblob.download_corpora
   - cp config.json.sample config.json
   - export SIMPLIFIED_CONFIGURATION_FILE="$TRAVIS_BUILD_DIR/config.json"
-  - wget ${ES_DOWNLOAD_URL}
+  - wget ${ES_DOWNLOAD_ONE}${ES_DOWNLOAD_TWO}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -753,7 +753,7 @@ class CirculationData(MetaToModelUtility):
                         rights_uri = RightsStatus.GENERIC_OPEN_ACCESS
                     format_found = False
                     for format in self.formats:
-                        if format.link and format.link.href == link.href:
+                        if format and format.link and format.link.href == link.href:
                             if not format.rights_uri:
                                 format.rights_uri = rights_uri
                             format_found = True

--- a/model.py
+++ b/model.py
@@ -6541,7 +6541,7 @@ class LicensePool(Base):
             new_licenses_reserved, new_patrons_in_hold_queue,
             analytics=None, as_of=None):
         """Update the LicensePool with new availability information.
-        Log the implied changes as CirculationEvents.
+        Log the implied changes with the analytics provider.
         """
         changes_made = False
         _db = Session.object_session(self)

--- a/model.py
+++ b/model.py
@@ -6719,7 +6719,16 @@ class LicensePool(Base):
                 if delta > new_patrons_in_hold_queue:
                     new_licenses_available += (delta-new_patrons_in_hold_queue)
         elif type == CE.DISTRIBUTOR_CHECKOUT:
-            new_licenses_available = deduct(new_licenses_available)
+            if new_licenses_available == 0:
+                # The only way to borrow books while there are no
+                # licenses available is to borrow reserved copies.
+                new_licenses_reserved = deduct(new_licenses_reserved)
+            else:
+                # We don't know whether this checkout came from
+                # licenses available or from a lingering reserved
+                # copy, but in most cases it came from licenses
+                # available.
+                new_licenses_available = deduct(new_licenses_available)
         elif type == CE.DISTRIBUTOR_LICENSE_ADD:
             new_licenses_owned += delta
         elif type == CE.DISTRIBUTOR_LICENSE_REMOVE:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2026,6 +2026,9 @@ class TestLicensePool(DatabaseTest):
         # thought. It's more likely that the sixth license expired and
         # we weren't notified.
 
+        # When there are no licenses available, a checkout event
+        # draws from the pool of licenses reserved instead.
+        eq_((5,0,0,3), calc(CE.DISTRIBUTOR_CHECKOUT, 2))
 
 class TestLicensePoolDeliveryMechanism(DatabaseTest):
 


### PR DESCRIPTION
This branch makes it possible to update a LicensePool's availability information based on the information in a CirculationEvent. Usually we update a LicensePool's availability information and then send out CirculationEvents to match, but for Bibliotheca we do things in the other order.

This is not 100% reliable because we a single event doesn't give us certainty about the complete state of a LicensePool, but it's better than nothing and it should do a good job of filling in the gaps between runs of the `BibliothecaCirculationSweep`.