### PR TITLE
Force the materialized view to show itself

### DIFF
--- a/model.py
+++ b/model.py
@@ -360,7 +360,8 @@ class SessionManager(object):
                 "Loading materialized view %s from %s.",
                 view_name, resource_file)
             sql = open(resource_file).read()
-            connection.execute(sql)
+            connection.execution_options(isolation_level='AUTOCOMMIT')\
+                .execute(text(sql))
 
             # NOTE: This is apparently necessary for the creation of
             # the materialized view to be finalized in all cases. As


### PR DESCRIPTION
Previously, the materialized views weren't being committed to the database at the point of initialization. This change forces the database to commit to something for once.