### PR TITLE
mv_works_for_lanes needs a unique index

### DIFF
--- a/files/materialized_view_for_lanes.sql
+++ b/files/materialized_view_for_lanes.sql
@@ -48,8 +48,8 @@ as
   ORDER BY (editions.sort_title, editions.sort_author, licensepools.availability_time)
   WITH NO DATA;
 
--- Create a work/genre lookup.
-create index mv_works_for_lanes_work_id_genre_id on mv_works_for_lanes (works_id, genre_id);
+-- First create an index that allows work/genre lookup. It's unique and incorporates license_pool_id so that the materialized view can be refreshed CONCURRENTLY.
+create unique index mv_works_for_lanes_unique on mv_works_for_lanes (works_id, genre_id, license_pool_id);
 
 -- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
 

--- a/migration/20180109-add-workgenres-index.sql
+++ b/migration/20180109-add-workgenres-index.sql
@@ -1,5 +1,3 @@
 drop index if exists mv_works_genres_work_id_genre_id;
 create index mv_works_genres_work_id_genre_id on mv_works_editions_workgenres_datasources_identifiers (works_id, genre_id); 
 
-drop index if exists mv_works_for_lanes_work_id_genre_id;
-create index mv_works_for_lanes_work_id_genre_id on mv_works_for_lanes (works_id, genre_id);

--- a/migration/20180117-add-unique-index-to-materialized-view.sql
+++ b/migration/20180117-add-unique-index-to-materialized-view.sql
@@ -1,0 +1,2 @@
+drop index if exists mv_works_for_lanes_work_id_genre_id;
+create index mv_works_for_lanes_unique on mv_works_for_lanes (works_id, genre_id, license_pool_id);


### PR DESCRIPTION
In an earlier branch we removed the unique index from mv_works_for_lanes because in some situations it wasn't actually unique. We recreated the same index as a non-unique index.

It turns out we need a unique index on a materialized view to do a REFRESH CONCURRENTLY. This branch makes sure mv_works_for_lanes always ends up with a unique index called `mv_works_for_lanes_unique`.

If this is a fresh install, `mv_works_for_lanes_unique` is created by the initialization SQL script.

If this is an upgrade from a pre-2.1.4 version, `20180109-add-workgenres-index.sql` no longer drops and rebuilds `mv_works_for_lanes_work_id_genre_id`. It's dropped in `20180117-add-unique-index-to-materialized-view.sql` and the unique index is built instead.

If this is an upgrade from 2.1.4, the `mv_works_for_lanes_work_id_genre_id` index was already dropped and rebuilt. `20180117-add-unique-index-to-materialized-view.sql` drops it again and builds the unique index.