### PR TITLE
Change log files

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -9,9 +9,14 @@
 # /bin directory. It assumes your LIBSIMPLE_DIR is /var/www/circulation
 # unless you set the environment variable otherwise.
 
-# Grab the script name and shift so any remaining arguments can be passed
-# to the script itself.
-SCRIPT=$(basename "$1")
+# This is the full script as entered and may include a directory name
+# relative to Library Simplified directory/circulation/bin.
+SCRIPT_PATH="$1"
+
+# Grab the script name for logging purposes.
+SCRIPT_NAME=$(basename $SCRIPT_PATH)
+
+# Shift so any remaining arguments can be passed to the script itself.
 shift
 
 piddir=/var/run/libsimple

--- a/bin/run
+++ b/bin/run
@@ -19,9 +19,9 @@ SCRIPT_NAME=$(basename $SCRIPT_PATH)
 # Shift so any remaining arguments can be passed to the script itself.
 shift
 
-piddir=/var/run/libsimple
+piddir=/var/run/simplified
 pidfile=$piddir/$SCRIPT_NAME.pid
-logdir=/var/log/libsimple
+logdir=/var/log/simplified
 logfile=$logdir/$SCRIPT_NAME.log
 
 # Assume this run file is the Library Simplified directory/core/bin

--- a/bin/run
+++ b/bin/run
@@ -20,9 +20,9 @@ SCRIPT_NAME=$(basename $SCRIPT_PATH)
 shift
 
 piddir=/var/run/libsimple
-pidfile=$piddir/$SCRIPT
+pidfile=$piddir/$SCRIPT_NAME.pid
 logdir=/var/log/libsimple
-logfile=$logdir/$SCRIPT
+logfile=$logdir/$SCRIPT_NAME.log
 
 # Assume this run file is the Library Simplified directory/core/bin
 # unless the Library Simplified directory has been set as an environment
@@ -54,7 +54,7 @@ create_pidfile () {
     echo "Could not create PID file"
     exit 1
   fi
-  echo "$SCRIPT PIDFILE created: $pidfile"
+  echo "$SCRIPT_NAME PIDFILE created: $pidfile"
 }
 
 # Create a directory for Library Simplified PID files
@@ -66,7 +66,7 @@ if [[ -f $pidfile ]]; then
   ps -p $pid > /dev/null 2>&1
   if [[ $? -eq 0 ]]; then
     # Last recorded PID was found in running processes
-    echo "$SCRIPT is already running"
+    echo "$SCRIPT_NAME is already running"
     exit 1
   else
     # Last recorded PID not running
@@ -84,9 +84,9 @@ if [[ ! -f $logfile ]]; then
 fi
 
 # Run the script and append its output to its log file.
-echo "Running $SCRIPT (PID: $$)"
+echo "Running $SCRIPT_NAME (PID: $$)"
 source $LIBSIMPLE_DIR/env/bin/activate && \
-  $LIBSIMPLE_DIR/bin/$SCRIPT "$@" >> $logfile 2>&1
+  $LIBSIMPLE_DIR/bin/$SCRIPT_PATH "$@" >> $logfile 2>&1
 
 # When it's done, remove the PID file.
 rm $pidfile


### PR DESCRIPTION
These changes allow `bin/run` to be used for any script in the `bin/` directory of a parent application (e.g. circulation, content_server) and not just those in the first level. It will log output and create a pid file to assist with tracking long-running `repair/` scripts, for example.

It also changes the directory where logs and pid files are held. I'm trying to keep the system consistent in using "simplified" to reference app-related variables and files.