### PR TITLE
Increase robustness of bulk URN parsing

### DIFF
--- a/model.py
+++ b/model.py
@@ -10788,7 +10788,7 @@ class IntegrationClient(Base):
 
         generate_secret = (client.shared_secret is None) or submitted_secret
         if generate_secret:
-            client.shared_secret = os.urandom(24).encode('hex')
+            client.shared_secret = unicode(os.urandom(24).encode('hex'))
 
         return client, is_new
 

--- a/model.py
+++ b/model.py
@@ -1899,16 +1899,25 @@ class Identifier(Base):
         # Find identifiers that are already in the database.
         find_existing_identifiers(identifier_details.values())
 
+        # Remove the existing identifiers from the identifier_details list,
+        # regardless of whether the provided URN was accurate.
+        existing_details = [(i.type, i.identifier) for i in identifiers_by_urn.values()]
+        identifier_details = {
+            k: v for k, v in identifier_details.items()
+            if v not in existing_details and k not in identifiers_by_urn.keys()
+        }
+
         # Find any identifier details that don't correspond to an existing
         # identifier. Try to create them.
         new_identifiers = list()
+        new_identifiers_details = set([])
         for urn, details in identifier_details.items():
-            if urn not in identifiers_by_urn:
-                new_identifiers.append(
-                    dict(type=details[0], identifier=details[1])
-                )
-            else:
-                del identifier_details[urn]
+            if details in new_identifiers_details:
+                # For some reason, this identifier is here twice.
+                # Don't try to insert it twice.
+                continue
+            new_identifiers.append(dict(type=details[0], identifier=details[1]))
+            new_identifiers_details.add(details)
 
         # Insert new identifiers into the database, then add them to the
         # results.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -339,9 +339,11 @@ class TestIdentifier(DatabaseTest):
 
     def test_parse_urns(self):
         identifier = self._identifier()
-        new_urn = Identifier.URN_SCHEME_PREFIX + "Overdrive%20ID/nosuchidentifier"
         fake_urn = "what_even_is_this"
-        urns = [identifier.urn, fake_urn, new_urn]
+        new_urn = Identifier.URN_SCHEME_PREFIX + "Overdrive%20ID/nosuchidentifier"
+        # Also create a different URN that would result in the same identifier.
+        same_new_urn = Identifier.URN_SCHEME_PREFIX + "Overdrive%20ID/NOSUCHidentifier"
+        urns = [identifier.urn, fake_urn, new_urn, same_new_urn]
 
         results = Identifier.parse_urns(self._db, urns)
         identifiers_by_urn, failures = results


### PR DESCRIPTION
This branch is a bit of a stab in the dark. I can't find metadata production request logging in loggly, and I can't recreate the error locally. Based on how URNs are parsed and the error I'm seeing in uwsgi.log, I hypothesize that the failure is occurring because either the URN that the circulation manager is passing is new and duplicated _or_ it's cased or whitespaced differently than the URN generated by `Identifier.urn` on this server.

In this branch, I try to head off both possibilities.

Here's the error:
```
DETAIL:  Key (type, identifier)=(Overdrive ID, 7a3d303d-7c64-4bed-adf8-4d2ec5de9af9) already exists.
    response = self.full_dispatch_request()
  File "/var/lib/app/env/local/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/var/lib/app/env/local/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/var/lib/app/env/local/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/var/lib/app/env/local/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "./app.py", line 61, in decorated
    return f(*args, **kwargs)
  File "./core/app_server.py", line 179, in decorated
    v = f(*args, **kwargs)
  File "./app.py", line 102, in lookup
    collection_details=collection_metadata_identifier
  File "./controller.py", line 615, in work_lookup
    response = self.process_urns(urns, **process_urn_kwargs)
  File "./controller.py", line 644, in process_urns
    identifiers_by_urn, failures = Identifier.parse_urns(self._db, urns)
  File "./core/model.py", line 1915, in parse_urns
    _db.bulk_insert_mappings(cls, new_identifiers)
  File "/var/lib/app/env/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 2269, in bulk_insert_mappings
    mapper, mappings, False, False, return_defaults, False)
  File "/var/lib/app/env/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 2340, in _bulk_save_mappings
    transaction.rollback(_capture_exception=True)
  File "/var/lib/app/env/local/lib/python2.7/site-packages/sqlalchemy/util/langhelpers.py", line 60, in __exit__
    compat.reraise(exc_type, exc_value, exc_tb)
  File "/var/lib/app/env/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 2335, in _bulk_save_mappings
    mapper, mappings, transaction, isstates, return_defaults)
  File "/var/lib/app/env/local/lib/python2.7/site-packages/sqlalchemy/orm/persistence.py", line 67, in _bulk_insert
    bookkeeping=return_defaults)
  File "/var/lib/app/env/local/lib/python2.7/site-packages/sqlalchemy/orm/persistence.py", line 748, in _emit_insert_statements
    execute(statement, multiparams)
  File "/var/lib/app/env/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 914, in execute
    return meth(self, multiparams, params)
  File "/var/lib/app/env/local/lib/python2.7/site-packages/sqlalchemy/sql/elements.py", line 323, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/var/lib/app/env/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1010, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/var/lib/app/env/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1146, in _execute_context
    context)
  File "/var/lib/app/env/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1341, in _handle_dbapi_exception
    exc_info
  File "/var/lib/app/env/local/lib/python2.7/site-packages/sqlalchemy/util/compat.py", line 199, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb)
  File "/var/lib/app/env/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1116, in _execute_context
    context)
  File "/var/lib/app/env/local/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 447, in do_executemany
    cursor.executemany(statement, parameters)
sqlalchemy.exc.IntegrityError: (psycopg2.IntegrityError) duplicate key value violates unique constraint "identifiers_type_identifier_key"
DETAIL:  Key (type, identifier)=(Overdrive ID, 7a3d303d-7c64-4bed-adf8-4d2ec5de9af9) already exists.
 [SQL: 'INSERT INTO identifiers (type, identifier) VALUES (%(type)s, %(identifier)s)'] [parameters: ({'identifier': u'7a3d303d-7c64-4bed-adf8-4d2ec5de9af9', 'type': u'Overdrive ID'}, {'identifier': u'b05cda64-e444-4749-8b7c-6cc7b7b374be', 'type': u'Overdrive ID'}, {'identifier': u'1123fed8-aad0-4dd8-98c6-3f9fa3aaadc9', 'type': u'Overdrive ID'}, {'identifier': u'f5e0570e-863e-4bce-a81d-39b1139cc924', 'type': u'Overdrive ID'}, {'identifier': u'efc1369b-9b32-4d68-b756-50fc208b75e3', 'type': u'Overdrive ID'}, {'identifier': u'5c50dddc-cecd-4073-9737-d32bf742b763', 'type': u'Overdrive ID'}, {'identifier': u'752877fb-1695-4948-a04f-1cef66c34b46', 'type': u'Overdrive ID'}, {'identifier': u'89c028d0-3225-48e3-87b1-43063764027b', 'type': u'Overdrive ID'}  ... displaying 10 of 25 total bound parameter sets ...  {'identifier': u'dc05ea88-b4f8-4fcf-b3b7-06ccea701cb4', 'type': u'Overdrive ID'}, {'identifier': u'd4a072d3-236d-45eb-be03-469d866a6e1d', 'type': u'Overdrive ID'})]
```

Also, I didn't mention this in the last PR, but these changes to URN parsing introduce a new problem for the circulation manager. If the URN that is given by circulation is different from the one that the metadata wrangler returns for some reason, the circulation manager won't be able to parse messages and entries that are returned.

I had hoped it wouldn't be a problem because URN code hasn't changed in a long time and all the server's share server_core. But listen, you know what happens when you assume. 😼 