### PR TITLE
Renamed default_loan_period to ebook_loan_duration.

### DIFF
--- a/migration/20171106-rename-default-loan-period.sql
+++ b/migration/20171106-rename-default-loan-period.sql
@@ -1,0 +1,1 @@
+update collectionsettings set name='ebook_loan_duration' where name='default_loan_period';

--- a/migration/20171106-rename-default-loan-period.sql
+++ b/migration/20171106-rename-default-loan-period.sql
@@ -1,1 +1,0 @@
-update collectionsettings set name='ebook_loan_duration' where name='default_loan_period';

--- a/model.py
+++ b/model.py
@@ -10447,44 +10447,33 @@ class Collection(Base, HasFullTableCache):
     EBOOK_LOAN_DURATION_KEY = 'ebook_loan_duration'
     STANDARD_DEFAULT_LOAN_PERIOD = 21
         
-    @hybrid_property
-    def default_loan_period(self):
+    def default_loan_period(self, library):
         """Until we hear otherwise from the license provider, we assume
         that someone who borrows a non-open-access item from this
         collection has it for this number of days.
         """
         return (
-            self.external_integration.setting(
-                self.EBOOK_LOAN_DURATION_KEY).int_value
-            or self.STANDARD_DEFAULT_LOAN_PERIOD
+            ConfigurationSetting.for_library_and_externalintegration(
+                None, library, self.EBOOK_LOAN_DURATION_KEY,
+                self.external_integration
+            ).intvalue or self.STANDARD_DEFAULT_LOAN_PERIOD
         )
-
-    @default_loan_period.setter
-    def set_default_loan_period(self, new_value):
-        new_value = int(new_value)
-        self.external_integration.setting(
-            self.EBOOK_LOAN_DURATION_KEY).value = str(new_value)
 
     DEFAULT_RESERVATION_PERIOD_KEY = 'default_reservation_period'
     STANDARD_DEFAULT_RESERVATION_PERIOD = 3
             
-    @hybrid_property
-    def default_reservation_period(self):
+    def default_reservation_period(self, library):
         """Until we hear otherwise from the license provider, we assume
         that someone who puts an item on hold has this many days to
         check it out before it goes to the next person in line.
         """
+        _db = Session.object_session(self)
         return (
-            self.external_integration.setting(
-                self.DEFAULT_RESERVATION_PERIOD_KEY).int_value
-            or self.STANDARD_DEFAULT_RESERVATION_PERIOD
+            ConfigurationSetting.for_library_and_externalintegration(
+                None, library, self.DEFAULT_RESERVATION_PERIOD_KEY,
+                self.external_integration
+            ).intvalue or self.STANDARD_DEFAULT_RESERVATION_PERIOD
         )
-
-    @default_reservation_period.setter
-    def set_default_reservation_period(self, new_value):
-        new_value = int(new_value)
-        self.external_integration.setting(
-            self.DEFAULT_RESERVATION_PERIOD__KEY).value = str(new_value)
             
     def create_external_integration(self, protocol):
         """Create an ExternalIntegration for this Collection.

--- a/model.py
+++ b/model.py
@@ -10471,7 +10471,7 @@ class Collection(Base, HasFullTableCache):
         """
         return (
             self.external_integration.setting(
-                _db, self.DEFAULT_RESERVATION_PERIOD_KEY,
+                self.DEFAULT_RESERVATION_PERIOD_KEY,
             ).int_value or self.STANDARD_DEFAULT_RESERVATION_PERIOD
         )
 
@@ -10479,8 +10479,8 @@ class Collection(Base, HasFullTableCache):
     def set_default_reservation_period(self, new_value):
         new_value = int(new_value)
         self.external_integration.setting(
-            self.DEFAULT_RESERVATION_PERIOD__KEY).value = str(new_value)
-    
+            self.DEFAULT_RESERVATION_PERIOD_KEY).value = str(new_value)
+
     def create_external_integration(self, protocol):
         """Create an ExternalIntegration for this Collection.
 

--- a/model.py
+++ b/model.py
@@ -10437,12 +10437,14 @@ class Collection(Base, HasFullTableCache):
         for child in self.children:
             child.protocol = new_protocol
 
-    # TODO: The default loan period needs to be expanded to handle
-    # different defaults for different media types (e.g. on Overdrive
-    # the default loan period for audiobooks is 14 days, and for video
-    # it's 5 days). This isn't a high priority because the license
-    # source generally tells us when each loan will end.
-    DEFAULT_LOAN_PERIOD_KEY = 'default_loan_period'
+    # For collections that can control the duration of the loans they
+    # create, the durations are stored in these settings and new loans are
+    # expected to be created using these settings. For collections
+    # where loan duration is negotiated out-of-bounds, all loans are
+    # _assumed_ to have these durations unless we hear otherwise from
+    # the server.
+    AUDIOBOOK_LOAN_DURATION_KEY = 'audio_loan_duration'
+    EBOOK_LOAN_DURATION_KEY = 'ebook_loan_duration'
     STANDARD_DEFAULT_LOAN_PERIOD = 21
         
     @hybrid_property
@@ -10453,7 +10455,7 @@ class Collection(Base, HasFullTableCache):
         """
         return (
             self.external_integration.setting(
-                self.DEFAULT_LOAN_PERIOD_KEY).int_value
+                self.EBOOK_LOAN_DURATION_KEY).int_value
             or self.STANDARD_DEFAULT_LOAN_PERIOD
         )
 
@@ -10461,7 +10463,7 @@ class Collection(Base, HasFullTableCache):
     def set_default_loan_period(self, new_value):
         new_value = int(new_value)
         self.external_integration.setting(
-            self.DEFAULT_LOAN_PERIOD_KEY).value = str(new_value)
+            self.EBOOK_LOAN_DURATION_KEY).value = str(new_value)
 
     DEFAULT_RESERVATION_PERIOD_KEY = 'default_reservation_period'
     STANDARD_DEFAULT_RESERVATION_PERIOD = 3

--- a/model.py
+++ b/model.py
@@ -10452,11 +10452,12 @@ class Collection(Base, HasFullTableCache):
         that someone who borrows a non-open-access item from this
         collection has it for this number of days.
         """
+        _db = Session.object_session(library)
         return (
             ConfigurationSetting.for_library_and_externalintegration(
-                None, library, self.EBOOK_LOAN_DURATION_KEY,
+                _db, self.EBOOK_LOAN_DURATION_KEY, library,
                 self.external_integration
-            ).intvalue or self.STANDARD_DEFAULT_LOAN_PERIOD
+            ).int_value or self.STANDARD_DEFAULT_LOAN_PERIOD
         )
 
     DEFAULT_RESERVATION_PERIOD_KEY = 'default_reservation_period'
@@ -10467,12 +10468,12 @@ class Collection(Base, HasFullTableCache):
         that someone who puts an item on hold has this many days to
         check it out before it goes to the next person in line.
         """
-        _db = Session.object_session(self)
+        _db = Session.object_session(library)
         return (
             ConfigurationSetting.for_library_and_externalintegration(
-                None, library, self.DEFAULT_RESERVATION_PERIOD_KEY,
-                self.external_integration
-            ).intvalue or self.STANDARD_DEFAULT_RESERVATION_PERIOD
+                _db, self.DEFAULT_RESERVATION_PERIOD_KEY,
+                library, self.external_integration
+            ).int_value or self.STANDARD_DEFAULT_RESERVATION_PERIOD
         )
             
     def create_external_integration(self, protocol):

--- a/opds.py
+++ b/opds.py
@@ -1115,8 +1115,13 @@ class AcquisitionFeed(OPDSFeed):
         default_loan_period = default_reservation_period = None
         collection = license_pool.collection
         if (loan or hold) and not license_pool.open_access:
+            if loan:
+                obj = loan
+            elif hold:
+                obj = hold
+            library = obj.patron.library
             default_loan_period = datetime.timedelta(
-                collection.default_loan_period
+                collection.default_loan_period(library)
             )
         if loan:
             status = 'available'

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7153,6 +7153,41 @@ class TestCollection(DatabaseTest):
         opds.data_source = None
         eq_(None, opds.data_source)
 
+    def test_default_loan_period(self):
+        library = self._default_library
+        library.collections.append(self.collection)
+
+        # The default when no value is set.
+        eq_(
+            Collection.STANDARD_DEFAULT_LOAN_PERIOD, 
+            self.collection.default_loan_period(library)
+        )
+
+        # Set a value, and it's used.
+        ConfigurationSetting.for_library_and_externalintegration(
+            self._db, Collection.EBOOK_LOAN_DURATION_KEY, library,
+            self.collection.external_integration
+        ).value = 604
+        eq_(604, self.collection.default_loan_period(library))
+
+    def test_default_reservation_period(self):
+        library = self._default_library
+        # The default when no value is set.
+        eq_(
+            Collection.STANDARD_DEFAULT_RESERVATION_PERIOD, 
+            self.collection.default_reservation_period
+        )
+
+        # Set a value, and it's used.
+        self.collection.default_reservation_period = 601
+        eq_(601, self.collection.default_reservation_period)
+
+        # The underlying value is controlled by a ConfigurationSetting.
+        self.collection.external_integration.setting(
+            Collection.DEFAULT_RESERVATION_PERIOD_KEY
+        ).value = 954
+        eq_(954, self.collection.default_reservation_period)
+
     def test_explain(self):
         """Test that Collection.explain gives all relevant information
         about a Collection.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7157,18 +7157,30 @@ class TestCollection(DatabaseTest):
         library = self._default_library
         library.collections.append(self.collection)
 
+        ebook = Edition.BOOK_MEDIUM
+        audio = Edition.AUDIO_MEDIUM
+
         # The default when no value is set.
         eq_(
             Collection.STANDARD_DEFAULT_LOAN_PERIOD, 
-            self.collection.default_loan_period(library)
+            self.collection.default_loan_period(library, ebook)
+        )
+
+        eq_(
+            Collection.STANDARD_DEFAULT_LOAN_PERIOD, 
+            self.collection.default_loan_period(library, audio)
         )
 
         # Set a value, and it's used.
-        ConfigurationSetting.for_library_and_externalintegration(
-            self._db, Collection.EBOOK_LOAN_DURATION_KEY, library,
-            self.collection.external_integration
-        ).value = 604
+        self.collection.default_loan_period_setting(library, ebook).value = 604
         eq_(604, self.collection.default_loan_period(library))
+        eq_(
+            Collection.STANDARD_DEFAULT_LOAN_PERIOD, 
+            self.collection.default_loan_period(library, audio)
+        )
+
+        self.collection.default_loan_period_setting(library, audio).value = 606
+        eq_(606, self.collection.default_loan_period(library, audio))
 
     def test_default_reservation_period(self):
         library = self._default_library


### PR DESCRIPTION
This branch replaces the `default_loan_period` setting with `audio_loan_duration` and `ebook_loan_duration`. The one used to estimate loan durations is `ebook_loan_duration`. In the circulation module, individual `CirculationAPI` subclasses will decide whether these settings are purely advisory, to be used only as estimates, or whether they can be used to _determine_ how long loans should be.