### PR TITLE
Overdrive "ils_name" setting is per library

### DIFF
--- a/migration/20171107-overdrive-ils-name-per-library.sql
+++ b/migration/20171107-overdrive-ils-name-per-library.sql
@@ -1,0 +1,15 @@
+-- Find every Overdrive integration that defines an 'ils_name' key,
+-- and copy that key to every library that uses the corresponding
+-- Overdrive collection.
+insert into configurationsettings (external_integration_id, library_id, key, value) 
+       select ei.id, cl.library_id, key, value
+       from configurationsettings cs
+       join externalintegrations ei on cs.external_integration_id=ei.id
+       join collections c on c.external_integration_id=ei.id
+       join collections_libraries cl on c.id=cl.collection_id
+       where ei.protocol='Overdrive'
+       and cs.key='ils_name';
+
+-- Delete all 'ils_name' configuration settings associated with an
+-- Overdrive integration but not affiliated with any library.
+delete from configurationsettings where library_id is null and key='ils_name' and external_integration_id in (select id from externalintegrations where protocol='Overdrive');

--- a/overdrive.py
+++ b/overdrive.py
@@ -140,10 +140,6 @@ class OverdriveAPI(object):
         self.client_key = collection.external_integration.username
         self.client_secret = collection.external_integration.password
         self.website_id = collection.external_integration.setting(self.WEBSITE_ID).value
-        self.ils_name = collection.external_integration.setting(self.ILS_NAME).value
-        if not self.ils_name:
-            self.ils_name = "default"
-
         if (not self.client_key or not self.client_secret or not self.website_id
             or not self.library_id):
             raise CannotLoadConfiguration(

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -76,11 +76,17 @@ class OverdriveTestWithAPI(OverdriveTest):
 class TestOverdriveAPI(OverdriveTestWithAPI):
 
     def test_default_ils_name(self):
-        # The 'ils_name' setting (defined in
-        # MockOverdriveAPI.mock_collection) becomes
-        # OverdriveAPI.ils_name.
-        eq_("e", self.api.ils_name)
-        
+        """The 'ils_name' setting (defined in
+        MockOverdriveAPI.mock_collection) is available through
+        OverdriveAPI.ils_name().
+        """
+        eq_("e", self.api.ils_name(self._default_library))
+
+        # The value must be explicitly set for a given library, or
+        # else the default will be used.
+        l2 = self._library()
+        eq_("default", self.api.ils_name(l2))
+
     def test_make_link_safe(self):
         eq_("http://foo.com?q=%2B%3A%7B%7D",
             OverdriveAPI.make_link_safe("http://foo.com?q=+:{}"))

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -75,7 +75,7 @@ class OverdriveTestWithAPI(OverdriveTest):
 
 class TestOverdriveAPI(OverdriveTestWithAPI):
 
-    def test_default_ils_name(self):
+    def test_ils_name(self):
         """The 'ils_name' setting (defined in
         MockOverdriveAPI.mock_collection) is available through
         OverdriveAPI.ils_name().


### PR DESCRIPTION
This branch comes after I finally figured out what the Overdrive "ils_name" setting is for. When two libraries share an Overdrive collection, "ils_name" lets Overdrive know which ILS it needs to ask when cross-checking a patron's credentials. This means ils_name is a configuration setting associated with the Overdrive account + the library, not just the Overdrive account.

This branch changes "ils_name" from a property of OverdriveAPI to a method that takes a `Library` as an argument. The corresponding circulation branch is https://github.com/NYPL-Simplified/circulation/pull/765.