### PR TITLE
Don't show target age for books unless they're children or YA.

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -194,7 +194,12 @@ class Annotator(object):
                 dict(term=work.audience, label=work.audience)
             ]
 
-        if work.target_age:
+        # Any book can have a target age, but the target age
+        # is only relevant for childrens' and YA books.
+        audiences_with_target_age = (
+            Classifier.AUDIENCE_CHILDREN, Classifier.AUDIENCE_YOUNG_ADULT
+        )
+        if (work.target_age and work.audience in audiences_with_target_age):
             uri = Subject.uri_lookup[Subject.AGE_RANGE]
             target_age = work.target_age_string
             if target_age:


### PR DESCRIPTION
This branch fixes a minor issue that has been driving me crazy for a long time. Books for adults have the target age (18,). This is definitional, it's not something that needs to go into the OPDS feed, but it does go into the OPDS feed, and since SimplyE doesn't distinguish between different types of category, it means that most of the books in the system are randomly classified under "18". 

This branch suppresses the target age categories for books that are not children or YA books.