### PR TITLE
Fix migration timestamping

### DIFF
--- a/migration/20171020-add-python-timestamp.sql
+++ b/migration/20171020-add-python-timestamp.sql
@@ -1,0 +1,3 @@
+insert into timestamps(service, timestamp)
+  values('Database Migration - Python', date '2017-10-20' + time '00:00');
+

--- a/scripts.py
+++ b/scripts.py
@@ -1736,8 +1736,7 @@ class DatabaseMigrationScript(Script):
         return [core, server]
 
     def load_configuration(self):
-        # TODO: Remove after 2.0.0 release, when CDNs are loaded from
-        # the database before the ExternalIntegration has been uploaded.
+        """Load configuration without accessing the database."""
         Configuration.load(None)
 
     def run(self, test=False, cmd_args=None):
@@ -1960,7 +1959,6 @@ class DatabaseMigrationScript(Script):
         # Update the script's Session to a new one that has the changed schema
         # and other important info.
         self._session = Session(connection)
-        SessionManager.initialize_data(self._db)
         self.load_configuration()
         DataSource.well_known_sources(self._db)
 

--- a/scripts.py
+++ b/scripts.py
@@ -1690,6 +1690,10 @@ class DatabaseMigrationScript(Script):
 
         def update(self, _db, timestamp, counter, migration_name=None):
             """Saves a TimestampInfo object to the database"""
+            # Reset values locally.
+            self.timestamp = timestamp
+            self.counter = counter
+
             sql = (
                 "UPDATE timestamps SET timestamp=:timestamp, counter=:counter"
                 " where service=:service"
@@ -1701,7 +1705,9 @@ class DatabaseMigrationScript(Script):
             _db.execute(text(sql), values)
             _db.flush()
 
-            message = "New timestamp created at "+self.timestamp.strftime('%Y-%m-%d')
+            message = "%s Timestamp stamped at %s" % (
+                self.service, self.timestamp.strftime('%Y-%m-%d')
+            )
             if migration_name:
                 message += " for %s" % migration_name
             print message
@@ -1858,7 +1864,7 @@ class DatabaseMigrationScript(Script):
 
         if not timestamp:
             # No timestamp was given. Get the timestamp from the database.
-            timestamp = TimestampInfo.find(self._db, self.name)
+            timestamp = self.TimestampInfo.find(self._db, self.name)
 
         if not timestamp or not self.overall_timestamp:
             # There's no timestamp in the database! Raise an error.
@@ -2130,7 +2136,7 @@ class DatabaseMigrationInitializationScript(DatabaseMigrationScript):
                     "%s timestamp already exists: %r. Use --force to update." %
                     (self.name, existing_timestamp))
 
-        # Initialize the required timestamps with the Space Jame release date.
+        # Initialize the required timestamps with the Space Jam release date.
         init_timestamp = self.parse_time('1996-11-15')
         overall_timestamp = existing_timestamp or Timestamp.stamp(
             self._db, self.SERVICE_NAME, None, date=init_timestamp


### PR DESCRIPTION
This branch add a distinct timestamp for python script migrations, to keep python migrations from being skipped in cases when the later SQL or python migrations error or fail in some way. Now, if an error arises in a python script, `core/bin/migrate_database --python-only` will re-run the busted scripts.

Notes:
- Interactions with the database have been moved to the `DatabaseMigrationScript.TimestampInfo` class.
- As usual, there's a ton of twisting and turning in the tests to get things working without running Actual Real Migrations.

Fixes #646.