### PR TITLE
Bibliotheca audiobooks have distinct delivery mechanism

### DIFF
--- a/bibliotheca.py
+++ b/bibliotheca.py
@@ -287,7 +287,7 @@ class ItemListParser(XMLParser):
             Representation.PDF_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM
         ),
         "MP3" : (
-            Representation.MP3_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM
+            Representation.MP3_MEDIA_TYPE, DeliveryMechanism.FINDAWAY_DRM
         ),
     }
 

--- a/config.py
+++ b/config.py
@@ -10,6 +10,7 @@ from sqlalchemy.engine.url import make_url
 from flask_babel import lazy_gettext as _
 
 from facets import FacetConstants
+from sqlalchemy.exc import ArgumentError
 
 class CannotLoadConfiguration(Exception):
     pass

--- a/migration/20170913-bibliotheca-books-delivered-through-findaway.sql
+++ b/migration/20170913-bibliotheca-books-delivered-through-findaway.sql
@@ -1,0 +1,22 @@
+-- Create a new delivery mechanism for audiobooks delivered
+-- through Findaway
+insert into deliverymechanisms (content_type, drm_scheme) values (
+       'audio/mpeg',
+       'application/vnd.librarysimplified.findaway.license+json'
+);
+
+-- Update all audiobooks delivered through Bibliotheca to use
+-- the new delivery mechanism.
+update licensepooldeliveries set delivery_mechanism_id = (
+ select id from deliverymechanisms where 
+  content_type='audio/mpeg' and 
+  drm_scheme='application/vnd.librarysimplified.findaway.license+json'
+) 
+
+where id in (
+ select lpd.id from licensepooldeliveries lpd
+  join deliverymechanisms dm on lpd.delivery_mechanism_id=dm.id
+  join datasources ds on lpd.data_source_id=ds.id 
+  where ds.name='Bibliotheca'
+  and dm.content_type='audio/mpeg'
+);

--- a/model.py
+++ b/model.py
@@ -8779,6 +8779,7 @@ class DeliveryMechanism(Base, HasFullTableCache):
 
     NO_DRM = None
     ADOBE_DRM = u"application/vnd.adobe.adept+xml"
+    FINDAWAY_DRM = u"application/vnd.librarysimplified.findaway.license+json"
     KINDLE_DRM = u"Kindle DRM"
     NOOK_DRM = u"Nook DRM"
     STREAMING_DRM = u"Streaming"

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -267,6 +267,7 @@ class TestBibliographicCoverageProvider(TestBibliothecaAPI):
 
         rep = Representation
         adobe = DeliveryMechanism.ADOBE_DRM
+        findaway = DeliveryMechanism.FINDAWAY_DRM
         book = Edition.BOOK_MEDIUM
 
         # Verify that we handle the known strings from Bibliotheca
@@ -274,7 +275,7 @@ class TestBibliographicCoverageProvider(TestBibliothecaAPI):
         _check_format("EPUB", book, rep.EPUB_MEDIA_TYPE, adobe)
         _check_format("EPUB3", book, rep.EPUB_MEDIA_TYPE, adobe)
         _check_format("PDF", book, rep.PDF_MEDIA_TYPE, adobe)
-        _check_format("MP3", Edition.AUDIO_MEDIUM, rep.MP3_MEDIA_TYPE, adobe)
+        _check_format("MP3", Edition.AUDIO_MEDIUM, rep.MP3_MEDIA_TYPE, findaway)
 
         # Now Try a string we don't recognize from Bibliotheca.
         medium, formats = m("Unknown")


### PR DESCRIPTION
This is support work for https://github.com/NYPL-Simplified/circulation/pull/771. Bibliotheca's "MP3" books are now recorded as having Findaway DRM, not Adobe DRM.