### PR TITLE
Message doesnt mean failure

### DIFF
--- a/axis.py
+++ b/axis.py
@@ -266,11 +266,6 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
     PROTOCOL = ExternalIntegration.AXIS_360
     INPUT_IDENTIFIER_TYPES = Identifier.AXIS_360_ID
     DEFAULT_BATCH_SIZE = 25
-
-    # Axis combines bibliographic and circulation metadata, so
-    # coverage gained for one collection does not count as coverage
-    # for another.
-    COVERAGE_COUNTS_FOR_EVERY_COLLECTION = False
     
     def __init__(self, collection, api_class=Axis360API, **kwargs):
         """Constructor.

--- a/axis.py
+++ b/axis.py
@@ -266,6 +266,11 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
     PROTOCOL = ExternalIntegration.AXIS_360
     INPUT_IDENTIFIER_TYPES = Identifier.AXIS_360_ID
     DEFAULT_BATCH_SIZE = 25
+
+    # Axis combines bibliographic and circulation metadata, so
+    # coverage gained for one collection does not count as coverage
+    # for another.
+    COVERAGE_COUNTS_FOR_EVERY_COLLECTION = False
     
     def __init__(self, collection, api_class=Axis360API, **kwargs):
         """Constructor.

--- a/coverage.py
+++ b/coverage.py
@@ -694,8 +694,15 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
             return self.failure(identifier, e, transient=True)
 
         try:
+            # We're passing in the Collection even if this
+            # CoverageProvider has
+            # COVERAGE_COUNTS_FOR_EVERY_COLLECTION set to False. If
+            # we did happen to get some circulation information while
+            # we were at it, we might as well store it properly.
+            # The metadata layer will not use the collection when creating
+            # CoverageRecords for the metadata actions.
             metadata.apply(
-                edition, collection=self.collection_or_not,
+                edition, collection=self.collection,
                 replace=self.replacement_policy,
             )
         except Exception as e:

--- a/coverage.py
+++ b/coverage.py
@@ -432,11 +432,12 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
     NO_SPECIFIED_TYPES = object()
     INPUT_IDENTIFIER_TYPES = NO_SPECIFIED_TYPES
 
-    # Set this to True if a given Identifier needs to be run through
+    # Set this to False if a given Identifier needs to be run through
     # this CoverageProvider once for every Collection that has this
-    # Identifier in its catalog. Otherwise, a given Identifier will be
-    # considered completely covered the first time it's run through
-    # this CoverageProvider.
+    # Identifier in its catalog. If this is set to True, a given
+    # Identifier will be considered completely covered the first time
+    # it's run through this CoverageProvider, no matter how many
+    # Collections the Identifier belongs to.
     COVERAGE_COUNTS_FOR_EVERY_COLLECTION = True
     
     def __init__(self, _db, collection=None, input_identifiers=None,

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1647,9 +1647,12 @@ class Metadata(MetaToModelUtility):
                                        status=CoverageRecord.TRANSIENT_FAILURE)
 
         # Finally, update the coverage record for this edition
-        # and data source.
+        # and data source. We omit the collection information,
+        # even if we know which collection this is, because
+        # we only changed metadata.
         CoverageRecord.add_for(
-            edition, data_source, timestamp=self.data_source_last_updated
+            edition, data_source, timestamp=self.data_source_last_updated,
+            collection=None
         )
         return edition, made_core_changes
 

--- a/model.py
+++ b/model.py
@@ -1370,7 +1370,8 @@ class CoverageRecord(Base, BaseCoverageRecord):
         )
 
     @classmethod
-    def lookup(self, edition_or_identifier, data_source, operation=None):
+    def lookup(self, edition_or_identifier, data_source, operation=None,
+               collection=None):
         _db = Session.object_session(edition_or_identifier)
         if isinstance(edition_or_identifier, Identifier):
             identifier = edition_or_identifier
@@ -1388,6 +1389,7 @@ class CoverageRecord(Base, BaseCoverageRecord):
             identifier=identifier,
             data_source=data_source,
             operation=operation,
+            collection=collection,
             on_multiple='interchangeable',
         )
 

--- a/model.py
+++ b/model.py
@@ -1370,7 +1370,7 @@ class CoverageRecord(Base, BaseCoverageRecord):
         )
 
     @classmethod
-    def lookup(self, edition_or_identifier, data_source, operation=None,
+    def lookup(cls, edition_or_identifier, data_source, operation=None,
                collection=None):
         _db = Session.object_session(edition_or_identifier)
         if isinstance(edition_or_identifier, Identifier):

--- a/model.py
+++ b/model.py
@@ -1309,7 +1309,6 @@ class CoverageRecord(Base, BaseCoverageRecord):
 
     SET_EDITION_METADATA_OPERATION = u'set-edition-metadata'
     CHOOSE_COVER_OPERATION = u'choose-cover'
-    SYNC_OPERATION = u'sync'
     REAP_OPERATION = u'reap'
     IMPORT_OPERATION = u'import'
     RESOLVE_IDENTIFIER_OPERATION = u'resolve-identifier'

--- a/opds_import.py
+++ b/opds_import.py
@@ -688,6 +688,12 @@ class OPDSImporter(object):
     def handle_failure(self, urn, failure):
         """Convert a URN and a failure message that came in through
         an OPDS feed into an Identifier and a CoverageFailure object.
+
+        The Identifier may not be the one designated by `urn` (if it's
+        found in self.identifier_mapping) and the 'failure' may turn out not
+        to be a CoverageFailure at all -- if it's an Identifier, that means
+        that what a normal OPDSImporter would consider 'failure' is
+        considered success.
         """
         external_identifier, ignore = Identifier.parse_urn(self._db, urn)
         if self.identifier_mapping:
@@ -811,9 +817,9 @@ class OPDSImporter(object):
                 data_source, parser, root
         ):
             if isinstance(failure, Identifier):
-                # A subclass believes that the Simplified <message>
-                # tag does not actually represent a failure -- it
-                # returned an Identifier instead of a CoverageFailure.
+                # The Simplified <message> tag does not actually
+                # represent a failure -- it was turned into an
+                # Identifier instead of a CoverageFailure.
                 urn = failure.urn
             else:
                 urn = failure.obj.urn

--- a/opds_import.py
+++ b/opds_import.py
@@ -705,13 +705,12 @@ class OPDSImporter(object):
             internal_identifier = external_identifier
         if isinstance(failure, Identifier):
             # The OPDSImporter does not actually consider this a
-            # failure. Signal success for the internal identifier
-            # instead of the external identifier.
+            # failure. Signal success by returning the internal
+            # identifier as the 'failure' object.
             failure = internal_identifier
         else:
             # This really is a failure. Associate the internal
-            # identifier with the CoverageRecord _instead_ of
-            # doing so with the external identifier.
+            # identifier with the CoverageFailure object.
             failure.obj = internal_identifier
         return internal_identifier, failure
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5833,19 +5833,43 @@ class TestCoverageRecord(DatabaseTest):
         source = DataSource.lookup(self._db, DataSource.OCLC)
         edition = self._edition()
         operation = 'foo'
-        record = self._coverage_record(edition, source, operation)
+        collection = self._default_collection
+        record = self._coverage_record(edition, source, operation, 
+                                       collection=collection)
 
-        lookup = CoverageRecord.lookup(edition, source, operation)
+
+        # To find the CoverageRecord, edition, source, operation,
+        # and collection must all match.
+        result = CoverageRecord.lookup(edition, source, operation, 
+                                       collection=collection)
+        eq_(record, result)
+
+        # You can substitute the Edition's primary identifier for the
+        # Edition iteslf.
+        lookup = CoverageRecord.lookup(
+            edition.primary_identifier, source, operation, 
+            collection=self._default_collection
+        )
         eq_(lookup, record)
 
-        lookup = CoverageRecord.lookup(edition, source)
-        eq_(None, lookup)
 
-        lookup = CoverageRecord.lookup(edition.primary_identifier, source, operation)
-        eq_(lookup, record)
+        # Omit the collection, and you find nothing.
+        result = CoverageRecord.lookup(edition, source, operation)
+        eq_(None, result)
 
-        lookup = CoverageRecord.lookup(edition.primary_identifier, source)
-        eq_(None, lookup)
+        # Same for operation.
+        result = CoverageRecord.lookup(edition, source, collection=collection)
+        eq_(None, result)
+
+        result = CoverageRecord.lookup(edition, source, "other operation",
+                                       collection=collection)
+        eq_(None, result)
+
+        # Same for data source.
+        other_source = DataSource.lookup(self._db, DataSource.OVERDRIVE)
+        result = CoverageRecord.lookup(edition, other_source, operation,
+                                       collection=collection)
+        eq_(None, result)
 
     def test_add_for(self):
         source = DataSource.lookup(self._db, DataSource.OCLC)

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -543,6 +543,16 @@ class TestOPDSImporter(OPDSImporterTest):
         this_is_fine = f(identifier.urn, "200", "description")
         eq_(None, this_is_fine)
 
+        # ...unless we pass in True for success_on_200 -- then the
+        # Identifier itself is returned. This can be useful if 
+        # a 200 response code means a CoverageRecord should be created
+        # for an Identifier.
+        message = OPDSMessage(identifier.urn, "200", "description")
+        this_is_fine = OPDSImporter.coveragefailure_from_message(
+            data_source, message, success_on_200=True
+        )
+        eq_(identifier, this_is_fine)
+
         # Test the various ways the status code and message might be
         # transformed into CoverageFailure.exception.
         description_and_status_code = f(identifier.urn, "404", "description")


### PR DESCRIPTION
This branch changes the behavior of the OPDSImporter to allow for the possibility that a <simplified:message> should be treated as success rather than failure. A subclass of OPDSImporter can cause this behavior by setting SUCCESS_STATUS_CODES to a list of status codes that indicate success rather than failure. An OPDSImporter that finds a message that indicates success will return the Identifier that caused the message, rather than creating a CoverageFailure from the message (or returning None, in the case where the status code is 200).

This branch also adds a new attribute of CoverageProviders, `COVERAGE_COUNTS_FOR_EVERY_COLLECTION`. If this is true (the default), then an Identifier will be covered once and that's it, no matter how many Collections contain the Identifier. As soon as there's a CoverageRecord for the Identifier that has no associated collection, then the work is done. If `COVERAGE_COUNTS_FOR_EVERY_COLLECTION` is false, then an Identifier will get separate coverage for every Collection that contains it.

The metadata wrangler coverage providers have `COVERAGE_COUNTS_FOR_EVERY_COLLECTION` set to false because their job is to tell the metadata wrangler which Identifiers are in which local Collections. As far as I know, all other coverage providers should have  `COVERAGE_COUNTS_FOR_EVERY_COLLECTION` set to true.