### PR TITLE
Helper method that creates a WorkList representing a library's collection.

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -485,6 +485,46 @@ class WorkList(object):
     # By default, a WorkList does not draw from CustomLists
     uses_customlists = False
 
+    @classmethod
+    def top_level_for_library(self, _db, library):
+        """Create a WorkList representing this library's collection
+        as a whole.
+
+        If no top-level visible lanes are configured, the WorkList
+        will be configured to show every book in the collection.
+
+        If a single top-level Lane is configured, it will returned as
+        the WorkList.
+
+        Otherwise, a WorkList containing the visible top-level lanes
+        is returned.
+        """
+        # Load all of this Library's visible top-level Lane objects
+        # from the database.
+        top_level_lanes = _db.query(Lane).filter(
+            Lane.library==library
+        ).filter(
+            Lane.parent==None
+        ).filter(
+            Lane._visible==True
+        ).order_by(
+            Lane.priority
+        ).all()
+
+        if len(top_level_lanes) == 1:
+            # The site configuration includes a single top-level lane;
+            # this can stand in for the library on its own.
+            return top_level_lanes[0]
+
+        # This WorkList contains every title available to this library
+        # in one of the media supported by the default client.
+        wl = WorkList()
+        wl.initialize(
+            library, display_name=library.name, children=top_level_lanes,
+            media=Edition.FULFILLABLE_MEDIA
+        )
+        return wl
+
     def initialize(self, library, display_name=None, genres=None, 
                    audiences=None, languages=None, media=None,
                    children=None, priority=None):

--- a/lane.py
+++ b/lane.py
@@ -671,9 +671,18 @@ class WorkList(object):
         # preserve the ordering of the children.
         relevant_lanes = []
         relevant_children = []
-        for child in self.visible_children:
+
+        # We use an explicit check for Lane.visible here, instead of
+        # iterating over self.visible_children, because Lane.visible only
+        # works when the Lane is merged into a database session.
+        for child in self.children:
             if isinstance(child, Lane):
                 child = _db.merge(child)
+
+            if not child.visible:
+                continue
+
+            if isinstance(child, Lane):
                 # Children that turn out to be Lanes go into relevant_lanes.
                 # Their Works will all be filled in with a single query.
                 relevant_lanes.append(child)

--- a/migration/20180110-lanes-limited-to-ebooks.sql
+++ b/migration/20180110-lanes-limited-to-ebooks.sql
@@ -1,0 +1,2 @@
+-- All lanes created up to this point should only display ebooks.
+update lanes set media='{"Book"}';

--- a/model.py
+++ b/model.py
@@ -2920,6 +2920,10 @@ class Edition(Base):
     ELECTRONIC_FORMAT = u"Electronic"
     CODEX_FORMAT = u"Codex"
 
+    # These are the media types currently fulfillable by the default
+    # client.
+    FULFILLABLE_MEDIA = [BOOK_MEDIUM]
+
     medium_to_additional_type = {
         BOOK_MEDIUM : u"http://schema.org/Book",
         AUDIO_MEDIUM : u"http://schema.org/AudioObject",

--- a/opds.py
+++ b/opds.py
@@ -473,7 +473,6 @@ class AcquisitionFeed(OPDSFeed):
             return cached
 
         all_works = []
-
         for work, sublane in works_and_lanes:
             if sublane==lane:
                 # We are looking at the groups feed for (e.g.)

--- a/opds.py
+++ b/opds.py
@@ -456,7 +456,7 @@ class AcquisitionFeed(OPDSFeed):
             if usable:
                 return cached
 
-        works_and_lanes = lane.groups(_db)
+        works_and_lanes = list(lane.groups(_db))
         if not works_and_lanes:
             # We did not find enough works for a groups feed.
             # Instead we need to display a flat feed--the
@@ -473,6 +473,7 @@ class AcquisitionFeed(OPDSFeed):
             return cached
 
         all_works = []
+        works_and_lanes = list(works_and_lanes)
         for work, sublane in works_and_lanes:
             if sublane==lane:
                 # We are looking at the groups feed for (e.g.)

--- a/opds.py
+++ b/opds.py
@@ -456,7 +456,7 @@ class AcquisitionFeed(OPDSFeed):
             if usable:
                 return cached
 
-        works_and_lanes = list(lane.groups(_db))
+        works_and_lanes = lane.groups(_db)
         if not works_and_lanes:
             # We did not find enough works for a groups feed.
             # Instead we need to display a flat feed--the
@@ -473,7 +473,7 @@ class AcquisitionFeed(OPDSFeed):
             return cached
 
         all_works = []
-        works_and_lanes = list(works_and_lanes)
+
         for work, sublane in works_and_lanes:
             if sublane==lane:
                 # We are looking at the groups feed for (e.g.)

--- a/scripts.py
+++ b/scripts.py
@@ -607,13 +607,7 @@ class LaneSweeperScript(LibraryInputScript):
 
     def process_library(self, library):
         from lane import WorkList
-        top_level_lanes = self._db.query(Lane).filter(
-            Lane.library==library).filter(
-                Lane.parent==None).all()
-        top_level = WorkList()
-        top_level.initialize(
-            library, library.name, children=list(top_level_lanes)
-        )
+        top_level = WorkList.top_level_for_library(self._db, library)
         queue = [top_level]
         while queue:
             new_queue = []

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -635,7 +635,6 @@ class TestWorkList(DatabaseTest):
         # The other library only has one top-level lane, so we use that lane.
         l = WorkList.top_level_for_library(self._db, other_library)
         eq_(other_library_lane, l)
-        eq_(Edition.FULFILLABLE_MEDIA, wl.media)
 
         # This library has no lanes configured at all.
         no_config_library = self._library(


### PR DESCRIPTION
This branch fixes two problems:

* Previously created lanes should have had their `medium` limited to `[Book]` but didn't. 
* We had two different ways of creating the WorkList corresponding to a library's entire collection: one in the circulation manager app server setup and one in the script setup. The WorkLists were slightly different and both might have included works that were not books.