### PR TITLE
Fix the usage of allowed_response_codes.

### DIFF
--- a/opds_import.py
+++ b/opds_import.py
@@ -125,7 +125,7 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup):
     NAME = _("Library Simplified Metadata Wrangler")
 
     SETTINGS = [
-        { "key": ExternalIntegration.URL, "label": _("URL"), "default": "https://metadata.librarysimplified.org/" },
+        { "key": ExternalIntegration.URL, "label": _("URL"), "default": "http://metadata.librarysimplified.org/" },
     ]
 
     SITEWIDE = True

--- a/opds_import.py
+++ b/opds_import.py
@@ -125,7 +125,7 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup):
     NAME = _("Library Simplified Metadata Wrangler")
 
     SETTINGS = [
-        { "key": ExternalIntegration.URL, "label": _("URL"), "default": "http://metadata.librarysimplified.org/" },
+        { "key": ExternalIntegration.URL, "label": _("URL"), "default": "https://metadata.librarysimplified.org/" },
     ]
 
     SITEWIDE = True

--- a/util/http.py
+++ b/util/http.py
@@ -290,7 +290,7 @@ class HTTP(object):
         if 'allowed_response_codes' in kwargs:
             # The caller wants to treat a specific set of response codes
             # as successful.
-            allowed_response_codes = kwargs
+            allowed_response_codes = kwargs['allowed_response_codes']
         else:
             # We want request_with_timeout to allow through all
             # response codes so that we can handle bad ones in a more


### PR DESCRIPTION
This branch fixes a bug in untestable code that makes HTTP requests. In some cases the `allowed_response_codes` argument was being set to the entire `kwargs` dict, not the `allowed_response_codes` part of the dict. This caused mysterious errors where a request that succeeded appeared to fail because the "allowed response codes" were nonsense.