### PR TITLE
Poetry and Drama do not have a default fiction setting

### DIFF
--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -852,7 +852,7 @@ class GenreData(object):
         """
         try:
             from ..lane import Lane
-        except ImportError, e:
+        except ValueError, e:
             from lane import Lane
         if self.name and not 'full_name' in args:
             args['full_name'] = self.name
@@ -3478,7 +3478,7 @@ class WorkClassifier(object):
         """Prepare a single Classification for consideration."""
         try:
             from ..model import DataSource, Subject
-        except ImportError:
+        except ValueError:
             from model import DataSource, Subject
 
         # We only consider a given classification once from a given
@@ -3874,7 +3874,7 @@ class WorkClassifier(object):
         """
         try:
             from ..model import Genre
-        except ImportError:
+        except ValueError:
             from model import Genre
         genre, ignore = Genre.lookup(self._db, genre_data.name)
         self.genre_weights[genre] += weight

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -850,7 +850,10 @@ class GenreData(object):
         """Turn this GenreData object into a Lane that matches
         every book in the genre.
         """
-        from lane import Lane
+        try:
+            from ..lane import Lane
+        except ImportError, e:
+            from lane import Lane
         if self.name and not 'full_name' in args:
             args['full_name'] = self.name
         if self.is_fiction:
@@ -3473,7 +3476,10 @@ class WorkClassifier(object):
 
     def add(self, classification):
         """Prepare a single Classification for consideration."""
-        from ..model import DataSource, Subject
+        try:
+            from ..model import DataSource, Subject
+        except ImportError:
+            from model import DataSource, Subject
 
         # We only consider a given classification once from a given
         # data source.
@@ -3866,7 +3872,10 @@ class WorkClassifier(object):
         """A helper method that ensure we always use database Genre
         objects, not GenreData objects, when weighting genres.
         """
-        from ..model import Genre
+        try:
+            from ..model import Genre
+        except ImportError:
+            from model import Genre
         genre, ignore = Genre.lookup(self._db, genre_data.name)
         self.genre_weights[genre] += weight
 

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -580,7 +580,7 @@ fiction_genres = [
     u"Adventure",
     u"Classics",
     COMICS_AND_GRAPHIC_NOVELS,
-    u"Drama",
+    dict(name=u"Drama", fiction=None),
     dict(name=u"Erotica", audiences=Classifier.AUDIENCE_ADULTS_ONLY),
     dict(name=u"Fantasy", subgenres=[
         u"Epic Fantasy", 
@@ -608,7 +608,7 @@ fiction_genres = [
         u"Paranormal Mystery",
         u"Women Detectives",
     ]),
-    u"Poetry",
+    dict(name=u"Poetry", fiction=None),
     u"Religious Fiction",
     dict(name=u"Romance", subgenres=[
         u"Contemporary Romance",
@@ -790,17 +790,19 @@ class GenreData(object):
         """Create a GenreData object for every genre and subgenre in the given
         list of fiction and nonfiction genres.
         """
-        for source, fiction in (
+        for source, default_fiction in (
                 (fiction_source, True),
                 (nonfiction_source, False)):
             for item in source:
                 subgenres = []
                 audience_restriction = None
                 name = item
+                fiction = default_fiction
                 if isinstance(item, dict):
                     name = item['name']
                     subgenres = item.get('subgenres', [])
                     audience_restriction = item.get('audience_restriction')
+                    fiction = item.get('fiction', default_fiction)
 
                 cls.add_genre(
                     namespace, genres, name, subgenres, fiction,

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -3473,7 +3473,7 @@ class WorkClassifier(object):
 
     def add(self, classification):
         """Prepare a single Classification for consideration."""
-        from model import DataSource, Subject
+        from ..model import DataSource, Subject
 
         # We only consider a given classification once from a given
         # data source.
@@ -3866,7 +3866,7 @@ class WorkClassifier(object):
         """A helper method that ensure we always use database Genre
         objects, not GenreData objects, when weighting genres.
         """
-        from model import Genre
+        from ..model import Genre
         genre, ignore = Genre.lookup(self._db, genre_data.name)
         self.genre_weights[genre] += weight
 

--- a/classifier/bisac.py
+++ b/classifier/bisac.py
@@ -248,7 +248,6 @@ class BISACClassifier(Classifier):
         m(False, "Juvenile Nonfiction"),
         m(True, "Young Adult Fiction"),
         m(False, "Young Adult Nonfiction"),
-        m(stop, "Humor"),
         m(stop, "Drama"),
         m(stop, "Poetry"),
         m(False, anything),

--- a/classifier/bisac.py
+++ b/classifier/bisac.py
@@ -248,6 +248,7 @@ class BISACClassifier(Classifier):
         m(False, "Juvenile Nonfiction"),
         m(True, "Young Adult Fiction"),
         m(False, "Young Adult Nonfiction"),
+        m(stop, "Humor"),
         m(stop, "Drama"),
         m(stop, "Poetry"),
         m(False, anything),

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -37,6 +37,18 @@ from classifier import (
 genres = dict()
 GenreData.populate(globals(), genres, fiction_genres, nonfiction_genres)
 
+class TestGenreData(object):
+
+    def test_fiction_default(self):
+        # Most genres contain either fiction or nonfiction.
+        eq_(True, Science_Fiction.is_fiction)
+        eq_(False, Science.is_fiction)
+
+        # But not Poetry and Drama, which transcend this distinction.
+        eq_(None, Poetry.is_fiction)
+        eq_(None, Drama.is_fiction)
+
+
 class TestClassifier(object):
 
     def test_default_target_age_for_audience(self):

--- a/tests/test_classifier_bisac.py
+++ b/tests/test_classifier_bisac.py
@@ -245,14 +245,17 @@ class TestBISACClassifier(object):
         fiction_is("Fiction / Science Fiction", True)
         fiction_is("Antiques & Collectibles / Kitchenware", False)
 
-        # Humor, drama, and poetry do not have fiction classifications
+        # drama and poetry do not have fiction classifications
         # unless the fiction classification comes from elsewhere in the
         # subject.
         fiction_is("Drama", None)
         fiction_is("Poetry", None)
         fiction_is("Young Adult Fiction / Poetry", True)
 
-        fiction_is("Humor", None)
+        # Humor probably shouldn't have a fiction classification, but
+        # the standard we've set elsewhere is that "Humor" by itself
+        # is nonfiction.
+        fiction_is("Humor", False)
         fiction_is("Young Adult Nonfiction / Humor", False)
         fiction_is("Juvenile Fiction / Humorous Stories", True)
 

--- a/tests/test_classifier_bisac.py
+++ b/tests/test_classifier_bisac.py
@@ -245,17 +245,14 @@ class TestBISACClassifier(object):
         fiction_is("Fiction / Science Fiction", True)
         fiction_is("Antiques & Collectibles / Kitchenware", False)
 
-        # drama and poetry do not have fiction classifications
+        # Humor, drama and poetry do not have fiction classifications
         # unless the fiction classification comes from elsewhere in the
         # subject.
+        fiction_is("Humor", None)
         fiction_is("Drama", None)
         fiction_is("Poetry", None)
         fiction_is("Young Adult Fiction / Poetry", True)
 
-        # Humor probably shouldn't have a fiction classification, but
-        # the standard we've set elsewhere is that "Humor" by itself
-        # is nonfiction.
-        fiction_is("Humor", False)
         fiction_is("Young Adult Nonfiction / Humor", False)
         fiction_is("Juvenile Fiction / Humorous Stories", True)
 


### PR DESCRIPTION
Although the Poetry and Drama genres are beneath "Fiction" for purposes of how we arrange the bookshelves, their contents are not actually limited to fiction, and `GenreData.is_fiction` should return None for them rather than a boolean value.

This branch also fixes some imports that broke when I turned classfier.py into the classifier module.