### PR TITLE
Set hold end date for position > 0.

### DIFF
--- a/model.py
+++ b/model.py
@@ -915,10 +915,8 @@ class Hold(Base, LoanAndHoldMixin):
         """
         if start is not None:
             self.start = start
-        if position == 0 and end is not None:
+        if end is not None:
             self.end = end
-        else:
-            self.end = None
         if position is not None:
             self.position = position
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4498,7 +4498,7 @@ class TestHold(DatabaseTest):
         hold, is_new = pool.on_hold_to(patron, now, later, 4)
         eq_(True, is_new)
         eq_(now, hold.start)
-        eq_(None, hold.end)
+        eq_(later, hold.end)
         eq_(4, hold.position)
 
         # Now update the position to 0. It's the patron's turn


### PR DESCRIPTION
This code was only setting the hold end date if the hold position was 0. That seems inconsistent with `Hold.until`, which wants to use the end date if the distributor provides one. I'm not sure if this will cause any problems - could a hold reach its end date and be deleted when it's still active? Maybe we shouldn't even use end date to store the estimated wait time.