### PR TITLE
Build the featured feed by running a lot of really fast queries, rather than one really fast query that doesn't always get enough results

### DIFF
--- a/files/materialized_view_for_lanes.sql
+++ b/files/materialized_view_for_lanes.sql
@@ -53,6 +53,8 @@ create unique index mv_works_for_lanes_work_id_genre_id on mv_works_for_lanes (w
 
 create index mv_works_for_lanes_by_availability on mv_works_for_lanes (availability_time DESC, sort_author, sort_title, works_id);
 
+create index mv_works_for_lanes_by_random_and_genre on mv_works_for_lanes (random, genre_id);
+
 -- Similarly, an index on everything, sorted by descending update time.
 
 create index mv_works_for_lanes_by_modification on mv_works_for_lanes (last_update_time DESC, sort_author, sort_title, works_id);

--- a/files/materialized_view_for_lanes.sql
+++ b/files/materialized_view_for_lanes.sql
@@ -53,7 +53,15 @@ create unique index mv_works_for_lanes_work_id_genre_id on mv_works_for_lanes (w
 
 create index mv_works_for_lanes_by_availability on mv_works_for_lanes (availability_time DESC, sort_author, sort_title, works_id);
 
-create index mv_works_for_lanes_by_random_and_genre on mv_works_for_lanes (random, genre_id);
+-- Create indexes that are helpful in running the query to find featured works.
+
+create index mv_works_for_lanes_by_random_and_genre on mv_works_for_lanes (random, language, genre_id);
+
+-- Not sure we need these two.
+
+-- create index mv_works_for_lanes_by_random_and_audience on mv_works_for_lanes (random, language, audience, target_age);
+
+-- create index mv_works_for_lanes_by_random_and_fiction on mv_works_for_lanes (random, language, fiction);
 
 -- Similarly, an index on everything, sorted by descending update time.
 

--- a/lane.py
+++ b/lane.py
@@ -339,10 +339,10 @@ class FeaturedFacets(object):
     def apply(self, _db, qu, distinct):
         """Order a query by quality tier, and then randomly.
 
-        This isn't usually necessary because _groups_query orders
-        items by quality tier, then lane ID, then randomly, but
-        if you want to call apply() on a query to get a featured
-        subset of that query, this will work.
+        This isn't usually necessary because works_in_window orders
+        items by quality tier, then randomly, but if you want to call
+        apply() on a query to get a featured subset of that query,
+        this will work.
         """
         from model import MaterializedWorkWithGenre as work_model
         quality = self.quality_tier_field()
@@ -995,7 +995,9 @@ class WorkList(object):
 
         queryable_lane_set = set(queryable_lanes)
 
-        work_quality_tier_lane = list(self._groups_query(_db, queryable_lanes))
+        work_quality_tier_lane = list(
+            self._featured_works_with_lanes(_db, queryable_lanes)
+        )
 
         def _done_with_lane(lane):
             """Called when we're done with a Lane, either because
@@ -1056,12 +1058,13 @@ class WorkList(object):
                 for x in lane.groups(_db, include_sublanes=False):
                     yield x
 
-    def _groups_query(self, _db, lanes):
-        """Create a query that pulls MaterializedWorkWithGenre
-        objects, plus additional lane classification information.
+    def _featured_works_with_lanes(self, _db, lanes):
+        """Find a sequence of works that can be used to 
+        populate this lane's grouped acquisition feed.
 
         :param lanes: Classify MaterializedWorkWithGenre objects
-        as belonging to one of these lanes.
+        as belonging to one of these lanes (presumably sublanes
+        of `self`).
 
         :yield: A sequence of (MaterializedWorkWithGenre,
         quality_tier, Lane) 3-tuples.

--- a/lane.py
+++ b/lane.py
@@ -1076,13 +1076,11 @@ class WorkList(object):
         library = self.get_library(_db)
         target_size = library.featured_lane_size
 
-        # Start with a basic works query.
         facets = FeaturedFacets(
             library.minimum_featured_quality,
             self.uses_customlists
         )
-        first_query = None
-        other_queries = []
+        # Pull a window of works for every lane we were given.
         for lane in lanes:
             for mw, quality_tier in lane.works_in_window(
                     _db, facets, target_size

--- a/lane.py
+++ b/lane.py
@@ -346,9 +346,9 @@ class FeaturedFacets(object):
         """
         from model import MaterializedWorkWithGenre as work_model
         quality = self.quality_tier_field()
-        #qu = qu.order_by(
-        #    quality.desc(), work_model.random.desc()
-        #)
+        qu = qu.order_by(
+            quality.desc(), work_model.random.desc()
+        )
         if distinct:
             qu = qu.distinct(work_model.works_id)
         return qu

--- a/lane.py
+++ b/lane.py
@@ -1100,7 +1100,7 @@ class WorkList(object):
             lane_query = lane._restrict_query_to_window(lane_query, target_size)
 
             lane_query = lane_query.order_by(
-                "quality_tier", "lane_id", work_model.random.desc()
+                "quality_tier desc", "lane_id", work_model.random.desc()
             )
 
             # Get slightly more items than we need, to reduce the risk

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -30,6 +30,7 @@ from lane import (
 )
 
 from model import (
+    get_one_or_create,
     tuple_to_numericrange,
     CustomListEntry,
     DataSource,
@@ -40,6 +41,7 @@ from model import (
     LicensePool,
     SessionManager,
     Work,
+    WorkGenre,
 )
 
 class TestFacets(DatabaseTest):
@@ -1821,6 +1823,14 @@ class TestWorkListGroups(DatabaseTest):
         lq_litfic.quality = 0
         hq_sf = _w(title="HQ SF", genre="Science Fiction", fiction=True)
         hq_sf.random = 0.25
+
+        # Add a lot of irrelevant genres to one of the works. This
+        # will clutter up the materialized view, but it won't affect
+        # the results.
+        for genre in ['Westerns', 'Horror', 'Erotica']:
+            genre_obj, is_new = Genre.lookup(self._db, genre)
+            get_one_or_create(self._db, WorkGenre, work=hq_sf, genre=genre_obj)
+
         hq_sf.quality = 0.8
         mq_sf = _w(title="MQ SF", genre="Science Fiction", fiction=True)
         mq_sf.quality = 0.6

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -2046,11 +2046,11 @@ class TestWorkListGroups(DatabaseTest):
         )
 
     def test_groups_query(self):
-        # Most of the _groups_query() code is tested on a lower level,
-        # with tests of its helper methods, or at a higher level, in
-        # test_groups(). This test verifies some features of the query
-        # returned by _groups_query() that are installed by the
-        # _groups_query() method itself.
+        """_groups_query used to return a complex query -- now it
+        runs some queries and aggregates the results into a list.
+
+        TODO: This needs work before landing.
+        """
         lane = self._lane(fiction=True)
         sublane = self._lane(parent=lane, fiction=False)
 
@@ -2058,19 +2058,8 @@ class TestWorkListGroups(DatabaseTest):
 
         # Generate the query.
         qu = lane._groups_query(self._db, relevant_lanes)
-
-        # A 'lane_id' field was added to the query
-        [lane_id] = [x for x in qu.column_descriptions if x['name'] == 'lane_id']
-        # The lane field is a CASE statement with one clause for each lane.
-        # The details of this are tested in test_add_lane_id_field.
-        element = lane_id['expr'].element
-        isinstance(element, Case)
-        eq_(2, len(element.whens))
-
-        # The LIMIT is set to get enough entries to supply every lane
-        # five times over.
-        eq_(qu._limit,
-            self._default_library.featured_lane_size * len(relevant_lanes) * 5)
+        
+        assert isinstance(qu, list)
 
     def test_add_lane_id_field(self):
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -2056,8 +2056,8 @@ class TestWorkListGroups(DatabaseTest):
             ]
         )
 
-    def test_groups_query(self):
-        """_groups_query calls works_in_window on every lane
+    def test_featured_works_with_lanes(self):
+        """_featured_works_with_lanes calls works_in_window on every lane
         pass in to it.
         """
         class Mock(object):
@@ -2074,7 +2074,7 @@ class TestWorkListGroups(DatabaseTest):
         mock2 = Mock(("mw2","quality2"))
 
         lane = self._lane()
-        results = lane._groups_query(self._db, [mock1, mock2])
+        results = lane._featured_works_with_lanes(self._db, [mock1, mock2])
 
         # The results of works_in_window were annotated with the
         # 'lane' that produced the result.


### PR DESCRIPTION
This branch gives up on the idea of building a grouped feed using a single database query. It comes close to working, but it doesn't reliably find enough books in cases where a lane is based on a genre that doesn't have very many books in it (like poetry, or bibliography on Open Ebooks).

Instead, we go back to running a query for every lane. The query is much faster than before because we add an index to the materialized view (which we should have added anyway), and the lanes will be filled to capacity more reliably (though not 100% reliable -- we could still end up short by a statistical fluke, but it's extremely unlikely).

There is one minor change in the rules about which books might show up in a grouped feed. It's now more likely that a book that showed up in a previous lane will show up again later on. Since we're no longer getting all the books in a single query, it's more difficult to exclude duplicates. For any given lane, we have a small buffer that lets us discard works that were used in a previous lane, but if we need those works to get that lane up to `target_size`, we will stick them on the end.

This branch includes a fair amount of cleanup and there's more that could be done, but I want to test this code on an NYPL-sized dataset to make sure we've really solved the performance problems before continuing.