### PR TITLE
Fixed OPDS and CachedFeed.refresh to handle WorkList and changed CachedFeed to store Lane id.

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -44,6 +44,7 @@ from model import (
     site_configuration_has_changed,
     tuple_to_numericrange,
     Base,
+    CachedFeed,
     CustomList,
     CustomListEntry,
     DataSource,
@@ -938,6 +939,13 @@ class Lane(Base, WorkList):
     # Only a visible lane will show up in the user interface.  The
     # admin interface can see all the lanes, visible or not.
     _visible = Column(Boolean, default=True, nullable=False, name="visible")
+
+    # A Lane may have many CachedFeeds.
+    cachedfeeds = relationship(
+        "CachedFeed", backref="lane",
+        cascade="all, delete-orphan",
+    )
+
 
     __table_args__ = (
         UniqueConstraint('library_id', 'identifier'),

--- a/migration/20171026-change-cachedfeeds-to-use-lane-id.sql
+++ b/migration/20171026-change-cachedfeeds-to-use-lane-id.sql
@@ -1,0 +1,1 @@
+drop table cachedfeeds;

--- a/model.py
+++ b/model.py
@@ -6193,9 +6193,14 @@ class CachedFeed(Base):
                 # Rather than generate an error (which will provide a
                 # terrible user experience), fall back to generating a
                 # default page-type feed, which should be cheap to fetch.
+                identifier = None
+                if isinstance(lane, Lane):
+                    identifier = lane.identifier
+                elif isinstance(lane, WorkList):
+                    identifier = lane.display_name
                 cls.log.warn(
                     "Could not generate a groups feed for %s, falling back to a page feed.",
-                    lane.display_name
+                    identifier
                 )
                 return cls.fetch(
                     _db, lane, CachedFeed.PAGE_TYPE, facets, pagination, 

--- a/model.py
+++ b/model.py
@@ -6224,7 +6224,7 @@ class CachedFeed(Base):
         else:
             length = "No content"
         return "<CachedFeed #%s %s %s %s %s %s %s >" % (
-            self.id, self.lane_identifier, self.type, 
+            self.id, self.lane_id, self.type, 
             self.facets, self.pagination,
             self.timestamp, length
         )

--- a/tests/test_cachedfeed.py
+++ b/tests/test_cachedfeed.py
@@ -20,6 +20,7 @@ from lane import (
     Lane,
     Pagination,
     Facets,
+    WorkList,
 )
 
 from opds import AcquisitionFeed
@@ -44,8 +45,40 @@ class TestCachedFeed(DatabaseTest):
 
         eq_(pagination.query_string, feed.pagination)
         eq_(facets.query_string, feed.facets)
-        eq_(lane.identifier, feed.lane_name)
-        eq_('eng,chi', feed.languages)
+        eq_(lane.id, feed.lane_id)
+
+        # Update the content
+        feed.update(self._db, u"The content")
+        self._db.commit()
+
+        # Fetch it again.
+        feed, fresh = CachedFeed.fetch(*args, max_age=0)
+
+        # Now it's cached! But not fresh, because max_age is zero
+        eq_("The content", feed.content)
+        eq_(False, fresh)
+
+        # Lower our standards, and it's fresh!
+        feed, fresh = CachedFeed.fetch(*args, max_age=1000)
+        eq_("The content", feed.content)
+        eq_(True, fresh)
+
+    def test_lifecycle_with_worklist(self):
+        facets = Facets.default(self._default_library)
+        pagination = Pagination.default()
+        lane = WorkList()
+        lane.initialize(self._default_library)
+
+        # Fetch a cached feed from the database--it's empty.
+        args = (self._db, lane, CachedFeed.PAGE_TYPE, facets, pagination, None)
+        feed, fresh = CachedFeed.fetch(*args, max_age=0)
+            
+        eq_(False, fresh)
+        eq_(None, feed.content)
+
+        eq_(pagination.query_string, feed.pagination)
+        eq_(facets.query_string, feed.facets)
+        eq_(None, feed.lane_id)
 
         # Update the content
         feed.update(self._db, u"The content")
@@ -71,9 +104,8 @@ class TestCachedFeed(DatabaseTest):
         # Create a feed without content (i.e. don't update it)
         contentless_feed = get_one_or_create(
             self._db, CachedFeed,
-            lane_name=lane.identifier,
+            lane_id=lane.id,
             type=CachedFeed.PAGE_TYPE,
-            languages=u"eng,chi",
             facets=unicode(facets.query_string),
             pagination=unicode(pagination.query_string))[0]
 

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -125,7 +125,7 @@ class AtomFeed(object):
     def __init__(self, title, url):
         self.feed = self.E.feed(
             self.E.id(url),
-            self.E.title(title),
+            self.E.title(str(title)),
             self.E.updated(self._strftime(datetime.datetime.utcnow())),
             self.E.link(href=url, rel="self"),
         )


### PR DESCRIPTION
This fixes a few problems I ran into trying to use this branch in circulation.

I changed CachedFeed to store Lane.id instead of the lane name and languages, now that lanes are in the database, and made CachedFeed.refresh and AcquisitionFeed.page work if they get WorkLists instead of Lanes.