### PR TITLE
Replace `apply_bibliographic_filter` with `bibliographic_filter_clause`

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -685,7 +685,7 @@ class WorkList(object):
         )
         if self.genre_ids:
             mw = MaterializedWorkWithGenre
-            # apply_bibliographic_filters() will apply the genre
+            # apply_filters() will apply the genre
             # restrictions.
         else:
             mw = MaterializedWork

--- a/lane.py
+++ b/lane.py
@@ -762,7 +762,7 @@ class WorkList(object):
             # bibliographic_filter_clause() may return a null query to
             # indicate that the WorkList should not exist at all.
             return None
-        if bibliographic_clause:
+        if bibliographic_clause is not None:
             qu = qu.filter(bibliographic_clause)
 
         if facets:

--- a/lane.py
+++ b/lane.py
@@ -759,7 +759,7 @@ class WorkList(object):
             _db, qu, work_model, featured
         )
         if not qu:
-            # apply_bibliographic_filters() may return a null query to
+            # bibliographic_filter_clause() may return a null query to
             # indicate that the WorkList should not exist at all.
             return None
         if bibliographic_clause:

--- a/lane.py
+++ b/lane.py
@@ -1520,7 +1520,8 @@ class Lane(Base, WorkList):
 
         # Actually build the restriction clauses.
         clauses = []
-        clauses.append(a_list.data_source==self.list_datasource)
+        if self.list_datasource:
+            clauses.append(a_list.data_source==self.list_datasource)
         customlist_ids = [x.id for x in self.customlists]
         if customlist_ids:
             clauses.append(a_list.id.in_(customlist_ids))

--- a/lane.py
+++ b/lane.py
@@ -747,8 +747,7 @@ class WorkList(object):
                       featured=False):
         """Apply common WorkList filters to a query. Also apply
         subclass-specific filters by calling
-        apply_bibliographic_filters(), which will call the
-        apply_custom_filters() hook method.
+        apply_bibliographic_filters().
         """
         # In general, we only show books that are ready to be delivered
         # to patrons.
@@ -801,14 +800,6 @@ class WorkList(object):
         if self.genre_ids:
             clauses.append(work_model.genre_id.in_(self.genre_ids))
         return qu, and_(*clauses), False
-
-    def apply_audience_filter(self, _db, qu, work_model):
-        """Make sure that only Works classified under this lane's
-        allowed audiences are returned.
-
-        This method should not be necessary anymore.
-        """
-        return qu.filter(and_(*self.audience_filter_clauses(_db, qu, work_model)))
 
     def audience_filter_clauses(self, _db, qu, work_model):
         if not self.audiences:

--- a/lane.py
+++ b/lane.py
@@ -1417,11 +1417,14 @@ class Lane(Base, WorkList):
         `distinct` is whether or not the query needs to be set as
         DISTINCT.
         """
-        clauses, superclass_distinct = super(
+        qu, superclass_clause, superclass_distinct = super(
             Lane, self
         ).bibliographic_filter_clause(
             _db, qu, work_model, featured
         )
+        clauses = []
+        if superclass_clause is not None:
+            clauses.append(superclass_clause)
         if self.parent and self.inherit_parent_restrictions:
             # In addition to the other restrictions imposed by this
             # Lane, books will show up here only if they would
@@ -1429,7 +1432,7 @@ class Lane(Base, WorkList):
             qu, clause, parent_distinct = self.parent.bibliographic_filter_clause(
                 _db, qu, work_model, featured
             )
-            if clause:
+            if clause is not None:
                 clauses.append(clause)
         else:
             parent_distinct = False
@@ -1446,13 +1449,13 @@ class Lane(Base, WorkList):
             clauses.append(work_model.medium.in_(self.media))
 
         clauses.extend(self.age_range_filter_clauses(work_model))
-        qu, customlist_clauses = self.customlist_filter_clauses(
+        qu, customlist_clauses, customlist_distinct = self.customlist_filter_clauses(
             qu, work_model, featured
         )
         clauses.extend(customlist_clauses)
         
         return qu, and_(*clauses), (
-            superclass_distinct or parent_distinct or child_distinct
+            superclass_distinct or parent_distinct or customlist_distinct
         )
 
     def age_range_filter_clauses(self, work_model):

--- a/lane.py
+++ b/lane.py
@@ -776,6 +776,17 @@ class WorkList(object):
             qu = pagination.apply(qu)
         return qu
 
+    def apply_bibliographic_filters(self, _db, qu, work_model, featured=False):
+        """Apply filters to a base query against a materialized view,
+        yielding a query that only finds books in this WorkList.
+
+        :param work_model: Either MaterializedWork or MaterializedWorkWithGenre
+        """
+        qu, filter_by, distinct = self.bibliographic_filter_clause(
+            _db, qu, work_model, featured
+        )
+        return qu.filter(filter_by), distinct
+
     def bibliographic_filter_clause(self, _db, qu, work_model, featured=False):
         """Filter out books whose bibliographic metadata doesn't match
         what we're looking for.
@@ -784,6 +795,7 @@ class WorkList(object):
         # WorkLists. (So are genre and collection restrictions, but those
         # were applied back in works().)
 
+        set_trace()
         clauses = self.audience_filter_clauses(_db, qu, work_model)
         if self.languages:
             clauses.append(work_model.language.in_(self.languages))
@@ -1385,17 +1397,6 @@ class Lane(Base, WorkList):
             return super(Lane, self).search(_db, query, search_client, pagination)
         else:
             return target.search(_db, query, search_client, pagination)
-
-    def apply_bibliographic_filters(self, _db, qu, work_model, featured=False):
-        """Apply filters to a base query against a materialized view,
-        yielding a query that only finds books in this Lane.
-
-        :param work_model: Either MaterializedWork or MaterializedWorkWithGenre
-        """
-        qu, filter_by, distinct = self.bibliographic_filter_clause(
-            qu, work_model, featured
-        )
-        return qu.filter(filter_by), distinct
 
     def bibliographic_filter_clause(self, _db, qu, work_model, featured):
         """Create an AND clause that restricts a query to find

--- a/lane.py
+++ b/lane.py
@@ -781,8 +781,10 @@ class WorkList(object):
         """Create a SQLAlchemy filter that excludes books whose bibliographic
         metadata doesn't match what we're looking for.
 
-        :return: None if there are no particular additional filters to
-        be added; otherwise a SQLAlchemy filter.
+        :return: A 3-tuple (query, clause, distinct).
+
+        - query is either `qu`, or a new query that has been modified to
+        join against additional tables.
         """
         # Audience and language restrictions are common to all
         # WorkLists. (So are genre and collection restrictions, but those
@@ -1424,9 +1426,11 @@ class Lane(Base, WorkList):
             # In addition to the other restrictions imposed by this
             # Lane, books will show up here only if they would
             # also show up in the parent Lane.
-            qu, parent_distinct = self.parent.bibliographic_filter_clause(
+            qu, clause, parent_distinct = self.parent.bibliographic_filter_clause(
                 _db, qu, work_model, featured
             )
+            if clause:
+                clauses.append(clause)
         else:
             parent_distinct = False
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -841,7 +841,7 @@ class TestWorkList(DatabaseTest):
             believes the WorkList should not exist at all.
             """
 
-            def apply_bibliographic_filters(
+            def bibliographic__bibliographic_filters(
                     self, _db, query, work_model, featured
             ):
                 return None, False
@@ -865,9 +865,9 @@ class TestWorkList(DatabaseTest):
                 self.genre_ids = genre_ids
                 self.media = media
 
-            def apply_audience_filter(self, _db, qu, work_model):
+            def audience_filter_clauses(self, _db, qu, work_model):
                 called['apply_audience_filter'] = True
-                return qu
+                return []
 
             def apply_custom_filters(self, _db, qu, work_model, featured):
                 called['apply_custom_filters'] = True

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -840,14 +840,14 @@ class TestWorkList(DatabaseTest):
 
     def test_apply_bibliographic_filters_short_circuits_apply_filters(self):
         class MockWorkList(WorkList):
-            """Mock WorkList whose apply_bibliographic_filters implementation
+            """Mock WorkList whose bibliographic_filter_clause implementation
             believes the WorkList should not exist at all.
             """
 
-            def bibliographic__bibliographic_filters(
+            def bibliographic_filter_clause(
                     self, _db, query, work_model, featured
             ):
-                return None, False
+                return None, None, False
 
         wl = MockWorkList()
         wl.initialize(self._default_library)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1579,12 +1579,15 @@ class TestLane(DatabaseTest):
             """
             qu = self._db.query(Work)
             clauses = lane.age_range_filter_clauses(Work)
-            qu.filter(and_(*clauses))
+            if clauses:
+                qu = qu.filter(and_(*clauses))
             return qu.all()
 
-        adult = self._work(audience=Classifier.AUDIENCE_ADULT)
+        adult = self._work(title="For adults", 
+                           audience=Classifier.AUDIENCE_ADULT)
         eq_(None, adult.target_age)
         fourteen_or_fifteen = self._work(
+            title="For teens",
             audience=Classifier.AUDIENCE_YOUNG_ADULT
         )
         fourteen_or_fifteen.target_age = tuple_to_numericrange((14,15))
@@ -1604,7 +1607,7 @@ class TestLane(DatabaseTest):
         # Expand it to include books for adults, and the adult book
         # shows up despite having no target age at all.
         older_ya.target_age = (16,18)
-        eq_([adult], filtered(older_ya_q))
+        eq_([adult], filtered(older_ya))
 
     def test_apply_customlist_filter(self):
         """Standalone test of apply_age_range_filter.

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1610,16 +1610,20 @@ class TestLane(DatabaseTest):
         eq_([adult], filtered(older_ya))
 
     def test_apply_customlist_filter(self):
-        """Standalone test of apply_age_range_filter.
+        """Standalone test of apply_customlist_filter.
         
         Some of this code is also tested by test_apply_custom_filters.
         """
-        qu = self._db.query(Work)
+
+        def filtered(lane):
+            qu = self._db.query(Work)
+            qu = qu.filter(lane.customlist_filter_clauses(qu, Work))
+            return qu.all()
 
         # If the lane has nothing to do with CustomLists,
         # apply_customlist_filter does nothing.
         no_lists = self._lane()
-        eq_((qu, False), no_lists.apply_customlist_filter(qu, Work))
+        eq_([], no_lists.customlist_filter_clauses(qu, Work))
 
         # Set up a Work and a CustomList that contains the work.
         work = self._work(with_license_pool=True)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -788,7 +788,7 @@ class TestWorkList(DatabaseTest):
                 called['only_show_ready_deliverable_works'] = True
                 return query
 
-            def apply_bibliographic_filters(
+            def bibliographic_filter_clause(
                     self, _db, query, work_model, featured
             ):
                 called['apply_bibliographic_filters'] = True

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -905,6 +905,9 @@ class TestWorkList(DatabaseTest):
         def worklist_has_books(
                 expect_books, **worklist_constructor_args
         ):
+            """Apply bibliographic filters to a query and verify
+            that it finds only the given books.
+            """
             worklist = MockWorkList(**worklist_constructor_args)
             qu, clause, distinct = worklist.bibliographic_filter_clause(
                 self._db, original_qu, wg, False

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1546,7 +1546,7 @@ class TestLane(DatabaseTest):
         best_sellers_lane.fiction = True
         match_works(best_selling_classics, [childrens_fiction])       
 
-    def test_apply_custom_filters_medium_restriction(self):
+    def test_bibliographic_filter_clause_medium_restriction(self):
         """We have to test the medium query specially in a kind of hacky way,
         since currently the materialized view only includes ebooks.
         """
@@ -1557,7 +1557,7 @@ class TestLane(DatabaseTest):
         # This lane only includes ebooks, and it's empty.
         lane.media = [Edition.BOOK_MEDIUM]
         qu = self._db.query(Work).join(Work.license_pools).join(Work.presentation_edition)
-        qu, distinct = lane.apply_bibliographic_filters(
+        qu, bib_filter, distinct = lane.bibliographic_filter_clause(
             self._db, qu, Edition, False
         )
         eq_([], qu.all())

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -869,11 +869,6 @@ class TestWorkList(DatabaseTest):
                 called['apply_audience_filter'] = True
                 return []
 
-            def apply_custom_filters(self, _db, qu, work_model, featured):
-                called['apply_custom_filters'] = True
-                called['apply_custom_filters.featured'] = featured
-                return qu, featured
-
         wl = MockWorkList()
         from model import MaterializedWorkWithGenre as wg
         original_qu = self._db.query(wg)


### PR DESCRIPTION
Currently we have a method called apply_bibliographic_filter which takes a Query object and modifies it so that it only finds books in a given lane.

This branch replaces that method with `bibliographic_filter_clause`, which returns a boolean clause that can be applied to a Query object. The `apply_filters` method works as it does before, so there shouldn't be any changes necessary outside of the `Lane` class.

This branch is a waystation on the way to a future branch that uses these boolean clause in CASE statements to pull a random sample of featured works from many lanes at once, rather than using them in a WHERE clause to find the works in a single lane.

There's no rush on reviewing this PR; it can wait until after the 2.1.0 release.