### PR TITLE
Support independent coverage providers on the metadata wrangler

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -418,7 +418,8 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
     INPUT_IDENTIFIER_TYPES = NO_SPECIFIED_TYPES
     
     def __init__(self, _db, collection=None, input_identifiers=None,
-                 replacement_policy=None, **kwargs):
+                 replacement_policy=None, preregistered_only=False, **kwargs
+    ):
         """Constructor.
 
         :param collection: Optional. If information comes in from a
@@ -434,6 +435,10 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
            Identifiers.
         :param replacement_policy: Optional. A ReplacementPolicy to use
            when updating local data with data from the third party.
+        :param preregistered_only: Optional. Determines whether this
+           CoverageProvider will only cover Identifiers that have been
+           "preregistered" with a failing CoverageRecord. This option is
+           only used on the Metadata Wrangler.
         """
         super(IdentifierCoverageProvider, self).__init__(_db, **kwargs)
 
@@ -447,7 +452,8 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
         self.replacement_policy = (
             replacement_policy or self._default_replacement_policy(_db)
         )
-        
+        self.preregistered_only = preregistered_only
+
         if not self.DATA_SOURCE_NAME:
             raise ValueError(
                 "%s must define DATA_SOURCE_NAME" % self.__class__.__name__
@@ -653,6 +659,11 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
         )
         if identifiers:
             qu = qu.filter(Identifier.id.in_([x.id for x in identifiers]))
+
+        if self.preregistered_only:
+            # Only return Identifiers that have been "preregistered" for
+            # coverage with a failing CoverageRecord.
+            qu = qu.filter(CoverageRecord.id != None)
 
         return qu
 

--- a/model.py
+++ b/model.py
@@ -10392,7 +10392,7 @@ class Collection(Base, HasFullTableCache):
 
             if protocol == ExternalIntegration.OPDS_IMPORT:
                 # Share the feed URL so the Metadata Wrangler can find it.
-               collection.external_account_id = account_id
+               collection.external_account_id = unicode(account_id)
 
         if data_source:
             collection.data_source = data_source

--- a/model.py
+++ b/model.py
@@ -9554,6 +9554,7 @@ class ExternalIntegration(Base, HasFullTableCache):
     RB_DIGITAL = DataSource.RB_DIGITAL
     ONE_CLICK = RB_DIGITAL
     OPDS_FOR_DISTRIBUTORS = u'OPDS for Distributors'
+    ENKI = DataSource.ENKI
 
     # These protocols are only used on the Content Server when mirroring
     # content from a given directory or directly from Project
@@ -9564,7 +9565,7 @@ class ExternalIntegration(Base, HasFullTableCache):
 
     LICENSE_PROTOCOLS = [
         OPDS_IMPORT, OVERDRIVE, BIBLIOTHECA, AXIS_360, RB_DIGITAL,
-        DIRECTORY_IMPORT, GUTENBERG,
+        DIRECTORY_IMPORT, GUTENBERG, ENKI,
     ]
 
     # Some integrations with LICENSE_GOAL imply that the data and
@@ -9573,7 +9574,8 @@ class ExternalIntegration(Base, HasFullTableCache):
         OVERDRIVE : DataSource.OVERDRIVE,
         BIBLIOTHECA : DataSource.BIBLIOTHECA,
         AXIS_360 : DataSource.AXIS_360,
-        RB_DIGITAL : DataSource.RB_DIGITAL
+        RB_DIGITAL : DataSource.RB_DIGITAL,
+        ENKI : DataSource.ENKI,
     }
 
     # Integrations with METADATA_GOAL

--- a/model.py
+++ b/model.py
@@ -10368,7 +10368,14 @@ class Collection(Base, HasFullTableCache):
         def encode(detail):
             return base64.urlsafe_b64encode(detail.encode('utf-8'))
 
-        account_id = encode(self.unique_account_id)
+        account_id = self.unique_account_id
+        if self.protocol == ExternalIntegration.OPDS_IMPORT:
+            # Remove ending / from OPDS url that could duplicate the collection
+            # on the Metadata Wrangler.
+            while account_id.endswith('/'):
+                account_id = account_id[:-1]
+
+        account_id = encode(account_id)
         protocol = encode(self.protocol)
 
         metadata_identifier = protocol + ':' + account_id

--- a/scripts.py
+++ b/scripts.py
@@ -242,6 +242,9 @@ class RunCoverageProvidersScript(Script):
 
     def do_run(self):
         providers = list(self.providers)
+        if not providers:
+            self.log.info('No CoverageProviders to run.')
+
         while providers:
             random.shuffle(providers)
             for provider in providers:

--- a/testing.py
+++ b/testing.py
@@ -771,9 +771,7 @@ class DatabaseTest(object):
         integration.password = password
 
         if data_source_name:
-            integration.set_setting(
-                Collection.DATA_SOURCE_NAME_SETTING, data_source_name
-            )
+            collection.data_source = data_source_name
         return collection
         
     @property

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -676,6 +676,22 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
         assert "ValueError" in result.exception
         test_metadata.primary_identifier = old_identifier
 
+    def test_items_that_need_coverage_respects_registration_reqs(self):
+        provider = AlwaysSuccessfulCoverageProvider(
+            self._db, preregistered_only=True
+        )
+
+        identifier = self._identifier()
+        items = provider.items_that_need_coverage()
+        assert identifier not in items
+
+        # With a failing CoverageRecord, the item shows up.
+        record = self._coverage_record(
+            identifier, provider.data_source,
+            status=CoverageRecord.TRANSIENT_FAILURE
+        )
+        assert identifier in items
+
     def test_items_that_need_coverage_respects_operation(self):
 
         # Here's a provider that carries out the 'foo' operation.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6731,7 +6731,9 @@ class TestCollection(DatabaseTest):
         )
         eq_(True, is_new)
         eq_(self.collection.metadata_identifier, mirror_collection.name)
-        eq_(self.collection.external_integration.protocol, mirror_collection.external_integration.protocol)
+        eq_(self.collection.protocol, mirror_collection.protocol)
+        # Because this isn't an OPDS collection, no account details are held.
+        eq_(None, mirror_collection.external_account_id)
 
         # If the mirrored collection already exists, it is returned.
         collection = self._collection(external_account_id=self._url)
@@ -6739,12 +6741,17 @@ class TestCollection(DatabaseTest):
             self._db, Collection,
             name=collection.metadata_identifier,
         )[0]
+        mirror_collection.create_external_integration(collection.protocol)
+        # Confirm that there's no external_account_id.
+        eq_(None, mirror_collection.external_account_id)
 
         result, is_new = Collection.from_metadata_identifier(
             self._db, collection.metadata_identifier
         )
         eq_(False, is_new)
         eq_(mirror_collection, result)
+        # The external_account_id has been set now.
+        eq_(collection.external_account_id, mirror_collection.external_account_id)
 
     def test_catalog_identifier(self):
         """#catalog_identifier associates an identifier with the catalog"""

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6763,6 +6763,15 @@ class TestCollection(DatabaseTest):
         expected = build_expected(ExternalIntegration.OPDS_IMPORT, 'id+%s' % child.external_account_id)
         eq_(expected, child.metadata_identifier)
 
+        # If it's an OPDS_IMPORT collection with a url external_account_id,
+        # closing '/' marks are removed.
+        opds = self._collection(
+            name='OPDS', protocol=ExternalIntegration.OPDS_IMPORT,
+            external_account_id=(self._url+'/')
+        )
+        expected = build_expected(ExternalIntegration.OPDS_IMPORT, opds.external_account_id[:-1])
+        eq_(expected, opds.metadata_identifier)
+
     def test_from_metadata_identifier(self):
         # If a mirrored collection doesn't exist, it is created.
         self.collection.external_account_id = 'id'


### PR DESCRIPTION
This branch makes a number of changes to support CoverageProviders on the metadata wrangler, including:

- Saving the external_account_id (OPDS feed url) for OPDS_IMPORT collections
- Allowing CoverageProviders of all shapes and sizes to determine whether or not they only cover preregistered / failure-covered items.
- Sets a Collection's data source via Collection method.

Supports NYPL-Simplified/metadata_wrangler#127