### PR TITLE
Record a transient metadata upload failure when applying metadata that should be sent to the metadata wrangler.

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1592,10 +1592,16 @@ class Metadata(MetaToModelUtility):
             # Create a transient failure CoverageRecord for this edition
             # so it will be processed by the MetadataUploadCoverageProvider.
             internal_processing = DataSource.lookup(_db, DataSource.INTERNAL_PROCESSING)
-            CoverageRecord.add_for(edition, internal_processing,
-                                   operation=CoverageRecord.METADATA_UPLOAD_OPERATION,
-                                   status=CoverageRecord.TRANSIENT_FAILURE,
-                                   collection=collection)
+
+            # If there's already a CoverageRecord, don't change it to transient failure.
+            # TODO: Once the metadata wrangler can handle it, we'd like to re-sync the
+            # metadata every time there's a change. For now,
+            cr = CoverageRecord.lookup(edition, internal_processing,
+                                       operation=CoverageRecord.METADATA_UPLOAD_OPERATION)
+            if not cr:
+                CoverageRecord.add_for(edition, internal_processing,
+                                       operation=CoverageRecord.METADATA_UPLOAD_OPERATION,
+                                       status=CoverageRecord.TRANSIENT_FAILURE)
 
         # Finally, update the coverage record for this edition
         # and data source.

--- a/model.py
+++ b/model.py
@@ -1304,6 +1304,7 @@ class CoverageRecord(Base, BaseCoverageRecord):
     IMPORT_OPERATION = u'import'
     RESOLVE_IDENTIFIER_OPERATION = u'resolve-identifier'
     REPAIR_SORT_NAME_OPERATION = u'repair-sort-name'
+    METADATA_UPLOAD_OPERATION = u'metadata-upload'
 
     id = Column(Integer, primary_key=True)
     identifier_id = Column(


### PR DESCRIPTION
This branch is the core component of https://github.com/NYPL-Simplified/circulation/issues/686.

Instead of making metadata upload part of Metadata.apply(), Metadata.apply creates a transient failure CoverageRecord indicating that the upload needs to be done, so a CoverageProvider can take care of it later.
