### PR TITLE
Commit instead of flushing after bulk_insert_mappings.

### DIFF
--- a/model.py
+++ b/model.py
@@ -10745,7 +10745,7 @@ class Collection(Base, HasFullTableCache):
             if identifier not in already_in_catalog
         ]
         _db.bulk_insert_mappings(CollectionIdentifier, new_catalog_entries)
-        flush(_db)
+        _db.commit()
 
     def works_updated_since(self, _db, timestamp):
         """Finds all works in a collection's catalog that have been updated


### PR DESCRIPTION
Flushing after a `bulk_insert_mappings` call won't actually emit any SQL; you need to commit. Discovered through metadata wrangler test failures. See `Identifier.parse_urns` for our other `bulk_insert_mappings` call.