### PR TITLE
Added optional Library to CustomLists, for lists that are created in the admin interface.

### DIFF
--- a/migration/20171004-add-customlists-library-id.sql
+++ b/migration/20171004-add-customlists-library-id.sql
@@ -1,0 +1,8 @@
+alter table customlists add column library_id integer;
+
+alter table customlists
+    add constraint customlists_library_id_fkey
+    foreign key (library_id)
+    references libraries(id);
+
+create index "ix_customlists_library_id" ON customlists (library_id);

--- a/model.py
+++ b/model.py
@@ -8745,6 +8745,7 @@ class CustomList(Base):
     created = Column(DateTime, index=True)
     updated = Column(DateTime, index=True)
     responsible_party = Column(Unicode)
+    library_id = Column(Integer, ForeignKey('libraries.id'), index=True, nullable=True)
 
     entries = relationship(
         "CustomListEntry", backref="customlist", lazy="joined")
@@ -9158,6 +9159,11 @@ class Library(Base, HasFullTableCache):
     cachedfeeds = relationship(
         "CachedFeed", backref="library",
         cascade="save-update, merge, delete, delete-orphan",
+    )
+
+    # A Library may have many CustomLists.
+    custom_lists = relationship(
+        "CustomList", backref="library", lazy='joined',
     )
     
     # A Library may have many ExternalIntegrations.


### PR DESCRIPTION
Lists like the NYT best sellers will continue to have no Library, and the admin interface will ignore them.