### PR TITLE
Added a media type for the Bearer Token document used to delivery books obtained through OPDS For Distributors.

### DIFF
--- a/model.py
+++ b/model.py
@@ -8694,6 +8694,7 @@ class DeliveryMechanism(Base, HasFullTableCache):
     NOOK_DRM = u"Nook DRM"
     STREAMING_DRM = u"Streaming"
     OVERDRIVE_DRM = u"Overdrive DRM"
+    BEARER_TOKEN = u"application/vnd.librarysimplified.bearer-token+json"
 
     STREAMING_PROFILE = ";profile=http://librarysimplified.org/terms/profiles/streaming-media"
     MEDIA_TYPES_FOR_STREAMING = {


### PR DESCRIPTION
as per https://github.com/NYPL-Simplified/Simplified/wiki/BearerTokenPropagation