### PR TITLE
Debuggable response handling

### DIFF
--- a/log.py
+++ b/log.py
@@ -186,7 +186,7 @@ class LogConfiguration(object):
     def _defaults(cls, testing=False):
         """Return default log configuration values."""
         if testing:
-            internal_log_level = 'INFO'
+            internal_log_level = 'DEBUG'
             internal_log_format = cls.TEXT_LOG_FORMAT
         else:
             internal_log_level = 'INFO'

--- a/log.py
+++ b/log.py
@@ -84,13 +84,14 @@ class LogConfiguration(object):
         log_level, database_log_level, new_handlers = (
             cls.from_configuration(_db, testing)
         )
-    
+        
         # Replace the set of handlers associated with the root logger.
         logger = logging.getLogger()
         logger.setLevel(log_level)
         old_handlers = list(logger.handlers)
         for handler in new_handlers:
             logger.addHandler(handler)
+            handler.setLevel(log_level)
         for handler in old_handlers:
             logger.removeHandler(handler)
 
@@ -186,12 +187,12 @@ class LogConfiguration(object):
     def _defaults(cls, testing=False):
         """Return default log configuration values."""
         if testing:
-            internal_log_level = 'DEBUG'
+            internal_log_level = cls.INFO
             internal_log_format = cls.TEXT_LOG_FORMAT
         else:
-            internal_log_level = 'INFO'
+            internal_log_level = cls.INFO
             internal_log_format = cls.JSON_LOG_FORMAT
-        database_log_level = 'WARN'
+        database_log_level = cls.WARN
         message_template = cls.DEFAULT_MESSAGE_TEMPLATE
         return (internal_log_level, internal_log_format, database_log_level,
                 message_template)

--- a/log.py
+++ b/log.py
@@ -186,7 +186,7 @@ class LogConfiguration(object):
     def _defaults(cls, testing=False):
         """Return default log configuration values."""
         if testing:
-            internal_log_level = 'DEBUG'
+            internal_log_level = 'INFO'
             internal_log_format = cls.TEXT_LOG_FORMAT
         else:
             internal_log_level = 'INFO'

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -97,10 +97,10 @@ class TestLogConfiguration(DatabaseTest):
             cls._defaults(testing=False)
         )
 
-        # When we're running unit tests, the default log level is DEBUG
+        # When we're running unit tests, the default log level is INFO
         # and log messages are emitted in text format.
         eq_(
-            (cls.DEBUG, cls.TEXT_LOG_FORMAT, cls.WARN,
+            (cls.INFO, cls.TEXT_LOG_FORMAT, cls.WARN,
              cls.DEFAULT_MESSAGE_TEMPLATE), 
             cls._defaults(testing=True)
         )

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -81,7 +81,7 @@ class TestLogConfiguration(DatabaseTest):
         internal_log_level, database_log_level, [handler] = m(
             self._db, testing=True
         )
-        eq_(cls.DEBUG, internal_log_level)
+        eq_(cls.INFO, internal_log_level)
         eq_(cls.WARN, database_log_level)
         eq_(cls.DEFAULT_MESSAGE_TEMPLATE, handler.formatter._fmt)
 

--- a/tests/test_util_http.py
+++ b/tests/test_util_http.py
@@ -19,6 +19,13 @@ from problem_details import INVALID_INPUT
 
 class TestHTTP(object):
 
+    def test_series(self):
+        m = HTTP.series
+        eq_("2xx", m(201))
+        eq_("3xx", m(399))
+        eq_("5xx", m(500))
+
+
     def test_request_with_timeout_success(self):
 
         def fake_200_response(*args, **kwargs):
@@ -188,6 +195,9 @@ class TestHTTP(object):
         success = MockRequestsResponse(200, content="Success!")
         eq_(success, m(success))
 
+        success = MockRequestsResponse(302, content="Success!")
+        eq_(success, m(success))
+
         # An error is turned into a detailed ProblemDetail
         error = MockRequestsResponse(500, content="Error!")
         problem = m(error)
@@ -202,6 +212,11 @@ class TestHTTP(object):
         eq_(INTEGRATION_ERROR.uri, problem.uri)
         eq_(u"Remote service returned a problem detail document: %r" % content,
             problem.detail)
+
+        # You can force a response to be treated as successful by
+        # passing in its response code as allowed_response_codes.
+        eq_(error, m(error, allowed_response_codes=[400]))
+        eq_(error, m(error, allowed_response_codes=['4xx']))
 
 class TestRemoteIntegrationException(object):
 

--- a/util/http.py
+++ b/util/http.py
@@ -260,20 +260,23 @@ class HTTP(object):
             )
         return response
 
-    def debuggable_get(self, url, **kwargs):
+    @classmethod
+    def debuggable_get(cls, url, **kwargs):
         """Make a GET request that returns a detailed problem
         detail document on error.
         """
-        return self._debuggable_request("GET", url, **kwargs)
+        return cls._debuggable_request("GET", url, **kwargs)
 
-    def debuggable_post(self, url, payload, **kwargs):
+    @classmethod
+    def debuggable_post(cls, url, payload, **kwargs):
         """Make a POST request that returns a detailed problem
         detail document on error.
         """
         kwargs['data'] = payload
-        return self._debuggable_request("POST", url, **kwargs)
+        return cls._debuggable_request("POST", url, **kwargs)
 
-    def debuggable_request(self, http_method, url, **kwargs):
+    @classmethod
+    def debuggable_request(cls, http_method, url, **kwargs):
         """Make a request that returns a detailed problem detail document on
         error, rather than a generic "an integration error occured"
         message.
@@ -281,7 +284,7 @@ class HTTP(object):
         if not 'allowed_response_codes' in kwargs:
             # We allow all response codes so that we can handle bad
             # ones in a more helpful way.
-            kwargs['allowed_response_codes']=["2xx", "3xx", "4xx", "5xx"]
+            kwargs['allowed_response_codes']=["1xx", "2xx", "3xx", "4xx", "5xx"]
         response = HTTP.request_with_timeout(http_method, url, **kwargs)
         return self.process_debuggable_response(response)
 

--- a/util/http.py
+++ b/util/http.py
@@ -265,7 +265,7 @@ class HTTP(object):
         """Make a GET request that returns a detailed problem
         detail document on error.
         """
-        return cls._debuggable_request("GET", url, **kwargs)
+        return cls.debuggable_request("GET", url, **kwargs)
 
     @classmethod
     def debuggable_post(cls, url, payload, **kwargs):
@@ -273,7 +273,7 @@ class HTTP(object):
         detail document on error.
         """
         kwargs['data'] = payload
-        return cls._debuggable_request("POST", url, **kwargs)
+        return cls.debuggable_request("POST", url, **kwargs)
 
     @classmethod
     def debuggable_request(cls, http_method, url, **kwargs):

--- a/util/http.py
+++ b/util/http.py
@@ -286,7 +286,7 @@ class HTTP(object):
             # ones in a more helpful way.
             kwargs['allowed_response_codes']=["1xx", "2xx", "3xx", "4xx", "5xx"]
         response = HTTP.request_with_timeout(http_method, url, **kwargs)
-        return self.process_debuggable_response(response)
+        return cls.process_debuggable_response(response)
 
     @classmethod
     def process_debuggable_response(cls, response):

--- a/util/http.py
+++ b/util/http.py
@@ -227,7 +227,7 @@ class HTTP(object):
             disallowed_response_codes = []
 
         code = response.status_code
-        series = "%sxx" % (code / 100)
+        series = cls.series(code)
         code = str(code)
 
         if allowed_response_codes and (
@@ -261,6 +261,11 @@ class HTTP(object):
         return response
 
     @classmethod
+    def series(cls, status_code):
+        """Return the HTTP series for the given status code."""
+        return "%sxx" % (status_code / 100)
+
+    @classmethod
     def debuggable_get(cls, url, **kwargs):
         """Make a GET request that returns a detailed problem
         detail document on error.
@@ -281,35 +286,55 @@ class HTTP(object):
         error, rather than a generic "an integration error occured"
         message.
         """
-        if not 'allowed_response_codes' in kwargs:
-            # We allow all response codes so that we can handle bad
-            # ones in a more helpful way.
+        if 'allowed_response_codes' in kwargs:
+            # The caller wants to treat a specific set of response codes
+            # as successful.
+            allowed_response_codes = kwargs
+        else:
+            # We want request_with_timeout to allow through all
+            # response codes so that we can handle bad ones in a more
+            # helpful way.
             kwargs['allowed_response_codes']=["1xx", "2xx", "3xx", "4xx", "5xx"]
+            
+            # But we want to apply the normal rules when deciding whether
+            # a given response is 'bad'.
+            allowed_response_codes = None
         response = HTTP.request_with_timeout(http_method, url, **kwargs)
-        return cls.process_debuggable_response(response)
+        return cls.process_debuggable_response(response, allowed_response_codes)
 
     @classmethod
-    def process_debuggable_response(cls, response):
+    def process_debuggable_response(cls, response, allowed_response_codes=None):
         """If there was a problem with an integration request,
         return an appropriate ProblemDetail. Otherwise, return the
         response to the original request.
 
         :param response: A Response object from the requests library.
         """
+
+        allowed_response_codes = allowed_response_codes or ['2xx', '3xx']
+        code = response.status_code
+        series = cls.series(code)
+        if code in allowed_response_codes or series in allowed_response_codes:
+            # Whether or not it looks like there's been a problem,
+            # we've been told to let this response code through.
+            return response
+
         content_type = response.headers.get('Content-Type')
         if content_type == PROBLEM_DETAIL_JSON_MEDIA_TYPE:
+            # The server returned a problem detail document. Wrap it
+            # in a new document that represents the integration
+            # failure.
             return INTEGRATION_ERROR.detailed(
                 _('Remote service returned a problem detail document: %r') % (
                     response.content
                 )
             )
-        elif response.status_code / 100 not in (2,3):
-            # Return the message we got from the server, verbatim.
-            return INTEGRATION_ERROR.detailed(
-                _("%s response from integration server: %r") % (
-                    response.status_code,
-                    response.content,
-                )
-            )
 
-        return response
+        # There's been a problem. Return the message we got from the
+        # server, verbatim.
+        return INTEGRATION_ERROR.detailed(
+            _("%s response from integration server: %r") % (
+                response.status_code,
+                response.content,
+            )
+        )


### PR DESCRIPTION
This branch creates an alternate way to make HTTP requests where errors on the other side are passed through in detail rather than hidden under a generic "server integration error" message. This is for use in administrative interfaces and other places where we'd rather know more about a problem than risk freaking someone out with an unfriendly error message.

* If a response yields a problem detail document, it's wrapped in another problem detail document (so that the response code is 502 instead of whatever the original response code was).
* If a response returns a status code outside the 2xx/3xx range, but no problem detail document is returned, the content from the server is reported inside a new problem detail document.
* Otherwise, the response is returned as-is.
