### PR TITLE
ODL with consolidated copies

### DIFF
--- a/migration/20171022-add-loan-and-hold-external-identifier.sql
+++ b/migration/20171022-add-loan-and-hold-external-identifier.sql
@@ -1,0 +1,1 @@
+ALTER TABLE loans ADD COLUMN external_identifier varchar UNIQUE;

--- a/model.py
+++ b/model.py
@@ -774,6 +774,9 @@ class Loan(Base, LoanAndHoldMixin):
     fulfillment_id = Column(Integer, ForeignKey('licensepooldeliveries.id'))
     start = Column(DateTime)
     end = Column(DateTime)
+    # Some distributors (e.g. Feedbooks) may have an identifier that can
+    # be used to check the status of a specific Loan.
+    external_identifier = Column(Unicode, unique=True, nullable=True)
 
     __table_args__ = (
         UniqueConstraint('patron_id', 'license_pool_id'),

--- a/model.py
+++ b/model.py
@@ -6889,7 +6889,7 @@ class LicensePool(Base):
         )
         return message, tuple(args)
 
-    def loan_to(self, patron, start=None, end=None, fulfillment=None):
+    def loan_to(self, patron, start=None, end=None, fulfillment=None, external_identifier=None):
         _db = Session.object_session(patron)
         kwargs = dict(start=start or datetime.datetime.utcnow(),
                       end=end)
@@ -6898,6 +6898,8 @@ class LicensePool(Base):
             create_method_kwargs=kwargs)
         if fulfillment:
             loan.fulfillment = fulfillment
+        if external_identifier:
+            loan.external_identifier = external_identifier
         return loan, is_new
 
     def on_hold_to(self, patron, start=None, end=None, position=None):

--- a/opds_import.py
+++ b/opds_import.py
@@ -342,6 +342,11 @@ class OPDSImporter(object):
         }
     ]
 
+    # Subclasses of OPDSImporter may define a different parser class that's
+    # a subclass of OPDSXMLParser. For example, a subclass may want to use
+    # tags from an additional namespace.
+    PARSER_CLASS = OPDSXMLParser
+
     def __init__(self, _db, collection, data_source_name=None,
                  identifier_mapping=None, mirror=None, http_get=None,
                  metadata_client=None, content_modifier=None,
@@ -371,7 +376,6 @@ class OPDSImporter(object):
         :param content_modifier: A function that may modify-in-place
         representations (such as images and EPUB documents) as they
         come in from the network.
-
         """
         self._db = _db
         self.log = logging.getLogger("OPDS Importer")
@@ -757,7 +761,7 @@ class OPDSImporter(object):
         """
         values = {}
         failures = {}
-        parser = OPDSXMLParser()
+        parser = cls.PARSER_CLASS()
         root = etree.parse(StringIO(feed))
 
         # Some OPDS feeds (eg Standard Ebooks) contain relative urls,
@@ -961,7 +965,7 @@ class OPDSImporter(object):
 
         :return: A rights URI.
         """
-        rights = OPDSXMLParser._xpath1(entry, 'rights')
+        rights = cls.PARSER_CLASS._xpath1(entry, 'rights')
         if rights:
             return cls.rights_uri(rights)
     

--- a/opds_import.py
+++ b/opds_import.py
@@ -1128,6 +1128,11 @@ class OPDSImporter(object):
             cls.extract_link(link_tag, feed_url, rights_uri)
             for link_tag in parser._xpath(entry_tag, 'atom:link')
         ])
+
+        series_tag = parser._xpath(entry_tag, 'schema:Series')
+        if series_tag:
+            data['series'], data['series_position'] = cls.extract_series(series_tag[0])
+
         return data
 
     @classmethod
@@ -1339,6 +1344,12 @@ class OPDSImporter(object):
         except ValueError:
             return None
 
+    @classmethod
+    def extract_series(cls, series_tag):
+        attr = series_tag.attrib
+        series_name = attr.get('{http://schema.org/}name', None)
+        series_position = attr.get('{http://schema.org/}position', None)
+        return series_name, series_position
 
 class OPDSImportMonitor(CollectionMonitor):
 

--- a/tests/files/opds/content_server.opds
+++ b/tests/files/opds/content_server.opds
@@ -12,6 +12,7 @@
       <simplified:sort_name>Chambers, Robert W. (Robert William)</simplified:sort_name>
     </author>
     <summary></summary>
+    <schema:Series schema:name="Animal Colors" schema:position="1"/>
     <updated>2015-01-02T16:56:40Z</updated>
     <simplified:pwid>6db4cf90-0129-0eaf-410a-502b20a45e67</simplified:pwid>
     <schema:Rating schema:ratingValue="0.3333" schema:additionalType="http://librarysimplified.org/terms/rel/quality"/>

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -432,6 +432,9 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(0.25, r3.value)
         eq_(1, r3.weight)
 
+        eq_('Animal Colors', periodical['series'])
+        eq_('1', periodical['series_position'])
+
     def test_extract_metadata_from_elementtree_treats_message_as_failure(self):
         data_source = DataSource.lookup(self._db, DataSource.OA_CONTENT_SERVER)
 


### PR DESCRIPTION
This branch has a few small changes to support a forthcoming pull request in circulation that will add support for ODL with consolidated copies, for the DPLA exchange.

- I added a column to the loans table to store an external identifier for the loan. When creating a loan for an ODL consolidated copy, the circulation manager gets a link to the license status document for that loan, which can be used to check on the loan's status later.
- I changed the OPDSImporter to allow subclasses to use a different class for parsing OPDS, so that I could add the ODL namespace.
- I made the OPDSImporter handle the `schema:Series` tag, which Feedbooks uses. That's generally useful and not specific to ODL.