### PR TITLE
Allow the local analytics provider to work with or without an association with a specific library.

### DIFF
--- a/local_analytics_provider.py
+++ b/local_analytics_provider.py
@@ -6,12 +6,18 @@ class LocalAnalyticsProvider(object):
 
     DESCRIPTION = _("Store analytics events in the 'circulationevents' database table.")
 
-    def __init__(self, integration):
+    def __init__(self, integration, library=None):
         self.integration_id = integration.id
+        if library:
+            self.library_id = library.id
+        else:
+            self.library_id = None
 
     def collect_event(self, library, license_pool, event_type, time, 
         old_value=None, new_value=None, **kwargs):
         _db = Session.object_session(library)
+        if library and self.library_id and library.id != self.library_id:
+            return
         
         CirculationEvent.log(
           _db, license_pool, event_type, old_value, new_value, start=time)

--- a/tests/test_local_analytics_provider.py
+++ b/tests/test_local_analytics_provider.py
@@ -13,11 +13,13 @@ import datetime
 class TestLocalAnalyticsProvider(DatabaseTest):
 
     def test_collect_event(self):
+        library2 = self._library()
+
         integration, ignore = create(
             self._db, ExternalIntegration,
             goal=ExternalIntegration.ANALYTICS_GOAL,
             protocol="core.local_analytics_provider")
-        la = LocalAnalyticsProvider(integration)
+        la = LocalAnalyticsProvider(integration, self._default_library)
         work = self._work(
             title="title", authors="author", fiction=True,
             audience="audience", language="lang",
@@ -28,11 +30,34 @@ class TestLocalAnalyticsProvider(DatabaseTest):
         la.collect_event(
             self._default_library, lp, CirculationEvent.DISTRIBUTOR_CHECKIN, now,
             old_value=None, new_value=None)
-        [event] = self._db \
-            .query(CirculationEvent) \
-            .filter(CirculationEvent.type == CirculationEvent.DISTRIBUTOR_CHECKIN) \
-            .all()
+
+        qu = self._db.query(CirculationEvent).filter(
+            CirculationEvent.type == CirculationEvent.DISTRIBUTOR_CHECKIN
+        )
+        eq_(1, qu.count())
+        [event] = qu.all()
 
         eq_(lp, event.license_pool)
         eq_(CirculationEvent.DISTRIBUTOR_CHECKIN, event.type)
         eq_(now, event.start)
+
+        # The LocalAnalyticsProvider will not handle an event intended
+        # for a different library.
+        now = datetime.datetime.now()
+        la.collect_event(
+            library2, lp, CirculationEvent.DISTRIBUTOR_CHECKIN, now,
+            old_value=None, new_value=None)
+        eq_(1, qu.count())
+
+        # It's possible to instantiate the LocalAnalyticsProvider
+        # without a library.
+        la = LocalAnalyticsProvider(integration)
+
+        # In that case, it will process events for any library.
+        for library in [self._default_library, library2]:
+            now = datetime.datetime.now()
+            la.collect_event(library, lp, 
+                             CirculationEvent.DISTRIBUTOR_CHECKIN, now,
+                             old_value=None, new_value=None
+            )
+        eq_(3, qu.count())


### PR DESCRIPTION
This branch changes LocalAnalyticsProvider so it works equally well with a Library in its constructor (it will only handle events for that library) or without (it will handle events for all libraries). Either is a possibility in the current admin interface setup.