### PR TITLE
Never show a total number of holds smaller than your current holds position

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -1189,7 +1189,7 @@ class AcquisitionFeed(OPDSFeed):
             position = hold.position
         if hold:
             if position and position > 0:
-                holds_kw['position'] = str(hold.position)
+                holds_kw['position'] = str(position)
             if position > total:
                 # The patron's hold position appears larger than the total
                 # number of holds. This happens frequently because the

--- a/opds.py
+++ b/opds.py
@@ -1181,9 +1181,14 @@ class AcquisitionFeed(OPDSFeed):
 
         holds_kw = dict()
         total = license_pool.patrons_in_hold_queue or 0
-        position = hold.position or 0
+        if hold.position is None:
+            # This shouldn't happen, but if it does, assume we're last
+            # in the list.
+            position = total
+        else:
+            position = hold.position
         if hold:
-            if position:
+            if position and position > 0:
                 holds_kw['position'] = str(hold.position)
             if position > total:
                 # The patron's hold position appears larger than the total

--- a/opds.py
+++ b/opds.py
@@ -1180,8 +1180,7 @@ class AcquisitionFeed(OPDSFeed):
 
 
         holds_kw = dict()
-        total = ((license_pool.patrons_in_hold_queue or 0) + 
-                 (license_pool.licenses_reserved or 0))
+        total = license_pool.patrons_in_hold_queue or 0
         position = hold.position or 0
         if hold:
             if position:
@@ -1194,8 +1193,10 @@ class AcquisitionFeed(OPDSFeed):
                 # appearance to the client.
                 total = position
             elif position == 0 and total == 0:
-                # The book is reserved for this patron, but they still
-                # count towards the total number of holds.
+                # The book is reserved for this patron but they're not
+                # counted as having it on hold. This is the only case
+                # where we know that the total number of holds is
+                # *greater* than the hold position.
                 total = 1
         holds_kw['total'] = str(total)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2470,7 +2470,7 @@ class TestWork(DatabaseTest):
             lp3, complaint_type, "blah", "blah"
         )
 
-        eq_([complaint1, complaint2], work.complaints)
+        eq_(set([complaint1, complaint2]), set(work.complaints))
         assert complaint3 not in work.complaints
 
     def test_all_identifier_ids(self):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1271,6 +1271,15 @@ class TestAcquisitionFeed(DatabaseTest):
         eq_('1', holds.attrib['position'])
         eq_('3', holds.attrib['total'])
 
+        # If the patron's hold position is missing, we assume they
+        # are last in the list.
+        hold.position = None
+        availability, holds, copies = AcquisitionFeed.license_tags(
+            pool, None, hold
+        )
+        eq_('3', holds.attrib['position'])
+        eq_('3', holds.attrib['total'])
+
         # If the patron's current hold position is greater than the
         # total recorded number of holds+reserves, their position will
         # be used as the value of opds:total.

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1262,8 +1262,7 @@ class TestAcquisitionFeed(DatabaseTest):
 
         # If the patron's hold position is less than the total number
         # of holds+reserves, that total is used as opds:total.
-        pool.licenses_reserved = 1
-        pool.patrons_in_hold_queue = 2
+        pool.patrons_in_hold_queue = 3
         hold, is_new = pool.on_hold_to(patron, position=1)
 
         availability, holds, copies = AcquisitionFeed.license_tags(
@@ -1300,7 +1299,6 @@ class TestAcquisitionFeed(DatabaseTest):
         # is out of date.
         hold.position = 0
         pool.patrons_in_hold_queue = 0
-        pool.licenses_reserved = 0
         availability, holds, copies = AcquisitionFeed.license_tags(
             pool, None, hold
         )


### PR DESCRIPTION
This branch addresses https://github.com/NYPL-Simplified/circulation/issues/835 by ensuring that in an opds:holds tag, opds:total is never smaller than opds:position.

This branch also changes the behavior of opds:holds so that copies in the 'reserved' state are counted towards `opds:total`.

`AcquisitionFeed.license_tags` was previously untested and this branch only tests the part that generates the `opds:holds` tag.