### PR TITLE
Bulk register for coverage

### DIFF
--- a/testing.py
+++ b/testing.py
@@ -417,7 +417,9 @@ class DatabaseTest(object):
         )
 
     def _coverage_record(self, edition, coverage_source, operation=None,
-                         status=CoverageRecord.SUCCESS, collection=None):
+                         status=CoverageRecord.SUCCESS, collection=None,
+                         exception=None,
+    ):
         if isinstance(edition, Identifier):
             identifier = edition
         else:
@@ -431,6 +433,7 @@ class DatabaseTest(object):
             create_method_kwargs = dict(
                 timestamp=datetime.utcnow(),
                 status=status,
+                exception=exception,
             )
         )
         return record

--- a/testing.py
+++ b/testing.py
@@ -417,8 +417,7 @@ class DatabaseTest(object):
         )
 
     def _coverage_record(self, edition, coverage_source, operation=None,
-                         status=CoverageRecord.SUCCESS, collection=None,
-                         exception=None,
+        status=CoverageRecord.SUCCESS, collection=None, exception=None,
     ):
         if isinstance(edition, Identifier):
             identifier = edition

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -543,34 +543,39 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
 
     def test_bulk_register_with_collection(self):
         provider = AlwaysSuccessfulCoverageProvider
-        provider_data_source = provider.DATA_SOURCE_NAME
-        provider.DATA_SOURCE_NAME = None
         collection = self._collection(data_source_name=DataSource.AXIS_360)
 
         try:
-            # If the provider has not set a DATA_SOURCE_NAME and a collection
-            # is given, a record is created with the collection's data_source.
-            provider.bulk_register([self.identifier], collection=collection)
+            # If a DataSource or data source name is provided, the record is
+            # created with that source.
+            provider.bulk_register(
+                [self.identifier], data_source=collection.name,
+                collection=collection
+            )
             [record] = self.identifier.coverage_records
 
-            record_data_source = record.data_source.name
-            assert provider.DATA_SOURCE_NAME != record_data_source
-            eq_(collection.data_source.name, record_data_source)
+            # A DataSource with the given name has been created.
+            collection_source = DataSource.lookup(self._db, collection.name)
+            assert collection_source
+            assert provider.DATA_SOURCE_NAME != record.data_source.name
+            eq_(collection_source, record.data_source)
 
-            # The record's collection has not been set, though.
+            # Even though a collection was given, the record's collection isn't
+            # set.
             eq_(None, record.collection)
 
             # However, when coverage is collection-specific the
             # CoverageRecord is related to the given collection.
             provider.COVERAGE_COUNTS_FOR_EVERY_COLLECTION = False
 
-            provider.bulk_register([self.identifier], collection=collection)
+            provider.bulk_register(
+                [self.identifier], collection_source, collection=collection
+            )
             records = self.identifier.coverage_records
             eq_(2, len(records))
             assert [r for r in records if r.collection==collection]
         finally:
             # Return the mock class to its original state for other tests.
-            provider.DATA_SOURCE_NAME = provider_data_source
             provider.COVERAGE_COUNTS_FOR_EVERY_COLLECTION = True
 
     def test_ensure_coverage(self):

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -546,11 +546,11 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
         collection = self._collection(data_source_name=DataSource.AXIS_360)
 
         try:
-            # If a DataSource or data source name is provided, the record is
-            # created with that source.
+            # If a DataSource or data source name is provided and
+            # autocreate is set True, the record is created with that source.
             provider.bulk_register(
                 [self.identifier], data_source=collection.name,
-                collection=collection
+                collection=collection, autocreate=True
             )
             [record] = self.identifier.coverage_records
 


### PR DESCRIPTION
I did all this work to support performance for a change in the metadata wrangler that it turns out isn't currently necessary. Shucks.

YAGNI aside, I'd like to keep the changes for future use -- possibly refactoring the `IdentifierResolutionRegistrar` to process batches of identifiers at a time, for example.