### PR TITLE
If an OPDS entry has no last-updated date, extract_last_update_dates should not return anything for it.

### DIFF
--- a/opds_import.py
+++ b/opds_import.py
@@ -576,10 +576,11 @@ class OPDSImporter(object):
             parsed_feed = feedparser.parse(feed)
         else:
             parsed_feed = feed
-        return [
+        dates = [
             cls.last_update_date_for_feedparser_entry(entry)
             for entry in parsed_feed['entries']
         ]
+        return [x for x in dates if x and x[1]]
 
     def build_identifier_mapping(self, external_urns):
         """Uses the given Collection and a list of URNs to reverse

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -240,6 +240,19 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_("urn:librarysimplified.org/terms/id/Gutenberg%20ID/10557", identifier2)
         eq_(datetime.datetime(2015, 1, 2, 16, 56, 40), updated2)
 
+    def test_extract_last_update_dates_ignores_entries_with_no_update(self):
+        importer = OPDSImporter(
+            self._db, collection=None, data_source_name=DataSource.NYT
+        )
+
+        # Rename the <updated> and <published> tags in the content
+        # server so they don't show up.
+        content = self.content_server_mini_feed.replace("updated>", "irrelevant>")
+        content = content.replace("published>", "irrelevant>")
+        last_update_dates = importer.extract_last_update_dates(content)
+
+        # No updated dates!
+        eq_([], last_update_dates)
 
     def test_extract_metadata(self):
         data_source_name = "Data source name " + self._str


### PR DESCRIPTION
extract_last_update_dates shouldn't return something that's not information on a last-update date. If an OPDS entry has no last-update date, this branch changes extract_last_update_dates so it doesn't even mention that entry.

This stops a crash in MWCollectionUpdateMonitor where it tries to call `min()` on a list of dates that includes None.

However, I haven't been able to figure out why the metadata wrangler is returning, in an update feed, items that have no last-update date.