### PR TITLE
Parse URNs in batches

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -311,7 +311,6 @@ class URNLookupController(object):
     def process_identifier(self, identifier, urn, **kwargs):
         """Turn a URN into a Work suitable for use in an OPDS feed.
         """
-        urn = urn or identifier.urn
         if not identifier.licensed_through:
             # The default URNLookupController cannot look up an
             # Identifier that has no associated LicensePool.

--- a/app_server.py
+++ b/app_server.py
@@ -271,8 +271,7 @@ class URNLookupController(object):
         urns = flask.request.args.getlist('urn')
 
         this_url = cdn_url_for(route_name, _external=True, urn=urns)
-        for urn in urns:
-            self.process_urn(urn, **process_urn_kwargs)
+        self.process_urns(urns)
         self.post_lookup_hook()
 
         opds_feed = LookupAcquisitionFeed(
@@ -284,7 +283,7 @@ class URNLookupController(object):
     def permalink(self, urn, annotator, route_name='work'):
         """Look up a single identifier and generate an OPDS feed."""
         this_url = cdn_url_for(route_name, _external=True, urn=urn)
-        self.process_urn(urn)
+        self.process_urns([urn])
         self.post_lookup_hook()
 
         # A LookupAcquisitionFeed's .works is a list of (identifier,
@@ -297,19 +296,22 @@ class URNLookupController(object):
         )
 
         return feed_response(opds_feed)
-    
-    def process_urn(self, urn, **kwargs):
+
+    def process_urns(self, urns, **process_urn_kwargs):
+        identifiers_by_urn, failures = Identifier.parse_urns(self._db, urns)
+        self.add_urn_failure_messages(failures)
+
+        for urn, identifier in identifiers_by_urn.items():
+            self.process_identifier(identifier, urn, **process_urn_kwargs)
+
+    def add_urn_failure_messages(self, failures):
+        for urn in failures:
+            self.add_message(urn, 400, INVALID_URN.detail)
+
+    def process_identifier(self, identifier, urn, **kwargs):
         """Turn a URN into a Work suitable for use in an OPDS feed.
         """
-        try:
-            identifier, is_new = Identifier.parse_urn(self._db, urn)
-        except ValueError, e:
-            identifier = None
-
-        if not identifier:
-            # Not a well-formed URN.
-            return self.add_message(urn, 400, INVALID_URN.detail)
-
+        urn = urn or identifier.urn
         if not identifier.licensed_through:
             # The default URNLookupController cannot look up an
             # Identifier that has no associated LicensePool.

--- a/app_server.py
+++ b/app_server.py
@@ -265,8 +265,7 @@ class URNLookupController(object):
         self.precomposed_entries = []
         self.unresolved_identifiers = []
 
-    def work_lookup(self, annotator, route_name='lookup',
-                    urns=[], **process_urn_kwargs):
+    def work_lookup(self, annotator, route_name='lookup', **process_urn_kwargs):
         """Generate an OPDS feed describing works identified by identifier."""
         urns = flask.request.args.getlist('urn')
 

--- a/model.py
+++ b/model.py
@@ -1380,6 +1380,10 @@ class CoverageRecord(Base, BaseCoverageRecord):
         else:
             raise ValueError(
                 "Cannot look up a coverage record for %r." % edition) 
+
+        if isinstance(data_source, basestring):
+            data_source = DataSource.lookup(_db, data_source)
+
         return get_one(
             _db, CoverageRecord,
             identifier=identifier,

--- a/model.py
+++ b/model.py
@@ -10648,11 +10648,20 @@ class Collection(Base, HasFullTableCache):
                 lines.append('Setting "%s": "%s"' % (setting.key, setting.value))
         return lines
 
-    def catalog_identifier(self, _db, identifier):
+    def catalog_identifier(self, identifier):
         """Inserts an identifier into a catalog"""
-        if identifier not in self.catalog:
-            self.catalog.append(identifier)
-            flush(_db)
+        self.catalog_identifiers([identifier])
+
+    def catalog_identifiers(self, identifiers):
+        """Inserts identifiers into the catalog"""
+        if not identifiers:
+            # Nothing to do.
+            return
+
+        _db = Session.object_session(identifiers[0])
+        uncatalogued = filter(lambda i: i not in self.catalog, identifiers)
+        self.catalog.extend(uncatalogued)
+        flush(_db)
 
     def works_updated_since(self, _db, timestamp):
         """Returns all works in a collection's catalog that have been updated

--- a/model.py
+++ b/model.py
@@ -1432,8 +1432,7 @@ class WorkCoverageRecord(Base, BaseCoverageRecord):
     UPDATE_SEARCH_INDEX_OPERATION = u'update-search-index'
 
     id = Column(Integer, primary_key=True)
-    work_id = Column(
-        Integer, ForeignKey('works.id'), index=True)
+    work_id = Column(Integer, ForeignKey('works.id'), index=True)
     operation = Column(String(255), index=True, default=None)
         
     timestamp = Column(DateTime, index=True)
@@ -1519,9 +1518,8 @@ class WorkCoverageRecord(Base, BaseCoverageRecord):
         # The SELECT part of the INSERT...SELECT query.
         new_records = _db.query(
             Work.id.label('work_id'), 
-            literal(operation, type_=BaseCoverageRecord.status_enum).label('operation'),
+            literal(operation, type_=String(255)).label('operation'),
             literal(timestamp, type_=DateTime).label('timestamp'), 
-
             literal(status, type_=BaseCoverageRecord.status_enum).label('status')
         ).select_from(
             Work

--- a/testing.py
+++ b/testing.py
@@ -353,7 +353,6 @@ class DatabaseTest(object):
             RightsStatus.IN_COPYRIGHT
         )
 
-        
     def _coverage_record(self, edition, coverage_source, operation=None,
                          status=CoverageRecord.SUCCESS, collection=None):
         if isinstance(edition, Identifier):
@@ -830,10 +829,12 @@ class DatabaseTest(object):
     def _catalog(self, name=u"Faketown Public Library"):
         source, ignore = get_one_or_create(self._db, DataSource, name=name)
         
-    def _integration_client(self, url=None):
+    def _integration_client(self, url=None, shared_secret=None):
         url = url or self._url
+        secret = shared_secret or u"secret"
         return get_one_or_create(
-            self._db, IntegrationClient, url=url, shared_secret=u"secret"
+            self._db, IntegrationClient, shared_secret=secret,
+            create_method_kwargs=dict(url=url)
         )[0]
 
     def _subject(self, type, identifier):

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -61,57 +61,56 @@ class TestURNLookupController(DatabaseTest):
         eq_(code, obj.status_code)
         eq_(message, obj.message)
         eq_([], self.controller.works)
-        
-    def test_process_urn_invalid_urn(self):
+
+    def test_process_urns_invalid_urn(self):
         urn = "not even a URN"
-        self.controller.process_urn(urn)
+        self.controller.process_urns([urn])
         self.assert_one_message(urn, 400, INVALID_URN.detail)
 
-    def test_process_urn_unrecognized_identifier(self):
+    def test_process_urns_unrecognized_identifier(self):
         # Give the controller a URN that, although valid, doesn't
         # correspond to any Identifier in the database.
         urn = Identifier.URN_SCHEME_PREFIX + 'Gutenberg%20ID/30000000'
-        self.controller.process_urn(urn)
+        self.controller.process_urns([urn])
 
         # The result is a 404 message.
         self.assert_one_message(
             urn, 404, self.controller.UNRECOGNIZED_IDENTIFIER
         )
 
-    def test_process_urn_no_license_pool(self):
+    def test_process_identifier_no_license_pool(self):
         # Give the controller a URN that corresponds to an Identifier
         # which has no LicensePool.
         identifier = self._identifier()
-        urn = identifier.urn
-        self.controller.process_urn(urn)
+        self.controller.process_identifier(identifier, identifier.urn)
 
         # The result is a 404 message.
         self.assert_one_message(
-            urn, 404, self.controller.UNRECOGNIZED_IDENTIFIER
+            identifier.urn, 404, self.controller.UNRECOGNIZED_IDENTIFIER
         )
 
-    def test_process_urn_license_pool_but_no_work(self):
+    def test_process_identifier_license_pool_but_no_work(self):
         edition, pool = self._edition(with_license_pool=True)
         identifier = edition.primary_identifier
-        self.controller.process_urn(identifier.urn)
+        self.controller.process_identifier(identifier, identifier.urn)
         self.assert_one_message(
             identifier.urn, 202, self.controller.WORK_NOT_CREATED
         )
 
-    def test_process_urn_work_not_presentation_ready(self):
+    def test_process_identifier_work_not_presentation_ready(self):
         work = self._work(with_license_pool=True)
         work.presentation_ready = False
         identifier = work.license_pools[0].identifier
-        self.controller.process_urn(identifier.urn)
+        self.controller.process_identifier(identifier, identifier.urn)
 
         self.assert_one_message(
             identifier.urn, 202, self.controller.WORK_NOT_PRESENTATION_READY
         )
         
-    def test_process_urn_work_is_presentation_ready(self):
+    def test_process_identifier_work_is_presentation_ready(self):
         work = self._work(with_license_pool=True)
         identifier = work.license_pools[0].identifier
-        self.controller.process_urn(identifier.urn)
+        self.controller.process_identifier(identifier, identifier.urn)
         eq_([], self.controller.precomposed_entries)
         eq_([(work.presentation_edition.primary_identifier, work)],
             self.controller.works

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -70,7 +70,7 @@ class TestURNLookupController(DatabaseTest):
     def test_process_urns_unrecognized_identifier(self):
         # Give the controller a URN that, although valid, doesn't
         # correspond to any Identifier in the database.
-        urn = Identifier.URN_SCHEME_PREFIX + 'Gutenberg%20ID/30000000'
+        urn = Identifier.GUTENBERG_URN_SCHEME_PREFIX + 'Gutenberg%20ID/000'
         self.controller.process_urns([urn])
 
         # The result is a 404 message.

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1295,10 +1295,10 @@ class TestCatalogCoverageProvider(CoverageProviderTest):
         c2 = self._collection()
 
         i1 = self._identifier()
-        c1.catalog_identifier(self._db, i1)
+        c1.catalog_identifier(i1)
 
         i2 = self._identifier()
-        c2.catalog_identifier(self._db, i2)
+        c2.catalog_identifier(i2)
 
         i3 = self._identifier()
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -337,6 +337,28 @@ class TestIdentifier(DatabaseTest):
         identifier = self._identifier(Identifier.OVERDRIVE_ID)
         assert identifier.urn.startswith(Identifier.URN_SCHEME_PREFIX)
 
+    def test_parse_urns(self):
+        identifier = self._identifier()
+        new_urn = Identifier.URN_SCHEME_PREFIX + "Overdrive%20ID/nosuchidentifier"
+        fake_urn = "what_even_is_this"
+        urns = [identifier.urn, fake_urn, new_urn]
+
+        results = Identifier.parse_urns(self._db, urns)
+        identifiers_by_urn, failures = results
+
+        # The fake URN is returned in the list of failures.
+        eq_(failures, [fake_urn])
+
+        eq_(2, len(identifiers_by_urn))
+        # The existing identifier is returned from its URN.
+        eq_(identifier, identifiers_by_urn[identifier.urn])
+
+        new_identifier = identifiers_by_urn[new_urn]
+        assert isinstance(new_identifier, Identifier)
+        assert new_identifier in self._db
+        eq_(Identifier.OVERDRIVE_ID, new_identifier.type)
+        eq_("nosuchidentifier", new_identifier.identifier)
+
     def test_parse_urn(self):
 
         # We can parse our custom URNs back into identifiers.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7219,10 +7219,22 @@ class TestCollection(DatabaseTest):
     def test_catalog_identifier(self):
         """#catalog_identifier associates an identifier with the catalog"""
         identifier = self._identifier()
-        self.collection.catalog_identifier(self._db, identifier)
+        self.collection.catalog_identifier(identifier)
 
         eq_(1, len(self.collection.catalog))
         eq_(identifier, self.collection.catalog[0])
+
+    def test_catalog_identifiers(self):
+        """#catalog_identifier associates multiple identifiers with a catalog"""
+        i1 = self._identifier()
+        i2 = self._identifier()
+        i3 = self._identifier()
+
+        # One of the identifiers is already in the catalog.
+        self.collection.catalog_identifier(i3)
+
+        self.collection.catalog_identifiers([i1, i2, i3])
+        assert sorted([i1, i2, i3]) == sorted(self.collection.catalog)
 
     def test_works_updated_since(self):
         w1 = self._work(with_license_pool=True)
@@ -7233,8 +7245,8 @@ class TestCollection(DatabaseTest):
         eq_([], self.collection.works_updated_since(self._db, timestamp).all())
 
         # When no timestamp is passed, all works in the catalog are returned.
-        self.collection.catalog_identifier(self._db, w1.license_pools[0].identifier)
-        self.collection.catalog_identifier(self._db, w2.license_pools[0].identifier)
+        self.collection.catalog_identifier(w1.license_pools[0].identifier)
+        self.collection.catalog_identifier(w2.license_pools[0].identifier)
         updated_works = self.collection.works_updated_since(self._db, None).all()
 
         eq_(2, len(updated_works))


### PR DESCRIPTION
This branch supports an attempt to limit the number of repetitive database touches in the Metadata Wrangler by parsing URNs in batches. It also allows identifiers to be added to a collections catalog in batches.