### PR TITLE
Allow URNLookupController.process_urns to return a ProblemDetail

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -301,6 +301,11 @@ class URNLookupController(object):
         return feed_response(opds_feed)
 
     def process_urns(self, urns, **process_urn_kwargs):
+        """Processes a list of URNs for a lookup request.
+
+        :return: None or, to override default feed behavior, a ProblemDetail
+        or Response
+        """
         identifiers_by_urn, failures = Identifier.parse_urns(self._db, urns)
         self.add_urn_failure_messages(failures)
 

--- a/app_server.py
+++ b/app_server.py
@@ -270,8 +270,12 @@ class URNLookupController(object):
         urns = flask.request.args.getlist('urn')
 
         this_url = cdn_url_for(route_name, _external=True, urn=urns)
-        self.process_urns(urns)
+        response = self.process_urns(urns)
         self.post_lookup_hook()
+
+        if response:
+            # In a subclass, self.process_urns may return a ProblemDetail
+            return response
 
         opds_feed = LookupAcquisitionFeed(
             self._db, "Lookup results", this_url, self.works, annotator,


### PR DESCRIPTION
This branch catches differences in the metadata wrangler, where `URNLookupController.process_urns` sometimes returns a ProblemDetail.