### PR TITLE
LGBTQ Fiction doesn't have any particular audience classification

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -586,7 +586,7 @@ fiction_genres = [
     ]),
     u"Humorous Fiction",
     u"Literary Fiction",
-    dict(name=u"LGBTQ Fiction", audiences=Classifier.AUDIENCE_ADULTS_ONLY),
+    u"LGBTQ Fiction",
     dict(name=u"Mystery", subgenres=[
         u"Crime & Detective Stories",
         u"Hard-Boiled Mystery",


### PR DESCRIPTION
This branch removes an erroneous implication about the audience for an "LGBTQ Fiction" lane, which I think was originally caused by a copy-and-paste error. The underlying intent is not to restrict how "LGBTQ Fiction" books are classified, but to create a "LGBTQ Fiction" lane in the Young Adult section. Since that happens in the lane definition, not in the genre definition, the restriction isn't necessary here and the incorrect code had no effect.

I think the whole 'audience restriction' feature can be removed, actually, but I'll investigate that later as part of my lane work.