### PR TITLE
Create a CoverageProvider that makes sure Works stay indexed

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -102,6 +102,8 @@ class BaseCoverageProvider(object):
 
     # In your subclass, you _may_ set this to a string that distinguishes
     # two different CoverageProviders from the same data source.
+    # (You may also override the get_operation() method, if you need 
+    # database access to determine which operation to use.)
     OPERATION = None
     
     # The database session will be committed each time the
@@ -127,7 +129,7 @@ class BaseCoverageProvider(object):
                 "%s must define SERVICE_NAME." % self.__class__.__name__
             )
         service_name = self.__class__.SERVICE_NAME
-        self.operation = self.OPERATION
+        self.operation = self.get_operation()
         
         if self.operation:
             service_name += ' (%s)' % self.operation
@@ -152,6 +154,13 @@ class BaseCoverageProvider(object):
         if not self.collection_id:
             return None
         return get_one(self._db, Collection, id=self.collection_id)
+
+    def get_operation(self):
+        """Which operation should this CoverageProvider use to
+        distinguish between multiple CoverageRecords from the same data
+        source?
+        """
+        return self.OPERATION
     
     def run(self):
         self.run_once_and_update_timestamp()

--- a/external_search.py
+++ b/external_search.py
@@ -855,12 +855,8 @@ class SearchIndexCoverageProvider(WorkCoverageProvider):
         return ExternalSearchIndex.search_index_update_operation(self._db)
 
     def process_batch(self, works):
-        """:return: A 2-tuple (counts, records). 
-
-        `counts` is a 3-tuple (successes, transient failures,
-        persistent_failures).
-
-        `records` is a mixed list of Works and CoverageFailure objects.
+        """
+        :return: a mixed list of Works and CoverageFailure objects.
         """
         successes, failures = self.search_index_client.bulk_update(works)
 

--- a/external_search.py
+++ b/external_search.py
@@ -558,7 +558,16 @@ class ExternalSearchIndex(object):
 
         clauses = []
         if collection_ids is not None:
-            clauses.append(dict(terms=dict(collection_id=list(collection_ids))))
+            # Either the collection ID field must be completely
+            # missing (as it will be in older indexes) or it must
+            # include one of the collection IDs we're looking for.
+            collection_id_matches = dict(
+                term=dict(collection_id=list(collection_ids))
+            )
+            no_collection_id = dict(
+                bool=dict(must_not=dict(exists=dict(field="collection_id")))
+            )
+            clauses.append({'or': [collection_id_matches, no_collection_id]})
         if languages:
             clauses.append(dict(terms=dict(language=list(languages))))
         if exclude_languages:

--- a/external_search.py
+++ b/external_search.py
@@ -57,18 +57,6 @@ class ExternalSearchIndex(object):
         cls.__client = None
 
     @classmethod
-    def search_index_update_operation(cls, _db):
-        """Determine the current name of the WorkCoverageRecord operation that
-        denotes "this work needs to be updated in the search index".
-
-        Because the name of the search index changes over time,
-        so does the name of the operation.
-        """
-        index_name = cls.works_index_name(_db) or ''
-        return (WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION
-                + '-' + index_name)
-
-    @classmethod
     def search_integration(cls, _db):
         """Look up the ExternalIntegration for ElasticSearch."""
         return ExternalIntegration.lookup(
@@ -844,15 +832,14 @@ class SearchIndexCoverageProvider(WorkCoverageProvider):
 
     DEFAULT_BATCH_SIZE = 500
 
+    OPERATION = WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION
+
     def __init__(self, *args, **kwargs):
         search_index_client = kwargs.pop('search_index_client', None)
         super(SearchIndexCoverageProvider, self).__init__(*args, **kwargs)
         self.search_index_client = (
             search_index_client or ExternalSearchIndex(self._db)
         )
-
-    def get_operation(self):
-        return ExternalSearchIndex.search_index_update_operation(self._db)
 
     def process_batch(self, works):
         """

--- a/external_search.py
+++ b/external_search.py
@@ -82,8 +82,8 @@ class ExternalSearchIndex(object):
         integration = cls.search_integration(_db)
         if not integration:
             return None
-        setting = integration.setting(self.WORKS_INDEX_KEY)
-        works_index = setting.value_or_default(self.DEFAULT_WORKS_INDEX)
+        setting = integration.setting(cls.WORKS_INDEX_KEY)
+        return setting.value_or_default(cls.DEFAULT_WORKS_INDEX)
 
     def __init__(self, _db, url=None, works_index=None):
     
@@ -97,14 +97,14 @@ class ExternalSearchIndex(object):
                 "Cannot load Elasticsearch configuration without a database.",
             )
         if not url or not works_index:
-            integration = cls.search_integration(_db)
+            integration = self.search_integration(_db)
             if not integration:
                 raise CannotLoadConfiguration(
                     "No Elasticsearch integration configured."
                 )
             url = url or integration.url
             if not works_index:
-                works_index = cls.works_index_name(_db)
+                works_index = self.works_index_name(_db)
         if not url:
             raise CannotLoadConfiguration(
                 "No URL configured to Elasticsearch server."
@@ -863,10 +863,9 @@ class SearchIndexCoverageProvider(WorkCoverageProvider):
         `records` is a mixed list of Works and CoverageFailure objects.
         """
         successes, failures = self.search_index_client.bulk_update(works)
-        counts = (len(successes), len(failures), 0)
 
         records = list(successes)
         for (work, error) in failures:
             records.append(CoverageFailure(work, error))
 
-        return counts, records
+        return records

--- a/external_search.py
+++ b/external_search.py
@@ -562,7 +562,7 @@ class ExternalSearchIndex(object):
             # missing (as it will be in older indexes) or it must
             # include one of the collection IDs we're looking for.
             collection_id_matches = dict(
-                term=dict(collection_id=list(collection_ids))
+                terms=dict(collection_id=list(collection_ids))
             )
             no_collection_id = dict(
                 bool=dict(must_not=dict(exists=dict(field="collection_id")))

--- a/external_search.py
+++ b/external_search.py
@@ -104,7 +104,7 @@ class ExternalSearchIndex(object):
                 )
             url = url or integration.url
             if not works_index:
-                works_index = cls.works_index(_db)
+                works_index = cls.works_index_name(_db)
         if not url:
             raise CannotLoadConfiguration(
                 "No URL configured to Elasticsearch server."

--- a/model.py
+++ b/model.py
@@ -580,7 +580,8 @@ def create(db, model, create_method='',
     kwargs.update(create_method_kwargs or {})
     created = getattr(model, create_method, model)(**kwargs)
     db.add(created)
-    db.flush()
+    if not db._flushing:
+        db.flush()
     return created, True
 
 Base = declarative_base()
@@ -2324,7 +2325,8 @@ class Contributor(Base):
                 try:
                     contributor = Contributor(**create_method_kwargs)
                     _db.add(contributor)
-                    _db.flush()
+                    if not _db._flushing:
+                        _db.flush()
                     contributors = [contributor]
                     new = True
                 except IntegrityError:
@@ -3955,7 +3957,8 @@ class Work(Base):
             cover.reject()
             if len(cover.cover_editions) > 1:
                 editions += cover.cover_editions
-        _db.flush()
+        if not _db._flushing:
+            _db.flush()
 
         editions = list(set(editions))
         if editions:
@@ -4249,7 +4252,8 @@ class Work(Base):
         if (changed or policy.update_search_index) and not exclude_search:
             # Ensure new changes are reflected in database queries
             _db = Session.object_session(self)
-            _db.flush()
+            if not _db._flushing:
+                _db.flush()
             self.update_external_index(search_index_client)
 
         # Now that everything's calculated, print it out.
@@ -6205,7 +6209,8 @@ class CachedFeed(Base):
     def update(self, _db, content):
         self.content = content
         self.timestamp = datetime.datetime.utcnow()
-        _db.flush()
+        if not _db._flushing:
+            _db.flush()
 
     def __repr__(self):
         if self.content:
@@ -7088,7 +7093,8 @@ class LicensePool(Base):
             work = Work()
             _db = Session.object_session(self)
             _db.add(work)
-            _db.flush()
+            if not _db.flushing:
+                _db.flush()
             licensepools_changed = True
 
         # Associate this LicensePool and its Edition with the work we
@@ -10553,7 +10559,8 @@ class Collection(Base, HasFullTableCache):
         """Inserts an identifier into a catalog"""
         if identifier not in self.catalog:
             self.catalog.append(identifier)
-            _db.flush()
+            if not _db._flushing:
+                _db.flush()
 
     def works_updated_since(self, _db, timestamp):
         """Returns all works in a collection's catalog that have been updated

--- a/model.py
+++ b/model.py
@@ -7093,7 +7093,7 @@ class LicensePool(Base):
             work = Work()
             _db = Session.object_session(self)
             _db.add(work)
-            if not _db.flushing:
+            if not _db._flushing:
                 _db.flush()
             licensepools_changed = True
 

--- a/model.py
+++ b/model.py
@@ -4359,8 +4359,7 @@ class Work(Base):
         since these WorkCoverageRecords are handled in large batches.
         """
         _db = Session.object_session(self)
-        from external_search import ExternalSearchIndex
-        operation = ExternalSearchIndex.search_index_update_operation(_db)
+        operation = WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION
         record, is_new = WorkCoverageRecord.add_for(
             self, operation=operation, status=CoverageRecord.REGISTERED
         )
@@ -4400,7 +4399,7 @@ class Work(Base):
                 client.delete(**args)
         if add_coverage_record and present_in_index:
             WorkCoverageRecord.add_for(
-                self, operation=(WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION + "-" + client.works_index)
+                self, operation=WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION
             )
         return present_in_index
 

--- a/model.py
+++ b/model.py
@@ -10760,6 +10760,19 @@ def licensepool_deleted(mapper, connection, target):
     if work:
         record = work.external_index_needs_updating()
 
+@event.listens_for(LicensePool.collection_id, 'set')
+def licensepool_collection_change(target, value, oldvalue, initiator):
+    """A LicensePool should never change collections, but if it is,
+    we need to keep the search index up to date.
+    """
+    work = target.work
+    if not work:
+        return
+    if value == oldvalue:
+        return
+    work.external_index_needs_updating()
+
+
 @event.listens_for(LicensePool.licenses_owned, 'set')
 def licenses_owned_change(target, value, oldvalue, initiator):
     """A Work may need to have its search document re-indexed if one of 

--- a/scripts.py
+++ b/scripts.py
@@ -260,7 +260,7 @@ class RunCoverageProvidersScript(Script):
 
                 self.log.debug("Completed %s", provider.service_name)
                 providers.remove(provider)
-
+    
 
 class RunCollectionCoverageProviderScript(RunCoverageProvidersScript):
     """Run the same CoverageProvider code for all Collections that
@@ -275,6 +275,17 @@ class RunCollectionCoverageProviderScript(RunCoverageProvidersScript):
 
     def get_providers(self, _db, provider_class, **kwargs):
         return list(provider_class.all(_db, **kwargs))
+
+
+class RunWorkCoverageProviderScript(RunCollectionCoverageProviderScript):
+    """Run a WorkCoverageProvider on every relevant Work in the system."""
+
+    # This class overrides RunCollectionCoverageProviderScript just to
+    # take advantage of the constructor; it doesn't actually use the
+    # concept of 'collections' at all.
+
+    def get_providers(self, _db, provider_class, **kwargs):
+        return [provider_class(_db, **kwargs)]
 
 
 class InputScript(Script):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -15,6 +15,7 @@ from lane import Lane
 from model import (
     Edition,
     ExternalIntegration,
+    WorkCoverageRecord,
 )
 from external_search import (
     ExternalSearchIndex,
@@ -947,7 +948,11 @@ class TestSearchFilterFromLane(DatabaseTest):
             lane.genre_ids,
         )
         collection_filter, medium_filter = filter['and']
-        eq_(collection_filter['terms'], dict(collection_id=collection_ids))
+        expect = [
+            {'term': {'collection_id': collection_ids}},
+            {'bool': {'must_not': {'exists': {'field': 'collection_id'}}}}
+        ]
+        eq_(expect, collection_filter['or'])
         
     def test_query_works_from_lane_definition_handles_age_range(self):
         search = DummyExternalSearchIndex()
@@ -1074,7 +1079,7 @@ class TestSearchIndexCoverageProvider(DatabaseTest):
         provider = SearchIndexCoverageProvider(
             self._db, search_index_client=index
         )
-        eq_(ExternalSearchIndex.search_index_update_operation(self._db),
+        eq_(WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION,
             provider.operation)
 
     def test_success(self):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -64,6 +64,11 @@ class ExternalSearchTest(DatabaseTest):
 
 class TestExternalSearch(ExternalSearchTest):
 
+    def test_works_index_name(self):
+        if not self.search:
+            return
+        eq_("test_index-v0", self.search.works_index_name(self._db))
+
     def test_setup_index_creates_new_index(self):
         if not self.search:
             return
@@ -1078,10 +1083,9 @@ class TestSearchIndexCoverageProvider(DatabaseTest):
         provider = SearchIndexCoverageProvider(
             self._db, search_index_client=index
         )
-        counts, results = provider.process_batch([work])
+        results = provider.process_batch([work])
 
         # We got one success and no failures.
-        eq_((1,0,0), counts)
         eq_([work], results)
 
         # The work was added to the search index.
@@ -1103,10 +1107,9 @@ class TestSearchIndexCoverageProvider(DatabaseTest):
         provider = SearchIndexCoverageProvider(
             self._db, search_index_client=index
         )
-        counts, results = provider.process_batch([work])
+        results = provider.process_batch([work])
 
         # We have one transient failure.
-        eq_((0,1,0), counts)
         [record] = results
         eq_(work, record.obj)
         eq_(True, record.transient)

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -949,7 +949,7 @@ class TestSearchFilterFromLane(DatabaseTest):
         )
         collection_filter, medium_filter = filter['and']
         expect = [
-            {'term': {'collection_id': collection_ids}},
+            {'terms': {'collection_id': collection_ids}},
             {'bool': {'must_not': {'exists': {'field': 'collection_id'}}}}
         ]
         eq_(expect, collection_filter['or'])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2443,7 +2443,7 @@ class TestWork(DatabaseTest):
             WorkCoverageRecord.SUMMARY_OPERATION,
             WorkCoverageRecord.QUALITY_OPERATION,
             WorkCoverageRecord.GENERATE_OPDS_OPERATION,
-            WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION + "-" + index.works_index,
+            WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION,
         ])
         eq_(expect, set([x.operation for x in records]))
         

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3148,8 +3148,15 @@ class TestWork(DatabaseTest):
         pool.open_access = True
         eq_(registered, record.status)
 
-        # If a LicensePool is deleted, its former Work needs to be
-        # reindexed.
+        # If its collection changes (which shouldn't happen), it needs
+        # to be reindexed.
+        record.status = success
+        collection2 = self._collection()
+        pool.collection_id = collection2.id
+        eq_(registered, record.status)
+
+        # If a LicensePool is deleted (which also shouldn't happen),
+        # its former Work needs to be reindexed.
         record.status = success
         self._db.delete(pool)
         work = self._db.query(Work).one()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3163,6 +3163,29 @@ class TestWork(DatabaseTest):
         record = find_record(work)
         eq_(registered, record.status)
 
+
+    def test_update_external_index(self):
+        work = self._work()
+        work.presentation_ready = True
+        records = [
+            x for x in work.coverage_records
+            if x.operation==WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION
+        ]
+        index = DummyExternalSearchIndex()
+        work.update_external_index(index)
+
+        # The work was added to the search index.
+        eq_([work.to_search_document()], index.docs.values())
+
+        # A WorkCoverageRecord was created to memorialize the work done.
+        [record] = [
+            x for x in work.coverage_records
+            if x.operation==WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION
+        ]
+        eq_(WorkCoverageRecord.SUCCESS, record.status)
+
+        
+
 class TestCirculationEvent(DatabaseTest):
 
     def _event_data(self, **kwargs):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3104,7 +3104,9 @@ class TestWork(DatabaseTest):
             """
             records = [
                 x for x in work.coverage_records 
-                if x.operation==WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION
+                if x.operation.startswith(
+                        WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION
+                )
             ]
             if records:
                 return records[0]
@@ -3152,12 +3154,6 @@ class TestWork(DatabaseTest):
         self._db.delete(pool)
         work = self._db.query(Work).one()
         record = find_record(work)
-
-        # TODO: This assertion fails. The record we end up is the same Python
-        # object as the record obtained in the licensepool_deleted listener,
-        # but its timestamp is earlier and its .status is 'success'.
-        # Basically, it's the record as it existed just before the delete()
-        # statement. I can't figure out why this happens.
         eq_(registered, record.status)
 
 class TestCirculationEvent(DatabaseTest):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -65,6 +65,7 @@ from scripts import (
     RunCollectionMonitorScript,
     RunCoverageProviderScript,
     RunMonitorScript,
+    RunWorkCoverageProviderScript,
     Script,
     ShowCollectionsScript,
     ShowIntegrationsScript,
@@ -74,6 +75,7 @@ from scripts import (
 from testing import(
     AlwaysSuccessfulBibliographicCoverageProvider,
     BrokenBibliographicCoverageProvider,
+    AlwaysSuccessfulWorkCoverageProvider,
 )
 from monitor import (
     CollectionMonitor,
@@ -441,7 +443,7 @@ class TestLibraryInputScript(DatabaseTest):
         eq_(True, l1.processed)
         eq_(False, l2.processed)
 
-        
+
 class TestRunCoverageProviderScript(DatabaseTest):
 
     def test_parse_command_line(self):
@@ -454,6 +456,18 @@ class TestRunCoverageProviderScript(DatabaseTest):
         eq_(datetime.datetime(2016, 5, 1), parsed.cutoff_time)
         eq_([identifier], parsed.identifiers)
         eq_(identifier.type, parsed.identifier_type)
+
+
+class TestRunWorkCoverageProviderScript(DatabaseTest):
+
+    def test_constructor(self):
+        script = RunWorkCoverageProviderScript(
+            AlwaysSuccessfulWorkCoverageProvider, _db=self._db,
+            batch_size=123
+        )
+        [provider] = script.providers
+        assert isinstance(provider, AlwaysSuccessfulWorkCoverageProvider)
+        eq_(123, provider.batch_size)
 
         
 class TestWorkProcessingScript(DatabaseTest):


### PR DESCRIPTION
This branch introduces a CoverageProvider that makes sure all Works have a WorkCoverageRecord associated with the current name of the search index (which means they have an up-to-date search document in the index).

Works will go into the 'registered' state (indicating that work needs to be done) when they enter or drop out of a Collection. 

A future branch will change `update_external_index` to add the coverage record in the 'registered' state, instead of doing the work and then adding the coverage record in the 'success' state. This should improve performance quite a bit.

When writing tests I noticed some incorrect edge cases in the ExternalSearchIndex error handling, which I think I've fixed. They had to do with what happens when every single document you try to index comes back with an error.