### PR TITLE
CoverageProvider.missing_coverage_from now only finds CoverageRecords…

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -705,7 +705,8 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
         qu = Identifier.missing_coverage_from(
             self._db, self.input_identifier_types, self.data_source,
             count_as_missing_before=self.cutoff_time, operation=self.operation,
-            identifiers=self.input_identifiers, **kwargs
+            identifiers=self.input_identifiers, collection=self.collection,
+            **kwargs
         )
         if identifiers:
             qu = qu.filter(Identifier.id.in_([x.id for x in identifiers]))

--- a/model.py
+++ b/model.py
@@ -2258,7 +2258,8 @@ class Identifier(Base):
     @classmethod
     def missing_coverage_from(
             cls, _db, identifier_types, coverage_data_source, operation=None,
-            count_as_covered=None, count_as_missing_before=None, identifiers=None
+            count_as_covered=None, count_as_missing_before=None, identifiers=None,
+            collection=None
     ):
         """Find identifiers of the given types which have no CoverageRecord
         from `coverage_data_source`.
@@ -2267,9 +2268,15 @@ class Identifier(Base):
         covered if their CoverageRecords have a status in this list.
         :param identifiers: Restrict search to a specific set of identifier objects.
         """
+        if collection:
+            collection_id = collection.id
+        else:
+            collection_id = None
         clause = and_(Identifier.id==CoverageRecord.identifier_id,
                       CoverageRecord.data_source==coverage_data_source,
-                      CoverageRecord.operation==operation)
+                      CoverageRecord.operation==operation,
+                      CoverageRecord.collection_id==collection_id
+        )
         qu = _db.query(Identifier).outerjoin(CoverageRecord, clause)
         if identifier_types:
             qu = qu.filter(Identifier.type.in_(identifier_types))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -654,6 +654,37 @@ class TestIdentifier(DatabaseTest):
                 self._db, [Identifier.GUTENBERG_ID], web)])
         )
 
+    def test_missing_coverage_from_with_collection(self):
+        gutenberg = DataSource.lookup(self._db, DataSource.GUTENBERG)
+        identifier = self._identifier()
+        collection1 = self._default_collection
+        collection2 = self._collection()
+        self._coverage_record(identifier, gutenberg, collection=collection1)
+
+        # The Identifier has coverage in collection 1.
+        eq_([], 
+            Identifier.missing_coverage_from(
+                self._db, [identifier.type], gutenberg, collection=collection1
+            ).all()
+        )
+
+        # It is missing coverage in collection 2.
+        eq_(
+            [identifier], Identifier.missing_coverage_from(
+                self._db, [identifier.type], gutenberg, collection=collection2
+            ).all()
+        )
+
+        # If no collection is specified, we look for a CoverageRecord
+        # that also has no collection specified, and the Identifier is
+        # not treated as covered.
+        eq_([identifier], 
+            Identifier.missing_coverage_from(
+                self._db, [identifier.type], gutenberg
+            ).all()
+        )
+
+
     def test_missing_coverage_from_with_cutoff_date(self):
         gutenberg = DataSource.lookup(self._db, DataSource.GUTENBERG)
         oclc = DataSource.lookup(self._db, DataSource.OCLC)


### PR DESCRIPTION
… associated with the same Collection associated with the CoverageProvider.

Without this branch, a CoverageProvider associated with a Collection will count an Identifier as covered if there is _any_ relevant CoverageRecord for that Identifier, no matter which Collection it's associated with. With this branch, only a relevant CoverageRecord that is _also_ associated with the CoverageProvider's collection will be counted.

Adding this branch will cause some work to appear undone, as old CoverageRecords that are not associated with any collection will stop being picked up, but right now I think the safest thing to do is to just do the work again. I migrated the CoverageRecords associated with NYPL, which is the main source of undone work, and it was iffy enough that for now I'd rather let the CoverageProviders do the work again.