### PR TITLE
Full title match is better than split match

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - wget ${ES_DOWNLOAD}
   - export ES_PATH=elasticsearch-${ES_VERSION}
   - tar -xzf ${ES_PATH}.tar.gz
-  - cp elasticsearch.yml.testing ./${ES_PATH}/config
+  - cp elasticsearch.yml.testing ./${ES_PATH}/config/elasticsearch.yml
   - ./${ES_PATH}/bin/elasticsearch &
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,12 @@ install:
   - pip install -r requirements.txt
   - python -m textblob.download_corpora
   - cp config.json.sample config.json
-  - export SIMPLIFIED_CONFIGURATION_FILE="$TRAVIS_BUILD_DIR/config.json"
+  - export SIMPLIFIED_CONFIGURATION_FILE="${TRAVIS_BUILD_DIR}/config.json"
   - wget ${ES_DOWNLOAD}
-  - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
-  - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &
+  - export ES_PATH=elasticsearch-${ES_VERSION}
+  - tar -xzf ${ES_PATH}.tar.gz
+  - cp elasticsearch.yml.testing ./${ES_PATH}/config
+  - ./${ES_PATH}/bin/elasticsearch &
 
 before_script:
   - psql -c 'create user simplified_test;' -U postgres

--- a/elasticsearch.yml.testing
+++ b/elasticsearch.yml.testing
@@ -1,0 +1,5 @@
+# Scores for search results are calculated on a per-shard basis.
+# Keeping everything in one shard while running unit testsensures that
+# we have complete control over how the scores are calculated.
+index.number_of_shards: 1
+index.number_of_replicas: 0

--- a/external_search.py
+++ b/external_search.py
@@ -450,9 +450,9 @@ class ExternalSearchIndex(object):
 
         # An exact title or author match outweighs a match that is split
         # across fields.
-        match_title = make_phrase_query(query_string, ['title.standard'], 100)
+        match_title = make_phrase_query(query_string, ['title.standard'], 200)
         must_match_options.append(match_title)
-        match_author = make_phrase_query(query_string, ['author.standard'], 100)
+        match_author = make_phrase_query(query_string, ['author.standard'], 200)
         must_match_options.append(match_author)
 
         if not fuzzy_blacklist_re.search(query_string):
@@ -538,7 +538,7 @@ class ExternalSearchIndex(object):
             match_classification_and_rest_of_query = {
                 'bool': {
                     'must': classification_queries,
-                    'boost': 100
+                    'boost': 200
                 }
             }
 

--- a/external_search.py
+++ b/external_search.py
@@ -339,7 +339,7 @@ class ExternalSearchIndex(object):
                 }
             }
 
-        def make_phrase_query(query_string, fields):
+        def make_phrase_query(query_string, fields, boost=100):
             field_queries = []
             for field in fields:
                 field_query = {
@@ -352,7 +352,7 @@ class ExternalSearchIndex(object):
                 'bool': {
                   'should': field_queries,
                   'minimum_should_match': 1,
-                  'boost': 100,
+                  'boost': boost,
                 }
               }
 
@@ -452,6 +452,11 @@ class ExternalSearchIndex(object):
 
         match_phrase = make_phrase_query(query_string, ['title.minimal', 'author', 'series.minimal'])
         must_match_options.append(match_phrase)
+
+        match_title = make_phrase_query(query_string, ['title.minimal'])
+        must_match_options.append(match_title)
+        match_author = make_phrase_query(query_string, ['author.minimal'])
+        must_match_options.append(match_author)
 
         if not fuzzy_blacklist_re.search(query_string):
             fuzzy_query = make_fuzzy_query(query_string, fuzzy_fields)

--- a/external_search.py
+++ b/external_search.py
@@ -538,7 +538,7 @@ class ExternalSearchIndex(object):
             match_classification_and_rest_of_query = {
                 'bool': {
                     'must': classification_queries,
-                    'boost': 200
+                    'boost': 200.0
                 }
             }
 

--- a/external_search.py
+++ b/external_search.py
@@ -324,9 +324,9 @@ class ExternalSearchIndex(object):
         )
         if fields is not None:
             search_args['fields'] = fields
-        #print "Args looks like: %r" % args
+        print "Args looks like: %r" % search_args
         results = self.search(**search_args)
-        #print "Results: %r" % results
+        print "Results: %r" % results
         return results
 
     def make_query(self, query_string):
@@ -527,7 +527,7 @@ class ExternalSearchIndex(object):
                 # However, it's possible that they're searching for a subject that's not
                 # mentioned in the summary (eg, a person's name in a biography). So title
                 # is a possible match, but is less important than author, subtitle, and summary.
-                match_rest_of_query = make_query_string_query(remaining_string, ["author^4", "subtitle^3", "summary^5", "title^1", "series^1"])
+                match_rest_of_query = make_query_string_query(remaining_string, ["author^3", "subtitle^2", "summary^4", "title^1", "series^1"])
                 classification_queries.append(match_rest_of_query)
             
             # If classification queries and the remaining string all match, the result will
@@ -536,7 +536,7 @@ class ExternalSearchIndex(object):
             match_classification_and_rest_of_query = {
                 'bool': {
                     'must': classification_queries,
-                    'boost': 200.0
+                    'boost': 100
                 }
             }
 

--- a/external_search.py
+++ b/external_search.py
@@ -456,9 +456,9 @@ class ExternalSearchIndex(object):
 
         # An exact title or author match outweighs a match that is split
         # across fields.
-        match_title = make_phrase_query(query_string, ['title.standard'], 200)
+        match_title = make_phrase_query(query_string, ['title.standard'], 100)
         must_match_options.append(match_title)
-        match_author = make_phrase_query(query_string, ['author.standard'], 200)
+        match_author = make_phrase_query(query_string, ['author.standard'], 100)
         must_match_options.append(match_author)
 
         if not fuzzy_blacklist_re.search(query_string):
@@ -535,7 +535,7 @@ class ExternalSearchIndex(object):
                 # However, it's possible that they're searching for a subject that's not
                 # mentioned in the summary (eg, a person's name in a biography). So title
                 # is a possible match, but is less important than author, subtitle, and summary.
-                match_rest_of_query = make_query_string_query(remaining_string, ["author^3", "subtitle^2", "summary^4", "title^1", "series^1"])
+                match_rest_of_query = make_query_string_query(remaining_string, ["author^4", "subtitle^2", "summary^4", "title^1", "series^1"])
                 classification_queries.append(match_rest_of_query)
             
             # If classification queries and the remaining string all match, the result will

--- a/external_search.py
+++ b/external_search.py
@@ -855,8 +855,7 @@ class ExternalSearchIndexVersions(object):
                 "fields": {
                     "minimal": {
                         "type": "string",
-                        "analyzer": "en_minimal_analyzer"},
-                }}
+                        "analyzer": "en_minimal_analyzer"}}}
         )
         mappings = { ExternalSearchIndex.work_document_type : mapping }
 

--- a/external_search.py
+++ b/external_search.py
@@ -453,9 +453,11 @@ class ExternalSearchIndex(object):
         match_phrase = make_phrase_query(query_string, ['title.minimal', 'author', 'series.minimal'])
         must_match_options.append(match_phrase)
 
-        match_title = make_phrase_query(query_string, ['title.minimal'])
+        # An exact title or author match outweighs a match that is split
+        # across fields.
+        match_title = make_phrase_query(query_string, ['title.minimal'], 150)
         must_match_options.append(match_title)
-        match_author = make_phrase_query(query_string, ['author.minimal'])
+        match_author = make_phrase_query(query_string, ['author.minimal'], 150)
         must_match_options.append(match_author)
 
         if not fuzzy_blacklist_re.search(query_string):

--- a/external_search.py
+++ b/external_search.py
@@ -529,7 +529,7 @@ class ExternalSearchIndex(object):
                 # However, it's possible that they're searching for a subject that's not
                 # mentioned in the summary (eg, a person's name in a biography). So title
                 # is a possible match, but is less important than author, subtitle, and summary.
-                match_rest_of_query = make_query_string_query(remaining_string, ["author^4", "subtitle^2", "summary^4", "title^1", "series^1"])
+                match_rest_of_query = make_query_string_query(remaining_string, ["author^4", "subtitle^3", "summary^5", "title^1", "series^1"])
                 classification_queries.append(match_rest_of_query)
             
             # If classification queries and the remaining string all match, the result will

--- a/external_search.py
+++ b/external_search.py
@@ -324,9 +324,10 @@ class ExternalSearchIndex(object):
         )
         if fields is not None:
             search_args['fields'] = fields
-        print "Args looks like: %r" % search_args
+        # search_args['explain'] = True
+        # print "Args looks like: %r" % search_args
         results = self.search(**search_args)
-        print "Results: %r" % results
+        # print "Results: %r" % results
         return results
 
     def make_query(self, query_string):
@@ -455,9 +456,9 @@ class ExternalSearchIndex(object):
 
         # An exact title or author match outweighs a match that is split
         # across fields.
-        match_title = make_phrase_query(query_string, ['title.minimal'], 150)
+        match_title = make_phrase_query(query_string, ['title.standard'], 200)
         must_match_options.append(match_title)
-        match_author = make_phrase_query(query_string, ['author.minimal'], 150)
+        match_author = make_phrase_query(query_string, ['author.standard'], 200)
         must_match_options.append(match_author)
 
         if not fuzzy_blacklist_re.search(query_string):
@@ -802,7 +803,12 @@ class ExternalSearchIndexVersions(object):
                 "fields": {
                     "minimal": {
                         "type": "string",
-                        "analyzer": "en_minimal_analyzer"}}}
+                        "analyzer": "en_minimal_analyzer"},
+                    "standard": {
+                        "type": "string",
+                        "analyzer": "standard"
+                    }
+                }}
         )
         mappings = { ExternalSearchIndex.work_document_type : mapping }
 

--- a/external_search.py
+++ b/external_search.py
@@ -32,7 +32,7 @@ class ExternalSearchIndex(object):
 
     WORKS_INDEX_PREFIX_KEY = u'works_index_prefix'
 
-    DEFAULT_WORKS_INDEX_PREFIX = u'works'
+    DEFAULT_WORKS_INDEX_PREFIX = u'circulation-works'
     
     work_document_type = 'work-type'
     __client = None

--- a/external_search.py
+++ b/external_search.py
@@ -152,35 +152,14 @@ class ExternalSearchIndex(object):
         """Finds or creates the works_index and works_alias based on
         the current configuration.
         """
-
-        # We always know what the name of the alias _should_ be.
-        alias_name = self.works_alias_name(_db)    
-        index_details = self.indices.get_alias(name=alias_name, ignore=[404])
-
-        # But the alias may not exist in Elasticsearch.
-        found = (
-            bool(index_details) and not (
-                index_details.get('status')==404 or 'error' in index_details
-            )
-        )
-
-        def _set_works_index(name):
-            self.works_index = self.__client.works_index = name
-
-        if found:
-            # The alias exists and points to a specific index.  Assume
-            # there is only one such index.
-            _set_works_index(index_details.keys()[0])
-        else:
-            # The alias doesn't point to anything. The index name to
-            # use is the one known to be right for this version.
-            _set_works_index(self.works_index_name(_db))
-
+        # The index name to use is the one known to be right for this
+        # version.
+        self.works_index = self.__client.works_index = self.works_index_name(_db)
         if not self.indices.exists(self.works_index):
-            # The index doesn't actually exist. Set it up.
+            # That index doesn't actually exist. Set it up.
             self.setup_index()
 
-        # Make sure the alias points to the index we're using.
+        # Make sure the alias points to the most recent index.
         self.setup_current_alias(_db)
 
     def setup_current_alias(self, _db):

--- a/migration/20171201-rebuild-search-index.py
+++ b/migration/20171201-rebuild-search-index.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""Running the search index updater script will create the new
+circulation-works-v3 index and change the circulation-works-current
+alias to point to it.
+"""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from scripts import UpdateSearchIndexScript
+UpdateSearchIndexScript().run()

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -843,11 +843,11 @@ class TestExactMatches(ExternalSearchTest):
 
         # TODO: Uncomment these lines and the 'modern romance'
         # test fails for some reason.
-        # self.parent_book = _work(
-        #     title="Our Son Aziz",
-        #     authors=["Fatima Ansari", "Shoukath Ansari"],
-        #     genre="Biography & Memoir",
-        # )
+        self.parent_book = _work(
+             title="Our Son Aziz",
+             authors=["Fatima Ansari", "Shoukath Ansari"],
+             genre="Biography & Memoir",
+        )
 
         self.behind_the_scenes = _work(
             title="The Making of Biography With Peter Graves",
@@ -909,12 +909,25 @@ class TestExactMatches(ExternalSearchTest):
 
         # A full title match takes precedence over a match that's
         # split across genre and subtitle.
-        expect_ids([self.modern_romance, self.ya_romance], "modern romance")
+        expect_ids(
+            [
+                self.modern_romance, # "modern romance" in title
+                self.ya_romance      # "modern" in subtitle, genre "romance"
+            ],
+            "modern romance"
+        )
 
         # A full author match takes precedence over a partial author
-        # match.
-        expect_ids([self.modern_romance, self.book_by_someone_else],
-                   "aziz ansari")
+        # match. A partial author match that matches the entire search
+        # string takes precedence over a partial author match that doesn't.
+        expect_ids(
+            [
+                self.modern_romance,      # "Aziz Ansari" in author
+                self.parent_book,         # "Aziz" in title, "Ansari" in author
+                self.book_by_someone_else # "Ansari" in author
+            ],
+            "aziz ansari"
+        )
 
         # When a string exactly matches both a title and an author,
         # the books that match exactly are promoted.
@@ -928,11 +941,15 @@ class TestExactMatches(ExternalSearchTest):
         # search for 'peter graves biography' than a biography whose
         # title includes the phrase 'peter graves'. Although the title
         # contains all three search terms, it's not an exact token
-        # match. But "The Making of..." still does better than book
-        # that matches the query string against two different fields.
+        # match. But "The Making of..." still does better than
+        # books that match 'peter graves' (or 'peter' and 'graves'),
+        # but not 'biography'.
         expect_ids(
-            [self.biography_of_peter_graves, self.book_by_peter_graves,
-             self.behind_the_scenes, self.book_by_someone_else],
+            [self.biography_of_peter_graves, # title + genre 'biography'
+             self.behind_the_scenes,         # all words match in title
+             self.book_by_peter_graves,      # author (no 'biography')
+             self.book_by_someone_else       # title + author (no 'biography')
+            ],
             "peter graves biography"
         )
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -878,6 +878,8 @@ class TestModernRomance(ExternalSearchTest):
         # split across genre and subtitle.
         expect_ids([self.modern_romance, self.ya_romance], "modern romance")
 
+        expect_ids([self.modern_romance, self.ya_romance], "modern romance")
+
 
 
 class TestSearchQuery(DatabaseTest):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -861,8 +861,6 @@ class TestExactMatches(ExternalSearchTest):
             "Modern Fairytale Series, Book 3"
         )
 
-        # TODO: Uncomment these lines and the 'modern romance'
-        # test fails for some reason.
         self.parent_book = _work(
              title="Our Son Aziz",
              authors=["Fatima Ansari", "Shoukath Ansari"],

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -260,7 +260,7 @@ class TestExternalSearchWithWorks(ExternalSearchTest):
                 audience=Classifier.AUDIENCE_YOUNG_ADULT, genre="Romance"
             )
             self.ya_romance.presentation_edition.subtitle = (
-                "Modern Fairytale Series, Book 7"
+                "Modern Fairytale Series, Volume 7"
             )
             self.ya_romance.set_presentation_ready()
 
@@ -558,9 +558,14 @@ class TestExternalSearchWithWorks(ExternalSearchTest):
 
         results = query("young adult romance", None, None, None, None, None, None, None)
         hits = results["hits"]["hits"]
-        eq_(1, len(hits))
-        eq_(unicode(self.ya_romance.id), hits[0]['_id'])
 
+        # The book with 'Romance' in the title also shows up, but it
+        # shows up after the book whose audience matches 'young adult'
+        # and whose genre matches 'romance'.
+        eq_(
+            map(unicode, [self.ya_romance.id, self.modern_romance.id]),
+            [x['_id'] for x in hits]
+        )
 
         # Matches age + fiction
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -44,7 +44,7 @@ class ExternalSearchTest(DatabaseTest):
             ExternalIntegration.ELASTICSEARCH,
             goal=ExternalIntegration.SEARCH_GOAL,
             url=u'http://localhost:9200',
-            settings={ExternalSearchIndex.WORKS_INDEX_KEY : u'test_index-v0'}
+            settings={ExternalSearchIndex.WORKS_INDEX_PREFIX_KEY : u'test_index'}
         )
 
         try:
@@ -108,7 +108,7 @@ class TestExternalSearch(ExternalSearchTest):
 
         # If -current alias is given but doesn't exist, the appropriate
         # index and alias will be created.
-        self.search.set_works_index_and_alias('banana-current')
+        self.search.set_works_index_and_alias(self._db, 'banana-current')
 
         expected_index = 'banana-' + ExternalSearchIndexVersions.latest()
         eq_(expected_index, self.search.works_index)


### PR DESCRIPTION
This branch adds two new ways a book might show up in search results: its title or one of its authors might be a near-exact match against the search term.

This should resolve the 'modern romance' and 'law of the mountain man' problems described in https://github.com/NYPL-Simplified/server_core/issues/482, where a book whose title includes a genre loses out to books that are in that genre. It may also resolve some of the 'game of thrones' problems described in that issue.

This branch changes the Elasticsearch configuration used by core during Travis runs so that everything runs in a single shard; this eliminates the possibility that search result ordering will be unpredictable because of how documents are assigned to shards.

This branch also changes the way Elasticsearch is configured: instead of separate configuration settings for the alias and the index, a single configuration setting controls the prefix used for both the alias and the index. This means that changing the alias to point to some other index is currently an unsupported operation -- it's supported by the code (transfer_current_alias) but nobody ever calls that method.

This is a good time to make that configuration change because this branch introduces a v3 of the search document, which requires that the entire index be rebuilt anyway. (The migration script should take care of this.)