### PR TITLE
Run Python migration scripts after SQL migration scripts.

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -1648,19 +1648,27 @@ class DatabaseMigrationScript(Script):
 
     @classmethod
     def sort_migrations(self, migrations):
-        """Ensures that migrations with a counter digit are sorted after
-        migrations without one.
+        """All Python migrations sort after all SQL migrations, since a Python
+        migration requires an up-to-date database schema.
+
+        Migrations with a counter digit sort after migrations without
+        one.
         """
 
         def compare_migrations(first, second):
             """Compares migrations according to ideal sorting order.
 
+            - All Python migrations run after all SQL migrations.
             - Migrations are first ordered by timestamp (asc).
             - If two migrations have the same timestamp, any migrations
               without counters come before migrations with counters.
             - If two migrations with the same timestamp, have counters,
               migrations are sorted by counter (asc).
             """
+            if first.endswith('.py') and second.endswith('.sql'):
+                return 1
+            elif first.endswith('.sql') and second.endswith('.py'):
+                return -1
             first_datestamp = int(first[:8])
             second_datestamp = int(second[:8])
             datestamp_difference = first_datestamp - second_datestamp

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -676,28 +676,34 @@ class TestDatabaseMigrationScript(DatabaseTest):
         """Filters out migrations that were run on or before a given timestamp"""
 
         migrations = [
+            '20271204-far-future-migration-funtime.sql',
             '20271202-future-migration-funtime.sql',
+            '20271203-do-another-thing.py',
             '20250521-make-bananas.sql',
             '20260810-last-timestamp',
             '20260811-do-a-thing.py',
-            '20260809-already-done.sql'
+            '20260809-already-done.sql',
         ]
 
         result = self.script.get_new_migrations(self.timestamp, migrations)
-        # Expected migrations will be sorted by timestamp.
+        # Expected migrations will be sorted by timestamp. Python migrations
+        # will be sorted after SQL migrations.
         expected = [
-            '20260811-do-a-thing.py', '20271202-future-migration-funtime.sql'
+            '20271202-future-migration-funtime.sql', 
+            '20271204-far-future-migration-funtime.sql',
+            '20260811-do-a-thing.py',
+            '20271203-do-another-thing.py',
         ]
 
-        eq_(2, len(result))
+        eq_(4, len(result))
         eq_(expected, result)
 
         # If the timestamp has a counter, the filter only finds new migrations
         # past the counter.
         migrations = [
-            '20271202-future-migration-funtime.sql',
             '20260810-last-timestamp.sql',
             '20260810-1-do-a-thing.sql',
+            '20271202-future-migration-funtime.sql',
             '20260810-2-do-all-the-things.sql',
             '20260809-already-done.sql'
         ]
@@ -705,7 +711,7 @@ class TestDatabaseMigrationScript(DatabaseTest):
         result = self.script.get_new_migrations(self.timestamp, migrations)
         expected = [
             '20260810-2-do-all-the-things.sql',
-            '20271202-future-migration-funtime.sql'
+            '20271202-future-migration-funtime.sql',
         ]
 
         eq_(2, len(result))


### PR DESCRIPTION
I tested this by migrating a dump of the Open Ebooks database and it worked well.