### PR TITLE
Treat BISAC-like subjects as BISAC

### DIFF
--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -2126,6 +2126,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    Eg("sorcery"),
                    Eg("witchcraft"),
                    Eg("wizardry"),
+                   Eg("unicorns"),
                ),
                
                Fashion: match_kw(
@@ -2696,6 +2697,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "self-improvement",
                ),
                Folklore : match_kw(
+                   "fables",
                    "folklore",
                    "folktales",
                    "folk tales",
@@ -2833,8 +2835,6 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                Urban_Fiction: match_kw(
                    "urban fiction",
                    Eg("fiction.*african american.*urban"),
-                   "fiction / urban",
-                   "fiction/urban",
                ),
                
                Vegetarian_Vegan: match_kw(

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -867,6 +867,9 @@ GenreData.populate(globals(), genres, fiction_genres, nonfiction_genres)
 class Lowercased(unicode):
     """A lowercased string that remembers its original value."""
     def __new__(cls, value):
+        if isinstance(value, Lowercased):
+            # Nothing to do.
+            return value
         new_value = value.lower()
         if new_value.endswith('.'):
             new_value = new_value[:-1]

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -117,11 +117,9 @@ class Classifier(object):
         """Try to determine genre, audience, target age, and fiction status
         for the given Subject.
         """
-        identifier = cls.scrub_identifier(subject.identifier)
-        if subject.name:
-            name = cls.scrub_name(subject.name)
-        else:
-            name = identifier
+        identifier, name = cls.scrub_identifier_and_name(
+            subject.identifier, subject.name
+        )
         fiction = cls.is_fiction(identifier, name)
         audience = cls.audience(identifier, name)
 
@@ -134,6 +132,20 @@ class Classifier(object):
                 target_age,
                 fiction,
                 )
+
+    @classmethod
+    def scrub_identifier_and_name(cls, identifier, name):
+        """Prepare identifier and name from within a call to classify()."""
+        identifier = cls.scrub_identifier(identifier)
+        if isinstance(identifier, tuple):
+            # scrub_identifier returned a canonical value for name as 
+            # well. Use it in preference to any name associated with
+            # the subject.
+            identifier, name = identifier
+        elif not name:
+            name = identifier
+        name = cls.scrub_name(name)
+        return identifier, name
 
     @classmethod
     def scrub_identifier(cls, identifier):

--- a/classifier/bisac.py
+++ b/classifier/bisac.py
@@ -5,15 +5,14 @@ import re
 import string
 from . import *
 
-# Special tokens used in matching rules.
 class CustomMatchToken(object):
     """A custom token used in matching rules."""
     def matches(self, subject_token):
         """Does the given token match this one?"""
-        raise NotImplementedError
+        raise NotImplementedError()
 
 class Something(CustomMatchToken):
-    """A CustomMatchToken that will match any token."""
+    """A CustomMatchToken that will match any single token."""
     def matches(self, subject_token):
         return True
 
@@ -32,10 +31,6 @@ class Interchangeable(CustomMatchToken):
         self.choices = set(map(string.lower, choices))
 
     def matches(self,subject_token):
-        if subject_token in self.choices:
-            print "Found %s in %s" % (subject_token, self.choices)
-        else:
-            print "Didn't find %s in %s" % (subject_token, self.choices)
         return subject_token in self.choices
 
 # Special tokens for use in matching rules.
@@ -86,7 +81,6 @@ class MatchingRule(object):
         # Track the subjects that were 'caught' by this rule,
         # for debugging purposes.
         self.caught = []
-
         
         for i, rule in enumerate(ruleset):
             if i > 0 and rule in special_variables:
@@ -196,7 +190,7 @@ class MatchingRule(object):
             match = rule_token.matches(subject_token)
         elif rule_token == nonfiction:
             # This is too complex to be a CustomMatchToken because
-            # we may be modifying the token list.
+            # we may be modifying the subject token list.
             match = subject_token not in (
                 'juvenile fiction', 'young adult fiction', 'fiction'
             )
@@ -270,7 +264,7 @@ class BISACClassifier(Classifier):
         m(Classifier.AUDIENCE_YOUNG_ADULT, "Bibles", anything, "Youth & Teen"),
         m(Classifier.AUDIENCE_ADULTS_ONLY, anything, "Erotica"),
         m(Classifier.AUDIENCE_ADULTS_ONLY, "Humor", "Topic", "Adult"),
-        m(Classifier.AUDIENCE_ADULT, RE(".*")),
+        m(Classifier.AUDIENCE_ADULT, anything),
     ]
 
     TARGET_AGE = [

--- a/classifier/bisac.py
+++ b/classifier/bisac.py
@@ -659,14 +659,14 @@ class BISACClassifier(Classifier):
         # A comma may have been replaced with a space.
         name = name.replace("  ", ", ")
 
-        # The name may be enclosed in an enametra set of quotes.
+        # The name may be enclosed in an extra set of quotes.
         for quote in ("'\""):
             if name.startswith(quote):
                 name = name[1:]
             if name.endswith(quote):
                 name = name[:-1]
             
-        # The name may end with an enametraneous marker character or 
+        # The name may end with an extraneous marker character or 
         # (if it was copied from the BISAC website) an asterisk.
         for separator in '|/*':
             if name.endswith(separator):

--- a/classifier/bisac.py
+++ b/classifier/bisac.py
@@ -28,10 +28,10 @@ class Interchangeable(CustomMatchToken):
     """A token that matches a list of strings."""
     def __init__(self, *choices):
         """All of these strings are interchangeable for matching purposes."""
-        self.choices = set(map(string.lower, choices))
+        self.choices = set([Lowercased(x) for x in choices])
 
     def matches(self,subject_token):
-        return subject_token in self.choices
+        return Lowercased(subject_token) in self.choices
 
 # Special tokens for use in matching rules.
 something = Something()
@@ -92,7 +92,7 @@ class MatchingRule(object):
             if isinstance(rule, basestring):
                 # It's a string. We do case-insensitive comparisons,
                 # so lowercase it.
-                self.ruleset.append(rule.lower())
+                self.ruleset.append(Lowercased(rule))
             else:
                 # It's a special object. Add it to the ruleset as-is.
                 self.ruleset.append(rule)
@@ -650,7 +650,7 @@ class BISACClassifier(Classifier):
         """Split the name into a list of lowercase keywords."""
 
         # All of our comparisons are case-insensitive.
-        name = name.lower()
+        name = Lowercased(name)
         
         # Take corrective action to finame a number of common problems
         # seen in the wild.

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -96,6 +96,34 @@ class TestClassifier(object):
         eq_(17, u(14, "14+."))
         eq_(18, u(18, "18+"))
 
+
+    def test_scrub_identifier_can_override_name(self):
+        """Test the ability of scrub_identifier to override the name
+        of the subject for classification purposes.
+
+        This is used e.g. in the BISACClassifier to ensure that a known BISAC
+        code is always mapped to its canonical name.
+        """
+        class SetsNameForOneIdentifier(Classifier):
+            "A Classifier that insists on a certain name for one specific identifier"
+            @classmethod
+            def scrub_identifier(self, identifier):
+                if identifier == 'A':
+                    return ('A', 'Use this name!')
+                else:
+                    return identifier
+
+            @classmethod
+            def scrub_name(self, name):
+                """This verifies that the override name still gets passed
+                into scrub_name.
+                """
+                return name.upper()
+
+        m = SetsNameForOneIdentifier.scrub_identifier_and_name
+        eq_(("A", "USE THIS NAME"), m("A", "name a"))
+        eq_(("B", "NAME B"), m("B", "name b"))
+
 class TestClassifierLookup(object):
 
     def test_lookup(self):

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -538,7 +538,7 @@ class TestKeyword(object):
         # African-American-focused "Urban Fiction" classification.
         eq_(None, Keyword.genre(None, "Fiction/Urban"))
 
-        eq_(Folklore, Keyword.genre("fables"))
+        eq_(Folklore, Keyword.genre(None, "fables"))
         
 class TestBISAC(object):
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -124,6 +124,7 @@ class TestClassifier(object):
         eq_(("A", "USE THIS NAME"), m("A", "name a"))
         eq_(("B", "NAME B"), m("B", "name b"))
 
+
 class TestClassifierLookup(object):
 
     def test_lookup(self):

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -533,6 +533,12 @@ class TestKeyword(object):
         # particular.
         eq_(classifier.Historical_Fiction, Keyword.genre(None, "Historical"))
         eq_(None, Keyword.genre(None, "Historicals"))
+
+        # The Fiction/Urban classification is different from the
+        # African-American-focused "Urban Fiction" classification.
+        eq_(None, Keyword.genre(None, "Fiction/Urban"))
+
+        eq_(Folklore, Keyword.genre("fables"))
         
 class TestBISAC(object):
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -121,7 +121,7 @@ class TestClassifier(object):
                 return name.upper()
 
         m = SetsNameForOneIdentifier.scrub_identifier_and_name
-        eq_(("A", "USE THIS NAME"), m("A", "name a"))
+        eq_(("A", "USE THIS NAME!"), m("A", "name a"))
         eq_(("B", "NAME B"), m("B", "name b"))
 
 
@@ -567,7 +567,7 @@ class TestKeyword(object):
         # African-American-focused "Urban Fiction" classification.
         eq_(None, Keyword.genre(None, "Fiction/Urban"))
 
-        eq_(Folklore, Keyword.genre(None, "fables"))
+        eq_(classifier.Folklore, Keyword.genre(None, "fables"))
         
 class TestBISAC(object):
 

--- a/tests/test_classifier_bisac.py
+++ b/tests/test_classifier_bisac.py
@@ -302,7 +302,7 @@ class TestBISACClassifier(object):
 
     def test_feedbooks_bisac(self):
         """Feedbooks uses a system based on BISAC but with different
-        identifiers, different names, and some additions. These are
+        identifiers, different names, and some additions. This is all
         handled transparently by the default BISAC classifier.
         """
         subject = self._subject("FBFIC022000", "Mystery & Detective")

--- a/tests/test_classifier_bisac.py
+++ b/tests/test_classifier_bisac.py
@@ -132,6 +132,13 @@ class TestBISACClassifier(object):
         subject.genre, subject.audience, subject.target_age, subject.fiction = BISACClassifier.classify(subject)
         return subject
 
+    def genre_is(self, name, expect):
+        subject = self._subject("", name)
+        if expect and subject.genre:
+            eq_(expect, subject.genre.name)
+        else:
+            eq_(expect, subject.genre)
+
     def test_every_rule_fires(self):
         """There's no point in having a rule that doesn't catch any real BISAC
         subjects. The presence of such a rule generally indicates a
@@ -185,12 +192,7 @@ class TestBISACClassifier(object):
         """Test some unusual cases with respect to how BISAC
         classifications are turned into genres.
         """
-        def genre_is(name, expect):
-            subject = self._subject("", name)
-            if expect and subject.genre:
-                eq_(expect, subject.genre.name)
-            else:
-                eq_(expect, subject.genre)
+        genre_is = self.genre_is
 
         genre_is("Fiction / Science Fiction / Erotica", "Erotica")
         genre_is("Literary Criticism / Science Fiction", "Literary Criticism")
@@ -216,18 +218,24 @@ class TestBISACClassifier(object):
         genre_is("Young Adult Fiction / Poetry", "Poetry")
         genre_is("Poetry", "Poetry")
 
-        # These BISAC terms have been deprecated. We classify them
-        # the same as the new terms.
-        genre_is("Psychology & Psychiatry / Jungian", "Psychology")
-        genre_is("Mind & Spirit / Crystals, Man", "Body, Mind & Spirit")
-        genre_is("Technology / Fire", "Technology")
-        genre_is("Young Adult Nonfiction / Social Situations / Junior Prom", 
-                 "Life Strategies")
+    def test_deprecated_bisac_terms(self):
+        """These BISAC terms have been deprecated. We classify them
+        the same as the new terms.
+        """
+        self.genre_is("Psychology & Psychiatry / Jungian", "Psychology")
+        self.genre_is("Mind & Spirit / Crystals, Man", "Body, Mind & Spirit")
+        self.genre_is("Technology / Fire", "Technology")
+        self.genre_is(
+            "Young Adult Nonfiction / Social Situations / Junior Prom", 
+            "Life Strategies"
+        )
 
-        # Categories that are not official BISAC categories (and any
-        # official BISAC categories we didn't catch) are classified
-        # as though they were free-text keywords.
-        genre_is("Fiction / Unicorns", "Fantasy")
+    def test_non_bisac_classified_as_keywords(self):
+        """Categories that are not official BISAC categories (and any official
+        BISAC categories our rules didn't catch) are classified as
+        though they were free-text keywords.
+        """
+        self.genre_is("Fiction / Unicorns", "Fantasy")
 
     def test_fiction_spot_checks(self):
         def fiction_is(name, expect):
@@ -291,3 +299,50 @@ class TestBISACClassifier(object):
         target_age_is("Juvenile Fiction / Science Fiction", (None, None))
         target_age_is("Young Adult Fiction / Science Fiction / General", 
                       (14, 17))
+
+    def test_feedbooks_bisac(self):
+        """Feedbooks uses a system based on BISAC but with different
+        identifiers, different names, and some additions. These are
+        handled transparently by the default BISAC classifier.
+        """
+        subject = self._subject("FBFIC022000", "Mystery & Detective")
+        eq_("Mystery", subject.genre.name)
+
+        # This is not an official BISAC classification, so we'll
+        # end up running it through the keyword classifier.
+        subject = self._subject("FSHUM000000N", "Human Science")
+        eq_("Social Sciences", subject.genre.name)
+
+    def test_scrub_identifier(self):
+        # FeedBooks prefixes are removed.
+        eq_("abc", BISACClassifier.scrub_identifier("FBabc"))
+
+        # Otherwise, the identifier is left alone.
+        eq_("abc", BISACClassifier.scrub_identifier("abc"))
+
+        # If the identifier is recognized as an official BISAC identifier,
+        # the canonical name is also returned. This will override
+        # any other name associated with the subject for classification
+        # purposes.
+        eq_(("FIC015000", "Fiction / Horror"), 
+            BISACClassifier.scrub_identifier("FBFIC015000"))
+
+    def test_scrub_name(self):
+        """Sometimes a data provider sends BISAC names that contain extra or
+        nonstandard characters. We store the data as it was provided to us,
+        but when it's time to classify things, we normalize it.
+        """
+        def scrubbed(before, after):
+            eq_(after, BISACClassifier.scrub_name(before))
+
+        scrubbed("ART/Collections  Catalogs  Exhibitions/", 
+                 ["art", "collections, catalogs, exhibitions"])
+        scrubbed("ARCHITECTURE|History|Contemporary|", 
+                 ["architecture", "history", "contemporary"])
+        scrubbed("BIOGRAPHY & AUTOBIOGRAPHY / Editors, Journalists, Publishers",
+                 ["biography & autobiography", "editors, journalists, publishers"])
+        scrubbed("EDUCATION/Teaching Methods & Materials/Arts & Humanities */",
+                 ["education", "teaching methods & materials",
+                  "arts & humanities"])
+        scrubbed("JUVENILE FICTION / Family / General (see also headings under Social Issues)",
+                 ["juvenile fiction", "family", "general"])

--- a/tests/test_classifier_bisac.py
+++ b/tests/test_classifier_bisac.py
@@ -227,7 +227,7 @@ class TestBISACClassifier(object):
         # Categories that are not official BISAC categories (and any
         # official BISAC categories we didn't catch) are classified
         # as though they were free-text keywords.
-        genre_is(Fantasy, fiction, "unicorns")
+        genre_is("Fiction / Unicorns", "Fantasy")
 
     def test_fiction_spot_checks(self):
         def fiction_is(name, expect):


### PR DESCRIPTION
This branch changes the BISACClassifier so that it can handle BISAC-like classifications from three other sources:

* Axis 360, which is mainly BISAC-compliant but which doesn't use the identifiers (only the names) and which has some copy-and-paste errors in their BISAC names.
* Bibliotheca, which uses an older version of BISAC, also doesn't use the identifiers, and uses pipes instead of slashes in its names, among other differences.
* Feedbooks, which uses standard BISAC identifiers prefixed with "FB", and also has its own custom classifications that are not in BISAC at all.

Apart from adding a lot of code to handle specific weird cases, I made three main changes to support this:

* I introduced `Classifier.scrub_identifier_and_name` to handle the case where `scrub_identifier` is able to recognize the identifier as being from a controlled vocabulary where each identifier has a canonical name. When that happens, `scrub_identifier` can return a 2-tuple (identifier, name) to ensure that the canonical name (once it itself is scrubbed) is used instead of whatever random name the distributor may have provided.

* I created `CustomMatchToken` to handle the increasingly common BISAC classification case where two or more strings should be treated as the same string. This is how I deal with changes in the names given to BISAC subjects.

* If BISACClassifier can't classify something, it runs it through the KeywordBasedClassifier before giving up.

I'm about to do a head-to-head test to make sure there are no regressions (or an acceptably small number of regressions) when running the existing Bibliotheca and BISAC classifications through the new system; then I'll do a branch that converts them over.