### PR TITLE
Worklist featured feed

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -1047,18 +1047,18 @@ class WorkList(object):
                     break
         used_in_parent = set()
         for lane in relevant_lanes:
-            if not lane in queryable_lane_set:
+            if lane in queryable_lane_set:
+                # We found results for this lane through the main query.
+                # Yield those results.
+                for mw in by_lane_id.get(lane.id, []):
+                    yield (mw, lane)
+            else:
                 # We didn't try to use the main query to find results
                 # for this lane because we knew the results, if there
                 # were any, wouldn't be representative. Do a whole
                 # separate query and plug it in at this point.
                 for x in lane.groups(_db, include_sublanes=False):
                     yield x
-                
-            # We found results for this lane through the main query.
-            # Yield those results.
-            for mw in by_lane_id.get(lane.id, []):
-                yield (mw, lane)
 
         if parent_lane:
             # To fill up the parent lane, we may need to use some of the

--- a/scripts.py
+++ b/scripts.py
@@ -1649,7 +1649,7 @@ class RefreshMaterializedViewsScript(Script):
             concurrently = 'CONCURRENTLY'
         # Initialize database
         db = self._db
-        for view_name in self.MATERIALIZED_VIEWS.keys():
+        for view_name in SessionManager.MATERIALIZED_VIEWS.keys():
             a = time.time()
             db.execute("REFRESH MATERIALIZED VIEW %s %s" % (concurrently, view_name))
             b = time.time()
@@ -1658,6 +1658,7 @@ class RefreshMaterializedViewsScript(Script):
         # Recalculate the sizes of lanes.
         for lane in db.query(Lane):
             lane.update_size(db)
+            print "Size of %s: %s" % (lane.full_identifier, lane.size)
 
         # Close out this session because we're about to create another one.
         db.commit()

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -447,8 +447,8 @@ class TestFeaturedFacets(DatabaseTest):
         base_query = self._db.query(work_model).join(work_model.license_pool)
 
         def expect(works, qu):
-            expect_ids = [x.works_id for x in qu]
-            actual_ids = [x.id for x in works]
+            expect_ids = [x.id for x in works]
+            actual_ids = [x.works_id for x in qu]
             eq_(expect_ids, actual_ids)
 
         # Higher-tier works show up before lower-tier works.
@@ -476,12 +476,6 @@ class TestFeaturedFacets(DatabaseTest):
         eq_(False, base_query._distinct)
         distinct_query = facets.apply(self._db, base_query, True)
         eq_([work_model.works_id], distinct_query._distinct)
-
-#        # Passing in distinct=True makes the query distinct on
-#        # three different fields.
-#        eq_(False, base_query._distinct)
-#        distinct_query = facets.apply(self._db, base_query, Work, True)
-#        eq_(3, len(distinct_query._distinct))
 
 
 class TestPagination(DatabaseTest):

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -529,7 +529,7 @@ class MockFeaturedWorks(object):
         """Set the next return value for featured_works()."""
         self._featured_works.append(works)
 
-    def featured_works(self, *args, **kwargs):
+    def groups(self, *args, **kwargs):
         try:
             return self._featured_works.pop(0)
         except IndexError:
@@ -1896,7 +1896,10 @@ class TestLaneGroups(DatabaseTest):
                 (x[0].sort_title, x[1].display_name) for x in results
             ]
             for i, expect_item in enumerate(expect):
-                actual_item = actual[i]
+                if i >= len(actual):
+                    actual_item = None
+                else:
+                    actual_item = actual[i]
                 eq_(
                     expect_item, actual_item,
                     "Mismatch in position %d: Expected %r, got %r.\nOverall, expected:\n%r\nGot:\n%r:" %

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -531,9 +531,10 @@ class MockFeaturedWorks(object):
 
     def groups(self, *args, **kwargs):
         try:
-            return self._featured_works.pop(0)
+            for work in self._featured_works.pop(0):
+                yield work, self
         except IndexError:
-            return []
+            return
 
 class MockWork(object):
     """Acts as a Work or a MaterializedWorkWithGenre interchangeably."""

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -2115,18 +2115,18 @@ class TestWorkListGroups(DatabaseTest):
     def test_featured_window(self):
         lane = self._lane()
 
-        # If the lane has fewer than 100 items, the 'window'
-        # spans the entire range from zero to one.
+        # Unless the lane has more items than we are asking for, the
+        # 'window' spans the entire range from zero to one.
         eq_((0,1), lane.featured_window(1))
         lane.size = 99
-        eq_((0,1), lane.featured_window(1))
+        eq_((0,1), lane.featured_window(99))
 
         # Otherwise, the 'window' is a smaller, randomly selected range
         # between zero and one.
         lane.size = 6094
         start, end = lane.featured_window(17)
-        start = 0.63050798
-        eq_(start, round(start, 8))
+        expect_start = 0.0246619
+        eq_(expect_start, round(start, 8))
         eq_(round(start+0.013948146,8), round(end, 8))
 
         # Given a lane with 6094 works, selecting works with .random


### PR DESCRIPTION
This branch moves functionality from `Lane.groups()` to `WorkList.groups()` so that the top level of the site (a WorkList that has a bunch of Lanes underneath it) can request a grouped feed using a single query. Without this code, only a Lane can request a grouped feed using a single query.

Most of the changes in here are caused by moving code from Lane to WorkList.

After getting this code to work I was able to confirm my fears about the chances that the single query might not pick up enough works to fill the entire lane. It's pretty likely that this will happen. I'm going to investigate going back to multiple queries, or many subqueries with a UNION clause, but I'd like to do that using this branch as a base rather than starting again from master. I think most of the code in this branch will still be useful, it just needs to be moved around a bit and it won't be quite as fast.