### PR TITLE
Dont update timestamp every time a script runs

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -139,6 +139,18 @@ class TestDatabaseInterface(DatabaseTest):
         result = get_one(self._db, Edition, constraint=constraint)
         eq_(None, result)
 
+    def initialize_data_does_not_reset_timestamp(self):
+        # initialize_data() has already been called, so the database is
+        # initialized and the 'site configuration changed' Timestamp has
+        # been set. Calling initialize_data() again won't change the 
+        # date on the timestamp.
+        timestamp = get_one(_db, Timestamp,
+                            collection=None, 
+                            service=Configuration.SITE_CONFIGURATION_CHANGED)
+        old_timestamp = timestamp.timestamp
+        SessionManager.initialize_data()
+        eq_(old_timestamp, timestamp.timestamp)
+
 
 class TestDataSource(DatabaseTest):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -139,16 +139,16 @@ class TestDatabaseInterface(DatabaseTest):
         result = get_one(self._db, Edition, constraint=constraint)
         eq_(None, result)
 
-    def initialize_data_does_not_reset_timestamp(self):
+    def test_initialize_data_does_not_reset_timestamp(self):
         # initialize_data() has already been called, so the database is
         # initialized and the 'site configuration changed' Timestamp has
         # been set. Calling initialize_data() again won't change the 
         # date on the timestamp.
-        timestamp = get_one(_db, Timestamp,
+        timestamp = get_one(self._db, Timestamp,
                             collection=None, 
                             service=Configuration.SITE_CONFIGURATION_CHANGED)
         old_timestamp = timestamp.timestamp
-        SessionManager.initialize_data()
+        SessionManager.initialize_data(self._db)
         eq_(old_timestamp, timestamp.timestamp)
 
 


### PR DESCRIPTION
This branch stops `initialize_data` from updating the 'site configuration changed' timestamp every time. `initialize_data` is called every time a script runs, and the vast majority of the time there's nothing to do. Since we're constantly running scripts, this was causing it to appear as though the site configuration was constantly changing, and the circ manager was spending a lot of time reloading its configuration.

We're now relying on the listener methods to catch any relevant data changes that happen during `initialize_data`, but it's hard for me to imagine any such changes.