### PR TITLE
An image can be its own thumbnail

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1508,6 +1508,7 @@ class Metadata(MetaToModelUtility):
                 identifier.links = surviving_hyperlinks
         
         link_objects = {}
+        thumbnails = {}
 
         for link in self.links:
             if link.rel in Hyperlink.METADATA_ALLOWED:
@@ -1517,6 +1518,25 @@ class Metadata(MetaToModelUtility):
                     content=link.content
                 )
             link_objects[link] = link_obj
+            if link.thumbnail:
+                if link.thumbnail.rel == Hyperlink.THUMBNAIL_IMAGE:
+                    thumbnail = link.thumbnail
+                    thumbnail_obj, ignore = identifier.add_link(
+                        rel=thumbnail.rel, href=thumbnail.href, 
+                        data_source=data_source, 
+                        media_type=thumbnail.media_type,
+                        content=thumbnail.content
+                    )
+                    thumbnail_obj.resource.representation.thumbnail_of = (
+                        link_obj.resource.representation
+                    )
+                else:
+                    self.log.error(
+                        "Thumbnail link %r does not have the thumbnail link relation! Not acceptable as a thumbnail of %r." % (
+                            link.thumbnail, link
+                        )
+                    )
+                    link.thumbnail = None
 
         # Apply all measurements to the primary identifier
         for measurement in self.measurements:

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1527,9 +1527,17 @@ class Metadata(MetaToModelUtility):
                         media_type=thumbnail.media_type,
                         content=thumbnail.content
                     )
-                    thumbnail_obj.resource.representation.thumbnail_of = (
-                        link_obj.resource.representation
-                    )
+                    if (thumbnail_obj.resource
+                        and thumbnail_obj.resource.representation):
+                        thumbnail_obj.resource.representation.thumbnail_of = (
+                            link_obj.resource.representation
+                        )
+                    else:
+                        self.log.error(
+                            "Thumbnail link %r cannot be marked as a thumbnail of %r because it has no Representation, probably due to a missing media type." % (
+                                link.thumbnail, link
+                            )
+                        )
                 else:
                     self.log.error(
                         "Thumbnail link %r does not have the thumbnail link relation! Not acceptable as a thumbnail of %r." % (

--- a/model.py
+++ b/model.py
@@ -3300,8 +3300,15 @@ class Edition(Base):
                 self.cover = None
                 self.cover_full_url = None
 
-            # It's possible there's a thumbnail even though there's no full-sized
-            # cover. Try to find a thumbnail the same way we'd look for a cover.
+        if not self.cover_thumbnail_url:
+            # The process we went through above did not result in the 
+            # setting of a thumbnail cover.
+            #
+            # It's possible there's a thumbnail even when there's no
+            # full-sized cover, or when the full-sized cover and
+            # thumbnail are different Resources on the same
+            # Identifier. Try to find a thumbnail the same way we'd
+            # look for a cover.
             for distance in (0, 5):
                 best_thumbnail, thumbnails = self.best_cover_within_distance(distance, rel=Hyperlink.THUMBNAIL_IMAGE)
                 if best_thumbnail:

--- a/model.py
+++ b/model.py
@@ -3269,6 +3269,8 @@ class Edition(Base):
 
     def choose_cover(self):
         """Try to find a cover that can be used for this Edition."""
+        self.cover_full_url = None
+        self.cover_thumbnail_url = None
         for distance in (0, 5):
             # If there's a cover directly associated with the
             # Edition's primary ID, use it. Otherwise, find the

--- a/model.py
+++ b/model.py
@@ -7791,7 +7791,7 @@ class Representation(Base):
     thumbnails = relationship(
         "Representation",
         backref=backref("thumbnail_of", remote_side = [id]),
-        lazy="joined")
+        lazy="joined", post_update=True)
 
     # The HTTP status code from the last fetch.
     status_code = Column(Integer)

--- a/model.py
+++ b/model.py
@@ -2613,6 +2613,10 @@ class Edition(Base):
     MAX_THUMBNAIL_HEIGHT = 300
     MAX_THUMBNAIL_WIDTH = 200
 
+    # A full-sized image no larger than this height can be used as a thumbnail
+    # in a pinch.
+    MAX_FALLBACK_THUMBNAIL_HEIGHT = 500
+
     # This Edition is associated with one particular
     # identifier--the one used by its data source to identify
     # it. Through the Equivalency class, it is associated with a
@@ -2982,6 +2986,12 @@ class Edition(Base):
                 if scaled_down.mirror_url and scaled_down.mirrored_at:
                     self.cover_thumbnail_url = scaled_down.mirror_url
                     break
+        if (not self.cover_thumbnail_url and 
+            resource.representation.image_height
+            and resource.representation.image_height <= self.MAX_FALLBACK_THUMBNAIL_HEIGHT):
+            # The full-sized image is too large to be a thumbnail, but it's
+            # not huge, and there is no other thumbnail, so use it.
+            self.cover_thumbnail_url = resource.representation.mirror_url
         if old_cover != self.cover or old_cover_full_url != self.cover_full_url:
             logging.debug(
                 "Setting cover for %s/%s: full=%s thumb=%s", 

--- a/model.py
+++ b/model.py
@@ -7739,7 +7739,18 @@ class Representation(Base):
         PNG_MEDIA_TYPE: "png",
         SVG_MEDIA_TYPE: "svg",
         GIF_MEDIA_TYPE: "gif",
+        TEXT_PLAIN: "txt",
+        TEXT_HTML_MEDIA_TYPE: "html",
+        APPLICATION_XML_MEDIA_TYPE: "xml",
     }
+
+    # Invert FILE_EXTENSIONS and add some extra guesses.
+    MEDIA_TYPE_FOR_EXTENSION = {
+        ".htm" : TEXT_HTML_MEDIA_TYPE,
+        ".jpeg" : JPEG_MEDIA_TYPE,
+    }
+    for media_type, extension in FILE_EXTENSIONS.items():
+        MEDIA_TYPE_FOR_EXTENSION['.' + extension] = media_type
 
     __tablename__ = 'representations'
     id = Column(Integer, primary_key=True)
@@ -7879,6 +7890,15 @@ class Representation(Base):
                    'text/', 
                    'video/'
         ])
+
+    @classmethod
+    def guess_media_type(cls, filename):
+        """Guess a likely media type from a filename."""
+        filename = filename.lower()
+        for extension, media_type in cls.MEDIA_TYPE_FOR_EXTENSION.items():
+            if filename.endswith(extension):
+                return media_type
+        return None
 
     def is_fresher_than(self, max_age):
         # Convert a max_age timedelta to a number of seconds.

--- a/tests/files/opds/content_server_mini.opds
+++ b/tests/files/opds/content_server_mini.opds
@@ -45,7 +45,7 @@
     <updated>2015-01-02T16:56:40Z</updated>
     <published>2014-01-02T16:56:40Z</published>
     <simplified:pwid>9acabf17-cea8-c7dd-8440-f12dfa75caa9</simplified:pwid>
-    <link href="/full-cover-image.png" rel="http://opds-spec.org/image"/>
+    <link href="/full-cover-image" rel="http://opds-spec.org/image"/>
     <category term="Animals -- Juvenile poetry" scheme="http://purl.org/dc/terms/LCSH"/>
     <category term="Nursery rhymes" scheme="http://purl.org/dc/terms/LCSH"/>
     <category term="PZ" label="Juvenile Fiction" scheme="http://purl.org/dc/terms/LCC"/>

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -656,6 +656,29 @@ class TestContributorData(DatabaseTest):
 
 
 
+class TestLinkData(DatabaseTest):
+
+    def test_guess_media_type(self):
+        rel = Hyperlink.IMAGE
+
+        # Sometimes we have no idea what media type is at the other
+        # end of a link.
+        unknown = LinkData(rel, href="http://foo/bar.unknown")
+        eq_(None, unknown.guessed_media_type)
+
+        # Sometimes we can guess based on the file extension.
+        jpeg = LinkData(rel, href="http://foo/bar.jpeg")
+        eq_(Representation.JPEG_MEDIA_TYPE, jpeg.guessed_media_type)
+
+        # An explicitly known media type takes precedence over 
+        # something we guess from the file extension.
+        png = LinkData(rel, href="http://foo/bar.jpeg", 
+                       media_type=Representation.PNG_MEDIA_TYPE)
+        eq_(Representation.PNG_MEDIA_TYPE, png.guessed_media_type)
+
+        description = LinkData(Hyperlink.DESCRIPTION, content="Some content")
+        eq_(None, description.guessed_media_type)
+
 class TestMetadata(DatabaseTest):
     def test_from_edition(self):
         # Makes sure Metadata.from_edition copies all the fields over.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4271,6 +4271,18 @@ class TestRepresentation(DatabaseTest):
         representation.media_type = "text/plain"
         eq_(False, representation.mirrorable_media_type)
 
+    def test_guess_media_type(self):
+        m = Representation.guess_media_type
+
+        eq_(Representation.JPEG_MEDIA_TYPE, m("file.jpg"))
+
+        for extension, media_type in Representation.MEDIA_TYPE_FOR_EXTENSION.items():
+            filename = "file" + extension
+            eq_(media_type, m(filename))
+
+        eq_(None, m("file"))
+        eq_(None, m("file.unknown-extension"))
+
     def test_external_media_type_and_extension(self):
         """Test the various transformations that might happen to media type
         and extension when we mirror a representation.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4333,10 +4333,15 @@ class TestRepresentation(DatabaseTest):
         and extension when we mirror a representation.
         """
 
+        # An unknown file at /foo
+        representation, ignore = self._representation(self._url, "text/unknown")
+        eq_("text/unknown", representation.external_media_type)
+        eq_('', representation.extension())
+
         # A text file at /foo
         representation, ignore = self._representation(self._url, "text/plain")
         eq_("text/plain", representation.external_media_type)
-        eq_('', representation.extension())
+        eq_('.txt', representation.extension())
 
         # A JPEG at /foo.jpg
         representation, ignore = self._representation(
@@ -4585,15 +4590,15 @@ class TestRepresentation(DatabaseTest):
         url = "http://example.com/1"
         representation, ignore = self._representation(url, "text/plain")
         filename = representation.default_filename()
-        eq_("1", filename)
+        eq_("1.txt", filename)
 
         # Again, file extension is always set based on media type.
         filename = representation.default_filename(destination_type="image/png")
         eq_("1.png", filename)
 
-        # In this case, don't have an extension registered for
-        # text/plain, so the extension is omitted.
-        filename = representation.default_filename(destination_type="text/plain")
+        # In this case, we don't have an extension registered for
+        # text/unknown, so the extension is omitted.
+        filename = representation.default_filename(destination_type="text/unknown")
         eq_("1", filename)
 
         # This URL has no path component, so we can't even come up with a

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4603,7 +4603,7 @@ class TestRepresentation(DatabaseTest):
 
         # This URL has no path component, so we can't even come up with a
         # decent default filename. We have to go with 'resource'.
-        representation, ignore = self._representation("http://example.com/", "text/plain")
+        representation, ignore = self._representation("http://example.com/", "text/unknown")
         eq_('resource', representation.default_filename())
         eq_('resource.png', representation.default_filename(destination_type="image/png"))
 

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -1168,7 +1168,7 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
         200, content='I am 10557.epub.images',
         media_type=Representation.EPUB_MEDIA_TYPE,
         )
-        # The request to http://root/full-cover-image.png
+        # The request to http://root/full-cover-image
         # will result in a 404 error, and the image will not be mirrored.
         http.queue_response(404, media_type="text/plain")
 
@@ -1196,18 +1196,35 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
             'http://www.gutenberg.org/ebooks/10441.epub.images',
             'https://s3.amazonaws.com/book-covers.nypl.org/Gutenberg-Illustrated/10441/cover_10441_9.png', 
             'http://www.gutenberg.org/ebooks/10557.epub.images',
-            'http://root/full-cover-image.png',
+            'http://root/full-cover-image',
         ])
 
-        [e1_oa_link, e1_image_link, e1_description_link] = sorted(
+        [e1_oa_link, e1_image_link, e1_thumbnail_link, 
+         e1_description_link ] = sorted(
             e1.primary_identifier.links, key=lambda x: x.rel
         )
         [e2_image_link, e2_oa_link] = e2.primary_identifier.links
 
+        # The thumbnail image is associated with the Identifier, but
+        # it's not used because it's associated with a representation
+        # (cover_10441_9.png with media type "image/png") that no
+        # longer has a resource associated with it.
+        eq_(Hyperlink.THUMBNAIL_IMAGE, e1_thumbnail_link.rel)
+        hypothetical_full_representation = e1_thumbnail_link.resource.representation.thumbnail_of
+        eq_(None, hypothetical_full_representation.resource)
+        eq_(Representation.PNG_MEDIA_TYPE, 
+            hypothetical_full_representation.media_type)
+
+        # That's because when we actually got cover_10441_9.png,
+        # it turned out to be an SVG file, not a PNG, so we created a new
+        # Representation. TODO: Obviously we could do better here.
+        eq_(Representation.SVG_MEDIA_TYPE, 
+            e1_image_link.resource.representation.media_type)
+
         # The two open-access links were mirrored to S3, as was the
-        # original SVG image and its PNG thumbnail. The PNG image was
-        # not mirrored because our attempt to download it resulted in
-        # a 404 error.
+        # original SVG image and the PNG thumbnail we generated. The
+        # PNG image was not mirrored because our attempt to download
+        # it resulted in a 404 error.
         imported_representations = [
             e1_oa_link.resource.representation,
             e1_image_link.resource.representation,
@@ -1308,7 +1325,7 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
 </svg>"""
 
         http = DummyHTTPClient()
-        # The request to http://root/full-cover-image.png
+        # The request to http://root/full-cover-image
         # will result in a 404 error, and the image will not be mirrored.
         http.queue_response(404, media_type="text/plain")
         http.queue_response(
@@ -1338,7 +1355,7 @@ class TestOPDSImporterWithS3Mirror(OPDSImporterTest):
         # were going to make our own thumbnail anyway.
         eq_(http.requests, [
             'https://s3.amazonaws.com/book-covers.nypl.org/Gutenberg-Illustrated/10441/cover_10441_9.png', 
-            'http://root/full-cover-image.png',
+            'http://root/full-cover-image',
         ])
 
 
@@ -1527,7 +1544,7 @@ class TestOPDSImportMonitor(OPDSImporterTest):
         # external_account_id.
         [cover]  = [x.resource.url for x in editions[0].primary_identifier.links
                     if x.rel==Hyperlink.IMAGE]
-        eq_("http://root-url/full-cover-image.png", cover)
+        eq_("http://root-url/full-cover-image", cover)
 
         # The 202 status message in the feed caused a transient failure.
         # The exception caused a persistent failure.


### PR DESCRIPTION
This branch adds support for a case (as with Enki) where the 'full-sized' image is about the size of a thumbnail. By setting an image as its own thumbnail, you can start showing an image immediately without needing to get a properly scaled-down image from the metadata wrangler.

This required a minor change to the model (but not the database schema) to avoid a CircularDependencyError when Representation.thumbnail_of pointed to itself.

A minor addition that is nice: if you give `apply` a Hyperlink that has a thumbnail, you don't also need to include that `Hyperlink` in the `links` list. The `apply` method will pick it up and (if it really is a thumbnail-type link) create it automatically.