### PR TITLE
Introduce audiobook manifest format constants and remove redundant RBdigital constants

### DIFF
--- a/migration/20171026-update-rbdigital-delivery-mechanism.sql
+++ b/migration/20171026-update-rbdigital-delivery-mechanism.sql
@@ -1,0 +1,1 @@
+update deliverymechanisms set content_type='application/audiobook+json', drm_scheme=null where content_type='vnd.librarysimplified/obfuscated-one-click' and drm_scheme='OneClick DRM';

--- a/model.py
+++ b/model.py
@@ -8693,7 +8693,6 @@ class DeliveryMechanism(Base, HasFullTableCache):
     KINDLE_DRM = u"Kindle DRM"
     NOOK_DRM = u"Nook DRM"
     STREAMING_DRM = u"Streaming"
-    ONECLICK_DRM = u"OneClick DRM"
     OVERDRIVE_DRM = u"Overdrive DRM"
 
     STREAMING_PROFILE = ";profile=http://librarysimplified.org/terms/profiles/streaming-media"

--- a/model.py
+++ b/model.py
@@ -7795,6 +7795,7 @@ class Representation(Base):
     MP3_MEDIA_TYPE = u"audio/mpeg"
     OCTET_STREAM_MEDIA_TYPE = u"application/octet-stream"
     TEXT_PLAIN = u"text/plain"
+    AUDIOBOOK_MANIFEST_MEDIA_TYPE = u"application/audiobook+json"
 
     BOOK_MEDIA_TYPES = [
         EPUB_MEDIA_TYPE,
@@ -7836,6 +7837,7 @@ class Representation(Base):
         TEXT_PLAIN: "txt",
         TEXT_HTML_MEDIA_TYPE: "html",
         APPLICATION_XML_MEDIA_TYPE: "xml",
+        AUDIOBOOK_MANIFEST_MEDIA_TYPE: "audiobook-manifest"
     }
 
     # Invert FILE_EXTENSIONS and add some extra guesses.

--- a/oneclick.py
+++ b/oneclick.py
@@ -603,6 +603,10 @@ class OneClickRepresentationExtractor(object):
     DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ" #ex: 2013-12-27T00:00:00Z
     DATE_FORMAT = "%Y-%m-%d" #ex: 2013-12-27
 
+    # We have not yet seen any titles obfuscated with RBdigital DRM and
+    # have no idea what the DRM document would look like.
+    OBFUSCATED_AUDIO_MEDIA_TYPE = "vnd.librarysimplified/rbdigital.obfuscated"
+
     log = logging.getLogger("OneClick representation extractor")
 
     oneclick_formats = {
@@ -610,10 +614,11 @@ class OneClickRepresentationExtractor(object):
             Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM
         ),
         "audiobook-mp3-oneclick" : (
-            "vnd.librarysimplified/obfuscated-one-click", DeliveryMechanism.ONECLICK_DRM
+            OBFUSCATED_AUDIO_MEDIA_TYPE, DeliveryMechanism.ONECLICK_DRM
         ),
         "audiobook-mp3-open" : (
-            "audio/mpeg3", DeliveryMechanism.NO_DRM
+            Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE, 
+            DeliveryMechanism.NO_DRM
         ),
     }
 

--- a/oneclick.py
+++ b/oneclick.py
@@ -603,10 +603,6 @@ class OneClickRepresentationExtractor(object):
     DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ" #ex: 2013-12-27T00:00:00Z
     DATE_FORMAT = "%Y-%m-%d" #ex: 2013-12-27
 
-    # We have not yet seen any titles obfuscated with RBdigital DRM and
-    # have no idea what the DRM document would look like.
-    OBFUSCATED_AUDIO_MEDIA_TYPE = "vnd.librarysimplified/rbdigital.obfuscated"
-
     log = logging.getLogger("OneClick representation extractor")
 
     oneclick_medium_to_simplified_medium = {

--- a/oneclick.py
+++ b/oneclick.py
@@ -609,24 +609,10 @@ class OneClickRepresentationExtractor(object):
 
     log = logging.getLogger("OneClick representation extractor")
 
-    oneclick_formats = {
-        "ebook-epub-oneclick" : (
-            Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM
-        ),
-        "audiobook-mp3-oneclick" : (
-            OBFUSCATED_AUDIO_MEDIA_TYPE, DeliveryMechanism.ONECLICK_DRM
-        ),
-        "audiobook-mp3-open" : (
-            Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE, 
-            DeliveryMechanism.NO_DRM
-        ),
-    }
-
     oneclick_medium_to_simplified_medium = {
         "eBook" : Edition.BOOK_MEDIUM,
         "eAudio" : Edition.AUDIO_MEDIUM,
     }
-
 
     @classmethod
     def image_link_to_linkdata(cls, link_url, rel):
@@ -821,10 +807,12 @@ class OneClickRepresentationExtractor(object):
         if include_formats:
             formats = []
             if metadata.medium == Edition.BOOK_MEDIUM:
-                content_type, drm_scheme = cls.oneclick_formats.get("ebook-epub-oneclick")
+                content_type = Representation.EPUB_MEDIA_TYPE
+                drm_scheme = DeliveryMechanism.ADOBE_DRM
                 formats.append(FormatData(content_type, drm_scheme))
             elif metadata.medium == Edition.AUDIO_MEDIUM:
-                content_type, drm_scheme = cls.oneclick_formats.get("audiobook-mp3-oneclick")
+                content_type = Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE, 
+                drm_scheme = DeliveryMechanism.NO_DRM
                 formats.append(FormatData(content_type, drm_scheme))
             else:
                 cls.log.warn("Unfamiliar format: %s", format_id)


### PR DESCRIPTION
This is a small core branch for some ongoing RBdigital work.

* There appears to be no distinctive RBdigital DRM scheme. Resources are either encrypted using Adobe DRM or they are gated with time-limited URLs.
* I removed the `oneclick_formats` dictionary, which was a copy-and-paste of code from Overdrive. RBdigital doesn't have Overdrive's notion of "internal format", and the Overdrive-like keys like 'audiobook-mp3-oneclick' didn't mean anything. I moved the information in that dictionary to the only piece of code that was using it.
* I changed the DeliveryMechanism for RBdigital audiobooks to indicate how those audiobooks will (eventually) be fulfilled -- RBdigital's private manifest format will be converted on the fly to an [Audiobook Manifest document](https://github.com/HadrienGardeur/audiobook-manifest).