### PR TITLE
Fix recurring Open Access coverage error

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -548,9 +548,14 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
         source = DataSource.lookup(_db, cls.DATA_SOURCE_NAME)
         if collection and not source:
             # The registration DataSource is based on a given Collection
-            # instead of the class.
+            # instead of the class. This happens on the Metadata Wrangler.
             source = collection.data_source
         operation = cls.OPERATION
+
+        if cls.COVERAGE_COUNTS_FOR_EVERY_COLLECTION:
+            # There's no need for a collection when registering this
+            # Identifier, even if it provided the DataSource.
+            collection = None
 
         was_registered = False
         existing_record = CoverageRecord.lookup(

--- a/model.py
+++ b/model.py
@@ -3936,7 +3936,8 @@ class Work(Base):
                 # This needs to have its own Work--we don't mix
                 # open-access and commercial versions of the same book.
                 pool.work = None
-                pool.presentation_edition.work = None
+                if pool.presentation_edition:
+                    pool.presentation_edition.work = None
                 other_work, is_new = pool.calculate_work()
             elif not pool.presentation_edition:
                 # A LicensePool with no presentation edition

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,13 @@
 feedparser
 pillow
 psycopg2
-requests
-sqlalchemy>=1.0.6
+requests>=2.18.4
+sqlalchemy>=1.1.15
 nose
 lxml
 flask
 isbnlib
-tinys3
+tinys3>=0.1.12
 textblob
 rdflib
 elasticsearch==2.1.0


### PR DESCRIPTION
This is an immediate bandaid to a recurring error in the logs that to the tune of:
```
Persistent failure covering Gutenberg ID/16945 ID=2423511 prim_ed=1027141 ("The White Road to Verdun"): Traceback (most recent call last):
File "/var/lib/app/metadata/core/opds_import.py", line 475, in import_from_feed
    edition, even_if_no_author, immediately_presentation_ready
File "/var/lib/app/metadata/core/opds_import.py", line 535, in update_work_for_edition
    work, is_new_work = pool.calculate_work(even_if_no_author=even_if_no_author)
File "/var/lib/app/metadata/core/model.py", line 7170, in calculate_work
    presentation_edition.medium
File "/var/lib/app/metadata/core/model.py", line 3939, in make_exclusive_open_access_for_permanent_work_id
    pool.presentation_edition.work = None
AttributeError: 'NoneType' object has no attribute 'work'
```

I also upgraded a few packages, which I'll explain more thoroughly in the metadata_wrangler PR. This particular upgrade is more permissive, because it's only used during the Travis CI build. I hope that keeping it regularly updated will help us find upgrade problems before we upgrade in QA or production.

In the future, I'd like to start using a separate requirements.txt file specifically for development and lockdown the production file versions.