### PR TITLE
Fix miscellaneous issues with OPDS entries

### DIFF
--- a/model.py
+++ b/model.py
@@ -2966,7 +2966,7 @@ class Edition(Base):
 
     medium_to_additional_type = {
         BOOK_MEDIUM : u"http://schema.org/EBook",
-        AUDIO_MEDIUM : u"http://bib.schema.org/AudioBook",
+        AUDIO_MEDIUM : u"http://bib.schema.org/Audiobook",
         PERIODICAL_MEDIUM : u"http://schema.org/PublicationIssue",
         MUSIC_MEDIUM :  u"http://schema.org/MusicRecording",
         VIDEO_MEDIUM :  u"http://schema.org/VideoObject",

--- a/model.py
+++ b/model.py
@@ -2965,13 +2965,13 @@ class Edition(Base):
     FULFILLABLE_MEDIA = [BOOK_MEDIUM]
 
     medium_to_additional_type = {
-        BOOK_MEDIUM : u"http://schema.org/Book",
-        AUDIO_MEDIUM : u"http://schema.org/AudioObject",
-        PERIODICAL_MEDIUM : u"http://schema.org/PublicationIssue",
-        MUSIC_MEDIUM :  u"http://schema.org/MusicRecording",
-        VIDEO_MEDIUM :  u"http://schema.org/VideoObject",
-        IMAGE_MEDIUM: u"http://schema.org/ImageObject",
-        COURSEWARE_MEDIUM: u"http://schema.org/Course"
+        BOOK_MEDIUM : u"https://schema.org/EBook",
+        AUDIO_MEDIUM : u"https://bib.schema.org/AudioBook",
+        PERIODICAL_MEDIUM : u"https://schema.org/PublicationIssue",
+        MUSIC_MEDIUM :  u"https://schema.org/MusicRecording",
+        VIDEO_MEDIUM :  u"https://schema.org/VideoObject",
+        IMAGE_MEDIUM: u"https://schema.org/ImageObject",
+        COURSEWARE_MEDIUM: u"https://schema.org/Course"
     }
 
     additional_type_to_medium = {}

--- a/model.py
+++ b/model.py
@@ -4651,7 +4651,7 @@ class Work(Base):
         simple = AcquisitionFeed.single_entry(
             _db, self, Annotator, force_create=True
         )
-        if verbose is not None:
+        if verbose is True:
             verbose = AcquisitionFeed.single_entry(
                 _db, self, VerboseAnnotator, force_create=True
             )

--- a/model.py
+++ b/model.py
@@ -4648,14 +4648,13 @@ class Work(Base):
             VerboseAnnotator,
         )
         _db = Session.object_session(self)
-        simple = AcquisitionFeed.single_entry(_db, self, Annotator,
-                                              force_create=True)
-        if simple is not None:
-            self.simple_opds_entry = unicode(etree.tostring(simple))
-        verbose = AcquisitionFeed.single_entry(_db, self, VerboseAnnotator,
-                                               force_create=True)
+        simple = AcquisitionFeed.single_entry(
+            _db, self, Annotator, force_create=True
+        )
         if verbose is not None:
-            self.verbose_opds_entry = unicode(etree.tostring(verbose))
+            verbose = AcquisitionFeed.single_entry(
+                _db, self, VerboseAnnotator, force_create=True
+            )
         WorkCoverageRecord.add_for(
             self, operation=WorkCoverageRecord.GENERATE_OPDS_OPERATION
         )

--- a/model.py
+++ b/model.py
@@ -2965,13 +2965,13 @@ class Edition(Base):
     FULFILLABLE_MEDIA = [BOOK_MEDIUM]
 
     medium_to_additional_type = {
-        BOOK_MEDIUM : u"https://schema.org/EBook",
-        AUDIO_MEDIUM : u"https://bib.schema.org/AudioBook",
-        PERIODICAL_MEDIUM : u"https://schema.org/PublicationIssue",
-        MUSIC_MEDIUM :  u"https://schema.org/MusicRecording",
-        VIDEO_MEDIUM :  u"https://schema.org/VideoObject",
-        IMAGE_MEDIUM: u"https://schema.org/ImageObject",
-        COURSEWARE_MEDIUM: u"https://schema.org/Course"
+        BOOK_MEDIUM : u"http://schema.org/EBook",
+        AUDIO_MEDIUM : u"http://bib.schema.org/AudioBook",
+        PERIODICAL_MEDIUM : u"http://schema.org/PublicationIssue",
+        MUSIC_MEDIUM :  u"http://schema.org/MusicRecording",
+        VIDEO_MEDIUM :  u"http://schema.org/VideoObject",
+        IMAGE_MEDIUM: u"http://schema.org/ImageObject",
+        COURSEWARE_MEDIUM: u"http://schema.org/Course"
     }
 
     additional_type_to_medium = {}

--- a/tests/files/opds/book_with_license.opds
+++ b/tests/files/opds/book_with_license.opds
@@ -3,7 +3,7 @@
   <title>Lookup results</title>
   <updated>2016-06-29T16:23:27Z</updated>
   <link href="http://content/lookup?urn=https%3A%2F%2Funglue.it%2Fapi%2Fid%2Fwork%2F7775%2F" rel="self"/>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>https://unglue.it/api/id/work/7775/</id>
     <title>Warbreaker</title>
     <bibframe:distribution bibframe:ProviderName="unglue.it"/>

--- a/tests/files/opds/book_without_license.opds
+++ b/tests/files/opds/book_without_license.opds
@@ -3,7 +3,7 @@
   <title>Lookup results</title>
   <updated>2016-06-29T16:04:36Z</updated>
   <link href="http://content/lookup?urn=https%3A%2F%2Funglue.it%2Fapi%2Fid%2Fwork%2F98398%2F" rel="self"/>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>https://unglue.it/api/id/work/98398/</id>
     <title>Howards End</title>
     <bibframe:distribution bibframe:ProviderName="unglue.it"/>

--- a/tests/files/opds/content_server.opds
+++ b/tests/files/opds/content_server.opds
@@ -31,7 +31,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10441.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10557</id>
     <title>Johnny Crow's Party</title>
     <author>
@@ -48,7 +48,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10557.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10522</id>
     <title>Beacon Lights of History, Volume 04: Imperial Antiquity</title>
     <author>
@@ -64,7 +64,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10522.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10596</id>
     <title>Cap and Gown</title>
     <schema:alternativeHeadline>A Treasury of College Verse</schema:alternativeHeadline>
@@ -78,7 +78,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10596.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10219</id>
     <title>The Poetical Works of William Wordsworth &#8212; Volume 1</title>
     <author>
@@ -95,7 +95,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10219.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10631</id>
     <title>Halleck's New English Literature</title>
     <author>
@@ -111,7 +111,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10631.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10394</id>
     <title>Stolen Treasure</title>
     <author>
@@ -128,7 +128,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10394.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10058</id>
     <title>The Divine Office</title>
     <schema:alternativeHeadline>A Study of the Roman Breviary</schema:alternativeHeadline>
@@ -146,7 +146,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10058.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10100</id>
     <title>Byron</title>
     <author>
@@ -162,7 +162,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10100.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10647</id>
     <title>Beacon Lights of History, Volume 12: American Leaders</title>
     <author>
@@ -180,7 +180,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10647.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10341</id>
     <title>The Great Events by Famous Historians, Volume 21</title>
     <schema:alternativeHeadline>The Recent Days (1910-1914)</schema:alternativeHeadline>
@@ -201,7 +201,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10341.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10029</id>
     <title>The Hunt Ball Mystery</title>
     <author>
@@ -217,7 +217,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10029.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10656</id>
     <title>A Collection of Old English Plays, Volume 2</title>
     <summary></summary>
@@ -229,7 +229,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10656.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10321</id>
     <title>Dragon's blood</title>
     <author>
@@ -245,7 +245,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10321.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10338</id>
     <title>With the Turks in Palestine</title>
     <author>
@@ -264,7 +264,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10338.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/1057</id>
     <title>Poems, with The Ballad of Reading Gaol</title>
     <author>
@@ -281,7 +281,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/1057.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/1055</id>
     <title>'Twixt Land &amp; Sea: Tales</title>
     <author>
@@ -298,7 +298,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/1055.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10064</id>
     <title>Beltane the Smith</title>
     <author>
@@ -314,7 +314,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10064.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10567</id>
     <title>The Guardian Angel</title>
     <schema:alternativeHeadline>Ship's Company, Part 7.</schema:alternativeHeadline>
@@ -332,7 +332,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10567.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10427</id>
     <title>Scientific Essays and Lectures</title>
     <author>
@@ -348,7 +348,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10427.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10134</id>
     <title>John Wesley, Jr.</title>
     <schema:alternativeHeadline>The Story of an Experiment</schema:alternativeHeadline>
@@ -366,7 +366,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10134.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10551</id>
     <title>Affair in Araby</title>
     <author>
@@ -385,7 +385,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10551.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10534</id>
     <title>The Double Traitor</title>
     <author>
@@ -401,7 +401,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10534.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10435</id>
     <title>The Atlantic Monthly, Volume 02, No. 12, October, 1858</title>
     <schema:alternativeHeadline>A Magazine of Literature, Art, and Politics</schema:alternativeHeadline>
@@ -418,7 +418,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10435.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/1022</id>
     <title>Walking</title>
     <author>
@@ -436,7 +436,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/1022.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10453</id>
     <title>A Practical Physiology: A Text-Book for Higher Schools</title>
     <author>
@@ -453,7 +453,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10453.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10572</id>
     <title>Manners Makyth Man</title>
     <schema:alternativeHeadline>Ship's Company, Part 12.</schema:alternativeHeadline>
@@ -471,7 +471,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10572.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/1065</id>
     <title>The Raven</title>
     <author>
@@ -487,7 +487,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/1065.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10690</id>
     <title>A Desperate Chance; Or, The Wizard Tramp's Revelation, a Thrilling Narrative</title>
     <author>
@@ -505,7 +505,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10690.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10467</id>
     <title>A Select Collection of Old English Plays, Volume 8</title>
     <summary></summary>
@@ -517,7 +517,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10467.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10595</id>
     <title>Punch, or the London Charivari, Volume 153, September 19, 1917</title>
     <author>
@@ -533,7 +533,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10595.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10122</id>
     <title>Fairies and Fusiliers</title>
     <author>
@@ -550,7 +550,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10122.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10133</id>
     <title>The Vigil of Venus and Other Poems by "Q"</title>
     <author>
@@ -566,7 +566,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10133.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10210</id>
     <title>Wolves of the Sea</title>
     <schema:alternativeHeadline>Being a Tale of the Colonies from the Manuscript of One Geoffry Carlyle, Seaman, Narrating Certain Strange Adventures Which Befell Him Aboard the Pirate Craft "Namur"</schema:alternativeHeadline>
@@ -584,7 +584,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10210.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10217</id>
     <title>The Land of Little Rain</title>
     <author>
@@ -604,7 +604,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10217.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10495</id>
     <title>Under King Constantine</title>
     <author>
@@ -620,7 +620,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10495.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10086</id>
     <title>The Minute Boys of the Mohawk Valley</title>
     <author>
@@ -636,7 +636,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10086.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10606</id>
     <title>The Tragedie of Hamlet, Prince of Denmark</title>
     <schema:alternativeHeadline>A Study with the Text of the Folio of 1623</schema:alternativeHeadline>
@@ -660,7 +660,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10606.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10609</id>
     <title>English Literature</title>
     <schema:alternativeHeadline>Its History and Its Significance for the Life of the English-Speaking World</schema:alternativeHeadline>
@@ -677,7 +677,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10609.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10111</id>
     <title>Boys and Girls from Thackeray</title>
     <author>
@@ -693,7 +693,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10111.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10478</id>
     <title>Beacon Lights of History, Volume 02: Jewish Heroes and Prophets</title>
     <author>
@@ -710,7 +710,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10478.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10532</id>
     <title>Beacon Lights of History, Volume 06: Renaissance and Reformation</title>
     <author>
@@ -726,7 +726,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10532.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10037</id>
     <title>A Beautiful Possibility</title>
     <author>
@@ -743,7 +743,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10037.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10212</id>
     <title>Peck's Bad Boy with the Circus</title>
     <author>
@@ -760,7 +760,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10212.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10556</id>
     <title>The Old Man in the Corner</title>
     <author>
@@ -776,7 +776,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10556.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10421</id>
     <title>The Life of Lord Byron</title>
     <author>
@@ -793,7 +793,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10421.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10624</id>
     <title>Three John Silence Stories</title>
     <author>
@@ -815,7 +815,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10624.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10131</id>
     <title>Required Poems for Reading and Memorizing</title>
     <schema:alternativeHeadline>Third and Fourth Grades, Prescribed by State Courses of Study</schema:alternativeHeadline>
@@ -832,7 +832,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10131.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10540</id>
     <title>Mother Carey's Chickens</title>
     <author>
@@ -849,7 +849,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10540.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10325</id>
     <title>The Gospel of the Pentateuch: A Set of Parish Sermons</title>
     <author>
@@ -868,7 +868,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10325.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10367</id>
     <title>Poems</title>
     <author>
@@ -884,7 +884,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10367.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10121</id>
     <title>The Literature of Arabia</title>
     <schema:alternativeHeadline>With Critical and Biographical Sketches by Epiphanius Wilson</schema:alternativeHeadline>
@@ -897,7 +897,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10121.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10623</id>
     <title>Plays</title>
     <author>
@@ -913,7 +913,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10623.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10251</id>
     <title>Town Geology</title>
     <author>
@@ -929,7 +929,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10251.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10546</id>
     <title>So Runs the World</title>
     <author>
@@ -945,7 +945,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10546.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10565</id>
     <title>Watch-Dogs</title>
     <schema:alternativeHeadline>Ship's Company, Part 5.</schema:alternativeHeadline>
@@ -963,7 +963,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10565.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10036</id>
     <title>Punchinello, Volume 2, No. 28, October 8, 1870</title>
     <author>
@@ -981,7 +981,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10036.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/1063</id>
     <title>The Cask of Amontillado</title>
     <author>
@@ -998,7 +998,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/1063.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10517</id>
     <title>Government and Rebellion</title>
     <schema:alternativeHeadline>A Sermon Delivered in the North Broad Street Presbyterian Church, Sunday Morning, April 28, 1861</schema:alternativeHeadline>
@@ -1018,7 +1018,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10517.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10102</id>
     <title>The Czar's Spy: The Mystery of a Silent Love</title>
     <author>
@@ -1034,7 +1034,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10102.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10583</id>
     <title>Holland: The History of the Netherlands</title>
     <author>
@@ -1050,7 +1050,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10583.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10409</id>
     <title>The Crisis of the Naval War</title>
     <author>
@@ -1067,7 +1067,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10409.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10518</id>
     <title>Poems</title>
     <author>
@@ -1083,7 +1083,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10518.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10328</id>
     <title>Poems</title>
     <author>
@@ -1099,7 +1099,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10328.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10452</id>
     <title>Peter's Mother</title>
     <author>
@@ -1120,7 +1120,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10452.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10560</id>
     <title>The Last of the Foresters</title>
     <schema:alternativeHeadline>Or, Humors on the Border; A story of the Old Virginia Frontier</schema:alternativeHeadline>
@@ -1138,7 +1138,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10560.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10135</id>
     <title>The Great English Short-Story Writers, Volume 1</title>
     <summary></summary>
@@ -1150,7 +1150,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10135.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10015</id>
     <title>Punchinello, Volume 1, No. 19, August 6, 1870</title>
     <author>
@@ -1168,7 +1168,7 @@
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10015.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10520</id>
     <title>The Compleat Cook</title>
     <schema:alternativeHeadline>Expertly Prescribing the Most Ready Wayes, Whether Italian,
@@ -1188,7 +1188,7 @@ Of Sauces or Making of Pastry</schema:alternativeHeadline>
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10520.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10357</id>
     <title>Life of Johnson, Volume 4</title>
     <schema:alternativeHeadline>1780-1784</schema:alternativeHeadline>
@@ -1208,7 +1208,7 @@ Of Sauces or Making of Pastry</schema:alternativeHeadline>
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10357.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10509</id>
     <title>The Bars of Iron</title>
     <author>
@@ -1224,7 +1224,7 @@ Of Sauces or Making of Pastry</schema:alternativeHeadline>
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10509.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10446</id>
     <title>The Green Flag, and Other Stories of War and Sport</title>
     <author>
@@ -1242,7 +1242,7 @@ Of Sauces or Making of Pastry</schema:alternativeHeadline>
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10446.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/1044</id>
     <title>Extract from Captain Stormfield's Visit to Heaven</title>
     <author>
@@ -1262,7 +1262,7 @@ Of Sauces or Making of Pastry</schema:alternativeHeadline>
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/1044.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/1003</id>
     <title>Divine Comedy, Longfellow's Translation, Paradise</title>
     <author>
@@ -1279,7 +1279,7 @@ Of Sauces or Making of Pastry</schema:alternativeHeadline>
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/1003.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10381</id>
     <title>The History of a Crime</title>
     <schema:alternativeHeadline>The Testimony of an Eye-Witness</schema:alternativeHeadline>
@@ -1296,7 +1296,7 @@ Of Sauces or Making of Pastry</schema:alternativeHeadline>
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <link href="http://www.gutenberg.org/ebooks/10381.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10095</id>
     <title>The Twilight of the Gods, and Other Tales</title>
     <author>

--- a/tests/files/opds/content_server_mini.opds
+++ b/tests/files/opds/content_server_mini.opds
@@ -34,7 +34,7 @@
     <link href="http://www.gutenberg.org/ebooks/10441.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
   
-  <entry schema:additionalType="http://schema.org/Book">
+  <entry schema:additionalType="http://schema.org/EBook">
     <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10557</id>
     <title>Johnny Crow's Party</title>
     <author>

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3435,8 +3435,10 @@ class TestWork(DatabaseTest):
         eq_(None, work.verbose_opds_entry)
 
         work.calculate_opds_entries(verbose=True)
-        # The simple OPDS entry is the same as before.
-        eq_(simple_entry, work.simple_opds_entry)
+        # The simple OPDS entry is the same length as before.
+        # It's not necessarily _exactly_ the same because the
+        # <updated> timestamp may be different.
+        eq_(len(simple_entry), len(work.simple_opds_entry))
 
         # The verbose OPDS entry is longer than the simple one.
         assert work.verbose_opds_entry.startswith('<entry')

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3421,6 +3421,27 @@ class TestWork(DatabaseTest):
         classification2.subject.checked = True
         eq_([], qu.all())
 
+    def test_calculate_opds_entries(self):
+        """Verify that calculate_opds_entries sets both simple and verbose
+        entries.
+        """
+        work = self._work()
+        work.simple_opds_entry = None
+        work.verbose_opds_entry = None
+
+        work.calculate_opds_entries(verbose=False)
+        simple_entry = work.simple_opds_entry
+        assert simple_entry.startswith('<entry')
+        eq_(None, work.verbose_opds_entry)
+
+        work.calculate_opds_entries(verbose=True)
+        # The simple OPDS entry is the same as before.
+        eq_(simple_entry, work.simple_opds_entry)
+
+        # The verbose OPDS entry is longer than the simple one.
+        assert work.verbose_opds_entry.startswith('<entry')
+        assert len(work.verbose_opds_entry) > len(simple_entry)
+
 
 class TestCirculationEvent(DatabaseTest):
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -472,9 +472,15 @@ class TestOPDS(DatabaseTest):
         work = self._work(with_open_access_download=True)
         feed = AcquisitionFeed(self._db, "test", "http://the-url.com/",
                                [work])
-        parsed = feedparser.parse(unicode(feed))
         gutenberg = DataSource.lookup(self._db, DataSource.GUTENBERG)
-        eq_(gutenberg.name, parsed.entries[0]['bibframe_distribution']['providername'])
+
+        # The <bibframe:distribution> tag containing the license
+        # source should show up once and only once. (At one point a
+        # bug caused it to be added to the generated OPDS twice.)
+        expect = '<bibframe:distribution bibframe:ProviderName="%s"/>' % (
+            gutenberg.name
+        )
+        assert (1, unicode(feed).count(expect))
 
     def test_acquisition_feed_includes_author_tag_even_when_no_author(self):
         work = self._work(with_open_access_download=True)

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -463,7 +463,7 @@ class TestOPDS(DatabaseTest):
         feed = AcquisitionFeed(self._db, "test", "http://the-url.com/",
                                [work])
         u = unicode(feed)
-        assert '<entry schema:additionalType="http://schema.org/Book">' in u
+        assert '<entry schema:additionalType="http://schema.org/EBook">' in u
         parsed = feedparser.parse(u)
         [with_author] = parsed['entries']
         eq_("Alice", with_author['authors'][0]['name'])

--- a/tests/test_util_web_publication_manifest.py
+++ b/tests/test_util_web_publication_manifest.py
@@ -31,7 +31,7 @@ class TestJSONable(object):
 class TestManifest(object):
 
     def test_defaults(self):
-        eq_("http://schema.org/EBook", Manifest.DEFAULT_TYPE)
+        eq_("http://schema.org/Book", Manifest.DEFAULT_TYPE)
         eq_("http://readium.org/webpub/default.jsonld",
             Manifest.DEFAULT_CONTEXT)
 

--- a/tests/test_util_web_publication_manifest.py
+++ b/tests/test_util_web_publication_manifest.py
@@ -31,7 +31,7 @@ class TestJSONable(object):
 class TestManifest(object):
 
     def test_defaults(self):
-        eq_("http://schema.org/Book", Manifest.DEFAULT_TYPE)
+        eq_("http://schema.org/EBook", Manifest.DEFAULT_TYPE)
         eq_("http://readium.org/webpub/default.jsonld",
             Manifest.DEFAULT_CONTEXT)
 


### PR DESCRIPTION
https://github.com/NYPL-Simplified/server_core/pull/769 makes it necessary to rebuild all cached OPDS entries. Since that's happening anyway I figured now is a good time to fix two other issues that also make it necessary to rebuild all cached OPDS entries.

* I updated the URIs used in `additionalType` to indicate whether a book is an ebook or an audiobook. Those URIs were chosen a long time ago and better alternatives are now part of schema.org.
* I fixed a bug which caused the `<bibframe:distribution>` tag to show up twice in an OPDS entry. It was added once (incorrectly) while the cached entry was being created and then added again (correctly) when it was time to add licensing information.

The changes to sample OPDS feeds are just changing http://schema.org/Book to http://schema.org/EBook.