### PR TITLE
Seemingly redundant migration script shouldn't crash entire migration process.

### DIFF
--- a/migration/20171004-add-customlists-library-id.sql
+++ b/migration/20171004-add-customlists-library-id.sql
@@ -1,12 +1,21 @@
-alter table customlists add column library_id integer;
+DO $$ 
+    BEGIN
+        BEGIN
+            ALTER TABLE customlists ADD COLUMN library_id integer;
+	    alter table customlists
+	        add constraint customlists_library_id_fkey
+		foreign key (library_id)
+		references libraries(id);
 
-alter table customlists
-    add constraint customlists_library_id_fkey
-    foreign key (library_id)
-    references libraries(id);
+	    create index "ix_customlists_library_id" ON customlists (library_id);
 
-create index "ix_customlists_library_id" ON customlists (library_id);
+	    alter table customlists drop constraint if exists "customlists_data_source_id_name_key";
+	    alter table customlists add constraint "customlists_data_source_id_name_library_id_key" unique (data_source_id, name, library_id);
 
-alter table customlists drop constraint if exists "customlists_data_source_id_name_key";
-alter table customlists add constraint "customlists_data_source_id_name_library_id_key" unique (data_source_id, name, library_id);
+        EXCEPTION
+            WHEN duplicate_column THEN RAISE NOTICE 'WARNING: column library_id already exists in customlists. Verify that 20171004-add-customlists-library-id.sql is redundant.';
+        END;
+    END;
+$$;
+
 

--- a/migration/20171204-set-library-id-for-lists.sql
+++ b/migration/20171204-set-library-id-for-lists.sql
@@ -1,0 +1,5 @@
+-- Associate all customlists with the default library, unless they're
+-- already associated with some other library.
+update customlists set library_id = (
+ select id from libraries where is_default=true limit 1
+) where library_id is null;

--- a/migration/20171204-set-library-id-for-lists.sql
+++ b/migration/20171204-set-library-id-for-lists.sql
@@ -1,5 +1,5 @@
--- Associate all customlists with the default library, unless they're
--- already associated with some other library.
+-- Associate all 'Staff Picks' customlists with the default library,
+-- unless they're already associated with some other library.
 update customlists set library_id = (
  select id from libraries where is_default=true limit 1
-) where library_id is null;
+) where library_id is null and foreign_identifier='Staff Picks';


### PR DESCRIPTION
The migration script `20171004-add-customlists-library-id.sql` seems to have already run, or to not need running, on all extant circulation manager databases, but it's still sometimes run in the migration to 2.2.0.

On the BPL production database (which I haven't migrated yet), the database migration timestamp is "2017-10-04". Is it possible that the migration script was run once on October 4th, but running the migration again now will run it again?

This branch changes the migration script so that if the field it's trying to create already exists, it succeeds with a message to verify that the script has already been run, rather than failing and screwing up the whole migration.

This branch also adds a new migration script which associates any existing 'Staff Picks' lists with the default library unless they're already associated with some other library.