### PR TITLE
Remove unique index on workgenres in materalized views

### DIFF
--- a/files/materialized_view_for_lanes.sql
+++ b/files/materialized_view_for_lanes.sql
@@ -49,7 +49,7 @@ as
   WITH NO DATA;
 
 -- Create a work/genre lookup.
-create unique index mv_works_for_lanes_work_id_genre_id on mv_works_for_lanes (works_id, genre_id);
+create index mv_works_for_lanes_work_id_genre_id on mv_works_for_lanes (works_id, genre_id);
 
 -- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
 

--- a/files/materialized_view_works_workgenres.sql
+++ b/files/materialized_view_works_workgenres.sql
@@ -48,7 +48,7 @@ as
   WITH NO DATA;
 
 -- Create a work/genre lookup.
-create unique index mv_works_genres_work_id_genre_id on mv_works_editions_workgenres_datasources_identifiers (works_id, genre_id);
+create index mv_works_genres_work_id_genre_id on mv_works_editions_workgenres_datasources_identifiers (works_id, genre_id);
 
 -- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
 

--- a/migration/20180105-2-materialized-work-for-lanes.sql
+++ b/migration/20180105-2-materialized-work-for-lanes.sql
@@ -49,7 +49,7 @@ as
   WITH NO DATA;
 
 -- Create a work/genre lookup.
-create unique index mv_works_for_lanes_work_id_genre_id on mv_works_for_lanes (works_id, genre_id);
+create index mv_works_for_lanes_work_id_genre_id on mv_works_for_lanes (works_id, genre_id);
 
 -- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
 

--- a/migration/20180109-add-workgenres-index.sql
+++ b/migration/20180109-add-workgenres-index.sql
@@ -1,0 +1,5 @@
+drop index if exists mv_works_genres_work_id_genre_id;
+create index mv_works_genres_work_id_genre_id on mv_works_editions_workgenres_datasources_identifiers (works_id, genre_id); 
+
+drop index if exists mv_works_for_lanes_work_id_genre_id;
+create index mv_works_for_lanes_work_id_genre_id on mv_works_for_lanes (works_id, genre_id);

--- a/model.py
+++ b/model.py
@@ -336,7 +336,7 @@ class SessionManager(object):
         return sessionmaker(bind=engine)
 
     @classmethod
-    def initialize(cls, url):
+    def initialize(cls, url, create_materialized_work_class=True):
         if url in cls.engine_for_url:
             engine = cls.engine_for_url[url]
             return engine, engine.connect()
@@ -395,22 +395,24 @@ class SessionManager(object):
         if connection:
             connection.close()
 
-        class MaterializedWorkWithGenre(Base, BaseMaterializedWork):
-            __table__ = Table(
-                cls.MATERIALIZED_VIEW_LANES,
-                Base.metadata,
-                Column('works_id', Integer, primary_key=True),
-                Column('workgenres_id', Integer, primary_key=True),
-                Column('license_pool_id', Integer, ForeignKey('licensepools.id')),
-                autoload=True,
-                autoload_with=engine
-            )
-            license_pool = relationship(
-                LicensePool,
-                primaryjoin="LicensePool.id==MaterializedWorkWithGenre.license_pool_id",
-                foreign_keys=LicensePool.id, lazy='joined', uselist=False)
+        if create_materialized_work_class:
+            class MaterializedWorkWithGenre(Base, BaseMaterializedWork):
+                __table__ = Table(
+                    cls.MATERIALIZED_VIEW_LANES,
+                    Base.metadata,
+                    Column('works_id', Integer, primary_key=True),
+                    Column('workgenres_id', Integer, primary_key=True),
+                    Column('license_pool_id', Integer, ForeignKey('licensepools.id')),
+                    autoload=True,
+                    autoload_with=engine
+                )
+                license_pool = relationship(
+                    LicensePool,
+                    primaryjoin="LicensePool.id==MaterializedWorkWithGenre.license_pool_id",
+                    foreign_keys=LicensePool.id, lazy='joined', uselist=False)
 
-        globals()['MaterializedWorkWithGenre'] = MaterializedWorkWithGenre
+            globals()['MaterializedWorkWithGenre'] = MaterializedWorkWithGenre
+
         cls.engine_for_url[url] = engine
         return engine, engine.connect()
 
@@ -430,7 +432,9 @@ class SessionManager(object):
         engine = connection = 0
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=sa_exc.SAWarning)
-            engine, connection = cls.initialize(url)
+            engine, connection = cls.initialize(
+                url, create_materialized_work_class=initialize_data
+            )
         session = Session(connection)
         if initialize_data:
             session = cls.initialize_data(session)


### PR DESCRIPTION
Previously, the materialized views that used the `workgenres` table created a unique index. However, if a Work in the materialized view has multiple licensepools, sometimes multiple records are created with the same workgenres records, causing a duplication error to be raised. See the log block below for the error itself.

This branch avoids the error by removing the unique constraint on the index. Eventually, at some future point, the materialized views may need to be corrected to avoid duplicate works. An official index on the `workgenres` table that sets a unique constraint on `work_id` and `genre_id` may also be necessary. (As of this comment, such an index exists in certain NYPL databases as `workgenres_test2`, but it isn't a part of the codebase.)

```
$ core/bin/migrate_database
Traceback (most recent call last):
  File "core/bin/migrate_database", line 11, in <module>
    DatabaseMigrationScript().run()
  File "/Users/courteneyervin/simplified/metadata/core/scripts.py", line 1895, in run
    self._session = SessionManager.session(url, initialize_data=False)
  File "/Users/courteneyervin/simplified/metadata/core/model.py", line 433, in session
    engine, connection = cls.initialize(url)
  File "/Users/courteneyervin/simplified/metadata/core/model.py", line 370, in initialize
    "REFRESH MATERIALIZED VIEW %s;" % view_name
  File "/usr/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 939, in execute
    return self._execute_text(object, multiparams, params)
  File "/usr/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1097, in _execute_text
    statement, parameters
  File "/usr/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1189, in _execute_context
    context)
  File "/usr/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1402, in _handle_dbapi_exception
    exc_info
  File "/usr/local/lib/python2.7/site-packages/sqlalchemy/util/compat.py", line 203, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "/usr/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1182, in _execute_context
    context)
  File "/usr/local/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 470, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.IntegrityError: (psycopg2.IntegrityError) could not create unique index "mv_works_for_lanes_work_id_genre_id"
DETAIL:  Key (works_id, genre_id)=(8, 54) is duplicated.
 [SQL: 'REFRESH MATERIALIZED VIEW mv_works_for_lanes;']
```