### PR TITLE
Incorrect migration date set by DatabaseMigrationInitializationScript

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -2174,11 +2174,12 @@ class DatabaseMigrationInitializationScript(DatabaseMigrationScript):
 
         migrations = self.sort_migrations(self.fetch_migration_files()[0])
         py_migrations = filter(lambda m: m.endswith('.py'), migrations)
+        sql_migrations = filter(lambda m: m.endswith('.sql'), migrations)
 
-        most_recent_migration = migrations[-1]
+        most_recent_sql_migration = sql_migrations[-1]
         most_recent_python_migration = py_migrations[-1]
 
-        self.update_timestamps(most_recent_migration)
+        self.update_timestamps(most_recent_sql_migration)
         self.update_timestamps(most_recent_python_migration)
         self._db.commit()
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1098,14 +1098,13 @@ class TestDatabaseMigrationInitializationScript(DatabaseMigrationScriptTest):
         last_migration_date = filter(lambda m: m.endswith('.py'), migrations_sorted)[-1][0:8]
         self.assert_matches_timestamp(timestamp, last_migration_date)
 
-    def assert_matches_latest_migration(self, timestamp, script=None, last_migration_date=None):
+    def assert_matches_latest_migration(self, timestamp, script=None):
         script = script or self.script
         migrations = script.fetch_migration_files()[0]
-        if not last_migration_date:
-            migrations_sorted = script.sort_migrations(migrations)
-            py_migration = filter(lambda m: m.endswith('.py'), migrations_sorted)[-1][0:8]
-            sql_migration = filter(lambda m: m.endswith('.sql'), migrations_sorted)[-1][0:8]
-            last_migration_date = py_migration if int(py_migration) > int(sql_migration) else sql_migration
+        migrations_sorted = script.sort_migrations(migrations)
+        py_migration = filter(lambda m: m.endswith('.py'), migrations_sorted)[-1][0:8]
+        sql_migration = filter(lambda m: m.endswith('.sql'), migrations_sorted)[-1][0:8]
+        last_migration_date = py_migration if int(py_migration) > int(sql_migration) else sql_migration
         self.assert_matches_timestamp(timestamp, last_migration_date)
 
     def assert_matches_timestamp(self, timestamp, migration_date):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1091,40 +1091,57 @@ class TestDatabaseMigrationInitializationScript(DatabaseMigrationScriptTest):
         super(TestDatabaseMigrationInitializationScript, self).setup()
         self.script = DatabaseMigrationInitializationScript(self._db)
 
+    def assert_matches_latest_python_migration(self, timestamp, script=None):
+        script = script or self.script
+        migrations = script.fetch_migration_files()[0]
+        migrations_sorted = script.sort_migrations(migrations)
+        last_migration_date = filter(lambda m: m.endswith('.py'), migrations_sorted)[-1][0:8]
+        self.assert_matches_timestamp(timestamp, last_migration_date)
+
     def assert_matches_latest_migration(self, timestamp, script=None, last_migration_date=None):
         script = script or self.script
         migrations = script.fetch_migration_files()[0]
         if not last_migration_date:
-            last_migration_date = script.sort_migrations(migrations)[-1][:8]
-        eq_(timestamp.timestamp.strftime('%Y%m%d'), last_migration_date)
+            migrations_sorted = script.sort_migrations(migrations)
+            py_migration = filter(lambda m: m.endswith('.py'), migrations_sorted)[-1][0:8]
+            sql_migration = filter(lambda m: m.endswith('.sql'), migrations_sorted)[-1][0:8]
+            last_migration_date = py_migration if int(py_migration) > int(sql_migration) else sql_migration
+        self.assert_matches_timestamp(timestamp, last_migration_date)
+
+    def assert_matches_timestamp(self, timestamp, migration_date):
+        eq_(timestamp.timestamp.strftime('%Y%m%d'), migration_date)
 
     def test_accurate_timestamps_created(self):
         eq_(None, Timestamp.value(self._db, self.script.name, collection=None))
-
         self.script.run()
         self.assert_matches_latest_migration(self.script.overall_timestamp)
-        self.assert_matches_latest_migration(self.script.python_timestamp)
+        self.assert_matches_latest_python_migration(self.script.python_timestamp)
 
-    def test_accurate_python_timestamp_craeted(self):
-        script = self.create_mock_script(
-            DatabaseMigrationInitializationScript, self._db
-        )
+    def test_accurate_python_timestamp_created_python_later(self):
+        script = self.create_mock_script(DatabaseMigrationInitializationScript, self._db)
         eq_(None, Timestamp.value(self._db, script.name, collection=None))
 
         # If the last python migration and the last SQL migration have
         # different timestamps, they're set accordingly.
-        self._create_test_migration_file(
-            self.core_migration_dir, 'CORE', 'sql', '20310101'
-        )
-        self._create_test_migration_file(
-            self.parent_migration_dir, 'SERVER', 'py', '20300101'
-        )
+        self._create_test_migration_file(self.core_migration_dir, 'CORE', 'sql', '20310101')
+        self._create_test_migration_file(self.parent_migration_dir, 'SERVER', 'py', '20300101')
 
         script.run()
-        self.assert_matches_latest_migration(script.overall_timestamp, script)
-        self.assert_matches_latest_migration(
-            script.python_timestamp, script, '20300101'
-        )
+        self.assert_matches_timestamp(script.overall_timestamp, '20310101')
+        self.assert_matches_timestamp(script.python_timestamp, '20300101')
+
+    def test_accurate_python_timestamp_created_python_earlier(self):
+        script = self.create_mock_script(DatabaseMigrationInitializationScript, self._db)
+        eq_(None, Timestamp.value(self._db, script.name, collection=None))
+
+        # If the last python migration and the last SQL migration have
+        # different timestamps, they're set accordingly.
+        self._create_test_migration_file(self.core_migration_dir, 'CORE', 'sql', '20310101')
+        self._create_test_migration_file(self.parent_migration_dir, 'SERVER', 'py', '20350101')
+
+        script.run()
+        self.assert_matches_timestamp(script.overall_timestamp, '20350101')
+        self.assert_matches_timestamp(script.python_timestamp, '20350101')
 
     def test_error_raised_when_timestamp_exists(self):
         Timestamp.stamp(self._db, self.script.name, None)
@@ -1135,7 +1152,7 @@ class TestDatabaseMigrationInitializationScript(DatabaseMigrationScriptTest):
         Timestamp.stamp(self._db, self.script.name, None, date=past)
         self.script.run(['-f'])
         self.assert_matches_latest_migration(self.script.overall_timestamp)
-        self.assert_matches_latest_migration(self.script.python_timestamp)
+        self.assert_matches_latest_python_migration(self.script.python_timestamp)
 
     def test_accepts_last_run_date(self):
         # A timestamp can be passed via the command line.
@@ -1144,7 +1161,6 @@ class TestDatabaseMigrationInitializationScript(DatabaseMigrationScriptTest):
         eq_(expected_stamp, self.script.overall_timestamp.timestamp)
 
         # It will override an existing timestamp if forced.
-        previous_timestamp = Timestamp.stamp(self._db, self.script.name, None)
         self.script.run(['--last-run-date', '20111111', '--force'])
         expected_stamp = datetime.datetime.strptime('20111111', '%Y%m%d')
         eq_(expected_stamp, self.script.overall_timestamp.timestamp)


### PR DESCRIPTION
## Summary

Currently the DatabaseMigrationInitializationScript only takes into account the dates of Python migrations not SQL migrations. So if there are newer SQL migrations then Python migrations then they will be run by the migration script, even if though shouldn't be.

## Details

The `run` function calls `sort_migrations` which returns a sorted list of migrations, first SQL migrations, then Python migrations.

Something like this:
```python
['20170928-add-registered-coverage-status.sql',
'20171004-add-customlists-library-id.sql',
'20171020-add-python-timestamp.sql', 
'20171022-add-loan-and-hold-external-identifier.sql', 
'20171026-update-rbdigital-delivery-mechanism.sql', 
'20171026-set-rbdigital-identifier-for-patrons-with-active-loans.sql', 
'20170713-18-move-third-party-config-to-external-integrations.py', 
'20170713-19-move-third-party-config-to-external-integrations.py', 
'20170714-add-collection-id-to-licensepools.py', 
'20170908-change-metadata-wrangler-settings.py', 
'20170926-migrate-log-configuration.py']
```

To get the newest migrations, we take the end of the list, and then filter for only py files, then take the end of that list. Which means that in both cases we get: `20170926-migrate-log-configuration.py`. However in this example `20171026` is actually the newest migration.

## How should this be tested?

* Run `bin/util/initialize_instance`
  - Without patch you should see the DB the migration date is set to: `20170926`
  - With the patch you should see that the migration date is set to: `20171026`