### PR TITLE
Make sure we can generate license tags when there is no loan or hold.

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -1181,14 +1181,16 @@ class AcquisitionFeed(OPDSFeed):
 
         holds_kw = dict()
         total = license_pool.patrons_in_hold_queue or 0
-        if hold.position is None:
-            # This shouldn't happen, but if it does, assume we're last
-            # in the list.
-            position = total
-        else:
-            position = hold.position
+
         if hold:
-            if position and position > 0:
+            if hold.position is None:
+                # This shouldn't happen, but if it does, assume we're last
+                # in the list.
+                position = total
+            else:
+                position = hold.position
+
+            if position > 0:
                 holds_kw['position'] = str(position)
             if position > total:
                 # The patron's hold position appears larger than the total

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1251,6 +1251,15 @@ class TestOPDS(DatabaseTest):
 
 class TestAcquisitionFeed(DatabaseTest):
 
+    def test_license_tags_no_loan_or_hold(self):
+        edition, pool = self._edition(with_license_pool=True)
+        availability, holds, copies = AcquisitionFeed.license_tags(
+            pool, None, None
+        )
+        eq_(dict(status='available'), availability.attrib)
+        eq_(dict(total='0'), holds.attrib)
+        eq_(dict(total='1', available='1'), copies.attrib)
+
     def test_license_tags_hold_position(self):
         # When a book is placed on hold, it typically takes a while
         # for the LicensePool to be updated with the new number of


### PR DESCRIPTION
This fixes a bug that got into my previous branch because we didn't have test coverage in the case where no `Hold` was passed into `license_tags`. This case _was_ tested in circulation, which gave us an unpleasant surprise.