### PR TITLE
Cache lane sizes

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -1254,6 +1254,10 @@ class Lane(Base, WorkList):
             return True
         return False        
 
+    def update_size(self, _db):
+        """Update the stored estimate of the number of Works in this Lane."""
+        self.size = fast_query_count(self.works(_db).limit(None))
+
     @property
     def genre_ids(self):
         """Find the database ID of every Genre such that a Work classified in

--- a/lane.py
+++ b/lane.py
@@ -577,11 +577,17 @@ class WorkList(object):
 
     @property
     def full_identifier(self):
-        """A human-readable identifier for this Lane that
+        """A human-readable identifier for this WorkList that
         captures its position within the heirarchy.
         """
-        full_parentage = list(self.parentage) + [self]
-        return " / ".join([x.display_name for x in full_parentage])
+        lane_parentage = list(self.parentage) + [self]
+        full_parentage = [x.display_name for x in lane_parentage]
+        if getattr(self, 'library', None):
+            # This WorkList is associated with a specific library.
+            # incorporate the library's name to distinguish between it
+            # and other lanes in the same position in another library.
+            full_parentage.insert(0, self.library.short_name)
+        return " / ".join(full_parentage)
 
     @property
     def language_key(self):

--- a/lane.py
+++ b/lane.py
@@ -1004,6 +1004,10 @@ class Lane(Base, WorkList):
                        nullable=True)
     priority = Column(Integer, index=True, nullable=False, default=0)
 
+    # How many titles are in this lane? This is periodically
+    # calculated and cached.
+    size = Column(Integer, nullable=False, default=0)
+
     # A lane may have one parent lane and many sublanes.
     sublanes = relationship(
         "Lane", 

--- a/migration/20171208-add-lane-size.sql
+++ b/migration/20171208-add-lane-size.sql
@@ -1,0 +1,1 @@
+alter table lanes add column size integer not null default 0;

--- a/model.py
+++ b/model.py
@@ -115,6 +115,7 @@ from classifier import (
 from facets import FacetConstants
 from user_profile import ProfileStorage
 from util import (
+    fast_query_count,
     LanguageCodes,
     MetadataSimilarity,
     TitleProcessor,
@@ -428,6 +429,11 @@ class SessionManager(object):
         for view_name in self.MATERIALIZED_VIEWS.keys():
             _db.execute("refresh materialized view %s;" % view_name)
             _db.commit()
+        # Immediately update the number of works associated with each
+        # lane.
+        from lane import Lane
+        for lane in _db.query(Lane):
+            lane.size = fast_query_count(lane.works(_db))
 
     @classmethod
     def session(cls, url, initialize_data=True):

--- a/model.py
+++ b/model.py
@@ -433,7 +433,7 @@ class SessionManager(object):
         # lane.
         from lane import Lane
         for lane in _db.query(Lane):
-            lane.size = fast_query_count(lane.works(_db))
+            lane.update_size(_db)
 
     @classmethod
     def session(cls, url, initialize_data=True):

--- a/scripts.py
+++ b/scripts.py
@@ -720,14 +720,6 @@ class RunCoverageProviderScript(IdentifierInputScript):
             self.provider.run()
 
 
-class LaneSizeScript(LaneSweeperScript):
-    """Update the in-database cache explaining how many titles are
-    in each lane."""
-    
-    def process_lane(self, lane):
-        lane.size = lane.works(self._db).count()
-
-
 class BibliographicRefreshScript(RunCollectionCoverageProviderScript, IdentifierInputScript):
     """Refresh the core bibliographic data for Editions direct from the
     license source.

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1137,10 +1137,16 @@ class TestLane(DatabaseTest):
         # this.
         eq_([], list(lane.parentage))
         eq_([lane], list(child_lane.parentage))
-        eq_(lane.display_name, lane.full_identifier)
+        eq_("%s / %s" % (lane.library.short_name, lane.display_name),
+            lane.full_identifier)
 
-        eq_("%s / %s" % (lane.display_name, child_lane.display_name), 
-            child_lane.full_identifier)
+        eq_(
+            "%s / %s / %s" % (
+                lane.library.short_name, lane.display_name, 
+                child_lane.display_name
+            ), 
+            child_lane.full_identifier
+        )
 
         # TODO: The error should be raised when we try to set the parent
         # to an illegal value, not afterwards.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -483,6 +483,7 @@ class TestLaneSweeperScript(DatabaseTest):
         # returned True.
         eq_([good, good_child], script.processed)
 
+
 class TestRunCoverageProviderScript(DatabaseTest):
 
     def test_parse_command_line(self):
@@ -555,6 +556,27 @@ class TestWorkProcessingScript(DatabaseTest):
             self._db, Identifier.URI, [], DataSource.STANDARD_EBOOKS
         )
         eq_([standard_ebooks], one_standard_ebook.all())
+
+
+class TestLaneSizeScript(DatabaseTest):
+
+    def test_do_run(self):
+
+        work = self._work(fiction=True, with_license_pool=True)
+        self.add_to_materialized_view([work])
+        fiction = self._lane(display_name="Fiction", fiction=True)
+        nonfiction = self._lane(display_name="Nonfiction", fiction=False)
+
+        # Set inaccurate counts.
+        fiction.size = 100
+        nonfiction.size = 100
+
+        script = LaneSizeScript(self._db)
+        script.do_run(cmd_args=[])
+
+        # Both lanes have had .size set to the correct value.
+        eq_(1, fiction.size)
+        eq_(0, nonfiction.size)
 
 
 class TestTimestampInfo(DatabaseTest):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -60,6 +60,8 @@ from scripts import (
     Explain,
     IdentifierInputScript,
     FixInvisibleWorksScript,
+    LaneSizeScript,
+    LaneSweeperScript,
     LibraryInputScript,
     ListCollectionMetadataIdentifiersScript,
     MockStdin,
@@ -448,6 +450,38 @@ class TestLibraryInputScript(DatabaseTest):
         eq_(True, l1.processed)
         eq_(False, l2.processed)
 
+
+class TestLaneSweeperScript(DatabaseTest):
+
+    def test_process_library(self):
+
+        class Mock(LaneSweeperScript):
+            def __init__(self, _db):
+                super(Mock, self).__init__(_db)
+                self.considered = []
+                self.processed = []
+
+            def should_process_lane(self, lane):
+                self.considered.append(lane)
+                return lane.display_name == 'process me'
+
+            def process_lane(self, lane):
+                self.processed.append(lane)
+
+        good = self._lane(display_name="process me")
+        bad = self._lane(display_name="don't process me")
+        good_child = self._lane(display_name="process me", parent=bad)
+
+        script = Mock(self._db)
+        script.do_run(cmd_args=[])
+
+        # Every lane was considered for processing, with top-level
+        # lanes considered first.
+        eq_([good, bad, good_child], script.considered)
+
+        # But a lane was processed only if should_process_lane
+        # returned True.
+        eq_([good, good_child], script.processed)
 
 class TestRunCoverageProviderScript(DatabaseTest):
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -60,7 +60,6 @@ from scripts import (
     Explain,
     IdentifierInputScript,
     FixInvisibleWorksScript,
-    LaneSizeScript,
     LaneSweeperScript,
     LibraryInputScript,
     ListCollectionMetadataIdentifiersScript,
@@ -556,27 +555,6 @@ class TestWorkProcessingScript(DatabaseTest):
             self._db, Identifier.URI, [], DataSource.STANDARD_EBOOKS
         )
         eq_([standard_ebooks], one_standard_ebook.all())
-
-
-class TestLaneSizeScript(DatabaseTest):
-
-    def test_do_run(self):
-
-        work = self._work(fiction=True, with_license_pool=True)
-        self.add_to_materialized_view([work])
-        fiction = self._lane(display_name="Fiction", fiction=True)
-        nonfiction = self._lane(display_name="Nonfiction", fiction=False)
-
-        # Set inaccurate counts.
-        fiction.size = 100
-        nonfiction.size = 100
-
-        script = LaneSizeScript(self._db)
-        script.do_run(cmd_args=[])
-
-        # Both lanes have had .size set to the correct value.
-        eq_(1, fiction.size)
-        eq_(0, nonfiction.size)
 
 
 class TestTimestampInfo(DatabaseTest):

--- a/tests/test_util_opds_writer.py
+++ b/tests/test_util_opds_writer.py
@@ -5,6 +5,7 @@ from nose.tools import (
 )
 from lxml import etree
 from util.opds_writer import (
+    AtomFeed,
     OPDSMessage
 )
 
@@ -41,3 +42,13 @@ class TestOPDSMessage(object):
         assert '<simplified:status_code>200</simplified:status_code>' in text
         assert '<schema:description>message</schema:description>' in text
         assert text.endswith('</simplified:message>')
+
+
+class TestAtomFeed(object):
+
+    def test_add_link_to_entry(self):
+        kwargs = dict(title=1, href="url", extra="extra info")
+        entry = AtomFeed.E.entry()
+        link_child = AtomFeed.E.link_child()
+        AtomFeed.add_link_to_entry(entry, [link_child], **kwargs)
+        assert '<link extra="extra info" href="url" title="1"><link_child/></link>' in etree.tostring(entry)

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -56,12 +56,12 @@ class AtomFeed(object):
 
     @classmethod
     def add_link_to_entry(cls, entry, children=None, **kwargs):
+        kwargs = dict([unicode(x), unicode(y)] for x, y in kwargs.items())
         link = cls.E.link(**kwargs)
         entry.append(link)
         if children:
             for i in children:
                 link.append(i)
-
 
     @classmethod
     def author(cls, *args, **kwargs):

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -56,7 +56,8 @@ class AtomFeed(object):
 
     @classmethod
     def add_link_to_entry(cls, entry, children=None, **kwargs):
-        kwargs = dict([unicode(x), unicode(y)] for x, y in kwargs.items())
+        if 'title' in kwargs:
+            kwargs['title'] = unicode(kwargs['title'])
         link = cls.E.link(**kwargs)
         entry.append(link)
         if children:


### PR DESCRIPTION
This branch creates a new field, `Lane.size`, which contains the pre-calculated number of works that show up in a lane. This number is updated whenever the materialized views are refreshed.