### PR TITLE
Add debugging and recovery for rare problems when objects can't be merged in with a database session

### DIFF
--- a/model.py
+++ b/model.py
@@ -276,7 +276,7 @@ class HasFullTableCache(object):
                 )
                 # Try to look up a fresh copy of the object.
                 obj, new = lookup_hook()
-                if obj and obj in _db and False:
+                if obj and obj in _db:
                     logging.error("Was able to look up a fresh copy of %r", obj)
                     return obj, new
 

--- a/model.py
+++ b/model.py
@@ -274,6 +274,15 @@ class HasFullTableCache(object):
                     "Unable to merge cached object %r into database session",
                     obj, exc_info=e
                 )
+                # Try to look up a fresh copy of the object.
+                obj, new = lookup_hook()
+                if obj and obj in _db and False:
+                    logging.error("Was able to look up a fresh copy of %r", obj)
+                    return obj, new
+
+                # That didn't work. Re-raise the original exception.
+                logging.error("Unable to look up a fresh copy of %r", obj)
+                raise e
         return obj, new
         
     @classmethod

--- a/model.py
+++ b/model.py
@@ -10149,7 +10149,7 @@ class Collection(Base, HasFullTableCache):
     # for Identifiers in its catalog.
     coverage_records = relationship(
         "CoverageRecord", backref="collection",
-        cascade="all, delete-orphan"
+        cascade="all"
     )
 
     _cache = HasFullTableCache.RESET

--- a/model.py
+++ b/model.py
@@ -271,7 +271,13 @@ class HasFullTableCache(object):
             cls._cache_insert(obj, cls._cache, cls._id_cache)
             
         if obj and obj not in _db:
-            obj = _db.merge(obj, load=False)
+            try:
+                obj = _db.merge(obj, load=False)
+            except Exception, e:
+                logging.error(
+                    "Unable to merge cached object %r into database session",
+                    obj, exc_info=e
+                )
         return obj, new
         
     @classmethod
@@ -9157,7 +9163,7 @@ class Library(Base, HasFullTableCache):
     # A Library may have many CachedFeeds.
     cachedfeeds = relationship(
         "CachedFeed", backref="library",
-        cascade="save-update, merge, delete, delete-orphan",
+        cascade="save-update, delete, delete-orphan",
     )
     
     # A Library may have many ExternalIntegrations.
@@ -9170,7 +9176,7 @@ class Library(Base, HasFullTableCache):
     # ConfigurationSettings.
     settings = relationship(
         "ConfigurationSetting", backref="library",
-        lazy="joined", cascade="save-update, merge, delete, delete-orphan",
+        lazy="joined", cascade="save-update, delete, delete-orphan",
     )
 
     _cache = HasFullTableCache.RESET
@@ -9705,7 +9711,7 @@ class ExternalIntegration(Base, HasFullTableCache):
     # ConfigurationSettings.
     settings = relationship(
         "ConfigurationSetting", backref="external_integration",
-        lazy="joined", cascade="save-update, merge, delete, delete-orphan",
+        lazy="joined", cascade="save-update, delete, delete-orphan",
     )
 
     def __repr__(self):
@@ -10122,7 +10128,7 @@ class Collection(Base, HasFullTableCache):
     # A Collection can include many LicensePools.
     licensepools = relationship(
         "LicensePool", backref="collection",
-        cascade="save-update, merge, delete"
+        cascade="save-update, delete"
     )
 
     # A Collection can be monitored by many Monitors, each of which
@@ -10138,7 +10144,7 @@ class Collection(Base, HasFullTableCache):
     # for Identifiers in its catalog.
     coverage_records = relationship(
         "CoverageRecord", backref="collection",
-        cascade="save-update, merge, delete"
+        cascade="save-update, delete"
     )
 
     _cache = HasFullTableCache.RESET

--- a/model.py
+++ b/model.py
@@ -125,11 +125,7 @@ from util.permanent_work_id import WorkIDCalculator
 from util.personal_names import display_name_to_sort_name
 from util.summary import SummaryEvaluator
 
-from sqlalchemy.orm.session import (
-    Session,
-    make_transient,
-    make_transient_to_detached,
-)
+from sqlalchemy.orm.session import Session
 
 from sqlalchemy.dialects.postgresql import (
     ARRAY,
@@ -1584,13 +1580,13 @@ class Identifier(Base):
     equivalencies = relationship(
         "Equivalency",
         primaryjoin=("Identifier.id==Equivalency.input_id"),
-        backref="input_identifiers", cascade="all, delete, delete-orphan"
+        backref="input_identifiers", cascade="all, delete-orphan"
     )
 
     inbound_equivalencies = relationship(
         "Equivalency",
         primaryjoin=("Identifier.id==Equivalency.output_id"),
-        backref="output_identifiers", cascade="all, delete, delete-orphan"
+        backref="output_identifiers", cascade="all, delete-orphan"
     )
 
     # One Identifier may have many associated CoverageRecords.
@@ -3482,7 +3478,7 @@ class Work(Base):
     genres = association_proxy('work_genres', 'genre',
                                creator=WorkGenre.from_genre)
     work_genres = relationship("WorkGenre", backref="work",
-                               cascade="all, delete, delete-orphan")
+                               cascade="all, delete-orphan")
     audience = Column(Unicode, index=True)
     target_age = Column(INT4RANGE, index=True)
     fiction = Column(Boolean, index=True)
@@ -5543,7 +5539,7 @@ class Genre(Base, HasFullTableCache):
     works = association_proxy('work_genres', 'work')
 
     work_genres = relationship("WorkGenre", backref="genre", 
-                               cascade="all, delete, delete-orphan")
+                               cascade="all, delete-orphan")
 
     _cache = HasFullTableCache.RESET
     _id_cache = HasFullTableCache.RESET
@@ -9157,13 +9153,13 @@ class Library(Base, HasFullTableCache):
 
     # A library may have many Patrons.
     patrons = relationship(
-        'Patron', backref='library', cascade="all, delete, delete-orphan"
+        'Patron', backref='library', cascade="all, delete-orphan"
     )
 
     # A Library may have many CachedFeeds.
     cachedfeeds = relationship(
         "CachedFeed", backref="library",
-        cascade="save-update, delete, delete-orphan",
+        cascade="all, delete-orphan",
     )
     
     # A Library may have many ExternalIntegrations.
@@ -9176,7 +9172,7 @@ class Library(Base, HasFullTableCache):
     # ConfigurationSettings.
     settings = relationship(
         "ConfigurationSetting", backref="library",
-        lazy="joined", cascade="save-update, delete, delete-orphan",
+        lazy="joined", cascade="all, delete-orphan",
     )
 
     _cache = HasFullTableCache.RESET
@@ -9711,7 +9707,7 @@ class ExternalIntegration(Base, HasFullTableCache):
     # ConfigurationSettings.
     settings = relationship(
         "ConfigurationSetting", backref="external_integration",
-        lazy="joined", cascade="save-update, delete, delete-orphan",
+        lazy="joined", cascade="all, delete-orphan",
     )
 
     def __repr__(self):
@@ -10128,7 +10124,7 @@ class Collection(Base, HasFullTableCache):
     # A Collection can include many LicensePools.
     licensepools = relationship(
         "LicensePool", backref="collection",
-        cascade="save-update, delete"
+        cascade="all, delete-orphan"
     )
 
     # A Collection can be monitored by many Monitors, each of which
@@ -10144,7 +10140,7 @@ class Collection(Base, HasFullTableCache):
     # for Identifiers in its catalog.
     coverage_records = relationship(
         "CoverageRecord", backref="collection",
-        cascade="save-update, delete"
+        cascade="all, delete-orphan"
     )
 
     _cache = HasFullTableCache.RESET


### PR DESCRIPTION
The main purpose of this branch is to give better visibility into a rare instance where an object loaded from the cache can't be merged in with the active database session.

As I tried to solve the problem I did a lot of research around the `cascade` option and what it means for merge (and other actions) to cascade. I still don't understand exactly what I'm seeing w/r/t this error, but I learned enough from http://docs.sqlalchemy.org/en/latest/orm/cascades.html to believe we really only need three values for `cascade`:

* The default value, mainly used for many-to-many relationships.
* `all`, for when we want the deletion of a parent to result in the deletion of all its children. 
* `all, delete-orphan`, for when we _also_ want a child object to be deleted rather than removed from its parent.

I went through `model.py` and changed a number of `cascade` values to one of these three, generally `all, delete-orphan`. I have not audited all our `relationship`s to make sure that the default value is appropriate, but I'm pretty sure that whenever we do specify a `relationship` it's now doing what we want.

However, I don't think this has any effect on the problem we're seeing -- it's just a minor bit of cleanup.

The name of this branch is misleading; this code ensures that merge operations _are_ cascaded in more cases than previously.