### PR TITLE
Take the site configuration timeout from a sitewide setting.

### DIFF
--- a/config.py
+++ b/config.py
@@ -341,6 +341,10 @@ class Configuration(object):
     # changed.
     LAST_CHECKED_FOR_SITE_CONFIGURATION_UPDATE = "last_checked_for_site_configuration_update"
 
+    # A sitewide configuration setting controlling *how often* to check
+    # whether the database configuration has changed.
+    SITE_CONFIGURATION_TIMEOUT = 'site_configuration_timeout'
+
     # The name of the service associated with a Timestamp that tracks
     # the last time the site's configuration changed in the database.
     SITE_CONFIGURATION_CHANGED = "Site Configuration Changed"
@@ -356,7 +360,7 @@ class Configuration(object):
 
     @classmethod
     def site_configuration_last_update(cls, _db, known_value=None,
-                                       timeout=600):
+                                       timeout=None):
         """Check when the site configuration was last updated.
 
         Updates Configuration.instance[Configuration.SITE_CONFIGURATION_LAST_UPDATE]. 
@@ -375,6 +379,11 @@ class Configuration(object):
         :return: a datetime object.
         """
         now = datetime.datetime.utcnow()
+
+        if timeout is None:
+            timeout = ConfigurationSettings.sitewide(
+                cls.SITE_CONFIGURATION_TIMEOUT
+            ).value_or_default(600)
 
         last_check = cls.instance.get(
             cls.LAST_CHECKED_FOR_SITE_CONFIGURATION_UPDATE

--- a/config.py
+++ b/config.py
@@ -380,10 +380,13 @@ class Configuration(object):
         """
         now = datetime.datetime.utcnow()
 
+        if _db and timeout is None:
+            from model import ConfigurationSetting
+            timeout = ConfigurationSetting.sitewide(
+                _db, cls.SITE_CONFIGURATION_TIMEOUT
+            ).value
         if timeout is None:
-            timeout = ConfigurationSettings.sitewide(
-                cls.SITE_CONFIGURATION_TIMEOUT
-            ).value_or_default(600)
+            timeout = 600
 
         last_check = cls.instance.get(
             cls.LAST_CHECKED_FOR_SITE_CONFIGURATION_UPDATE

--- a/model.py
+++ b/model.py
@@ -9536,7 +9536,7 @@ class Library(Base, HasFullTableCache):
             lines.append("Configuration settings:")
             lines.append("-----------------------")
         for setting in settings:
-            if include_secrets or not setting.is_secret:
+            if (include_secrets or not setting.is_secret) and setting.value is not None:
                 lines.append("%s='%s'" % (setting.key, setting.value))
             
         integrations = list(self.integrations)
@@ -9887,6 +9887,9 @@ class ExternalIntegration(Base, HasFullTableCache):
                 # This is a different library's specialization of
                 # this integration. Ignore it.
                 continue
+            if setting.value is None:
+                # The setting has no value. Ignore it.
+                continue
             explanation = "%s='%s'" % (setting.key, setting.value)
             if setting.library:
                 explanation = "%s (applies only to %s)" % (
@@ -9971,6 +9974,8 @@ class ConfigurationSetting(Base, HasFullTableCache):
             lines.append("Site-wide configuration settings:")
             lines.append("---------------------------------")
         for setting in sorted(site_wide_settings, key=lambda s: s.key):
+            if setting.value is None:
+                continue
             lines.append("%s='%s'" % (setting.key, setting.value))
         return lines
 
@@ -10559,7 +10564,7 @@ class Collection(Base, HasFullTableCache):
         if self.external_account_id:
             lines.append('External account ID: "%s"' % self.external_account_id)
         for setting in sorted(integration.settings, key=lambda x: x.key):
-            if include_secrets or not setting.is_secret:
+            if (include_secrets or not setting.is_secret) and setting.value is not None:
                 lines.append('Setting "%s": "%s"' % (setting.key, setting.value))
         return lines
 

--- a/scripts.py
+++ b/scripts.py
@@ -891,14 +891,11 @@ class ConfigureSiteScript(ConfigurationSettingScript):
                     )
                 else:
                     ConfigurationSetting.sitewide(_db, key).value = value
-        settings = _db.query(ConfigurationSetting).filter(
-            ConfigurationSetting.library==None).filter(
-                ConfigurationSetting.external_integration==None
-            ).order_by(ConfigurationSetting.key)
-        output.write("Current site-wide settings:\n")
-        for setting in settings:
-            if args.show_secrets or not setting.is_secret:
-                output.write("%s='%s'\n" % (setting.key, setting.value))
+        output.write(
+            "\n".join(ConfigurationSetting.explain(
+                _db, include_secrets=args.show_secrets
+            ))
+        )
         site_configuration_has_changed(_db)
         _db.commit()
         


### PR DESCRIPTION
Our circulation managers are still having mysterious errors that seem to coincide with the time the site configuration is being reloaded, compounded by another mysterious problem that is causing it to appear as though the site configuration is constantly changing. Until we can diagnose these errors I'd like the site configuration to be reloaded as infrequently as possible, but I don't want to have to change core and circulation every time I change the timeout value.

This branch creates a sitewide setting which is used to determine how often the site configuration is reloaded.

Hopefully we won't need a user interface for this setting because it will become unnecessary once we fix the underlying problems. I'd like to go back to always checking once a minute.