### PR TITLE
Add `<contributor>` tags to OPDS entries for non-author contributors

### DIFF
--- a/bin/opds_entry_coverage
+++ b/bin/opds_entry_coverage
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+"""Make sure all presentation-ready works have up-to-date """
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from coverage import OPDSEntryWorkCoverageProvider
+from scripts import RunWorkCoverageProviderScript
+
+RunWorkCoverageProviderScript(
+    OPDSEntryWorkCoverageProvider
+).run()

--- a/bin/opds_entry_coverage
+++ b/bin/opds_entry_coverage
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Make sure all presentation-ready works have up-to-date """
+"""Make sure all presentation-ready works have up-to-date OPDS entries."""
 import os
 import sys
 bin_dir = os.path.split(__file__)[0]
@@ -8,6 +8,4 @@ sys.path.append(os.path.abspath(package_dir))
 from coverage import OPDSEntryWorkCoverageProvider
 from scripts import RunWorkCoverageProviderScript
 
-RunWorkCoverageProviderScript(
-    OPDSEntryWorkCoverageProvider
-).run()
+RunWorkCoverageProviderScript(OPDSEntryWorkCoverageProvider).run()

--- a/migration/20180112-redo-opds-for-non-author-contributors.sql
+++ b/migration/20180112-redo-opds-for-non-author-contributors.sql
@@ -1,0 +1,14 @@
+-- Remove the 'generate-opds` coverage record for any works
+-- that have an associated series.
+delete from workcoveragerecords where operation='generate-opds' and work_id in (
+       select w.id from works w join editions e on w.presentation_edition_id=e.id where e.series is not null
+);
+
+-- Remove the 'generate-opds` coverage record for any works
+-- that have contributors in non-author roles.
+delete from workcoveragerecords where operation='generate-opds' and work_id in (
+       select distinct w.id from works w join editions e on w.presentation_edition_id=e.id join contributions c on e.id=c.edition_id where c.role not in ('Author', 'Primary Author')
+);
+
+-- These records will be added back when the OPDSEntryWorkCoverageProvider
+-- regenerates their OPDS entries.

--- a/model.py
+++ b/model.py
@@ -2466,7 +2466,6 @@ class Contributor(Base):
     # Types of roles
     AUTHOR_ROLE = u"Author"
     PRIMARY_AUTHOR_ROLE = u"Primary Author"
-    PERFORMER_ROLE = u"Performer"
     EDITOR_ROLE = u"Editor"
     ARTIST_ROLE = u"Artist"
     PHOTOGRAPHER_ROLE = u"Photographer"
@@ -2497,12 +2496,49 @@ class Contributor(Base):
     DESIGNER_ROLE = u'Designer'
     AUTHOR_ROLES = set([PRIMARY_AUTHOR_ROLE, AUTHOR_ROLE])
 
+    # Map our recognized roles to MARC relators.
+    # https://www.loc.gov/marc/relators/relaterm.html
+    #
+    # This is used when crediting contributors in OPDS feeds.
+    MARC_ROLE_CODES = {
+        ACTOR_ROLE : 'act',
+        ADAPTER_ROLE : 'adp',
+        AFTERWORD_ROLE : 'aft',
+        ARTIST_ROLE : 'art',
+        ASSOCIATED_ROLE : 'asn',
+        AUTHOR_ROLE : 'aut',            # Joint author: USE Author
+        COLLABORATOR_ROLE : 'ctb',      # USE Contributor
+        COLOPHON_ROLE : 'aft',          # Author of afterword, colophon, etc.
+        COMPILER_ROLE : 'com',
+        COMPOSER_ROLE : 'cmp',
+        CONTRIBUTOR_ROLE : 'ctb',
+        COPYRIGHT_HOLDER_ROLE : 'cph',
+        DESIGNER_ROLE : 'dsr',
+        DIRECTOR_ROLE : 'drt',
+        EDITOR_ROLE : 'edt',
+        ENGINEER_ROLE : 'eng',
+        EXECUTIVE_PRODUCER_ROLE : 'pro',
+        FOREWORD_ROLE : 'wpr',          # Writer of preface
+        ILLUSTRATOR_ROLE : 'ill',
+        INTRODUCTION_ROLE : 'win',
+        LYRICIST_ROLE : 'lyr',
+        MUSICIAN_ROLE : 'mus',
+        NARRATOR_ROLE : 'nrt',
+        PERFORMER_ROLE : 'prf',
+        PHOTOGRAPHER_ROLE : 'pht',
+        PRIMARY_AUTHOR_ROLE : 'aut',
+        PRODUCER_ROLE : 'pro',
+        TRANSCRIBER_ROLE : 'trc',
+        TRANSLATOR_ROLE : 'trl',
+        UNKNOWN_ROLE : 'asn',
+    }
+
     # People from these roles can be put into the 'author' slot if no
     # author proper is given.
     AUTHOR_SUBSTITUTE_ROLES = [
         EDITOR_ROLE, COMPILER_ROLE, COMPOSER_ROLE, DIRECTOR_ROLE,
-         CONTRIBUTOR_ROLE, TRANSLATOR_ROLE, ADAPTER_ROLE, PHOTOGRAPHER_ROLE,
-         ARTIST_ROLE, LYRICIST_ROLE, COPYRIGHT_HOLDER_ROLE
+        CONTRIBUTOR_ROLE, TRANSLATOR_ROLE, ADAPTER_ROLE, PHOTOGRAPHER_ROLE,
+        ARTIST_ROLE, LYRICIST_ROLE, COPYRIGHT_HOLDER_ROLE
     ]
 
     PERFORMER_ROLES = [ACTOR_ROLE, PERFORMER_ROLE, NARRATOR_ROLE, MUSICIAN_ROLE]

--- a/monitor.py
+++ b/monitor.py
@@ -485,6 +485,10 @@ class NotPresentationReadyWorkSweepMonitor(WorkSweepMonitor):
 class OPDSEntryCacheMonitor(PresentationReadyWorkSweepMonitor):
     """A Monitor that recalculates the OPDS entries for every
     presentation-ready Work.
+
+    This is different from the OPDSEntryWorkCoverageProvider,
+    which only processes works that are missing a WorkCoverageRecord
+    with the 'generate-opds' operation.
     """
     SERVICE_NAME = "ODPS Entry Cache Monitor"
     

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1793,7 +1793,7 @@ class TestOPDSEntryWorkCoverageProvider(DatabaseTest):
         eq_('old long junk', work.verbose_opds_entry)
 
         # The work is presentation-ready, so its OPDS entries are
-        # generated.
+        # regenerated.
         work.presentation_ready = True
         provider.run()
         assert work.simple_opds_entry.startswith('<entry')

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -997,6 +997,17 @@ class TestSubject(DatabaseTest):
 
 class TestContributor(DatabaseTest):
 
+    def test_marc_code_for_every_role_constant(self):
+        """We have determined the MARC Role Code for every role
+        that's important enough we gave it a constant in the Contributor
+        class.
+        """
+        for constant, value in Contributor.__dict__.items():
+            if not constant.endswith('_ROLE'):
+                # Not a constant.
+                continue
+            assert value in Contributor.MARC_ROLE_CODES
+
     def test_lookup_by_viaf(self):
 
         # Two contributors named Bob.

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -137,6 +137,32 @@ class TestBaseAnnotator(DatabaseTest):
         pool2.presentation_edition.title = None
         eq_(pool1, Annotator.active_licensepool_for(work))
 
+    def test_authors(self):
+        # Create an Edition with an author and a narrator.
+        edition = self._edition(authors=["King, Steven"])
+        edition.add_contributor(
+            "Frakes, Jonathan", Contributor.NARRATOR_ROLE
+        )
+        author, contributor = Annotator.authors(None, None, edition, None)
+
+        # The <author> tag indicates a role of 'author', so there's no
+        # need for an explicitly specified role property.
+        eq_('author', author.tag)
+        [name] = author.getchildren()
+        eq_("name", name.tag)
+        eq_("Steven King", name.text)
+        eq_({}, author.attrib)
+
+        # The <contributor> tag includes an explicitly specified role
+        # property to explain the nature of the contribution.
+        eq_('contributor', contributor.tag)
+        [name] = contributor.getchildren()
+        eq_("name", name.tag)
+        eq_("Jonathan Frakes", name.text)
+        prop_name = '{%s}role' % AtomFeed.OPF_NS
+        eq_(Contributor.MARC_ROLE_CODES[Contributor.NARRATOR_ROLE],
+            contributor.attrib[prop_name])
+
 
 class TestAnnotators(DatabaseTest):
 

--- a/tests/test_util_opds_writer.py
+++ b/tests/test_util_opds_writer.py
@@ -52,3 +52,10 @@ class TestAtomFeed(object):
         link_child = AtomFeed.E.link_child()
         AtomFeed.add_link_to_entry(entry, [link_child], **kwargs)
         assert '<link extra="extra info" href="url" title="1"><link_child/></link>' in etree.tostring(entry)
+
+    def test_contributor(self):
+        kwargs = { '{%s}role' % AtomFeed.OPF_NS : 'ctb' }
+        tag = etree.tostring(AtomFeed.author(**kwargs))
+        assert tag.startswith('<author')
+        assert 'xmlns:opf="http://www.idpf.org/2007/opf"' in tag
+        assert tag.endswith('opf:role="ctb"/>')

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -17,6 +17,7 @@ class AtomFeed(object):
     OPDS_NS = 'http://opds-spec.org/2010/catalog'
     SCHEMA_NS = 'http://schema.org/'
     DRM_NS = 'http://librarysimplified.org/terms/drm'
+    OPF_NS = 'http://www.idpf.org/2007/opf'
     
     SIMPLIFIED_NS = "http://librarysimplified.org/terms/"
     BIBFRAME_NS = "http://bibframe.org/vocab/"
@@ -26,6 +27,7 @@ class AtomFeed(object):
         'app': APP_NS,
         'dcterms' : DCTERMS_NS,
         'opds' : OPDS_NS,
+        'opf' : OPF_NS,
         'drm' : DRM_NS,
         'schema' : SCHEMA_NS,
         'simplified' : SIMPLIFIED_NS,
@@ -68,6 +70,9 @@ class AtomFeed(object):
     def author(cls, *args, **kwargs):
         return cls.E.author(*args, **kwargs)
 
+    @classmethod
+    def contributor(cls, *args, **kwargs):
+        return cls.E.contributor(*args, **kwargs)
 
     @classmethod
     def category(cls, *args, **kwargs):


### PR DESCRIPTION
This branch represents non-author contributors to a work using the Atom `<contributor>` tag. It uses the unofficial OPDS standard technique of putting the contributor role in the `opf:role` attribute, and as specified in 1.4.1.2.x of the [OPF spec](http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section1.4.1.2) it uses [MARC Relator Codes](https://www.loc.gov/marc/relators/relaterm.html) to explain what role a contributor had in the work.

The migration script in this branch removes the `opds-entry` WorkCoverageRecords for any works with non-author contributors, so that those entries can be regenerated. The `bin/opds_entry_coverage` script takes care of regenerating OPDS entries for any works missing their `opds-entry` coverage records.

We'll need a docker branch to run that script on a regular basis to clean up after this migration script and any future ones.