### PR TITLE
Make sure a lane's groups feed includes that lane's paginated feed as a group

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -1301,7 +1301,17 @@ class Lane(Base, WorkList):
         # This takes care of all of the children.
         works_and_lanes = super(Lane, self).groups(_db)
 
-        # Now add additional works for the lane itself.
+        if not works_and_lanes:
+            # The children of this Lane did not contribute any works
+            # to the groups feed. This means there should not be
+            # a groups feed in the first place -- we should send a list
+            # feed instead.
+            return works_and_lanes
+
+        # The children of this Lane contributed works to the groups
+        # feed, which means we need an additional group in the feed
+        # representing everything in the Lane (since the child lanes
+        # are almost never exhaustive).
         lane = _db.merge(self)
         works = lane.featured_works(_db)
         for work in works:

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1161,13 +1161,20 @@ class TestLane(DatabaseTest):
         child.featured_works = mock_child_featured_works
 
         # Calling groups() on the parent Lane returns three
-        # 2-tuples; one for a work featured in the sublanes,
+        # 2-tuples; one for a work featured in the sublane,
         # and then two for a work featured in the parent lane.
         [wwl1, wwl2, wwl3] = parent.groups(self._db)
         eq_((w2, child), wwl1)
         eq_((w1, parent), wwl2)
         eq_((w2, parent), wwl3)
 
+        # If a lane's sublanes don't contribute any books, then
+        # groups() returns an entirely empty list, indicating that no
+        # groups feed should be displayed.
+        def mock_child_featured_works(_db):
+            return []
+        child.featured_works = mock_child_featured_works
+        eq_([], parent.groups(self._db))
 
     def test_search_target(self):
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1029,6 +1029,10 @@ class TestLane(DatabaseTest):
         lane = self._lane("Fantasy / Science Fiction")
         eq_(lane.id, lane.url_name)
 
+    def test_display_name_for_all(self):
+        lane = self._lane("Fantasy / Science Fiction")
+        eq_("All Fantasy / Science Fiction", lane.display_name_for_all)
+
     def test_setting_target_age_locks_audiences(self):
         lane = self._lane()
         lane.target_age = (16, 18)
@@ -1139,6 +1143,31 @@ class TestLane(DatabaseTest):
         no_inclusive_genres.add_genre("Science Fiction", inclusive=False)
         assert len(no_inclusive_genres.genre_ids) > 10
         assert science_fiction.id not in no_inclusive_genres.genre_ids
+
+    def test_groups(self):
+        w1 = MockWork(1)
+        w2 = MockWork(2)
+        w3 = MockWork(3)
+
+        parent = self._lane()
+        def mock_parent_featured_works(_db):
+            return [w1, w2]
+        parent.featured_works = mock_parent_featured_works
+
+        child = self._lane()
+        parent.sublanes = [child]
+        def mock_child_featured_works(_db):
+            return [w2]
+        child.featured_works = mock_child_featured_works
+
+        # Calling groups() on the parent Lane returns three
+        # 2-tuples; one for a work featured in the sublanes,
+        # and then two for a work featured in the parent lane.
+        [wwl1, wwl2, wwl3] = parent.groups(self._db)
+        eq_((w2, child), wwl1)
+        eq_((w1, parent), wwl2)
+        eq_((w2, parent), wwl3)
+
 
     def test_search_target(self):
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -973,6 +973,10 @@ class TestOPDS(DatabaseTest):
         eq_(l1['title'], 'Group Title for Epic Fantasy!')
         eq_(l2['href'], 'http://group/Urban Fantasy')
         eq_(l2['title'], 'Group Title for Urban Fantasy!')
+        eq_(l3['href'], 'http://group/Fantasy')
+        eq_(l3['title'], 'Group Title for Fantasy!')
+        eq_(l4['href'], 'http://group/Fantasy')
+        eq_(l4['title'], 'Group Title for Fantasy!')
 
         # The feed itself has an 'up' link which points to the
         # groups for Fiction, and a 'start' link which points to


### PR DESCRIPTION
This branch changes `Lane.groups()` to return (or not return) books in that lane as part of an 'All [lane]' group which points to the paginated version of that lane's feed.

I feel like this would have worked before, since there were already tests covering this stuff, which makes me think I've overlooked something or misunderstood the work that needs to be done. I feel like all I've done is move some code around. But at any rate it's better to have this code in `groups()`.