### PR TITLE
Add registered CoverageRecord status

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -505,6 +505,8 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
         This method is primarily for use with CoverageProviders that use the
         `preregistered_only` flag to process items. It's currently only in use
         on the Metadata Wrangler.
+
+        TODO: Take identifier eligibility into account when registering.
         """
         name = cls.SERVICE_NAME or cls.__name__
         log = logging.getLogger(name)
@@ -520,7 +522,7 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
         was_registered = False
         existing_record = CoverageRecord.lookup(identifier, source, operation)
         if existing_record:
-            log.info('[%s] FOUND %r' % (cls.__name__, existing_record))
+            log.info('FOUND %r' % existing_record)
             return existing_record, was_registered
 
         was_registered = True
@@ -528,7 +530,7 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
             identifier, source, operation=operation,
             status=CoverageRecord.REGISTERED
         )
-        log.info('[%s] CREATED %r' % (cls.__name__, new_record))
+        log.info('CREATED %r' % new_record)
         return new_record, was_registered
 
     @property

--- a/migration/20170928-add-registered-coverage-status.sql
+++ b/migration/20170928-add-registered-coverage-status.sql
@@ -1,0 +1,9 @@
+ALTER TYPE coverage_status ADD VALUE IF NOT EXISTS 'registered' AFTER 'persistent failure';
+
+update coveragerecords
+  set
+    status = 'registered',
+    exception = null
+  where
+    status = 'transient failure' and exception like 'No work done yet%';
+

--- a/model.py
+++ b/model.py
@@ -1241,8 +1241,9 @@ class BaseCoverageRecord(object):
     SUCCESS = u'success'
     TRANSIENT_FAILURE = u'transient failure'
     PERSISTENT_FAILURE = u'persistent failure'
+    REGISTERED = u'registered'
 
-    ALL_STATUSES = [SUCCESS, TRANSIENT_FAILURE, PERSISTENT_FAILURE]
+    ALL_STATUSES = [REGISTERED, SUCCESS, TRANSIENT_FAILURE, PERSISTENT_FAILURE]
 
     # By default, count coverage as present if it ended in
     # success or in persistent failure. Do not count coverage
@@ -1250,7 +1251,7 @@ class BaseCoverageRecord(object):
     DEFAULT_COUNT_AS_COVERED = [SUCCESS, PERSISTENT_FAILURE]
 
     status_enum = Enum(SUCCESS, TRANSIENT_FAILURE, PERSISTENT_FAILURE, 
-                       name='coverage_status')
+                       REGISTERED, name='coverage_status')
 
     @classmethod
     def not_covered(cls, count_as_covered=None, 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -478,7 +478,33 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
             self._db, replacement_policy=policy
         )
         eq_(policy, provider.replacement_policy)
+
+    def test_register(self):
+        # The identifier has no coverage.
+        eq_(0, len(self.identifier.coverage_records))
+
+        provider = AlwaysSuccessfulCoverageProvider
         
+        # If a CoverageRecord doesn't exist for the provider,
+        # a 'registered' record is created.
+        provider.register(self.identifier)
+
+        [record] = self.identifier.coverage_records
+        eq_(provider.DATA_SOURCE_NAME, record.data_source.name)
+        eq_(CoverageRecord.REGISTERED, record.status)
+        eq_(None, record.exception)
+
+        # If a CoverageRecord exists already, it's returned.
+        existing = record
+        existing.status = CoverageRecord.SUCCESS
+
+        provider.register(self.identifier)
+        [record] = self.identifier.coverage_records
+        eq_(existing, record)
+        # Its details haven't been changed in any way.
+        eq_(CoverageRecord.SUCCESS, record.status)
+        eq_(None, record.exception)
+
     def test_ensure_coverage(self):
         """Verify that ensure_coverage creates a CoverageRecord for an
         Identifier, assuming that the CoverageProvider succeeds.
@@ -681,16 +707,18 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
             self._db, preregistered_only=True
         )
 
-        identifier = self._identifier()
         items = provider.items_that_need_coverage()
-        assert identifier not in items
+        assert self.identifier not in items
+
+        # Once the identifier is registered, it shows up.
+        provider.register(self.identifier)
+        assert self.identifier in items
 
         # With a failing CoverageRecord, the item shows up.
-        record = self._coverage_record(
-            identifier, provider.data_source,
-            status=CoverageRecord.TRANSIENT_FAILURE
-        )
-        assert identifier in items
+        [record] = self.identifier.coverage_records
+        record.status = CoverageRecord.TRANSIENT_FAILURE
+        record.exception = 'Oh no!'
+        assert self.identifier in items
 
     def test_items_that_need_coverage_respects_operation(self):
 


### PR DESCRIPTION
Based on the recommendation in #654, this branch adds a "registered" state to CoverageRecords and allows IdentifierCoverageProvider classes to register identifiers directly.

While perhaps not ideal in the long-term, `IdentifierCoverageProvider.register` is a class method to better support the work already done in metadata and avoid creating provider instances for each identifier when registering in bulk. This may need to change if registration becomes popular for other uses.