### PR TITLE
OneClickImportMonitor can be run multiple times, but does nothing after the first time

### DIFF
--- a/model.py
+++ b/model.py
@@ -6847,18 +6847,24 @@ class LicensePool(Base):
         logging.info or a similar method
         """
         edition = self.presentation_edition
-        message = 'CHANGED '
+        message = u'CHANGED '
         args = []
+        if self.identifier:
+            identifier_template = '%s/%s'
+            identifier_args = [self.identifier.type, self.identifier.identifier]
+        else:
+            identifier_template = '%s'
+            identifier_args = [self.identifier]
         if edition:
-            message += '%s "%s" %s (%s)'
+            message += u'%s "%s" %s (' + identifier_template + ')'
             args.extend([edition.medium, 
                          edition.title or "[NO TITLE]",
-                         edition.author or "[NO AUTHOR]",
-                         self.identifier]
+                         edition.author or "[NO AUTHOR]"]
                     )
+            args.extend(identifier_args)
         else:
-            message += '%s'
-            args.append(self.identifier)
+            message += identifier_template
+            args.extend(identifier_args)
 
         def _part(message, args, string, old_value, new_value):
             if old_value != new_value:

--- a/oneclick.py
+++ b/oneclick.py
@@ -961,7 +961,6 @@ class OneClickImportMonitor(OneClickSyncMonitor):
     
     def invoke(self):
         timestamp = self.timestamp()
-        set_trace()
         if timestamp.counter and timestamp.counter > 0:
             self.log.debug(
                 "Collection %s has already had its initial import; doing nothing.", 
@@ -970,8 +969,11 @@ class OneClickImportMonitor(OneClickSyncMonitor):
             return 0, 0
         result = self.api.populate_all_catalog()
 
-        # Don't do this work again.
-        timestamp.counter += 1
+        # Record the work was done so it's not done again.
+        if not timestamp.counter:
+            timestamp.counter = 1
+        else:
+            timestamp.counter += 1
         return result
 
 

--- a/oneclick.py
+++ b/oneclick.py
@@ -166,7 +166,8 @@ class OneClickAPI(object):
             disallowed_response_codes=disallowed_response_codes
         )
     
-        if 'Invalid Basic Token or permission denied' in response.content:
+        if (response.content
+            and 'Invalid Basic Token or permission denied' in response.content):
             raise BadResponseException(
                 url, "Permission denied. This may be a temporary rate-limiting issue, or the credentials for this collection may be wrong.",
                 debug_message=response.content,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1935,24 +1935,26 @@ class TestLicensePool(DatabaseTest):
         # Since all four circulation values changed, the message is as
         # long as it could possibly get.
         eq_(
-            'CHANGED %s "%s" %s (%s) %s: %s=>%s %s: %s=>%s %s: %s=>%s %s: %s=>%s',
+            'CHANGED %s "%s" %s (%s/%s) %s: %s=>%s %s: %s=>%s %s: %s=>%s %s: %s=>%s',
             msg
         )
         eq_(
             args,
-            (edition.medium, edition.title, edition.author, pool.identifier,
+            (edition.medium, edition.title, edition.author, 
+             pool.identifier.type, pool.identifier.identifier,
              'OWN', 1, 10, 'AVAIL', 2, 9, 'RSRV', 3, 8, 'HOLD', 4, 7)
         )
 
         # If only one circulation value changes, the message is a lot shorter.
         msg, args = pool.circulation_changelog(10, 9, 8, 15)
         eq_(
-            'CHANGED %s "%s" %s (%s) %s: %s=>%s',
+            'CHANGED %s "%s" %s (%s/%s) %s: %s=>%s',
             msg
         )
         eq_(
             args,
-            (edition.medium, edition.title, edition.author, pool.identifier,
+            (edition.medium, edition.title, edition.author, 
+             pool.identifier.type, pool.identifier.identifier,
              'HOLD', 15, 7)
         )
 

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -459,3 +459,7 @@ class TestOneClickSyncMonitor(DatabaseTest):
         # make sure there are still 8 LicensePools
         pools = self._db.query(LicensePool).all()
         eq_(8, len(pools))
+
+        # Running the monitor again does nothing. Since no more responses
+        # are queued, doing any work at this point would crash the test.
+        eq_((0,0), monitor.invoke())


### PR DESCRIPTION
There are a number of minor changes in this branch, but the main one is changing OneClickImportMonitor so it can be run on a regular schedule without killing the RBdigital servers. The work of the monitor will only be done once for any given collection.