### PR TITLE
Stop situations where we pass a non-integer into random.randint().

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -857,7 +857,7 @@ class WorkList(object):
             quality_coefficient = 0.1
         if quality_coefficient > 1:
             quality_coefficient = 1
-        max_offset = (total_size * quality_coefficient)-target_size
+        max_offset = int((total_size * quality_coefficient)-target_size)
 
         if max_offset > 0:
             # There are enough high-quality items that we can pick a

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1049,6 +1049,12 @@ class TestWorkList(DatabaseTest):
             [set(x) for x in samples]
         )
 
+        # This works even if the quality coefficient appears to limit
+        # selection to a fractional number of works.
+        sample = WorkList.random_sample(qu, 2, quality_coefficient=0.23109)
+        eq_([i1, i2], sorted(sample, key=lambda x: x.id))
+
+
     def test_search_target(self):
         # A WorkList can be searched - it is its own search target.
         wl = WorkList()


### PR DESCRIPTION
In circulation, the old code caused an exception when generating a feed from a query where the total number of results wasn't an even multiple of the quality coefficient.