### PR TITLE
Move log configuration into the database

### DIFF
--- a/config.py
+++ b/config.py
@@ -329,11 +329,6 @@ class Configuration(object):
         config_instance[EI.CDN] = cdn_integration
 
     @classmethod
-    def logging_policy(cls):
-        default_logging = {}
-        return cls.get(cls.LOGGING, default_logging)
-
-    @classmethod
     def localization_languages(cls):
         languages = cls.policy(cls.LOCALIZATION_LANGUAGES, default=["eng"])
         return [LanguageCodes.three_to_two[l] for l in languages]

--- a/log.py
+++ b/log.py
@@ -115,11 +115,13 @@ class LogConfiguration(object):
         be ignored in favor of a known test-friendly policy. (It's
         okay to pass in False during a test *of this method*.)
 
-        :return: A 3-tuple (handlers, database_log_level). `handlers`
-        is a list of Handler objects that will be associated with the
-        top-level logger. database_log_level is the log level to be
-        applied to the loggers for the database connector and other
-        verbose third-party libraries.
+        :return: A 3-tuple (internal_log_level, database_log_level,
+        handlers). `internal_log_level` is the log level to be used
+        for most log messages. `database_log_level` is the log level
+        to be applied to the loggers for the database connector and
+        other verbose third-party libraries. `handlers` is a list of
+        Handler objects that will be associated with the top-level
+        logger.
         """
 
         # Establish defaults, in case the database is not initialized or

--- a/log.py
+++ b/log.py
@@ -6,11 +6,10 @@ import os
 import socket
 from config import Configuration
 from StringIO import StringIO
+from loggly.handlers import HTTPSHandler as LogglyHandler
 
 if not Configuration.instance:
     Configuration.load()
-
-DEFAULT_DATA_FORMAT = "%(asctime)s:%(name)s:%(levelname)s:%(filename)s:%(message)s"
 
 class JSONFormatter(logging.Formatter):
     hostname = socket.gethostname()
@@ -48,50 +47,181 @@ class UTF8Formatter(logging.Formatter):
             data = data.encode("utf8")
         return data
 
-class LogglyAPI(object):
+       
+class LogConfiguration(object):
+    """Configures the active Python logging handlers based on logging
+    configuration from the database.
+    """
+
+    DEFAULT_MESSAGE_TEMPLATE = "%(asctime)s:%(name)s:%(levelname)s:%(filename)s:%(message)s"
+    DEFAULT_LOGGLY_URL = "https://logs-01.loggly.com/inputs/%(token)s/tag/python/"
+
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARN = "WARN"
+    ERROR = "ERROR"
+
+    JSON_LOG_FORMAT = 'json'
+    TEXT_LOG_FORMAT = 'text'
+
+    # Settings for the integration with protocol=INTERNAL_LOGGING
+    LOG_LEVEL = 'log_level'
+    LOG_FORMAT = 'log_format'
+    DATABASE_LOG_LEVEL = 'database_log_level'
+    LOG_MESSAGE_TEMPLATE = 'message_template'
 
     @classmethod
-    def handler(cls, log_level):
-        integration = Configuration.integration('loggly', required=True)
-        token = integration['token']
-        url = integration['url'] % dict(token=token)
-        from loggly.handlers import HTTPSHandler
-        return HTTPSHandler(url)
-       
+    def initialize(cls, _db, testing=False):
+        """Make the logging handlers reflect the current logging rules
+        as configured in the database.
 
-def set_formatter(handler, output_type=None, data_format=None):
-    log_config = Configuration.logging_policy()
-    if not output_type:
-        output_type = log_config.get(Configuration.LOG_OUTPUT_TYPE, 'text')
-    if not data_format:
-        data_format = log_config.get(Configuration.LOG_DATA_FORMAT, DEFAULT_DATA_FORMAT)
-    if output_type in ('json', 'loggly'):
-        cls = JSONFormatter
-    else:
-        cls = UTF8Formatter
-    handler.setFormatter(cls(data_format))
-    return handler
+        :param _db: A database connection. If this is None, the default logging
+        configuration will be used.
 
-log_config = Configuration.logging_policy()
-logger = logging.getLogger()
-if os.environ.get('TESTING'):
-    log_level = 'DEBUG'
-    output_type = 'text'
-else:
-    log_level = log_config.get(Configuration.LOG_LEVEL, 'INFO').upper()
-    output_type = log_config.get(Configuration.LOG_OUTPUT_TYPE, 'text').lower()
-    if output_type == 'loggly':
-        logging.getLogger().addHandler(LogglyAPI.handler(log_level))
-    stderr_handler = logging.StreamHandler()
-    logging.getLogger().addHandler(stderr_handler)
+        :param testing: True if unit tests are currently running; otherwise
+        False.
+        """
+        log_level, database_log_level, new_handlers = (
+            cls.from_configuration(_db, testing)
+        )
+    
+        # Replace the set of handlers associated with the root logger.
+        logger = logging.getLogger()
+        logger.setLevel(log_level)
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
 
-logger.setLevel(log_level)
-for handler in logger.handlers:
-    set_formatter(handler, output_type)
+        for handler in new_handlers:
+            logger.addHandler(handler)
 
-database_log_level = log_config.get(Configuration.DATABASE_LOG_LEVEL, 'WARN')
-for logger in (
-        'sqlalchemy.engine', 'elasticsearch', 
-        'requests.packages.urllib3.connectionpool'
-):
-    logging.getLogger(logger).setLevel(database_log_level)
+        # Set the loggers for various verbose libraries to the database
+        # log level, which is probably higher than the normal log level.
+        for logger in (
+                'sqlalchemy.engine', 'elasticsearch', 
+                'requests.packages.urllib3.connectionpool'
+        ):
+            logging.getLogger(logger).setLevel(database_log_level)
+        return log_level
+
+    @classmethod
+    def from_configuration(cls, _db, testing=False):
+        """Return the logging policy as configured in the database.
+
+        :param _db: A database connection. If None, the default
+        logging policy will be used.
+
+        :param testing: A boolean indicating whether a unit test is
+        happening right now. If True, the database configuration will
+        be ignored in favor of a known test-friendly policy. (It's
+        okay to pass in False during a test *of this method*.)
+
+        :return: A 2-tuple (handlers, database_log_level). `handlers`
+        is a list of Handler objects that will be associated with the
+        top-level logger. database_log_level is the log level to be
+        applied to the loggers for the database connector and other
+        verbose third-party libraries.
+        """
+
+        # Establish defaults, in case the database is not initialized or
+        # it is initialized but logging is not configured.
+        (internal_log_level, internal_log_format, database_log_level, 
+         message_template) = cls._defaults(testing)
+
+        handlers = []
+        from model import ExternalIntegration
+        if _db and not testing:
+            goal = ExternalIntegration.LOGGING_GOAL
+            internal = ExternalIntegration.lookup(
+                _db, ExternalIntegration.INTERNAL_LOGGING, goal
+            )
+            loggly = ExternalIntegration.lookup(
+                _db, ExternalIntegration.LOGGLY, goal
+            )
+            if internal:
+                internal_log_level = (
+                    internal.setting(cls.LOG_LEVEL).value 
+                    or internal_log_level
+                )
+                internal_log_format = (
+                    internal.setting(cls.LOG_FORMAT).value 
+                    or internal_log_format
+                )
+                database_log_level = (
+                    internal.setting(cls.DATABASE_LOG_LEVEL).value
+                    or database_log_level
+                )
+                message_template = (
+                    internal.setting(cls.LOG_MESSAGE_TEMPLATE).value
+                    or message_template
+                )
+
+            if loggly:
+                handlers.append(cls.loggly_handler(loggly))
+
+        # handlers is either empty or it contains a loggly handler.
+        # Let's also add a handler that logs to standard error.
+        handlers.append(logging.StreamHandler())
+
+        for handler in handlers:
+            cls.set_formatter(
+                handler, internal_log_format, message_template
+            )
+
+        return internal_log_level, database_log_level, handlers
+
+    @classmethod
+    def _defaults(cls, testing=False):
+        """Return default log configuration values."""
+        if testing:
+            internal_log_level = 'DEBUG'
+            internal_log_format = cls.TEXT_LOG_FORMAT
+        else:
+            internal_log_level = 'INFO'
+            internal_log_format = cls.JSON_LOG_FORMAT
+        database_log_level = 'WARN'
+        message_template = cls.DEFAULT_MESSAGE_TEMPLATE
+        return (internal_log_level, internal_log_format, database_log_level,
+                message_template)
+
+    @classmethod
+    def set_formatter(cls, handler, log_format, message_template):
+        """Tell the given `handler` to format its log messages in a
+        certain way.
+        """
+        if (log_format==cls.JSON_LOG_FORMAT
+            or isinstance(handler, LogglyHandler)):
+            formatter = JSONFormatter()
+        else:
+            formatter = UTF8Formatter(message_template)
+        handler.setFormatter(formatter)
+
+    @classmethod
+    def loggly_handler(cls, externalintegration):
+        """Turn a Loggly ExternalIntegration into a log handler.
+        """
+        token = externalintegration.password
+        url = externalintegration.url or cls.DEFAULT_LOGGLY_URL
+        if not url:
+            raise CannotLoadConfiguration(
+                "Loggly integration configured but no URL provided."
+            )
+        try:
+            url = cls._interpolate_loggly_url(url, token)
+        except (TypeError, KeyError), e:
+            raise CannotLoadConfiguraiton(
+                "Cannot interpolate token %s into loggly URL %s" % (
+                    token, url,
+                )
+            )
+        return LogglyHandler(url)
+
+    @classmethod
+    def _interpolate_loggly_url(cls, url, token):
+        if '%s' in url:
+            return url % token
+        if '%(' in url:
+            return url % dict(token=token)
+
+        # Assume the token is already in the URL.
+        return url
+

--- a/log.py
+++ b/log.py
@@ -115,7 +115,7 @@ class LogConfiguration(object):
         be ignored in favor of a known test-friendly policy. (It's
         okay to pass in False during a test *of this method*.)
 
-        :return: A 2-tuple (handlers, database_log_level). `handlers`
+        :return: A 3-tuple (handlers, database_log_level). `handlers`
         is a list of Handler objects that will be associated with the
         top-level logger. database_log_level is the log level to be
         applied to the loggers for the database connector and other

--- a/log.py
+++ b/log.py
@@ -88,11 +88,11 @@ class LogConfiguration(object):
         # Replace the set of handlers associated with the root logger.
         logger = logging.getLogger()
         logger.setLevel(log_level)
-        for handler in list(logger.handlers):
-            logger.removeHandler(handler)
-
+        old_handlers = list(logger.handlers)
         for handler in new_handlers:
             logger.addHandler(handler)
+        for handler in old_handlers:
+            logger.removeHandler(handler)
 
         # Set the loggers for various verbose libraries to the database
         # log level, which is probably higher than the normal log level.

--- a/migration/20170926-migrate-log-configuration.py
+++ b/migration/20170926-migrate-log-configuration.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""Move log details from the Configuration file into the
+database as ExternalIntegrations
+"""
+
+import os
+import sys
+import logging
+from nose.tools import set_trace
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from config import Configuration
+from model import (
+    ExternalIntegration as EI,
+    production_session,
+)
+_db = production_session()
+log = logging.getLogger(name="Log configuration import")
+loggly_conf = Configuration.integration(u'loggly')
+
+if loggly_conf:
+    integration = EI(goal=EI.LOGGING_GOAL, protocol=EI.LOGGLY)
+    _db.add(integration)
+    integration.url = loggly_conf.get(
+        'url', 'https://logs-01.loggly.com/inputs/%(token)s/tag/python/'
+    )
+    integration.password = loggly_conf.get('token')
+_db.commit()
+    

--- a/model.py
+++ b/model.py
@@ -9557,6 +9557,10 @@ class ExternalIntegration(Base, HasFullTableCache):
     # help patrons find libraries.
     DISCOVERY_GOAL = u'discovery'
 
+    # These integrations are associated with external services that
+    # collect logs of server-side events.
+    LOGGING_GOAL = u'logging'
+
     # Supported protocols for ExternalIntegrations with LICENSE_GOAL.
     OPDS_IMPORT = u'OPDS Import'
     OVERDRIVE = DataSource.OVERDRIVE
@@ -9619,6 +9623,10 @@ class ExternalIntegration(Base, HasFullTableCache):
 
     # List of such ADMIN_AUTH_GOAL integrations
     ADMIN_AUTH_PROTOCOLS = [GOOGLE_OAUTH]
+
+    # Integrations with LOGGING_GOAL
+    INTERNAL_LOGGING = u'Internal logging'
+    LOGGLY = u"Loggly"
 
     # Keys for common configuration settings
 

--- a/model.py
+++ b/model.py
@@ -145,7 +145,18 @@ def production_session():
     if url.startswith('"'):
         url = url[1:]
     logging.debug("Database url: %s", url)
-    return SessionManager.session(url)
+    _db = SessionManager.session(url)
+
+    # The first thing to do after getting a database connection is to
+    # set up the logging configuration.
+    #
+    # If called during a unit test, this will configure logging
+    # incorrectly, but 1) this method isn't normally called during
+    # unit tests, and 2) package_setup() will call initialize() again
+    # with the right arguments.
+    from log import LogConfiguration
+    LogConfiguration.initialize(_db)
+    return _db
 
 class PolicyException(Exception):
     pass

--- a/testing.py
+++ b/testing.py
@@ -43,7 +43,6 @@ from model import (
     Work,
     WorkCoverageRecord,
     get_one_or_create,
-    production_session
 )
 from classifier import Classifier
 from coverage import (

--- a/testing.py
+++ b/testing.py
@@ -55,6 +55,7 @@ from coverage import (
 )
 
 from external_search import DummyExternalSearchIndex
+from log import LogConfiguration
 import external_search
 import mock
 import inspect
@@ -64,6 +65,10 @@ def package_setup():
     """Make sure the database schema is initialized and initial
     data is in place.
     """
+
+    # Ensure that the log configuration starts in a known state.
+    LogConfiguration.initialize(None, testing=True)
+
     engine, connection = DatabaseTest.get_database_connection()
 
     # First, recreate the schema.

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,172 @@
+import logging
+from nose.tools import (
+    assert_raises,
+    assert_raises_regexp,
+    eq_,
+    set_trace
+)
+
+from . import DatabaseTest
+from log import (
+    UTF8Formatter,
+    JSONFormatter,
+    LogglyHandler,
+    LogConfiguration,
+)
+from model import (
+    ExternalIntegration,
+)
+
+class TestLogConfiguration(DatabaseTest):
+
+    def loggly_integration(self):
+        """Create an ExternalIntegration for a Loggly account."""
+        integration = self._external_integration(
+            protocol=ExternalIntegration.LOGGLY,
+            goal=ExternalIntegration.LOGGING_GOAL
+        )
+        integration.url = "http://example.com/%s/"
+        integration.password = "a_token"
+        return integration
+
+    def test_from_configuration(self):
+        cls = LogConfiguration
+        m = cls.from_configuration
+
+        # When logging is configured on initial startup, with no
+        # database connection, these are the defaults.
+        internal_log_level, database_log_level, [handler] = m(
+            None, testing=False
+        )
+        eq_(cls.INFO, internal_log_level)
+        eq_(cls.WARN, database_log_level)
+        assert isinstance(handler.formatter, JSONFormatter)
+
+        # The same defaults hold when there is a database connection
+        # but nothing is actually configured.
+        internal_log_level, database_log_level, [handler] = m(
+            self._db, testing=False
+        )
+        eq_(cls.INFO, internal_log_level)
+        eq_(cls.WARN, database_log_level)
+        assert isinstance(handler.formatter, JSONFormatter)
+
+        # Let's set up a Loggly integration and change the defaults.
+        loggly = self.loggly_integration()
+        internal = self._external_integration(
+            protocol=ExternalIntegration.INTERNAL_LOGGING,
+            goal=ExternalIntegration.LOGGING_GOAL
+        )
+        internal.setting(cls.LOG_LEVEL).value = cls.ERROR
+        internal.setting(cls.LOG_FORMAT).value = cls.TEXT_LOG_FORMAT
+        internal.setting(cls.DATABASE_LOG_LEVEL).value = cls.DEBUG
+        template = "%(filename)s:%(message)s"
+        internal.setting(cls.LOG_MESSAGE_TEMPLATE).value = template
+        internal_log_level, database_log_level, handlers = m(
+            self._db, testing=False
+        )
+        eq_(cls.ERROR, internal_log_level)
+        eq_(cls.DEBUG, database_log_level)
+        [loggly_handler] = [x for x in handlers if isinstance(x, LogglyHandler)]
+        eq_("http://example.com/a_token/", loggly_handler.url)
+
+        [stream_handler] = [x for x in handlers 
+                            if isinstance(x, logging.StreamHandler)]
+        assert isinstance(stream_handler.formatter, UTF8Formatter)
+        eq_(template, stream_handler.formatter._fmt)
+
+        # If testing=True, then the database configuration is ignored,
+        # and the log setup is one that's appropriate for display
+        # alongside unit test output.
+        internal_log_level, database_log_level, [handler] = m(
+            self._db, testing=True
+        )
+        eq_(cls.DEBUG, internal_log_level)
+        eq_(cls.WARN, database_log_level)
+        eq_(cls.DEFAULT_MESSAGE_TEMPLATE, handler.formatter._fmt)
+
+    def test_defaults(self):
+        cls = LogConfiguration
+        template = cls.DEFAULT_MESSAGE_TEMPLATE
+
+        # Normally the default log level is INFO and log messages are
+        # emitted in JSON format.
+        eq_(
+            (cls.INFO, cls.JSON_LOG_FORMAT, cls.WARN, 
+             cls.DEFAULT_MESSAGE_TEMPLATE), 
+            cls._defaults(testing=False)
+        )
+
+        # When we're running unit tests, the default log level is DEBUG
+        # and log messages are emitted in text format.
+        eq_(
+            (cls.DEBUG, cls.TEXT_LOG_FORMAT, cls.WARN,
+             cls.DEFAULT_MESSAGE_TEMPLATE), 
+            cls._defaults(testing=True)
+        )
+
+    def test_set_formatter(self):
+        # Create a generic handler.
+        handler = logging.StreamHandler()
+
+        # Configure it for text output.
+        template = '%(filename)s:%(message)s'
+        LogConfiguration.set_formatter(
+            handler, LogConfiguration.TEXT_LOG_FORMAT, template
+        )
+        formatter = handler.formatter
+        assert isinstance(formatter, UTF8Formatter)
+        eq_(template, formatter._fmt)
+
+        # Configure a similar handler for JSON output.
+        handler = logging.StreamHandler()
+        LogConfiguration.set_formatter(
+            handler, LogConfiguration.JSON_LOG_FORMAT, template
+        )
+        formatter = handler.formatter
+        assert isinstance(formatter, JSONFormatter)
+
+        # In this case the template is irrelevant. The JSONFormatter
+        # uses the default format template, but it doesn't matter,
+        # because JSONFormatter overrides the format() method.
+        eq_('%(message)s', formatter._fmt)
+
+        # Configure a handler for output to Loggly. In this case
+        # the format and template are irrelevant.
+        handler = LogglyHandler("no-such-url")
+        LogConfiguration.set_formatter(handler, None, None)
+        assert isinstance(formatter, JSONFormatter)
+
+    def test_loggly_handler(self):
+        """Turn an appropriate ExternalIntegration into a LogglyHandler."""
+
+        integration = self.loggly_integration()
+        handler = LogConfiguration.loggly_handler(integration)
+        assert isinstance(handler, LogglyHandler)
+        eq_("http://example.com/a_token/", handler.url)
+
+        # Remove the loggly handler's .url, and the default URL will
+        # be used.
+        integration.url = None
+        handler = LogConfiguration.loggly_handler(integration)
+        eq_(LogConfiguration.DEFAULT_LOGGLY_URL % dict(token="a_token"),
+            handler.url)
+
+    def test_interpolate_loggly_url(self):
+        m = LogConfiguration._interpolate_loggly_url
+
+        # We support two string interpolation techniques for combining
+        # a token with a URL.
+        eq_("http://foo/token/bar/", m("http://foo/%s/bar/", "token"))
+        eq_("http://foo/token/bar/", m("http://foo/%(token)s/bar/", "token"))
+
+        # If the URL contains no string interpolation, we assume the token's
+        # already in there.
+        eq_("http://foo/othertoken/bar/", 
+            m("http://foo/othertoken/bar/", "token"))
+
+        # Anything that doesn't fall under one of these cases will raise an
+        # exception.
+        assert_raises(TypeError, m, "http://%s/%s", "token")
+        assert_raises(KeyError, m, "http://%(atoken)s/", "token")
+


### PR DESCRIPTION
This branch replaces `Configuration.log_policy` with `LogConfiguration.initialize`, a method that configures (or reconfigures) the Python logging system based on the current database configuration.

If there is no database configuration to be found, we use one set of defaults when running unit tests, and another set of defaults everywhere else.

`LogConfiguration.initialize` is automatically called from the unit test runner and from `production_session`. This ensures that logging is properly configured as soon as possible. The applications may need to be changed, but hopefully it will only be to remove code (and to add configuration settings to the admin interface).