### PR TITLE
Increase site configuration timeout

### DIFF
--- a/bibliotheca.py
+++ b/bibliotheca.py
@@ -275,6 +275,22 @@ class ItemListParser(XMLParser):
 
     parenthetical = re.compile(" \([^)]+\)$")
 
+
+    format_data_for_bibliotheca_format = {
+        "EPUB" : (
+            Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM
+        ),
+        "EPUB3" : (
+            Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM
+        ),
+        "PDF" : (
+            Representation.PDF_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM
+        ),
+        "MP3" : (
+            Representation.MP3_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM
+        ),
+    }
+
     @classmethod
     def contributors_from_string(cls, string):
         contributors = []
@@ -373,28 +389,7 @@ class ItemListParser(XMLParser):
                                 value=pages)
             )
 
-        medium = Edition.BOOK_MEDIUM
-
-        book_format = value("BookFormat")
-        format = None
-        if book_format == 'EPUB':
-            format = FormatData(
-                content_type=Representation.EPUB_MEDIA_TYPE,
-                drm_scheme=DeliveryMechanism.ADOBE_DRM
-            )
-        elif book_format == 'PDF':
-            format = FormatData(
-                content_type=Representation.PDF_MEDIA_TYPE,
-                drm_scheme=DeliveryMechanism.ADOBE_DRM
-            )
-        elif book_format == 'MP3':
-            format = FormatData(
-                content_type=Representation.MP3_MEDIA_TYPE,
-                drm_scheme=DeliveryMechanism.ADOBE_DRM
-            )
-            medium = Edition.AUDIO_MEDIUM
-
-        formats = [format]
+        medium, formats = self.internal_formats(book_format)
 
         metadata = Metadata(
             data_source=DataSource.BIBLIOTHECA,
@@ -422,6 +417,28 @@ class ItemListParser(XMLParser):
 
         metadata.circulation = circulationdata
         return metadata
+
+    @classmethod
+    def internal_formats(cls, book_format):
+        """Convert the term Bibliotheca uses to refer to a book
+        format into a (medium [formats]) 2-tuple.
+        """
+        medium = Edition.BOOK_MEDIUM
+        format = None
+        if book_format not in cls.format_data_for_bibliotheca_format:
+            logging.error("Unrecognized BookFormat: %s", book_format)
+            return medium, []
+
+        content_type, drm_scheme = cls.format_data_for_bibliotheca_format[
+            book_format
+        ]
+
+        format = FormatData(content_type=content_type, drm_scheme=drm_scheme)
+        if book_format == 'MP3':
+            medium = Edition.AUDIO_MEDIUM
+        else:
+            medium = Edition.BOOK_MEDIUM
+        return medium, [format]
 
 
 class BibliothecaBibliographicCoverageProvider(BibliographicCoverageProvider):

--- a/bibliotheca.py
+++ b/bibliotheca.py
@@ -389,6 +389,7 @@ class ItemListParser(XMLParser):
                                 value=pages)
             )
 
+        book_format = value("BookFormat")
         medium, formats = self.internal_formats(book_format)
 
         metadata = Metadata(

--- a/config.py
+++ b/config.py
@@ -360,7 +360,7 @@ class Configuration(object):
 
     @classmethod
     def site_configuration_last_update(cls, _db, known_value=None,
-                                       timeout=300):
+                                       timeout=600):
         """Check when the site configuration was last updated.
 
         Updates Configuration.instance[Configuration.SITE_CONFIGURATION_LAST_UPDATE]. 

--- a/config.py
+++ b/config.py
@@ -360,7 +360,7 @@ class Configuration(object):
 
     @classmethod
     def site_configuration_last_update(cls, _db, known_value=None,
-                                       timeout=60):
+                                       timeout=300):
         """Check when the site configuration was last updated.
 
         Updates Configuration.instance[Configuration.SITE_CONFIGURATION_LAST_UPDATE]. 
@@ -399,7 +399,6 @@ class Configuration(object):
             known_value = Timestamp.value(
                 _db, cls.SITE_CONFIGURATION_CHANGED, None
             )
-            logging.error("Retrieved known value %s from database.", known_value)
         if not known_value:
             # The site configuration has never changed.
             last_update = None

--- a/model.py
+++ b/model.py
@@ -1869,6 +1869,16 @@ class Identifier(Base):
         return Identifier.recursively_equivalent_identifier_ids(
             _db, [self.id], levels, threshold)
 
+    def licensed_through_collection(self, collection):
+        """Find the LicensePool, if any, for this Identifier
+        in the given Collection.
+
+        :return: At most one LicensePool.
+        """
+        for lp in self.licensed_through:
+            if lp.collection == collection:
+                return lp
+
     def add_link(self, rel, href, data_source, media_type=None, content=None,
                  content_path=None):
         """Create a link between this Identifier and a (potentially new)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -537,6 +537,20 @@ class TestIdentifier(DatabaseTest):
                  level_3_equivalent.id]),
             set(equivalent_ids))
 
+    def test_licensed_through_collection(self):
+        c1 = self._default_collection
+        c2 = self._collection()
+        c3 = self._collection()
+
+        edition, lp1 = self._edition(collection=c1, with_license_pool=True)
+        lp2 = self._licensepool(collection=c2, edition=edition)
+
+        identifier = lp1.identifier
+        eq_(lp2.identifier, identifier)
+
+        eq_(lp1, identifier.licensed_through_collection(c1))
+        eq_(lp2, identifier.licensed_through_collection(c2))
+        eq_(None, identifier.licensed_through_collection(c3))
 
     def test_missing_coverage_from(self):
         gutenberg = DataSource.lookup(self._db, DataSource.GUTENBERG)


### PR DESCRIPTION
This is a miscellaneous branch supporting my cleanup work following the 2.0 release on NYPL's server.

* The site configuration timeout is increased to 10 minutes from 1 minute. It's being triggered with great frequency and although it doesn't have the performance hit it used to, it's still not good. I'm unable to investigate it while Brett is away, so I'm increasing the timeout as a way of improving performance in the meantime.

* I introduce `Identifier.licensed_through_collection` which finds the LicensePool for a given book in a given collection. (There should be at most one.) I found a mistake in circulation that this would have avoided, and nearly made the same mistake myself while fixing some other code.

* Some Bibliotheca books were not being put into the collection because Bibliotheca reported their format as "EPUB3" instead of "EPUB". This branch adds "EPUB3" as a recognized format, fixes the code to report and avoid a crash when an unrecognized format is received, and splits out the part of the code that converts Bibliotheca formats to FormatData objects, so that each possibility can be tested independently.