### PR TITLE
Stop using deprecated materialized views

### DIFF
--- a/migration/20180117-add-unique-index-to-materialized-view.sql
+++ b/migration/20180117-add-unique-index-to-materialized-view.sql
@@ -1,2 +1,8 @@
 drop index if exists mv_works_for_lanes_work_id_genre_id;
 create index mv_works_for_lanes_unique on mv_works_for_lanes (works_id, genre_id, license_pool_id);
+
+-- This materialized view will be deleted soon, but until it is deleted,
+-- it needs to have a unique index, and work+genre ID isn't necessarily
+-- unique.
+drop index if exists mv_works_editions_work_id;
+create unique index mv_works_editions_work_id on mv_works_editions_datasources_identifiers (works_id, license_pool_id);

--- a/migration/20180117-add-unique-index-to-materialized-view.sql
+++ b/migration/20180117-add-unique-index-to-materialized-view.sql
@@ -1,8 +1,2 @@
 drop index if exists mv_works_for_lanes_work_id_genre_id;
 create index mv_works_for_lanes_unique on mv_works_for_lanes (works_id, genre_id, license_pool_id);
-
--- This materialized view will be deleted soon, but until it is deleted,
--- it needs to have a unique index, and work+genre ID isn't necessarily
--- unique.
-drop index if exists mv_works_editions_work_id;
-create unique index mv_works_editions_work_id on mv_works_editions_datasources_identifiers (works_id, license_pool_id);

--- a/model.py
+++ b/model.py
@@ -314,8 +314,8 @@ class SessionManager(object):
     MATERIALIZED_VIEW_WORKS_WORKGENRES = 'mv_works_editions_workgenres_datasources_identifiers'
     MATERIALIZED_VIEW_LANES = 'mv_works_for_lanes'
     MATERIALIZED_VIEWS = {
-        MATERIALIZED_VIEW_WORKS : 'materialized_view_works.sql',
-        MATERIALIZED_VIEW_WORKS_WORKGENRES : 'materialized_view_works_workgenres.sql',
+        #MATERIALIZED_VIEW_WORKS : 'materialized_view_works.sql',
+        #MATERIALIZED_VIEW_WORKS_WORKGENRES : 'materialized_view_works_workgenres.sql',
         MATERIALIZED_VIEW_LANES : 'materialized_view_for_lanes.sql',
     }
 


### PR DESCRIPTION
A user ran into a problem where the deprecated materialized views couldn't be updated because the unique index stopped being valid. Rather than add a migration script to change the unique index, I wrote this branch, which makes the application completely forget about those materialized views and not try to create them, or keep them updated, anymore.

The materialized views will still be there in existing deployments, in case mv_works_for_lanes doesn't work out and we have to go back. But I'd rather stop looking at them than slow down migration with an expensive script to manage views that are no longer used.