### PR TITLE
Support metadata updates feed

### DIFF
--- a/model.py
+++ b/model.py
@@ -10865,7 +10865,7 @@ class IntegrationClient(Base):
 
     @classmethod
     def authenticate(cls, _db, shared_secret):
-        client = get_one(_db, cls, shared_secret=shared_secret)
+        client = get_one(_db, cls, shared_secret=unicode(shared_secret))
         if client:
             client.last_accessed = datetime.datetime.utcnow()
             return client

--- a/model.py
+++ b/model.py
@@ -2308,11 +2308,17 @@ class Identifier(Base):
                 if not description or resource.quality > description.quality:
                     description = resource
 
+        last_coverage_update = None
+        if self.coverage_records:
+            timestamps = [c.timestamp for c in self.coverage_records]
+            last_coverage_update = max(timestamps)
+
         quality = Measurement.overall_quality(self.measurements)
         from opds import AcquisitionFeed
         return AcquisitionFeed.minimal_opds_entry(
-            identifier=self, cover=cover_image, 
-            description=description, quality=quality)
+            identifier=self, cover=cover_image, description=description,
+            quality=quality, most_recent_update=last_coverage_update
+        )
 
 
 class Contributor(Base):
@@ -10767,9 +10773,7 @@ class Collection(Base, HasFullTableCache):
             .options(joinedload(Identifier.coverage_records))
 
         if timestamp:
-            isbns = isbns.filter(
-                CoverageRecord.timestamp > timestamp
-            )
+            isbns = isbns.filter(CoverageRecord.timestamp > timestamp)
 
         return isbns
 

--- a/opds.py
+++ b/opds.py
@@ -1018,7 +1018,9 @@ class AcquisitionFeed(OPDSFeed):
             self.feed.append(breadcrumbs)
 
     @classmethod
-    def minimal_opds_entry(cls, identifier, cover, description, quality):
+    def minimal_opds_entry(cls, identifier, cover, description, quality,
+        most_recent_update=None
+    ):
         elements = []
         representations = []
         most_recent_update = None
@@ -1056,7 +1058,9 @@ class AcquisitionFeed(OPDSFeed):
             r.mirrored_at or r.fetched_at for r in representations
             if r.mirrored_at or r.fetched_at
         ]
-        
+        if most_recent_update:
+            potential_update_dates.append(most_recent_update)
+
         if potential_update_dates:
             update_date = max(potential_update_dates)
             elements.append(AtomFeed.updated(AtomFeed._strftime(update_date)))

--- a/testing.py
+++ b/testing.py
@@ -142,7 +142,9 @@ class DatabaseTest(object):
         self.counter = 2000
 
         self.time_counter = datetime(2014, 1, 1)
-        self.isbns = ["9780674368279", "0636920028468", "9781936460236"]
+        self.isbns = [
+            "9780674368279", "0636920028468", "9781936460236", "9780316075978"
+        ]
         if mock_search:
             self.search_mock = mock.patch(external_search.__name__ + ".ExternalSearchIndex", DummyExternalSearchIndex)
             self.search_mock.start()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7421,7 +7421,11 @@ class TestCollection(DatabaseTest):
 
         # When a timestamp is passed, only works that have been updated
         # since then will be returned
-        w1.coverage_records[0].timestamp = datetime.datetime.utcnow()
+        [w1_coverage_record] = [
+            c for c in w1.coverage_records
+            if c.operation == WorkCoverageRecord.GENERATE_OPDS_OPERATION
+        ]
+        w1_coverage_record.timestamp = datetime.datetime.utcnow()
         eq_([w1], self.collection.works_updated_since(self._db, timestamp).all())
 
     def test_isbns_updated_since(self):
@@ -7442,7 +7446,7 @@ class TestCollection(DatabaseTest):
 
         # Give one ISBN more than one coverage record.
         oclc = DataSource.lookup(self._db, DataSource.OCLC)
-        self._coverage_record(i1, oclc)
+        i1_oclc_record = self._coverage_record(i1, oclc)
 
         def assert_isbns(expected, result_query):
             results = [r[0] for r in result_query]
@@ -7455,8 +7459,9 @@ class TestCollection(DatabaseTest):
         assert_isbns([i2, i1], updated_isbns)
 
         # That CoverageRecord timestamp is also returned.
-        first_result = updated_isbns[0]
-        assert isinstance(first_result[1], datetime.datetime)
+        i1_timestamp = updated_isbns[1][1]
+        assert isinstance(i1_timestamp, datetime.datetime)
+        eq_(i1_oclc_record.timestamp, i1_timestamp)
 
         # When a timestamp is passed, only works that have been updated since
         # then will be returned.


### PR DESCRIPTION
This moves some catalog query work from the metadata wrangler into the Collection class. The call to `Query.distinct()` was causing the metadata wrangler to hang on updates.

Supports NYPL-Simplified/metadata_wrangler#142.