### PR TITLE
Manage randomly-generated patron identifiers for identifying a patron with an external service

### DIFF
--- a/model.py
+++ b/model.py
@@ -647,17 +647,25 @@ class Patron(Base):
     
     AUDIENCE_RESTRICTION_POLICY = 'audiences'
 
-    @property
-    def best_unique_identifier(self):
-        """Return the best available unique identifier for this Patron.
+    def identifier_to_remote_service(self, remote_data_source, generator=None):
+        """Find or randomly create an identifier to use when identifying
+        this patron to a remote service.
 
-        'best' is a combination of 'used throughout the library' and
-        'unlikely to change'.
+        :param remote_data_source: A DataSource object (or name of a
+        DataSource) corresponding to the remote service.
         """
-        return str(
-            self.external_identifier or self.username
-            or self.authorization_identifier or self.id
+        _db = Session.object_session(self)
+        def refresh(credential):
+            if generator and callable(generator):
+                identifier = generator()
+            else:
+                identifier = str(uuid.uuid1())
+            credential.credential = identifier
+        credential = Credential.lookup(
+            _db, remote_data_source, Credential.IDENTIFIER_TO_REMOTE_SERVICE,
+            self, refresh, allow_persistent_token=True
         )
+        return credential.credential
     
     def works_on_loan(self):
         db = Session.object_session(self)
@@ -7515,6 +7523,14 @@ class Credential(Base):
     __table_args__ = (
         UniqueConstraint('data_source_id', 'patron_id', 'type'),
     )
+
+
+    # A meaningless identifier used to identify this patron (and no other)
+    # to a remote service.
+    IDENTIFIER_TO_REMOTE_SERVICE = "Identifier Sent To Remote Service"
+
+    # An identifier used by a remote service to identify this patron.
+    IDENTIFIER_FROM_REMOTE_SERVICE = "Identifier Received From Remote Service"
 
     @classmethod
     def lookup(self, _db, data_source, type, patron, refresher_method,

--- a/model.py
+++ b/model.py
@@ -646,6 +646,18 @@ class Patron(Base):
     )
     
     AUDIENCE_RESTRICTION_POLICY = 'audiences'
+
+    @property
+    def best_unique_identifier(self):
+        """Return the best available unique identifier for this Patron.
+
+        'best' is a combination of 'used throughout the library' and
+        'unlikely to change'.
+        """
+        return str(
+            self.external_identifier or self.username
+            or self.authorization_identifier or self.id
+        )
     
     def works_on_loan(self):
         db = Session.object_session(self)


### PR DESCRIPTION
For external services like RBdigital, Bibliotheca, and Axis 360, we can send whatever string we want as a patron ID -- it doesn't have to be the patron's actual ID, which is good because their actual ID tends to change a lot.

This branch makes it easy to manage external-facing patron identifiers for different services. I'm about to start using this with RBdigital, but by adding a migration to handle people with active loans, we can also start using it for Bibliotheca and Axis 360.