### PR TITLE
Make sure the index called '_unique' is actually unique.

### DIFF
--- a/migration/20180117-add-unique-index-to-materialized-view.sql
+++ b/migration/20180117-add-unique-index-to-materialized-view.sql
@@ -1,2 +1,0 @@
-drop index if exists mv_works_for_lanes_work_id_genre_id;
-create index mv_works_for_lanes_unique on mv_works_for_lanes (works_id, genre_id, license_pool_id);

--- a/migration/20180119-add-unique-index-to-materialized-view.sql
+++ b/migration/20180119-add-unique-index-to-materialized-view.sql
@@ -1,0 +1,3 @@
+drop index if exists mv_works_for_lanes_work_id_genre_id;
+drop index if exists mv_works_for_lanes_unique;
+create unique index mv_works_for_lanes_unique on mv_works_for_lanes (works_id, genre_id, license_pool_id);


### PR DESCRIPTION
20180117-add-index-to-materialized-view.sql created an index called '_unique' but didn't actually make it unique. This script drops it (if it was created) and recreates it correctly.

I looked at `materialized_view_for_lanes.sql` and verified that the index was created as unique there, so this only affects sites that migrated to 2.1.1 and then to 2.1.5.