### PR TITLE
Fix logging on unrecognized Axis format

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -536,7 +536,7 @@ class BibliographicParser(Axis360Parser):
             informal_name = format_tag.text
             seen_formats.append(informal_name)
             if informal_name not in self.DELIVERY_DATA_FOR_AXIS_FORMAT:
-                self.log("Unrecognized Axis format name for %s: %s" % (
+                self.log.error("Unrecognized Axis format name for %s: %s" % (
                     identifier, informal_name
                 ))
             elif self.DELIVERY_DATA_FOR_AXIS_FORMAT.get(informal_name):


### PR DESCRIPTION
This branch simply adds a missing error function call when logging an unrecognized Axis format.