### PR TITLE
Improve RBdigital subject classification

### DIFF
--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -43,7 +43,7 @@ class Classifier(object):
     LCSH = "LCSH"
     FAST = "FAST"
     OVERDRIVE = "Overdrive"
-    ONECLICK = "OneClick"
+    RBDIGITAL = "RBdigital"
     BISAC = "BISAC"
     BIC = "BIC"
     TAG = "tag"   # Folksonomic tags.
@@ -54,7 +54,7 @@ class Classifier(object):
     GRADE_LEVEL = "Grade level" # "1-2", "Grade 4", "Kindergarten", etc.
     AGE_RANGE = "schema:typicalAgeRange" # "0-2", etc.
     AXIS_360_AUDIENCE = "Axis 360 Audience"
-    ONECLICK_AUDIENCE = "OneClick Audience"
+    RBDIGITAL_AUDIENCE = "RBdigital Audience"
 
     # We know this says something about the audience but we're not sure what.
     # Could be any of the values from GRADE_LEVEL or AGE_RANGE, plus
@@ -2235,9 +2235,6 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    Eg("handwriting"),
                    Eg("information sciences"),
                    Eg("journalism"),
-                   Eg("language arts & disciplines"),
-                   Eg("language arts and disciplines"),
-                   Eg("language arts"),
                    Eg("library & information sciences"),
                    Eg("linguistics"),
                    Eg("literacy"),
@@ -2258,6 +2255,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    Eg("taoism"),
                    Eg("taoist"),
                    Eg("confucianism"),
+                   Eg("inspirational nonfiction"),
                ),
                
                Renaissance_Early_Modern_History: match_kw(
@@ -2312,6 +2310,8 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                
                Science_Fiction : match_kw(
                    "speculative fiction",
+                   "sci-fi",
+                   "sci fi",
                    Eg("time travel"),
                ),
                
@@ -2444,11 +2444,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                    "travelers",
                    "description.*travel",
                ),
-               
-               True_Crime: match_kw(
-                   "true crime",
-               ),
-               
+                              
                United_States_History: match_kw(
                    "united states history",
                    "u.s. history",
@@ -2491,6 +2487,8 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
                Womens_Fiction : match_kw(
                    "contemporary women",
                    "chick lit",
+                   "womens fiction",
+                   "women's fiction",
                ),
                
                World_History: match_kw(
@@ -2500,6 +2498,12 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
     }
 
     LEVEL_2_KEYWORDS = {
+        Reference_Study_Aids : match_kw(
+            # Formerly in 'Language Arts & Disciplines'
+            Eg("language arts & disciplines"),
+            Eg("language arts and disciplines"),
+            Eg("language arts"),
+        ),
         Design : match_kw(
             "arts and crafts movement",
         ),
@@ -2554,6 +2558,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
         # Stop the 'religious' from matching Religion/Spirituality.
         Religious_Fiction: match_kw(
             Eg("christian fiction"),
+            Eg("inspirational fiction"),
             Eg("fiction.*christian"),
             "religious fiction",
             "fiction.*religious",
@@ -2584,6 +2589,11 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
         Supernatural_Thriller: match_kw(
             "thriller.*supernatural",
             "supernatural.*thriller",
+        ),
+
+        # Stop from going into Mystery due to 'crime' 
+        True_Crime: match_kw(
+            "true crime",
         ),
 
         # Otherwise fiction.*urban turns Urban Fantasy into Urban Fiction
@@ -2969,7 +2979,7 @@ class GutenbergBookshelfClassifier(Classifier):
 class FreeformAudienceClassifier(AgeOrGradeClassifier):
     @classmethod
     def audience(cls, identifier, name):
-        if identifier in ('children', 'pre-adolescent'):
+        if identifier in ('children', 'pre-adolescent', 'beginning reader'):
             return cls.AUDIENCE_CHILDREN
         elif identifier in ('young adult', 'ya', 'teenagers', 'adolescent',
                             'early adolescents'):
@@ -2982,6 +2992,8 @@ class FreeformAudienceClassifier(AgeOrGradeClassifier):
 
     @classmethod
     def target_age(cls, identifier, name):
+        if identifier == 'beginning reader':
+            return cls.range_tuple(5,8)
         if identifier == 'pre-adolescent':
             return cls.range_tuple(9, 12)
         if identifier == 'early adolescents':
@@ -3762,3 +3774,7 @@ Classifier.classifiers[Classifier.SIMPLIFIED_FICTION_STATUS] = SimplifiedFiction
 
 # Finally, import classifiers described in submodules.
 from bisac import BISACClassifier
+from rbdigital import (
+    RBDigitalAudienceClassifier,
+    RBDigitalSubjectClassifier,
+)

--- a/classifier/rbdigital.py
+++ b/classifier/rbdigital.py
@@ -1,0 +1,92 @@
+from . import *
+
+class RBDigitalAudienceClassifier(FreeformAudienceClassifier):
+
+    @classmethod
+    def target_age(cls, identifier, name):
+        # RBdigital uses 'beginning reader' to refer to books
+        # suitable from birth to age 8, rather than (as is more common)
+        # ages 5 to 8.
+        #
+        # Rather than covering the entire early lifespan of a child,
+        # the normally vague 'childrens' is used here to cover the
+        # time in between 'beginnign reader' and 'young adult'
+        if identifier == 'beginning reader':
+            return cls.range_tuple(0,8)
+        elif identifier == 'childrens':
+            return cls.range_tuple(9, 13)
+        return FreeformAudienceClassifier.target_age(identifier, name)
+
+class RBDigitalSubjectClassifier(KeywordBasedClassifier):
+
+    # We have subgenres for fiction in these categories but not for
+    # nonfiction in these categories (thus the None mapping in
+    # 'genres' below).
+    fiction_genres = {
+        'lgbt interest' : LGBTQ_Fiction,
+    }
+
+    genres = {
+        # This isn't true in general but because RBdigital is heavy on
+        # audio content, 'arts and entertainment' is more likely to be
+        # entertainment (e.g. music) than arts.
+        'arts entertainment' : Entertainment,
+        'business economics' : Business,
+        'comics graphic novels' : Comics_Graphic_Novels,
+        'home garden' : Hobbies_Home,
+        # Determined by looking at a sample collection.
+        'humor' : Humorous_Nonfiction,
+
+        # We don't check this in KeywordBasedClassifier to avoid
+        # confusion with e.g. 'western civ'.
+        'western' : Westerns,
+
+        # If we go to this point we know it's not fiction so we have
+        # nothing to say about the genre -- it could be anything.
+        'lgbt interest' : None,
+    }
+
+    @classmethod
+    def scrub_identifier(cls, identifier):
+        return identifier.replace('-', ' ')
+
+    @classmethod
+    def genre(cls, identifier, name, fiction=None, audience=None, **kwargs):
+        if fiction and identifier in cls.fiction_genres:
+            return cls.fiction_genres[identifier]
+        if identifier in cls.genres:
+            return cls.genres[identifier]
+        return KeywordBasedClassifier.genre(
+            identifier, name, fiction, audience, **kwargs
+        )
+
+    @classmethod
+    def audience(self, identifier, name):
+        """The two subjects here that imply an audience, juvenile-fiction and
+        juvenile-nonfiction, could be either Childrens or YA, and
+        RBdigital always provides a more specific audience
+        classification, so we don't try to derive audience information
+        from an RBDigital Subject.
+        """
+        if identifier == 'erotica':
+            return Classifier.AUDIENCE_ADULTS_ONLY
+        return None
+
+    @classmethod
+    def target_age(self, identifier, name):
+        """RBdigital's audience classification is much more useful for this
+        purpose, so we don't try to derive target age from an RBDigital
+        Subject.
+        """
+        return None
+
+    @classmethod
+    def is_fiction(self, identifier, name):
+        # RBdigital files nonfiction under 'humor' and fiction under
+        # 'humorous fiction'
+        if identifier == 'humor':
+            return False
+        return KeywordBasedClassifier.is_fiction(identifier, name)
+
+Classifier.classifiers[Classifier.RBDIGITAL_AUDIENCE] = RBDigitalAudienceClassifier
+Classifier.classifiers[Classifier.RBDIGITAL] = RBDigitalSubjectClassifier

--- a/classifier/rbdigital.py
+++ b/classifier/rbdigital.py
@@ -10,7 +10,7 @@ class RBDigitalAudienceClassifier(FreeformAudienceClassifier):
         #
         # Rather than covering the entire early lifespan of a child,
         # the normally vague 'childrens' is used here to cover the
-        # time in between 'beginnign reader' and 'young adult'
+        # time in between 'beginning reader' and 'young adult'
         if identifier == 'beginning reader':
             return cls.range_tuple(0,8)
         elif identifier == 'childrens':
@@ -25,25 +25,6 @@ class RBDigitalSubjectClassifier(KeywordBasedClassifier):
     fiction_genres = {
         'lgbt interest' : LGBTQ_Fiction,
     }
-
-    # These subjects do not end with '-fiction' but reliabily indicate
-    # fiction.
-    known_fiction = set([
-        'short-stories',
-        'classics',
-        'comics-graphic-novels',
-        'drama',
-        'poetry',
-        'sci-fi',
-        'fantasy',
-    ])
-
-    # These subjects contain both fiction and nonfiction, or
-    # otherwise have no fiction status.
-    no_fiction_status = set([
-        'african-american-interest',
-        'lgbt-interest',
-    ])
 
     genres = {
         # This isn't true in general but because RBdigital is heavy on

--- a/classifier/rbdigital.py
+++ b/classifier/rbdigital.py
@@ -26,6 +26,25 @@ class RBDigitalSubjectClassifier(KeywordBasedClassifier):
         'lgbt interest' : LGBTQ_Fiction,
     }
 
+    # These subjects do not end with '-fiction' but reliabily indicate
+    # fiction.
+    known_fiction = set([
+        'short-stories',
+        'classics',
+        'comics-graphic-novels',
+        'drama',
+        'poetry',
+        'sci-fi',
+        'fantasy',
+    ])
+
+    # These subjects contain both fiction and nonfiction, or
+    # otherwise have no fiction status.
+    no_fiction_status = set([
+        'african-american-interest',
+        'lgbt-interest',
+    ])
+
     genres = {
         # This isn't true in general but because RBdigital is heavy on
         # audio content, 'arts and entertainment' is more likely to be
@@ -61,7 +80,7 @@ class RBDigitalSubjectClassifier(KeywordBasedClassifier):
         )
 
     @classmethod
-    def audience(self, identifier, name):
+    def audience(cls, identifier, name):
         """The two subjects here that imply an audience, juvenile-fiction and
         juvenile-nonfiction, could be either Childrens or YA, and
         RBdigital always provides a more specific audience
@@ -73,7 +92,7 @@ class RBDigitalSubjectClassifier(KeywordBasedClassifier):
         return None
 
     @classmethod
-    def target_age(self, identifier, name):
+    def target_age(cls, identifier, name):
         """RBdigital's audience classification is much more useful for this
         purpose, so we don't try to derive target age from an RBDigital
         Subject.
@@ -81,12 +100,17 @@ class RBDigitalSubjectClassifier(KeywordBasedClassifier):
         return None
 
     @classmethod
-    def is_fiction(self, identifier, name):
-        # RBdigital files nonfiction under 'humor' and fiction under
-        # 'humorous fiction'
-        if identifier == 'humor':
+    def is_fiction(cls, identifier, name):
+        # In general, the fiction status of a RBdigital subject
+        # is the default fiction status of its genre.
+        genre = cls.genre(identifier, name)
+        if genre and genre.is_fiction is not None:
+            return genre.is_fiction
+        if identifier.endswith(' fiction'):
+            return True
+        if identifier.endswith(' nonfiction'):
             return False
-        return KeywordBasedClassifier.is_fiction(identifier, name)
+        return None
 
 Classifier.classifiers[Classifier.RBDIGITAL_AUDIENCE] = RBDigitalAudienceClassifier
 Classifier.classifiers[Classifier.RBDIGITAL] = RBDigitalSubjectClassifier

--- a/migration/20171107-rename-rbdigital-subjects.sql
+++ b/migration/20171107-rename-rbdigital-subjects.sql
@@ -1,0 +1,14 @@
+-- Rename former OneClick subjects to RBdigital subjects.
+update subjects set type='RBdigital' where type='OneClick';
+update subjects set type='RBdigital Audience' where type='OneClick Audience';
+update subjects set checked=false where type like 'RBdigital';
+
+-- Mark subjects as unchecked where classification rules have been improved
+-- so that bin/repair/work_reclassify_unchecked_subjects can reclassify
+-- the books that use these subjects.
+update subjects set checked=false where identifier ilike 'true%crime';
+update subjects set checked=false where identifier ilike 'sci%fi';
+update subjects set checked=false where identifier ilike 'language arts%';
+update subjects set checked=false where identifier ilike 'inspirational nonfiction';
+update subjects set checked=false where identifier ilike 'women%s fiction';
+update subjects set checked=false where identifier ilike 'beginning reader';

--- a/migration/20171107-rename-rbdigital-subjects.sql
+++ b/migration/20171107-rename-rbdigital-subjects.sql
@@ -1,11 +1,16 @@
--- Rename former OneClick subjects to RBdigital subjects.
+-- Rename OneClick subject types to RBdigital types.
 update subjects set type='RBdigital' where type='OneClick';
 update subjects set type='RBdigital Audience' where type='OneClick Audience';
-update subjects set checked=false where type like 'RBdigital';
+
+-- Re-weight RBdigital classifications based on observed reliability.
+update classifications set weight=500 where subject_id in (select id from subjects where type='RBdigital Audience');
+update classifications set weight=200 where subject_id in (select id from subjects where type='RBdigital');
 
 -- Mark subjects as unchecked where classification rules have been improved
--- so that bin/repair/work_reclassify_unchecked_subjects can reclassify
+-- so that bin/work_classify_unchecked_subjects can reclassify
 -- the books that use these subjects.
+update subjects set checked=false where type like 'RBdigital';
+
 update subjects set checked=false where identifier ilike 'true%crime';
 update subjects set checked=false where identifier ilike 'sci%fi';
 update subjects set checked=false where identifier ilike 'language arts%';

--- a/model.py
+++ b/model.py
@@ -6025,7 +6025,8 @@ class Subject(Base):
                 )
         self.fiction = fiction
 
-        if numericrange_to_tuple(self.target_age) != target_age:
+        if (numericrange_to_tuple(self.target_age) != target_age and 
+            not (not self.target_age and not target_age)):
             log.info(
                 "%s:%s target_age %r=>%r", self.type, self.identifier,
                 self.target_age, tuple_to_numericrange(target_age)

--- a/model.py
+++ b/model.py
@@ -5762,7 +5762,7 @@ class Subject(Base):
     FAST = Classifier.FAST
     DDC = Classifier.DDC              # Dewey Decimal Classification
     OVERDRIVE = Classifier.OVERDRIVE  # Overdrive's classification system
-    ONECLICK = Classifier.ONECLICK    # OneClick's genre system
+    RBDIGITAL = Classifier.RBDIGITAL  # RBdigital's genre system
     BISAC = Classifier.BISAC
     BIC = Classifier.BIC              # BIC Subject Categories
     TAG = Classifier.TAG              # Folksonomic tags.
@@ -5775,7 +5775,7 @@ class Subject(Base):
     ]
 
     AXIS_360_AUDIENCE = Classifier.AXIS_360_AUDIENCE
-    ONECLICK_AUDIENCE = Classifier.ONECLICK_AUDIENCE
+    RBDIGITAL_AUDIENCE = Classifier.RBDIGITAL_AUDIENCE
     GRADE_LEVEL = Classifier.GRADE_LEVEL
     AGE_RANGE = Classifier.AGE_RANGE
     LEXILE_SCORE = Classifier.LEXILE_SCORE

--- a/model.py
+++ b/model.py
@@ -10851,6 +10851,8 @@ def numericrange_to_tuple(r):
 
 def tuple_to_numericrange(t):
     """Helper method to convert a tuple to an inclusive NumericRange."""
+    if not t:
+        return None
     return NumericRange(t[0], t[1], '[]')
 
 def site_configuration_has_changed(_db, timeout=1):

--- a/oneclick.py
+++ b/oneclick.py
@@ -720,8 +720,8 @@ class OneClickRepresentationExtractor(object):
                 genres = book['primaryGenre']
                 for genre in genres.split(","):
                     subject = SubjectData(
-                        type=Subject.ONECLICK, identifier=genre.strip(),
-                        weight=100
+                        type=Subject.RBDIGITAL, identifier=genre.strip(),
+                        weight=200
                     )
                     subjects.append(subject)
 
@@ -730,9 +730,9 @@ class OneClickRepresentationExtractor(object):
             audience = book.get('audience', None)
             if audience:
                 subject = SubjectData(
-                    type=Subject.ONECLICK_AUDIENCE,
+                    type=Subject.RBDIGITAL_AUDIENCE,
                     identifier=audience.strip().lower(),
-                    weight=10
+                    weight=500
                 )
                 subjects.append(subject)
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -29,11 +29,12 @@ from classifier import (
     WorkClassifier,
     fiction_genres,
     nonfiction_genres,
-    GenreData
+    GenreData,
     )
 
 genres = dict()
 GenreData.populate(globals(), genres, fiction_genres, nonfiction_genres)
+
 
 class TestGenreData(object):
 

--- a/tests/test_classifier_rbdigital.py
+++ b/tests/test_classifier_rbdigital.py
@@ -71,9 +71,15 @@ class TestRBDigitalSubjectClassifier(ClassifierTest):
 
         # Most subjects will inherit fiction status from the genre
         # default.
-	self.fiction_is("cooking", None)
-	self.fiction_is("true-crime", None)
-	self.fiction_is("romance", None)
+	self.fiction_is("cooking", False)
+	self.fiction_is("true-crime", False)
+	self.fiction_is("romance", True)
+	self.fiction_is("drama", True)
+
+        # Some subjects have no fiction status because they
+        # contain both fiction and nonfiction.
+	self.fiction_is("african-american-interest", None)
+	self.fiction_is("lgbt-interest", None)
 
     def test_audience(self):
         # We generally don't try to derive audience information from

--- a/tests/test_classifier_rbdigital.py
+++ b/tests/test_classifier_rbdigital.py
@@ -1,0 +1,148 @@
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+from classifier import (
+    RBDigitalAudienceClassifier,
+    RBDigitalSubjectClassifier,
+    Classifier,
+)
+
+class MockSubject(object):
+    def __init__(self, identifier, name):
+        self.identifier = identifier
+        self.name = name
+
+class ClassifierTest(object):
+
+    CLASSIFIER = None
+
+    def _subject(self, identifier, name):
+        subject = MockSubject(identifier, name)
+        (subject.genre, subject.audience, subject.target_age, 
+         subject.fiction) = self.CLASSIFIER.classify(subject)
+        return subject
+
+    def genre_is(self, identifier, expect, name=None):
+        subject = self._subject(identifier, name)
+        if expect and subject.genre:
+            eq_(expect, subject.genre.name)
+        else:
+            eq_(expect, subject.genre)
+
+    def fiction_is(self, identifier, expect, name=None):
+        subject = self._subject(identifier, name)
+        eq_(expect, subject.fiction)
+
+    def audience_is(self, identifier, expect, name=None):
+        subject = self._subject(identifier, name)
+        eq_(expect, subject.audience)
+
+    def target_age_is(self, identifier, expect, name=None):
+        subject = self._subject(identifier, name)
+        eq_(expect, subject.target_age)
+
+class TestRBDigitalAudienceClassifier(ClassifierTest):
+
+    CLASSIFIER = RBDigitalAudienceClassifier
+
+    def test_target_age(self):
+        self.target_age_is("Adult", (18, None))
+        self.target_age_is("young adult", (14, 17))
+
+        # RBdigital splits up childrens books into "beginning reader"
+        # (birth-8 years) and "childrens" (9-13 years).
+        self.target_age_is("beginning reader", (0, 8))
+        self.target_age_is("childrens", (9, 13))
+
+
+class TestRBDigitalSubjectClassifier(ClassifierTest):
+
+    CLASSIFIER = RBDigitalSubjectClassifier
+
+    def test_fiction(self):
+	self.fiction_is("general-nonfiction", False)
+	self.fiction_is("juvenile-nonfiction", False)
+	self.fiction_is("humor", False)
+
+	self.fiction_is("juvenile-fiction", True)
+	self.fiction_is("humorous-fiction", True)
+	self.fiction_is("general-fiction", True)
+
+        # Most subjects will inherit fiction status from the genre
+        # default.
+	self.fiction_is("cooking", None)
+	self.fiction_is("true-crime", None)
+	self.fiction_is("romance", None)
+
+    def test_audience(self):
+        # We generally don't try to derive audience information from
+        # subjects of this type because RBdigital always provides an
+        # explicit audience.
+	self.audience_is("erotica", Classifier.AUDIENCE_ADULTS_ONLY)
+	self.audience_is("cooking", None)
+	self.audience_is("juvenile-nonfiction", None)
+	self.audience_is("juvenile-fiction", None)
+
+    def test_target_age(self):
+        # We don't even try to derive audience information from
+        # subjects of this type, because RBdigital always provides an
+        # explicit audience which is more useful for this purpose.
+	self.target_age_is("erotica", None)
+	self.target_age_is("cooking", None)
+	self.target_age_is("juvenile-nonfiction", None)
+	self.target_age_is("juvenile-fiction", None)
+
+    def test_genre(self):
+        # Some RBdigital subjects can't be assigned to genres at all.
+	self.genre_is("general-nonfiction", None)
+	self.genre_is("juvenile-fiction", None)
+	self.genre_is("juvenile-nonfiction", None)
+        self.genre_is("african-american-interest", None)
+
+        # Fiction in some subjects can be assigned to a subgenre even though
+        # nonfiction in the same subject cannot.
+	self.genre_is("lgbt-interest", None)
+        eq_(
+            self.CLASSIFIER.genre('lgbt interest', None, True).name,
+            "LGBTQ Fiction",
+        )
+
+        # But most subjects can be assigned to a genre no matter what.
+	self.genre_is("arts-entertainment", "Entertainment")
+	self.genre_is("biography-autobiography-memoir", "Biography & Memoir")
+	self.genre_is("business-economics", "Business")
+	self.genre_is("classics", "Classics")
+	self.genre_is("comics-graphic-novels", "Comics & Graphic Novels")
+	self.genre_is("cooking", "Cooking")
+	self.genre_is("drama", "Drama")
+	self.genre_is("fantasy", "Fantasy")
+	self.genre_is("foreign-language-study", "Foreign Language Study")
+	self.genre_is("general-fiction", "Literary Fiction")
+	self.genre_is("historical-fiction", "Historical Fiction")
+	self.genre_is("history", "History")
+	self.genre_is("home-garden", "Hobbies & Home")
+	self.genre_is("horror", "Horror")
+	self.genre_is("humor", "Humorous Nonfiction")
+	self.genre_is("humorous-fiction", "Humorous Fiction")
+	self.genre_is("inspirational-fiction", "Religious Fiction")
+	self.genre_is("inspirational-nonfiction", "Religion & Spirituality")
+	self.genre_is("language-arts", "Reference & Study Aids")
+	self.genre_is("literary-fiction", "Literary Fiction")
+	self.genre_is("mystery", "Mystery")
+	self.genre_is("poetry", "Poetry")
+	self.genre_is("politics-current-events", "Political Science")
+	self.genre_is("religion", "Religion & Spirituality")
+	self.genre_is("romance", "Romance")
+	self.genre_is("science", "Science")
+	self.genre_is("sci-fi", "Science Fiction")
+	self.genre_is("self-help", "Self-Help")
+	self.genre_is("short-stories", "Short Stories")
+	self.genre_is("social-science", "Social Sciences")
+	self.genre_is("sports", "Sports")
+	self.genre_is("suspense-thriller", "Suspense/Thriller")
+	self.genre_is("travel", "Travel")
+	self.genre_is("true-crime", "True Crime")
+	self.genre_is("urban-fiction", "Urban Fiction")
+	self.genre_is("western", "Westerns")
+	self.genre_is("womens-fiction", "Women's Fiction")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -84,6 +84,7 @@ from model import (
     get_one,
     get_one_or_create,
     site_configuration_has_changed,
+    tuple_to_numericrange,
 )
 from external_search import (
     DummyExternalSearchIndex,
@@ -7568,6 +7569,33 @@ class TestAdmin(DatabaseTest):
         eq_(self.admin, Admin.authenticate(self._db, "admin@nypl.org", "password"))
         eq_(None, Admin.authenticate(self._db, "other@nypl.org", "password"))
         eq_(None, Admin.authenticate(self._db, "example@nypl.org", "password"))
+
+
+class TestTupleToNumericrange(object):
+    """Test the tuple_to_numericrange helper function."""
+
+    def test_tuple_to_numericrange(self):
+        f = tuple_to_numericrange
+        eq_(None, f(None))
+
+        one_to_ten = f((1,10))
+        assert isinstance(one_to_ten, NumericRange)
+        eq_(1, one_to_ten.lower)
+        eq_(10, one_to_ten.upper)
+        eq_(True, one_to_ten.upper_inc)
+
+        up_to_ten = f((None, 10))
+        assert isinstance(up_to_ten, NumericRange)
+        eq_(None, up_to_ten.lower)
+        eq_(10, up_to_ten.upper)
+        eq_(True, up_to_ten.upper_inc)
+
+        ten_and_up = f((10,None))
+        assert isinstance(ten_and_up, NumericRange)
+        eq_(10, ten_and_up.lower)
+        eq_(None, ten_and_up.upper)
+        eq_(False, ten_and_up.upper_inc)
+
 
 
 class MockHasTableCache(HasFullTableCache):

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -201,11 +201,11 @@ class TestOneClickRepresentationExtractor(OneClickTest):
 
         eq_([(None, u"FICTION / Humorous / General", Subject.BISAC, 100),
 
-            (u'adult', None, Classifier.ONECLICK_AUDIENCE, 10), 
+            (u'adult', None, Classifier.RBDIGITAL_AUDIENCE, 500), 
 
-            (u'humorous-fiction', None, Subject.ONECLICK, 100), 
-            (u'mystery', None, Subject.ONECLICK, 100), 
-            (u'womens-fiction', None, Subject.ONECLICK, 100)
+            (u'humorous-fiction', None, Subject.RBDIGITAL, 200), 
+            (u'mystery', None, Subject.RBDIGITAL, 200), 
+            (u'womens-fiction', None, Subject.RBDIGITAL, 200)
          ],
             [(x.identifier, x.name, x.type, x.weight) for x in subjects]
         )


### PR DESCRIPTION
This branch creates and registers proper classifiers for "RBdigital" and "RBdigital audience" type subjects. There are a small number of subjects in both categories so I was able to determine the classification rules by exhaustion, running spot checks whenever I was unsure about a subject like 'beginning readers'.

The RBdigital-specific subjects seem more accurate than the BISAC subjects also provided by RBdigital, so I've changed the weights of new RBdigital-specific subjects going forward.

The "RBdigital" classifier falls back to the standard KeywordBasedClassifier and this allowed me to find some errors in how the KeywordBasedClassifier classifies things. This should improve classifications for `tag` and other subject types that use the KeywordBasedClassifier.