### PR TITLE
Changed dc:created to dc:issued in OPDS, and added a staff rating scale.

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1208,7 +1208,7 @@ class Metadata(MetaToModelUtility):
         fields = self.BASIC_EDITION_FIELDS
         for field in fields:
             new_value = getattr(metadata, field)
-            if new_value:
+            if new_value != None and new_value != '':
                 setattr(self, field, new_value)
 
         new_value = getattr(metadata, 'contributors')
@@ -1442,7 +1442,7 @@ class Metadata(MetaToModelUtility):
         for field in fields:
             old_edition_value = getattr(edition, field)
             new_metadata_value = getattr(self, field)
-            if new_metadata_value and (new_metadata_value != old_edition_value):
+            if new_metadata_value != None and new_metadata_value != '' and (new_metadata_value != old_edition_value):
                 if new_metadata_value in [NO_VALUE, NO_NUMBER]:
                     new_metadata_value = None
                 setattr(edition, field, new_metadata_value)

--- a/migration/20180117-regenerate-opds-for-dc-issued.sql
+++ b/migration/20180117-regenerate-opds-for-dc-issued.sql
@@ -1,0 +1,2 @@
+-- Remove the 'generate-opds` coverage record for all works.
+delete from workcoveragerecords where operation='generate-opds';

--- a/model.py
+++ b/model.py
@@ -5209,7 +5209,8 @@ class Measurement(Base):
         DataSource.OVERDRIVE : [1, 5],
         DataSource.AMAZON : [1, 5],
         DataSource.UNGLUE_IT: [1, 5],
-        DataSource.NOVELIST: [0, 5]
+        DataSource.NOVELIST: [0, 5],
+        DataSource.LIBRARY_STAFF: [1, 5],
     }
 
     id = Column(Integer, primary_key=True)

--- a/opds.py
+++ b/opds.py
@@ -967,16 +967,17 @@ class AcquisitionFeed(OPDSFeed):
         # from Entry.published (which may refer to the print edition
         # or some original edition way back when).
         #
-        # For Dublin Core 'created' we use Entry.issued if we have it
+        # For Dublin Core 'issued' we use Entry.issued if we have it
         # and Entry.published if not. In general this means we use
         # issued date for Gutenberg and published date for other
         # sources.
         #
-        # We use dc:created instead of dc:issued because dc:issued is
-        # commonly conflated with atom:published.
-        #
         # For the date the book was added to our collection we use
         # atom:published.
+        #
+        # Note: feedparser conflates dc:issued and atom:published, so
+        # it can't be used to extract this information. However, these
+        # tags are consistent with the OPDS spec.
         issued = edition.issued or edition.published
         if (isinstance(issued, datetime.datetime) 
             or isinstance(issued, datetime.date)):
@@ -986,7 +987,7 @@ class AcquisitionFeed(OPDSFeed):
             elif isinstance(issued, datetime.date):
                 issued_already = (issued <= today)
             if issued_already:
-                issued_tag = AtomFeed.makeelement("{%s}created" % AtomFeed.DCTERMS_NS)
+                issued_tag = AtomFeed.makeelement("{%s}issued" % AtomFeed.DCTERMS_NS)
                 # Use datetime.isoformat instead of datetime.strftime because
                 # strftime only works on dates after 1890, and we have works
                 # that were issued much earlier than that.

--- a/opds.py
+++ b/opds.py
@@ -251,7 +251,7 @@ class Annotator(object):
             return None
         series_details = dict()
         series_details['name'] = series_name
-        if series_position:
+        if series_position != None:
             series_details[AtomFeed.schema_('position')] = unicode(series_position)
         series_tag = AtomFeed.makeelement(AtomFeed.schema_("Series"), **series_details)
         return series_tag

--- a/opds.py
+++ b/opds.py
@@ -949,6 +949,11 @@ class AcquisitionFeed(OPDSFeed):
             publisher_tag.text = edition.publisher
             entry.extend([publisher_tag])
 
+        if edition.imprint:
+            imprint_tag = AtomFeed.makeelement("{%s}publisherImprint" % AtomFeed.BIB_SCHEMA_NS)
+            imprint_tag.text = edition.imprint
+            entry.extend([imprint_tag])
+
         # We use Atom 'published' for the date the book first became
         # available to people using this application.
         now = datetime.datetime.utcnow()

--- a/opds_import.py
+++ b/opds_import.py
@@ -929,7 +929,6 @@ class OPDSImporter(object):
                         )
                     )
         last_opds_update = cls._datetime(entry, 'updated_parsed')
-        added_to_collection_time = cls._datetime(entry, 'published_parsed')
             
         publisher = entry.get('publisher', None)
         if not publisher:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -741,6 +741,11 @@ class TestMetadata(DatabaseTest):
         eq_(e_link.rel, m_link.rel)
         eq_(e_link.resource.url, m_link.href)
 
+        # The series position can also be 0.
+        edition.series_position = 0
+        metadata = Metadata.from_edition(edition)
+        eq_(edition.series_position, metadata.series_position)
+
     def test_update(self):
         # Tests that Metadata.update correctly prefers new fields to old, unless 
         # new fields aren't defined.
@@ -748,18 +753,24 @@ class TestMetadata(DatabaseTest):
         edition_old, pool = self._edition(with_license_pool=True)
         edition_old.publisher = "test_old_publisher"
         edition_old.subtitle = "old_subtitile"
+        edition_old.series = "old_series"
+        edition_old.series_position = 5
         metadata_old = Metadata.from_edition(edition_old)
 
         edition_new, pool = self._edition(with_license_pool=True)
         # set more fields on metadatas
         edition_new.publisher = None
         edition_new.subtitle = "new_updated_subtitile"
+        edition_new.series = "new_series"
+        edition_new.series_position = 0
         metadata_new = Metadata.from_edition(edition_new)
 
         metadata_old.update(metadata_new)
 
         eq_(metadata_old.publisher, "test_old_publisher")
         eq_(metadata_old.subtitle, metadata_new.subtitle)
+        eq_(metadata_old.series, edition_new.series)
+        eq_(metadata_old.series_position, edition_new.series_position)
 
     def test_apply(self):
         edition_old, pool = self._edition(with_license_pool=True)
@@ -796,6 +807,12 @@ class TestMetadata(DatabaseTest):
 
         edition_new, changed = metadata.apply(edition_new, pool.collection)
         eq_(changed, False)
+
+        # The series position can also be 0.
+        metadata.series_position = 0
+        edition_new, changed = metadata.apply(edition_new, pool.collection)
+        eq_(changed, True)
+        eq_(edition_new.series_position, 0)
 
     def test_apply_identifier_equivalency(self):
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -626,9 +626,10 @@ class TestOPDS(DatabaseTest):
         eq_(None, e4['issued'])
         eq_(None, e4['published'])
 
-    def test_acquisition_feed_includes_language_tag(self):
+    def test_acquisition_feed_includes_publisher_and_imprint_tag(self):
         work = self._work(with_open_access_download=True)
         work.presentation_edition.publisher = "The Publisher"
+        work.presentation_edition.imprint = "The Imprint"
         work2 = self._work(with_open_access_download=True)
         work2.presentation_edition.publisher = None
 
@@ -642,6 +643,7 @@ class TestOPDS(DatabaseTest):
         with_publisher = feedparser.parse(unicode(with_publisher))
         entries = sorted(with_publisher['entries'], key = lambda x: x['title'])
         eq_('The Publisher', entries[0]['dcterms_publisher'])
+        eq_('The Imprint', entries[0]['bib_publisherimprint'])
         assert 'publisher' not in entries[1]
 
     def test_acquisition_feed_includes_audience_as_category(self):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -374,6 +374,21 @@ class TestAnnotators(DatabaseTest):
         eq_(work.presentation_edition.series, schema_entry['name'])
         eq_(str(work.presentation_edition.series_position), schema_entry['schema:position'])
 
+        # The series position can be 0, for a prequel for example.
+        work.presentation_edition.series_position = 0
+        work.calculate_opds_entries()
+
+        raw_feed = unicode(AcquisitionFeed(
+            self._db, self._str, self._url, [work], Annotator
+        ))
+        assert "schema:Series" in raw_feed
+        assert work.presentation_edition.series in raw_feed
+
+        feed = feedparser.parse(unicode(raw_feed))
+        schema_entry = feed['entries'][0]['schema_series']
+        eq_(work.presentation_edition.series, schema_entry['name'])
+        eq_(str(work.presentation_edition.series_position), schema_entry['schema:position'])
+
         # If there's no series title, the series tag isn't included.
         work.presentation_edition.series = None
         work.calculate_opds_entries()

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -21,6 +21,7 @@ class AtomFeed(object):
     
     SIMPLIFIED_NS = "http://librarysimplified.org/terms/"
     BIBFRAME_NS = "http://bibframe.org/vocab/"
+    BIB_SCHEMA_NS = "http://bib.schema.org/"
 
     nsmap = {
         None: ATOM_NS,
@@ -32,6 +33,7 @@ class AtomFeed(object):
         'schema' : SCHEMA_NS,
         'simplified' : SIMPLIFIED_NS,
         'bibframe' : BIBFRAME_NS,
+        'bib': BIB_SCHEMA_NS
     }
 
     default_typemap = {datetime: lambda e, v: _strftime(v)}


### PR DESCRIPTION
As part of improving book metadata editing in the admin interface, I wanted to add the publication date to the editable fields. However, I discovered that there was a lot of inconsistency in where that date is.

The admin interface uses the book's OPDS entry to fill in the initial form values. According to the OPDS spec, dc:issued "SHOULD be used to indicate the first publication date of the Publication". Our server was putting it in dc:created, and there was a comment that dc:issued is commonly conflated with atom:published. That didn't seem like a good reason not to follow the spec though.

The web client and the iOS client were using atom:published as the publication date, when that is actually the date the publication became available in the catalog according to both our server and the spec. Based on that it seems like using dc:created didn't solve the problem.

So I tried making this change and when I went to fix the tests I found that it's actually _feedparser_ that conflates atom:published and dc:issued, so if we use both we can no longer use feedparser for that information. This mostly affects OPDS import, which was already not using that info, maybe because it was likely to be inaccurate if others' feeds were following the spec. If we want to start using it now, we'd just have to do that in the etree part.

It's annoying that we can't use feedparser but I still think this is the right thing to do. I'm updating the web client and the mobile apps should be changed too, but this PR won't actually affect old versions since they're already using the wrong values (at least iOS is, I didn't check Android).

I also made one other change in this PR so that staff can add a rating to a book from the admin interface. I picked 1-5 as the rating scale.