### PR TITLE
Implemented and tested WorkCoverageRecord.bulk_add.

### DIFF
--- a/model.py
+++ b/model.py
@@ -1555,9 +1555,13 @@ class WorkCoverageRecord(Base, BaseCoverageRecord):
         # Make sure that works that previously had a
         # WorkCoverageRecord for this operation have their timestamp
         # and status updated.
+        #
+        # We always set exception to None because if there are
+        # individual differences between the records being created,
+        # they need to be created one at a time and not in a batch.
         update = WorkCoverageRecord.__table__.update().where(
             Work.id.in_(work_ids)
-        ).values(timestamp=timestamp, status=status)
+        ).values(dict(timestamp=timestamp, status=status, exception=None))
         _db.execute(update)
 
 

--- a/model.py
+++ b/model.py
@@ -1512,6 +1512,15 @@ class WorkCoverageRecord(Base, BaseCoverageRecord):
         timestamp = timestamp or datetime.datetime.utcnow()
         work_ids = [w.id for w in works]
 
+        # Make sure that works that previously had a
+        # WorkCoverageRecord for this operation have their timestamp
+        # and status updated.
+        update = WorkCoverageRecord.__table__.update().where(
+            and_(WorkCoverageRecord.work_id.in_(work_ids),
+                 WorkCoverageRecord.operation==operation)
+        ).values(dict(timestamp=timestamp, status=status, exception=exception))
+        _db.execute(update)
+
         # Make sure that any works that are missing a
         # WorkCoverageRecord for this operation get one.
 
@@ -1551,16 +1560,6 @@ class WorkCoverageRecord(Base, BaseCoverageRecord):
             new_records
         )
         _db.execute(insert)
-
-        # Make sure that works that previously had a
-        # WorkCoverageRecord for this operation have their timestamp
-        # and status updated.
-        update = WorkCoverageRecord.__table__.update().where(
-            and_(WorkCoverageRecord.work_id.in_(work_ids),
-                 WorkCoverageRecord.operation==operation)
-        ).values(dict(timestamp=timestamp, status=status, exception=exception))
-        _db.execute(update)
-
 
 Index("ix_workcoveragerecords_operation_work_id", WorkCoverageRecord.operation, WorkCoverageRecord.work_id)
 

--- a/model.py
+++ b/model.py
@@ -77,7 +77,6 @@ from sqlalchemy.sql.expression import (
     literal_column,
     case,
     table,
-    Insert,
 )
 from sqlalchemy.exc import (
     IntegrityError

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5773,6 +5773,7 @@ class TestWorkCoverageRecord(DatabaseTest):
             [not_already_covered, already_covered],
             operation, new_timestamp, status=new_status
         )
+        self._db.commit()
         def relevant_records(work):
             return [x for x in work.coverage_records
                     if x.operation == operation]
@@ -5782,7 +5783,8 @@ class TestWorkCoverageRecord(DatabaseTest):
         eq_([], relevant_records(not_affected))
         assert not_modified.timestamp < new_timestamp
 
-        # The record associated with already_covered has been updated.
+        # The record associated with already_covered has been updated,
+        # and its exception removed.
         [record] = relevant_records(already_covered)
         eq_(new_timestamp, record.timestamp)
         eq_(new_status, record.status)
@@ -5793,9 +5795,12 @@ class TestWorkCoverageRecord(DatabaseTest):
         eq_(new_timestamp, record.timestamp)
         eq_(new_status, record.status)
 
-        # The irrelevant WorkCoverageRecord is not affected by the update.
+        # The irrelevant WorkCoverageRecord is not affected by the update,
+        # even though its Work was affected, because it's a record for
+        # a different operation.
         eq_(WorkCoverageRecord.SUCCESS, irrelevant_record.status)
         assert irrelevant_record.timestamp < new_timestamp
+
 
 class TestComplaint(DatabaseTest):
 


### PR DESCRIPTION
This branch implements a new method which takes a list of Works and makes sure every work has an up-to-date WorkCoverageRecord, whether that means inserting a new row into the database or updating an old row.