### PR TITLE
Cheap works make tests faster

### DIFF
--- a/testing.py
+++ b/testing.py
@@ -35,6 +35,7 @@ from model import (
     LicensePool,
     LicensePoolDeliveryMechanism,
     Patron,
+    PresentationCalculationPolicy,
     Representation,
     Resource,
     RightsStatus,
@@ -278,6 +279,14 @@ class DatabaseTest(object):
               audience=None, fiction=True, with_license_pool=False, 
               with_open_access_download=False, quality=0.5, series=None,
               presentation_edition=None, collection=None):
+        """Create a Work.
+
+        For performance reasons, this method does not generate OPDS
+        entries or calculate a presentation edition for the new
+        Work. Tests that rely on this information being present
+        should call _slow_work() instead, which takes more care to present
+        the sort of Work that would be created in a real environment.
+        """
         pools = []
         if with_open_access_download:
             with_license_pool = True
@@ -311,8 +320,6 @@ class DatabaseTest(object):
                 pools = [pool]
         else:
             pools = presentation_edition.license_pools
-        if new_edition:
-            presentation_edition.calculate_presentation()
         work, ignore = get_one_or_create(
             self._db, Work, create_method_kwargs=dict(
                 audience=audience,
@@ -323,16 +330,14 @@ class DatabaseTest(object):
                 genre, ignore = Genre.lookup(self._db, genre, autocreate=True)
             work.genres = [genre]
         work.random = 0.5
-
         work.set_presentation_edition(presentation_edition)
-        work.calculate_presentation_edition()
 
         if pools:
             # make sure the pool's presentation_edition is set, 
             # bc loan tests assume that.
             if not work.license_pools:
                 for pool in pools:
-                    work.license_pools.append(pools)
+                    work.license_pools.append(pool)
 
             for pool in pools:
                 pool.set_presentation_edition()
@@ -342,6 +347,17 @@ class DatabaseTest(object):
             work.presentation_ready = True
             work.calculate_opds_entries(verbose=False)
 
+        return work
+
+    def _slow_work(self, *args, **kwargs):
+        """Create a work that closely resembles one that might be found in the
+        wild.
+
+        This is significantly slower than _work() but more reliable.
+        """
+        work = self._work(*args, **kwargs)
+        work.calculate_presentation_edition()
+        work.calculate_opds_entries(verbose=False)
         return work
 
     def _add_generic_delivery_mechanism(self, license_pool):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2499,7 +2499,7 @@ class TestWork(DatabaseTest):
         edition3.add_contributor(bob, Contributor.AUTHOR_ROLE)
         edition3.add_contributor(alice, Contributor.AUTHOR_ROLE)
 
-        work = self._work(presentation_edition=edition2)
+        work = self._slow_work(presentation_edition=edition2)
         # add in 3, 2, 1 order to make sure the selection of edition1 as presentation
         # in the second half of the test is based on business logic, not list order.
         for p in pool3, pool1:


### PR DESCRIPTION
In almost all cases a `Work` created for test purposes does not need to have `calculate_presentation` called on its presentation edition and does not need to have an OPDS entry generated for it. This branch changes `DatabaseTest._work()` to create a cheap Work very quickly, speeding up the core and circulation tests by about 20 seconds each. The new `DatabaseTest._slow_work()` method acts like `_work()` used to and is, so far, only needed in a single test.