### PR TITLE
Remove lane identifier

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -486,6 +486,14 @@ class WorkList(object):
         return []
 
     @property
+    def full_identifier(self):
+        """A human-readable identifier for this Lane that
+        captures its position within the heirarchy.
+        """
+        full_parentage = list(self.parentage) + [self]
+        return " / ".join([x.display_name for x in full_parentage])
+
+    @property
     def language_key(self):
         """Return a string identifying the languages used in this WorkList.
         This will usually be in the form of 'eng,spa' (English and Spanish).

--- a/lane.py
+++ b/lane.py
@@ -1202,7 +1202,7 @@ class Lane(Base, WorkList):
             else:
                 bucket = excluded_ids
             if self.fiction != None and genre.default_fiction != None and self.fiction != genre.default_fiction:
-                logging.error("Lane %s (%s) has a genre %s that does not match its fiction restriction.", (self.id, self.display_name, genre.name))
+                logging.error("Lane %s has a genre %s that does not match its fiction restriction.", (self.full_identifier, genre.name))
             bucket.add(genre.id)
             if lanegenre.recursive:
                 for subgenre in genre.subgenres:
@@ -1218,8 +1218,8 @@ class Lane(Base, WorkList):
             # Fantasy' is included but 'Fantasy' and its subgenres are
             # excluded.
             logging.error(
-                "Lane %s (%s) has a self-negating set of genre IDs.", 
-                self.id, self.display_name
+                "Lane %s has a self-negating set of genre IDs.", 
+                self.full_identifier
             )
         return genre_ids
 

--- a/lane.py
+++ b/lane.py
@@ -943,14 +943,8 @@ class Lane(Base, WorkList):
         cascade='all, delete-orphan'
     )
 
-    # identifier is a name for this lane that is unique across the
-    # library.  "Adult Fiction" is a good example. We can't have an
-    # adult fiction lane called "Fiction" and a YA fiction lane called
-    # "Fiction".
-    identifier = Column(Unicode)
-
     # display_name is the name of the lane as shown to patrons.  It's
-    # okay for this to be duplicated across the library, but it's not
+    # okay for this to be duplicated within a library, but it's not
     # okay to have two lanes with the same parent and the same display
     # name -- that would be confusing.
     display_name = Column(Unicode)
@@ -1030,7 +1024,6 @@ class Lane(Base, WorkList):
 
 
     __table_args__ = (
-        UniqueConstraint('library_id', 'identifier'),
         UniqueConstraint('parent_id', 'display_name'),
     )
 
@@ -1083,11 +1076,10 @@ class Lane(Base, WorkList):
     def url_name(self):
         """Return the name of this lane to be used in URLs.
 
-        Basically, forward slash is changed to "__". This is necessary
-        because Flask tries to route "feed/Suspense%2FThriller" to
-        feed/Suspense/Thriller.
+        Since most aspects of the lane can change through administrative
+        action, we use the internal database ID of the lane in URLs.
         """
-        return self.identifier.replace("/", "__")
+        return self.id
 
     @hybrid_property
     def audiences(self):
@@ -1202,7 +1194,7 @@ class Lane(Base, WorkList):
             else:
                 bucket = excluded_ids
             if self.fiction != None and genre.default_fiction != None and self.fiction != genre.default_fiction:
-                logging.error("Lane %s has a genre %s that does not match its fiction restriction.", (self.identifier, genre.name))
+                logging.error("Lane %s (%s) has a genre %s that does not match its fiction restriction.", (self.id, self.display_name, genre.name))
             bucket.add(genre.id)
             if lanegenre.recursive:
                 for subgenre in genre.subgenres:
@@ -1218,7 +1210,8 @@ class Lane(Base, WorkList):
             # Fantasy' is included but 'Fantasy' and its subgenres are
             # excluded.
             logging.error(
-                "Lane %s has a self-negating set of genre IDs.", self.identifier
+                "Lane %s (%s) has a self-negating set of genre IDs.", 
+                self.id, self.display_name
             )
         return genre_ids
 

--- a/model.py
+++ b/model.py
@@ -6285,7 +6285,7 @@ class CachedFeed(Base):
                 # default page-type feed, which should be cheap to fetch.
                 identifier = None
                 if isinstance(lane, Lane):
-                    identifier = lane.identifier
+                    identifier = lane.id
                 elif isinstance(lane, WorkList):
                     identifier = lane.display_name
                 cls.log.warn(

--- a/opds.py
+++ b/opds.py
@@ -1278,7 +1278,7 @@ class TestAnnotator(Annotator):
     @classmethod
     def groups_url(cls, lane):
         if lane and isinstance(lane, Lane):
-            identifier = lane.identifier
+            identifier = lane.id
         else:
             identifier = ""
         return "http://groups/%s" % identifier

--- a/testing.py
+++ b/testing.py
@@ -363,13 +363,16 @@ class DatabaseTest(object):
         SessionManager.refresh_materialized_views(self._db)
 
     def _lane(self, display_name=None, library=None, 
-              parent=None, genres=None, languages=None):
+              parent=None, genres=None, languages=None,
+              fiction=None
+    ):
         display_name = display_name or self._str
         library = library or self._default_library
         lane, is_new = get_one_or_create(
             self._db, Lane,
             library=library,
-            parent=parent, display_name=display_name
+            parent=parent, display_name=display_name,
+            create_method_kwargs=dict(fiction=fiction)
         )
         if genres:
             if not isinstance(genres, list):

--- a/testing.py
+++ b/testing.py
@@ -362,14 +362,13 @@ class DatabaseTest(object):
         self._db.commit()
         SessionManager.refresh_materialized_views(self._db)
 
-    def _lane(self, identifier=None, display_name=None, library=None, 
+    def _lane(self, display_name=None, library=None, 
               parent=None, genres=None, languages=None):
-        identifier = identifier or self._str
-        display_name = display_name or identifier
+        display_name = display_name or self._str
         library = library or self._default_library
         lane, is_new = get_one_or_create(
             self._db, Lane,
-            identifier=identifier, library=library,
+            library=library,
             parent=parent, display_name=display_name
         )
         if genres:

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1021,9 +1021,7 @@ class TestLane(DatabaseTest):
 
     def test_url_name(self):
         lane = self._lane("Fantasy / Science Fiction")
-        eq_("Fantasy __ Science Fiction", lane.url_name)
-        lane.identifier = "Fantasy"
-        eq_("Fantasy", lane.url_name)
+        eq_(lane.id, lane.url_name)
 
     def test_setting_target_age_locks_audiences(self):
         lane = self._lane()

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -992,6 +992,7 @@ class TestLane(DatabaseTest):
 
     def test_parentage(self):
         worklist = WorkList()
+        worklist.display_name = "A WorkList"
         lane = self._lane()
         child_lane = self._lane(parent=lane)
         unrelated = self._lane()
@@ -999,11 +1000,16 @@ class TestLane(DatabaseTest):
 
         # A WorkList has no parentage.
         eq_([], list(worklist.parentage))
+        eq_("A WorkList", worklist.full_identifier)
 
         # The WorkList has the Lane as a child, but the Lane doesn't know
         # this.
         eq_([], list(lane.parentage))
         eq_([lane], list(child_lane.parentage))
+        eq_(lane.display_name, lane.full_identifier)
+
+        eq_("%s / %s" % (lane.display_name, child_lane.display_name), 
+            child_lane.full_identifier)
 
         # TODO: The error should be raised when we try to set the parent
         # to an illegal value, not afterwards.

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -978,7 +978,7 @@ class TestOPDS(DatabaseTest):
         # groups for Fiction, and a 'start' link which points to
         # the top-level groups feed.
         [up_link] = self.links(parsed['feed'], 'up')
-        eq_("http://groups/Fiction", up_link['href'])
+        eq_("http://groups/%s" % self.fiction.id, up_link['href'])
         eq_("Fiction", up_link['title'])
 
         [start_link] = self.links(parsed['feed'], 'start')


### PR DESCRIPTION
This branch removes the `Lane.identifier` field, which was a unique ID that was also supposed to be human-readable. Not many humans actually see these values (they're used in URLs and that's about it) and it was unnecessary to make admins come up with two different names for each lane, one of which has to be unique and one of which doesn't.

The new `full_identifier` property is only supposed to be used in things like log statements.