### PR TITLE
Fixed edge case errors in update_work_for_edition and parse_urns.

### DIFF
--- a/classifier/rbdigital.py
+++ b/classifier/rbdigital.py
@@ -34,6 +34,7 @@ class RBDigitalSubjectClassifier(KeywordBasedClassifier):
         'business economics' : Business,
         'comics graphic novels' : Comics_Graphic_Novels,
         'home garden' : Hobbies_Home,
+        'humorous fiction' : Humorous_Fiction,
         # Determined by looking at a sample collection.
         'humor' : Humorous_Nonfiction,
 

--- a/model.py
+++ b/model.py
@@ -1886,6 +1886,8 @@ class Identifier(Base):
 
         identifiers_by_urn = dict()
         def find_existing_identifiers(identifier_details):
+            if not identifier_details:
+                return
             and_clauses = list()
             for type, identifier in identifier_details:
                 and_clauses.append(
@@ -1921,8 +1923,9 @@ class Identifier(Base):
 
         # Insert new identifiers into the database, then add them to the
         # results.
-        _db.bulk_insert_mappings(cls, new_identifiers)
-        _db.commit()
+        if new_identifiers:
+            _db.bulk_insert_mappings(cls, new_identifiers)
+            _db.commit()
         find_existing_identifiers(identifier_details.values())
 
         return identifiers_by_urn, failures

--- a/opds_import.py
+++ b/opds_import.py
@@ -517,7 +517,8 @@ class OPDSImporter(object):
         # different data source or a different collection, that's fine
         # too.
         pool = get_one(
-            self._db, LicensePool, identifier=edition.primary_identifier
+            self._db, LicensePool, identifier=edition.primary_identifier,
+            on_multiple='interchangeable'
         )
 
         if pool:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -362,6 +362,15 @@ class TestIdentifier(DatabaseTest):
         eq_(Identifier.OVERDRIVE_ID, new_identifier.type)
         eq_("nosuchidentifier", new_identifier.identifier)
 
+        # It also works if we ask only for identifiers that already exist.
+        urns = [identifier.urn]
+        [results, errors] = Identifier.parse_urns(self._db, urns)
+
+        # We got no errors and one successful lookup.
+        eq_([], errors)
+        eq_(1, len(results))
+        eq_(identifier, results[identifier.urn])
+
     def test_parse_urn(self):
 
         # We can parse our custom URNs back into identifiers.

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -50,6 +50,7 @@ from model import (
     Representation,
     RightsStatus,
     Subject,
+    Work,
 )
 from coverage import CoverageFailure
 
@@ -1045,6 +1046,26 @@ class TestOPDSImporter(OPDSImporterTest):
         importer = OPDSImporter(self._db, None)
         importer.build_identifier_mapping([isbn1])
         eq_(None, importer.identifier_mapping)
+
+    def test_update_work_for_edition_having_multiple_license_pools(self):
+        # There are two collections with a LicensePool associated with
+        # this Edition.
+        edition, lp = self._edition(with_license_pool=True)
+        collection2 = self._collection()
+        lp2 = self._licensepool(edition=edition, collection=collection2)
+        importer = OPDSImporter(self._db, None)
+
+        # Calling update_work_for_edition creates a Work and associates
+        # it with the edition.
+        eq_(None, edition.work)
+        importer.update_work_for_edition(edition)
+        work = edition.work
+        assert isinstance(work, Work)
+
+        # Both LicensePools are associated with that work.
+        eq_(lp.work, work)
+        eq_(lp2.work, work)
+        
 
 class TestCombine(object):
     """Test that OPDSImporter.combine combines dictionaries in sensible


### PR DESCRIPTION
This branch fixes two edge cases:

* If parse_urns is asked only about identifiers that are already in the system, it was running a query that lacked any restrictions and included every identifier on the site.

* If OPDSImporter.update_work_for_edition is called on an Edition whose Identifier has more than one LicensePool, it doesn't matter which LicensePool is chosen, but they weren't actually being treated as interchangeable.