### PR TITLE
Update availability from event part 2

### DIFF
--- a/model.py
+++ b/model.py
@@ -6734,8 +6734,15 @@ class LicensePool(Base):
                 new_licenses_available = deduct(new_licenses_available)
         elif type == CE.DISTRIBUTOR_LICENSE_ADD:
             new_licenses_owned += delta
+            # Newly added licenses start out as available, unless there
+            # are patrons in the holds queue.
+            if new_patrons_in_hold_queue == 0:
+                new_licenses_available += delta
         elif type == CE.DISTRIBUTOR_LICENSE_REMOVE:
             new_licenses_owned = deduct(new_licenses_owned)
+            # We can't say whether or not the removed licenses should
+            # be deducted from the list of available licenses, because they
+            # might already be checked out.
         elif type == CE.DISTRIBUTOR_AVAILABILITY_NOTIFY:
             new_patrons_in_hold_queue = deduct(new_patrons_in_hold_queue)
             new_licenses_reserved += delta

--- a/monitor.py
+++ b/monitor.py
@@ -314,11 +314,10 @@ class SweepMonitor(CollectionMonitor):
 
     def process_batch(self, offset):
         """Process one batch of work."""
+        offset = offset or 0
         items = self.fetch_batch(offset).all()
         if items:
-            for item in items:
-                self.process_item(item)
-                self.log.log(self.COMPLETION_LOG_LEVEL, "Completed %r", item)
+            self.process_items(items)
             # We've completed a batch. Return the ID of the last item
             # in the batch so we don't do this work again.
             return items[-1].id
@@ -326,6 +325,12 @@ class SweepMonitor(CollectionMonitor):
             # There are no more items in this database table, so we
             # are done with the sweep. Reset the counter.
             return 0
+
+    def process_items(self, items):
+        """Process a list of items."""
+        for item in items:
+            self.process_item(item)
+            self.log.log(self.COMPLETION_LOG_LEVEL, "Completed %r", item)
 
     def fetch_batch(self, offset):
         """Retrieve one batch of work from the database."""


### PR DESCRIPTION
This branch makes minor changes to support https://github.com/NYPL-Simplified/circulation/pull/672

1. If there are no patrons in the hold queue when licenses are added, the new licenses are implicitly made available.
2. `Monitor.process_batch` calls a new method, `Monitor.process_items`, which can be overridden by a Monitor that handles the entire batch at once rather than one item at a time.