### PR TITLE
Database lanes updates

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -289,8 +289,8 @@ class ExternalSearchIndex(object):
 
         return base_works_index
 
-    def query_works(self, library, query_string, media, languages, fiction, audience,
-                    age_range, in_any_of_these_genres=[], fields=None, size=30, offset=0):
+    def query_works(self, library, query_string, media, languages, fiction, audiences,
+                    target_age, in_any_of_these_genres=[], fields=None, size=30, offset=0):
         if not self.works_alias:
             return []
 
@@ -307,7 +307,7 @@ class ExternalSearchIndex(object):
 
         filter = self.make_filter(
             collection_ids, media, languages, fiction, 
-            audience, age_range, in_any_of_these_genres
+            audiences, target_age, in_any_of_these_genres
         )
         q = dict(
             filtered=dict(
@@ -551,7 +551,7 @@ class ExternalSearchIndex(object):
             }
         }
         
-    def make_filter(self, collection_ids, media, languages, fiction, audience, age_range, genres):
+    def make_filter(self, collection_ids, media, languages, fiction, audiences, target_age, genres):
         def _f(s):
             if not s:
                 return s
@@ -588,16 +588,16 @@ class ExternalSearchIndex(object):
             clauses.append(dict(term=dict(fiction="fiction")))
         elif fiction == False:
             clauses.append(dict(term=dict(fiction="nonfiction")))
-        if audience:
-            if isinstance(audience, list) or isinstance(audience, set):
-                audience = [_f(aud) for aud in audience]
-                clauses.append(dict(terms=dict(audience=audience)))
-        if age_range:
-            if isinstance(age_range, tuple) and len(age_range) == 2:
-                lower, upper = age_range
+        if audiences:
+            if isinstance(audiences, list) or isinstance(audiences, set):
+                audiences = [_f(aud) for aud in audiences]
+                clauses.append(dict(terms=dict(audience=audiences)))
+        if target_age:
+            if isinstance(target_age, tuple) and len(target_age) == 2:
+                lower, upper = target_age
             else:
-                lower = age_range.lower
-                upper = age_range.upper
+                lower = target_age.lower
+                upper = target_age.upper
 
             age_clause = {
                 "and": [

--- a/lane.py
+++ b/lane.py
@@ -993,7 +993,19 @@ class Lane(Base, WorkList):
                 raise ValueError("Lane parentage loop detected")
             seen.add(parent)
             yield parent
-    
+
+    @property
+    def depth(self):
+        """How deep is this lane in this site's hierarchy?
+        i.e. how many times do we have to follow .parent before we get None?
+        """
+        depth = 0
+        tmp = self
+        while tmp.parent:
+            depth += 1
+            tmp = tmp.parent
+        return depth    
+
     @hybrid_property
     def visible(self):
         return self._visible and (not self.parent or self.parent.visible)

--- a/lane.py
+++ b/lane.py
@@ -1149,6 +1149,11 @@ class Lane(Base, WorkList):
             if lanegenre.recursive:
                 for subgenre in genre.subgenres:
                     bucket.add(subgenre.id)
+        if not included_ids:
+            # No genres have been explicitly included, so this lane
+            # includes all genres that aren't excluded.
+            _db = Session.object_session(self)
+            included_ids = set([genre.id for genre in _db.query(Genre)])
         genre_ids = included_ids - excluded_ids
         if not genre_ids:
             # This can happen if you create a lane where 'Epic

--- a/lane.py
+++ b/lane.py
@@ -492,7 +492,7 @@ class WorkList(object):
         """
         key = ""
         if self.languages:
-            key += ",".join(self.languages)
+            key += ",".join(sorted(self.languages))
         return key
 
     @property
@@ -1069,12 +1069,7 @@ class Lane(Base, WorkList):
         """How deep is this lane in this site's hierarchy?
         i.e. how many times do we have to follow .parent before we get None?
         """
-        depth = 0
-        tmp = self
-        while tmp.parent:
-            depth += 1
-            tmp = tmp.parent
-        return depth    
+        return len(list(self.parentage))
 
     @hybrid_property
     def visible(self):

--- a/lane.py
+++ b/lane.py
@@ -800,6 +800,15 @@ class WorkList(object):
         else:
             return query.options(defer(work_model.simple_opds_entry))
 
+    @property
+    def search_target(self):
+        """By default, work lists are not searchable."""
+        return None
+
+    def search(self, _db, query, search_client, pagination=None):
+        """By default, work lists are not searchable."""
+        return None
+
 
 class LaneGenre(Base):
     """Relationship object between Lane and Genre."""

--- a/lane.py
+++ b/lane.py
@@ -60,7 +60,11 @@ from model import (
     WorkGenre,
 )
 from facets import FacetConstants
-from util import fast_query_count
+from util import (
+    fast_query_count,
+    LanguageCodes,
+)
+
 import elasticsearch
 
 from sqlalchemy import (
@@ -398,8 +402,8 @@ class WorkList(object):
     uses_customlists = False
 
     def initialize(self, library, display_name=None, genres=None, 
-                   audiences=None, languages=None, children=None,
-                   priority=None):
+                   audiences=None, languages=None, media=None,
+                   children=None, priority=None):
         """Initialize with basic data.
 
         This is not a constructor, to avoid conflicts with `Lane`, an
@@ -421,6 +425,9 @@ class WorkList(object):
         :param languages: Only Works in one of these languages will be
         included in lists.
 
+        :param media: Only Works in one of these media will be included
+        in lists.
+
         :param children: This WorkList has children, which are also
         WorkLists.
 
@@ -439,6 +446,14 @@ class WorkList(object):
             self.genre_ids = None
         self.audiences = audiences
         self.languages = languages
+        self.media = media
+
+        # By default, a WorkList doesn't have a fiction status or target age.
+        # Set them to None so they can be ignored in search on a WorkList, but
+        # used when calling search on a Lane.
+        self.fiction = None
+        self.target_age = None
+
         self.children = children or []
         self.priority = priority or 0
 
@@ -723,6 +738,8 @@ class WorkList(object):
         qu = self.apply_audience_filter(_db, qu, work_model)
         if self.languages:
             qu = qu.filter(work_model.language.in_(self.languages))
+        if self.media:
+            qu = qu.filter(work_model.medium.in_(self.media))
         if self.genre_ids:
             qu = qu.filter(work_model.genre_id.in_(self.genre_ids))
         return qu, False
@@ -802,12 +819,56 @@ class WorkList(object):
 
     @property
     def search_target(self):
-        """By default, work lists are not searchable."""
-        return None
+        """By default, a WorkList is searchable."""
+        return self
 
     def search(self, _db, query, search_client, pagination=None):
-        """By default, work lists are not searchable."""
-        return None
+        """Find works in this WorkList that match a search query."""
+        if not pagination:
+            pagination = Pagination(
+                offset=0, size=Pagination.DEFAULT_SEARCH_SIZE
+            )
+
+        # Get the search results from Elasticsearch.
+        results = None
+
+        if self.target_age:
+            target_age = numericrange_to_tuple(self.target_age)
+        else:
+            target_age = None
+
+        if search_client:
+            docs = None
+            a = time.time()
+            try:
+                docs = search_client.query_works(
+                    library=self.get_library(_db),
+                    query_string=query,
+                    media=self.media,
+                    languages=self.languages,
+                    fiction=self.fiction,
+                    audiences=self.audiences,
+                    target_age=target_age,
+                    in_any_of_these_genres=self.genre_ids,
+                    fields=["_id", "title", "author", "license_pool_id"],
+                    size=pagination.size,
+                    offset=pagination.offset,
+                )
+            except elasticsearch.exceptions.ConnectionError, e:
+                logging.error(
+                    "Could not connect to ElasticSearch. Returning empty list of search results."
+                )
+            b = time.time()
+            logging.debug("Elasticsearch query completed in %.2fsec", b-a)
+            results = []
+            if docs:
+                doc_ids = [
+                    int(x['_id']) for x in docs['hits']['hits']
+                ]
+                if doc_ids:
+                    results = self.works_for_specific_ids(_db, doc_ids)
+
+        return results
 
 
 class LaneGenre(Base):
@@ -1183,94 +1244,56 @@ class Lane(Base, WorkList):
 
     @property
     def search_target(self):
-        """When someone in this lane wants to do a search, determine which
-        Lane should actually be searched.
-        """
-        if self.parent is None:
-            # We are at the top level. Search everything.
-            return self
+        """Obtain the WorkList that should be searched when someone
+        initiates a search from this Lane."""
 
+        # See if this Lane is the root lane for a patron type, or has an
+        # ancestor that's the root lane for a patron type. If so, search
+        # that Lane.
         if self.root_for_patron_type:
-            # This lane acts as the "top level" for one or more patron
-            # types.  Search it, even if the active patron is not of
-            # that type. (This avoids panic reactions when an admin
-            # searches the 'Early Grades' lane and finds books from
-            # other lanes.)
             return self
 
-        if not self.genres and not self.customlists:
-            # This lane is not restricted to any particular genres or
-            # lists. It can be searched and any lane below it should
-            # search this one.
-            return self
+        for parent in self.parentage:
+            if parent.root_for_patron_type:
+                return parent
 
-        # Any other lane cannot be searched directly, but maybe its
-        # parent can be searched.
-        logging.debug(
-            "Lane %s is not searchable; using parent %s" % (
-                self.identifier, self.parent.identifier)
-        )
-        return self.parent.search_target
+        # Otherwise, we want to use the lane's languages, media, and
+        # juvenile audiences in search.
+        languages = self.languages
+        media = self.media
+        audiences = None
+        if Classifier.AUDIENCE_YOUNG_ADULT in self.audiences or Classifier.AUDIENCE_CHILDREN in self.audiences:
+            audiences = self.audiences
 
+        # If there are too many languages or audiences, the description
+        # could get too long to be useful, so we'll leave them out.
+        # Media isn't part of the description yet.
+
+        display_name_parts = []
+        if languages and len(languages) <= 2:
+            display_name_parts.append(LanguageCodes.name_for_languageset(languages))
+
+        if audiences:
+            if len(audiences) <= 2:
+                display_name_parts.append(" and ".join(audiences))
+
+        display_name = " ".join(display_name_parts)
+
+        wl = WorkList()
+        wl.initialize(self.library, display_name=display_name,
+                      languages=languages, media=media, audiences=audiences)
+        return wl
+
+           
     def search(self, _db, query, search_client, pagination=None):
         """Find works in this lane that also match a search query.
-        """        
-           
-        if not pagination:
-            pagination = Pagination(
-                offset=0, size=Pagination.DEFAULT_SEARCH_SIZE
-            )
+        """
+        target = self.search_target
 
-        search_lane = self.search_target
-        if not search_lane:
-            # This lane is not searchable, and neither are any of its
-            # parents. There are no search results. This should not
-            # happen because a top-level lane is always searchable.
-            return []
-
-        if search_lane.fiction in (True, False):
-            fiction = search_lane.fiction
+        if target == self:
+            return super(Lane, self).search(_db, query, search_client, pagination)
         else:
-            fiction = None
-
-        # Get the search results from Elasticsearch.
-        results = None
-        if search_client:
-            docs = None
-            a = time.time()
-            try:
-                if search_lane.audiences:
-                    audiences = list(search_lane.audiences)
-                else:
-                    audiences = []
-                docs = search_client.query_works(
-                    library=self.library, 
-                    query_string=query, 
-                    media=search_lane.media,
-                    languages=search_lane.languages,
-                    fiction=fiction, 
-                    audiences=audiences, 
-                    target_age=numericrange_to_tuple(search_lane.target_age),
-                    in_any_of_these_genres=search_lane.genre_ids,
-                    fields=["_id", "title", "author", "license_pool_id"],
-                    size=pagination.size,
-                    offset=pagination.offset,
-                )
-            except elasticsearch.exceptions.ConnectionError, e:
-                logging.error(
-                    "Could not connect to ElasticSearch. Returning empty list of search results."
-                )
-            b = time.time()
-            logging.debug("Elasticsearch query completed in %.2fsec", b-a)
-            results = []
-            if docs:
-                doc_ids = [
-                    int(x['_id']) for x in docs['hits']['hits']
-                ]
-                if doc_ids:
-                    results = self.works_for_specific_ids(_db, doc_ids)
-
-        return results
+            return target.search(_db, query, search_client, pagination)
 
     def apply_bibliographic_filters(self, _db, qu, work_model, featured=False):
         """Apply filters to a base query against a materialized view,

--- a/lane.py
+++ b/lane.py
@@ -1206,6 +1206,8 @@ class Lane(Base, WorkList):
                 bucket = included_ids
             else:
                 bucket = excluded_ids
+            if self.fiction != None and genre.default_fiction != None and self.fiction != genre.default_fiction:
+                logging.error("Lane %s has a genre %s that does not match its fiction restriction.", (self.identifier, genre.name))
             bucket.add(genre.id)
             if lanegenre.recursive:
                 for subgenre in genre.subgenres:

--- a/lane.py
+++ b/lane.py
@@ -471,6 +471,16 @@ class WorkList(object):
         return []
 
     @property
+    def language_key(self):
+        """Return a string identifying the languages used in this WorkList.
+        This will usually be in the form of 'eng,spa' (English and Spanish).
+        """
+        key = ""
+        if self.languages:
+            key += ",".join(self.languages)
+        return key
+
+    @property
     def audience_key(self):
         """Translates audiences list into url-safe string"""
         key = u''
@@ -493,6 +503,8 @@ class WorkList(object):
         # preserve the ordering of the children.
         works_and_worklists = []
         for child in self.visible_children:
+            if isinstance(child, Lane):
+                child = _db.merge(child)
             works = child.featured_works(_db)
             for work in works:
                 works_and_worklists.append((work, child))
@@ -1341,7 +1353,7 @@ class Lane(Base, WorkList):
         # DISTINCT to True on the query.
         return qu, True
 
-Library.lanes = relationship("Lane", backref="library", foreign_keys=Lane.library_id)
+Library.lanes = relationship("Lane", backref="library", foreign_keys=Lane.library_id, cascade='all, delete-orphan')
 DataSource.list_lanes = relationship("Lane", backref="_list_datasource", foreign_keys=Lane._list_datasource_id)
 DataSource.license_lanes = relationship("Lane", backref="license_datasource", foreign_keys=Lane.license_datasource_id)
 

--- a/model.py
+++ b/model.py
@@ -6095,6 +6095,10 @@ class CachedFeed(Base):
     # A feed is of a certain type--currently either 'page' or 'groups'.
     type = Column(Unicode, nullable=False)
 
+    # A feed associated with a WorkList can have a unique key.
+    # This should be null if the feed is associated with a Lane.
+    unique_key = Column(Unicode, nullable=True)
+
     # A 'page' feed is associated with a set of values for the facet
     # groups.
     facets = Column(Unicode, nullable=True)
@@ -6140,8 +6144,10 @@ class CachedFeed(Base):
             max_age = datetime.timedelta(seconds=max_age)
         if lane and isinstance(lane, Lane):
             lane_id = lane.id
+            unique_key = None
         else:
             lane_id = None
+            unique_key = "%s-%s-%s" % (lane.display_name, lane.language_key, lane.audience_key)
         work = None
         if lane:
             work = getattr(lane, 'work', None)
@@ -6169,6 +6175,7 @@ class CachedFeed(Base):
             on_multiple='interchangeable',
             constraint=constraint_clause,
             lane_id=lane_id,
+            unique_key=unique_key,
             library=library,
             work=work,
             type=type,

--- a/opds.py
+++ b/opds.py
@@ -600,13 +600,7 @@ class AcquisitionFeed(OPDSFeed):
     def search(cls, _db, title, url, lane, search_engine, query, pagination=None,
                annotator=None
     ):
-        if not isinstance(lane, Lane):
-            search_lane = Lane(
-                _db, "Everything", searchable=True, fiction=Lane.BOTH_FICTION_AND_NONFICTION)
-        else:
-            search_lane = lane
-
-        results = search_lane.search(
+        results = lane.search(
             _db, query, search_engine, pagination=pagination
         )
         opds_feed = AcquisitionFeed(_db, title, url, results, annotator=annotator)
@@ -624,8 +618,8 @@ class AcquisitionFeed(OPDSFeed):
             AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, rel="previous", href=annotator.search_url(lane, query, previous_page))
 
         # Add "up" link and breadcrumbs
-        AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, rel="up", href=annotator.lane_url(search_lane), title=lane.display_name)
-        opds_feed.add_breadcrumbs(search_lane, annotator, include_lane=True)
+        AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, rel="up", href=annotator.lane_url(lane), title=str(lane.display_name))
+        opds_feed.add_breadcrumbs(lane, annotator, include_lane=True)
 
         annotator.annotate_feed(opds_feed, lane)
         return unicode(opds_feed)

--- a/testing.py
+++ b/testing.py
@@ -278,18 +278,18 @@ class DatabaseTest(object):
     def _work(self, title=None, authors=None, genre=None, language=None,
               audience=None, fiction=True, with_license_pool=False, 
               with_open_access_download=False, quality=0.5, series=None,
-              presentation_edition=None, collection=None):
+              presentation_edition=None, collection=None, data_source_name=None):
         pools = []
         if with_open_access_download:
             with_license_pool = True
         language = language or "eng"
         title = unicode(title or self._str)
         audience = audience or Classifier.AUDIENCE_ADULT
-        if audience == Classifier.AUDIENCE_CHILDREN:
+        if audience == Classifier.AUDIENCE_CHILDREN and not data_source_name:
             # TODO: This is necessary because Gutenberg's childrens books
             # get filtered out at the moment.
             data_source_name = DataSource.OVERDRIVE
-        else:
+        elif not data_source_name:
             data_source_name = DataSource.GUTENBERG
         if fiction is None:
             fiction = True

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -711,6 +711,7 @@ class TestExternalSearchWithWorks(ExternalSearchTest):
         biography_lane = self._lane("Biography", genres=["Biography & Memoir"])
         fantasy_lane = self._lane("Fantasy", genres=["Fantasy"])
         both_lane = self._lane("Both", genres=["Biography & Memoir", "Fantasy"])
+        self._db.flush()
 
         results = query("lincoln", None, None, None, None, None, biography_lane.genre_ids)
         hits = results["hits"]["hits"]

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -955,6 +955,13 @@ class TestLane(DatabaseTest):
             ValueError, "Lane parentage loop detected", list, lane.parentage
         )
 
+    def test_depth(self):
+        child = self._lane("sublane")
+        parent = self._lane("parent")
+        parent.sublanes.append(child)
+        eq_(0, parent.depth)
+        eq_(1, child.depth)
+
     def test_url_name(self):
         lane = self._lane("Fantasy / Science Fiction")
         eq_("Fantasy __ Science Fiction", lane.url_name)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1072,6 +1072,13 @@ class TestLane(DatabaseTest):
         # of its subgenres is exclused recursively (in which case the
         # sub-subgenre would be excluded), but it should work.
 
+        # We can exclude a genre even when no genres are explicitly included.
+        # The lane will include all genres that aren't excluded.
+        no_inclusive_genres = self._lane()
+        no_inclusive_genres.add_genre("Science Fiction", inclusive=False)
+        assert len(no_inclusive_genres.genre_ids) > 10
+        assert science_fiction.id not in no_inclusive_genres.genre_ids
+
     def test_search_target(self):
 
         # A top-level lane can be searched.


### PR DESCRIPTION
More changes to get database lanes working in circulation:

- Changed the way search works so that WorkList is searchable and has the implementation of search. When searching a Lane, it will use the `search_target`, which will be any ancestor that is the root for a patron type, or a WorkList created using some of the Lane's restrictions.
- Brought back a few things that were removed but still used - `language_key`, `depth`.
- Added code to handle a Lane like "Children's Informational Books", which has a fiction restriction and an excluded genre (Biography) but no included genres.