### PR TITLE
Configure the app name to be used when formatting a log message as JSON

### DIFF
--- a/log.py
+++ b/log.py
@@ -19,7 +19,7 @@ class JSONFormatter(logging.Formatter):
 
     def __init__(self, app_name):
         super(JSONFormatter, self).__init__()
-        self.app_name = app_name
+        self.app_name = app_name or LogConfiguration.DEFAULT_APP_NAME
 
     def format(self, record):
         message = record.msg
@@ -153,6 +153,7 @@ class LogConfiguration(object):
 
         handlers = []
         from model import ExternalIntegration
+        app_name = cls.DEFAULT_APP_NAME
         if _db and not testing:
             goal = ExternalIntegration.LOGGING_GOAL
             internal = ExternalIntegration.lookup(
@@ -161,7 +162,6 @@ class LogConfiguration(object):
             loggly = ExternalIntegration.lookup(
                 _db, ExternalIntegration.LOGGLY, goal
             )
-            app_name = cls.DEFAULT_APP_NAME
             if internal:
                 internal_log_level = (
                     internal.setting(cls.LOG_LEVEL).value 

--- a/log.py
+++ b/log.py
@@ -183,7 +183,6 @@ class LogConfiguration(object):
 
             if loggly:
                 handlers.append(cls.loggly_handler(loggly))
-                app_name = loggly.setting(cls.LOG_APP_NAME).value or app_name
 
         # handlers is either empty or it contains a loggly handler.
         # Let's also add a handler that logs to standard error.


### PR DESCRIPTION
This makes it easy to distinguish between Loggly logs that come from NYPL's circ manager versus BPL's circ manager versus the metadata wrangler.

Since we don't yet have admin interface for log integrations, the configuration setting needs to be snuck into the database.