### PR TITLE
Put the new BISACClassifier in the 'classifier' module -- this ensures that it's always registered.

### DIFF
--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -3759,3 +3759,6 @@ Classifier.classifiers[Classifier.INTEREST_LEVEL] = InterestLevelClassifier
 Classifier.classifiers[Classifier.AXIS_360_AUDIENCE] = AgeOrGradeClassifier
 Classifier.classifiers[Classifier.SIMPLIFIED_GENRE] = SimplifiedGenreClassifier
 Classifier.classifiers[Classifier.SIMPLIFIED_FICTION_STATUS] = SimplifiedFictionClassifier
+
+# Finally, import classifiers described in submodules.
+from bisac import BISACClassifier

--- a/tests/test_classifier_bisac.py
+++ b/tests/test_classifier_bisac.py
@@ -4,8 +4,11 @@ from nose.tools import (
     eq_,
     set_trace
 )
-from classifier.bisac import (
+from classifier import (
     BISACClassifier,
+    Classifier,
+)
+from classifier.bisac import (
     MatchingRule,
     RE,
     anything,
@@ -16,7 +19,6 @@ from classifier.bisac import (
     something,
     ya,
 )
-from classifier import Classifier
 
 class TestMatchingRule(object):
 


### PR DESCRIPTION
Currently the code that registers `BISACClassifier` as handling Subjects of type 'BISAC' is in code that isn't imported by `classifier/__init__.py`. This can create a situation where the 'BISAC' subject type has no registered classifier, and subjects of that type don't contribute to a Work's classification. This branch makes `__init__.py` import the `bisac` module at the end, ensuring that the registration code always runs.

This also ensures that you can import `classifier.BISACClassifier` even though the old `BISACClassifier` class is gone.