### PR TITLE
A Collection may have a designated ExternalIntegration that's used to mirror things on OPDS import

### DIFF
--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -155,12 +155,17 @@ class Classifier(object):
         This may involve data normalization, conversion to lowercase,
         etc.
         """
+        if identifier is None:
+            return None
         return Lowercased(identifier)
 
     @classmethod
     def scrub_name(cls, name):
         """Prepare a name from within a call to classify()."""
+        if name is None:
+            return None
         return Lowercased(name)
+
 
     @classmethod
     def genre(cls, identifier, name, fiction=None, audience=None):
@@ -973,7 +978,10 @@ class DeweyDecimalClassifier(Classifier):
             identifier = int(identifier)
         except ValueError:
             pass
-        return identifier
+
+        # For our purposes, Dewey Decimal numbers are identifiers
+        # without names.
+        return identifier, None
 
     @classmethod
     def is_fiction(cls, identifier, name):

--- a/migration/20180129-collection-mirror-integration.sql
+++ b/migration/20180129-collection-mirror-integration.sql
@@ -1,0 +1,4 @@
+-- Add collections.mirror_integration_id, a foreign key
+-- against externalintegrations.id
+alter table collections add column mirror_integration_id integer;
+alter table collections add constraint collections_mirror_integration_id_fkey FOREIGN KEY (mirror_integration_id) REFERENCES externalintegrations(id);

--- a/model.py
+++ b/model.py
@@ -120,6 +120,7 @@ from util import (
     MetadataSimilarity,
     TitleProcessor,
 )
+from util.mirror import MirrorUploader
 from util.http import (
     HTTP,
     RemoteIntegrationException,
@@ -10004,7 +10005,7 @@ class ExternalIntegration(Base, HasFullTableCache):
 
     # These integrations are associated with external services such as
     # S3 that provide access to book covers.
-    STORAGE_GOAL = u'storage'
+    STORAGE_GOAL = MirrorUploader.STORAGE_GOAL
 
     # These integrations are associated with external services like
     # Cloudfront or other CDNs that mirror and/or cache certain domains.
@@ -10137,6 +10138,13 @@ class ExternalIntegration(Base, HasFullTableCache):
     settings = relationship(
         "ConfigurationSetting", backref="external_integration",
         lazy="joined", cascade="all, delete-orphan",
+    )
+
+    # An ExternalIntegration may be used by many Collections
+    # to mirror book covers or other files.
+    mirror_for = relationship(
+        "Collection", backref="mirror_integration",
+        foreign_keys='Collection.mirror_integration_id',
     )
 
     def __repr__(self):

--- a/model.py
+++ b/model.py
@@ -10542,6 +10542,14 @@ class Collection(Base, HasFullTableCache):
     # external_account_id.
     parent_id = Column(Integer, ForeignKey('collections.id'), index=True)
 
+    # Some Collections use an ExternalIntegration to mirror books and
+    # cover images they discover. Such a collection should use an
+    # ExternalIntegration to set up its mirroring technique, and keep
+    # a reference to that ExternalIntegration here.
+    mirror_integration_id = Column(
+        Integer, ForeignKey('externalintegrations.id'), nullable=True
+    )
+
     # A collection may have many child collections. For example,
     # An Overdrive collection may have many children corresponding
     # to Overdrive Advantage collections.

--- a/model.py
+++ b/model.py
@@ -3991,7 +3991,7 @@ class Work(Base):
             LicensePool.identifier).join(
                 Identifier.classifications).join(
                     Classification.subject)
-        return qu.filter(Subject.checked==False).distinct()
+        return qu.filter(Subject.checked==False).order_by(Subject.id)
 
     @classmethod
     def open_access_for_permanent_work_id(cls, _db, pwid, medium):
@@ -6219,33 +6219,36 @@ class Subject(Base):
             genre, was_new = Genre.lookup(_db, genredata.name, True)
         else:
             genre = None
+
+        # Create a shorthand way of referring to this Subject in log
+        # messages.
+        parts = [self.type, self.identifier, self.name]
+        shorthand = ":".join(x for x in parts if x)
+
         if genre != self.genre:
             log.info(
-                "%s:%s genre %r=>%r", self.type, self.identifier,
-                self.genre, genre
+                "%s genre %r=>%r", shorthand, self.genre, genre
             )
         self.genre = genre
 
         if audience:
             if self.audience != audience:
                 log.info(
-                    "%s:%s audience %s=>%s", self.type, self.identifier,
-                    self.audience, audience
+                    "%s audience %s=>%s", shorthand, self.audience, audience
                 )
         self.audience = audience
 
         if fiction is not None:
             if self.fiction != fiction:
                 log.info(
-                    "%s:%s fiction %s=>%s", self.type, self.identifier,
-                    self.fiction, fiction
+                    "%s fiction %s=>%s", shorthand, self.fiction, fiction
                 )
         self.fiction = fiction
 
         if (numericrange_to_tuple(self.target_age) != target_age and 
             not (not self.target_age and not target_age)):
             log.info(
-                "%s:%s target_age %r=>%r", self.type, self.identifier,
+                "%s target_age %r=>%r", shorthand,
                 self.target_age, tuple_to_numericrange(target_age)
             )
         self.target_age = tuple_to_numericrange(target_age)

--- a/monitor.py
+++ b/monitor.py
@@ -496,14 +496,6 @@ class OPDSEntryCacheMonitor(PresentationReadyWorkSweepMonitor):
         work.calculate_opds_entries()
 
 
-class SubjectAssignmentMonitor(SubjectSweepMonitor):
-    """A Monitor that assigns or reassigns Subjects to Genres."""
-    SERVICE_NAME = "Subject assignment monitor"
-
-    def process_item(self, subject):
-        subject.assign_to_genre()
-
-
 class PermanentWorkIDRefreshMonitor(EditionSweepMonitor):
     """A monitor that calculates or recalculates the permanent work ID for
     every edition.

--- a/opds_import.py
+++ b/opds_import.py
@@ -420,7 +420,7 @@ class OPDSImporter(object):
             self.log.warn("Metadata Wrangler integration couldn't be loaded, importing without it.")
             self.metadata_client = None
 
-        if not mirror:
+        if collection and not mirror:
             # If this Collection is configured to mirror the assets it
             # discovers to S3, this will create an S3Uploader for that
             # Collection. Otherwise, this will return None.

--- a/opds_import.py
+++ b/opds_import.py
@@ -58,7 +58,7 @@ from util.opds_writer import (
     OPDSFeed,
     OPDSMessage,
 )
-from s3 import S3Uploader
+from util.mirror import MirrorUploader
 
 
 class AccessNotAuthenticated(Exception):
@@ -422,9 +422,9 @@ class OPDSImporter(object):
 
         if collection and not mirror:
             # If this Collection is configured to mirror the assets it
-            # discovers to S3, this will create an S3Uploader for that
+            # discovers, this will create a MirrorUploader for that
             # Collection. Otherwise, this will return None.
-            mirror = S3Uploader.for_collection(_db, collection)
+            mirror = MirrorUploader.for_collection(_db, collection)
         self.mirror = mirror
         self.content_modifier = content_modifier
         self.http_get = http_get

--- a/opds_import.py
+++ b/opds_import.py
@@ -419,6 +419,12 @@ class OPDSImporter(object):
             # The Metadata Wrangler isn't configured, but we can import without it.
             self.log.warn("Metadata Wrangler integration couldn't be loaded, importing without it.")
             self.metadata_client = None
+
+        if not mirror:
+            # If this Collection is configured to mirror the assets it
+            # discovers to S3, this will create an S3Uploader for that
+            # Collection. Otherwise, this will return None.
+            mirror = S3Uploader.for_collection(_db, collection)
         self.mirror = mirror
         self.content_modifier = content_modifier
         self.http_get = http_get
@@ -1648,15 +1654,3 @@ class OPDSImportMonitor(CollectionMonitor):
             self.log.info("Importing next feed: %s", link)
             self.import_one_feed(feed)
             self._db.commit()
-
-
-class OPDSImporterWithS3Mirror(OPDSImporter):
-    """OPDS Importer that mirrors content to S3."""
-
-    def __init__(self, _db, collection, **kwargs):
-        kwargs = dict(kwargs)
-        if 'mirror' not in kwargs:
-            kwargs['mirror'] = S3Uploader.from_config(_db)
-        super(OPDSImporterWithS3Mirror, self).__init__(
-            _db, collection, **kwargs
-        )

--- a/s3.py
+++ b/s3.py
@@ -206,7 +206,10 @@ class S3Uploader(MirrorUploader):
         for fh in filehandles:
             fh.close()
 
+# MirrorUploader.implementation will instantiate an S3Uploader
+# for storage integrations with protocol 'S3'.
 MirrorUploader.IMPLEMENTATION_REGISTRY[ExternalIntegration.S3] = S3Uploader
+
 
 class DummyS3Uploader(S3Uploader):
     """A dummy uploader for use in tests."""

--- a/s3.py
+++ b/s3.py
@@ -70,7 +70,8 @@ class S3Uploader(MirrorUploader):
             url += '/'
         return url + path
 
-    def cover_image_root(self, bucket, data_source, scaled_size=None):
+    @classmethod
+    def cover_image_root(cls, bucket, data_source, scaled_size=None):
         """The root URL to the S3 location of cover images for
         the given data source.
         """
@@ -84,18 +85,19 @@ class S3Uploader(MirrorUploader):
             data_source_name = data_source.name
         data_source_name = urllib.quote(data_source_name)
         path += data_source_name + "/"
-        url = self.url(bucket, path)
+        url = cls.url(bucket, path)
         if not url.endswith('/'):
             url += '/'
         return url
 
-    def content_root(self, bucket, open_access=True):
+    @classmethod
+    def content_root(cls, bucket, open_access=True):
         """The root URL to the S3 location of hosted content of
         the given type.
         """
         if not open_access:
             raise NotImplementedError()
-        return self.url(bucket, '/')
+        return cls.url(bucket, '/')
 
     def book_url(self, identifier, extension='.epub', open_access=True, 
                  data_source=None, title=None):

--- a/s3.py
+++ b/s3.py
@@ -99,7 +99,7 @@ class S3Uploader(MirrorUploader):
     def book_url(self, identifier, extension='.epub', open_access=True, 
                  data_source=None, title=None):
         """The path to the hosted EPUB file for the given identifier."""
-        bucket = self.get_bucket(self.OA_CONTENT_BUCKET_KEY, identifier)
+        bucket = self.get_bucket(self.OA_CONTENT_BUCKET_KEY)
         root = self.content_root(bucket, open_access)
 
         if not extension.startswith('.'):
@@ -120,17 +120,18 @@ class S3Uploader(MirrorUploader):
 
         return root + template % tuple(args + [extension])
 
-    def cover_image_url(self, data_source, identifier, filename=None,
+    def cover_image_url(self, data_source, identifier, filename,
                         scaled_size=None):
         """The path to the hosted cover image for the given identifier."""
-        bucket = self.get_bucket(self.BOOK_COVERS_BUCKET_KEY, identifier)
+        bucket = self.get_bucket(self.BOOK_COVERS_BUCKET_KEY)
         root = self.cover_image_root(bucket, data_source, scaled_size)
 
         args = [identifier.type, identifier.identifier, filename]
         args = [urllib.quote(x) for x in args]
         return root + "%s/%s/%s" % tuple(args)
 
-    def bucket_and_filename(self, url):
+    @classmethod
+    def bucket_and_filename(cls, url):
         scheme, netloc, path, query, fragment = urlsplit(url)
         if netloc == 's3.amazonaws.com':
             if path.startswith('/'):
@@ -211,7 +212,7 @@ class S3Uploader(MirrorUploader):
 MirrorUploader.IMPLEMENTATION_REGISTRY[ExternalIntegration.S3] = S3Uploader
 
 
-class DummyS3Uploader(S3Uploader):
+class MockS3Uploader(S3Uploader):
     """A dummy uploader for use in tests."""
 
     buckets = {
@@ -245,7 +246,9 @@ class MockS3Pool(object):
     pool.
     """
 
-    def __init__(self):
+    def __init__(self, access_key, secret_key):
+        self.access_key = access_key
+        self.secret_key = secret_key
         self.uploads = []
         self.in_progress = []
         self.n = 0

--- a/scripts.py
+++ b/scripts.py
@@ -2661,15 +2661,6 @@ class FixInvisibleWorksScript(CollectionInputScript):
             "I would now expect you to be able to find %d works.\n" % mv_works_count
         )
 
-class SubjectAssignmentScript(SubjectInputScript):
-
-    def do_run(self):
-        args = self.parse_command_line(self._db)
-        monitor = SubjectAssignmentMonitor(
-            self._db, args.subject_type, args.subject_filter
-        )
-        monitor.run()
-
 
 class ListCollectionMetadataIdentifiersScript(CollectionInputScript):
     """List the metadata identifiers for Collections in the database.

--- a/scripts.py
+++ b/scripts.py
@@ -73,7 +73,6 @@ from model import (
     site_configuration_has_changed,
 )
 from monitor import (
-    SubjectAssignmentMonitor,
     CollectionMonitor,
 )
 from opds_import import (

--- a/testing.py
+++ b/testing.py
@@ -915,6 +915,19 @@ class DatabaseTest(object):
             data_source=data_source, weight=weight
         )[0]
 
+    def sample_cover_path(self, name):
+        """The path to the sample cover with the given filename."""
+        base_path = os.path.split(__file__)[0]
+        resource_path = os.path.join(base_path, "tests", "files", "covers")
+        sample_cover_path = os.path.join(resource_path, name)
+        return sample_cover_path
+
+    def sample_cover_representation(self, name):
+        """A Representation of the sample cover with the given filename."""
+        sample_cover_path = self.sample_cover_path(name)
+        return self._representation(
+            media_type="image/png", content=open(sample_cover_path).read())[0]
+
 
 class MockCoverageProvider(object):
     """Mixin class for mock CoverageProviders that defines common constants."""

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -34,7 +34,7 @@ from . import (
     DummyHTTPClient,
 )
 
-from s3 import DummyS3Uploader
+from s3 import MockS3Uploader
 
 
 class TestCirculationData(DatabaseTest):
@@ -553,7 +553,7 @@ class TestMetaToModelUtility(DatabaseTest):
         # Note: Mirroring tests passing does not guarantee that all code now 
         # correctly calls on CirculationData, as well as Metadata.  This is a risk.
 
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         # Here's a book.
         edition, pool = self._edition(with_license_pool=True)
         
@@ -622,7 +622,7 @@ class TestMetaToModelUtility(DatabaseTest):
 
 
     def test_mirror_open_access_link_fetch_failure(self):
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         h = DummyHTTPClient()
 
         edition, pool = self._edition(with_license_pool=True)
@@ -665,7 +665,7 @@ class TestMetaToModelUtility(DatabaseTest):
 
 
     def test_mirror_open_access_link_mirror_failure(self):
-        mirror = DummyS3Uploader(fail=True)
+        mirror = MockS3Uploader(fail=True)
         h = DummyHTTPClient()
 
         edition, pool = self._edition(with_license_pool=True)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -26,6 +26,7 @@ from classifier import (
     AgeOrGradeClassifier,
     InterestLevelClassifier,
     Axis360AudienceClassifier,
+    Lowercased,
     WorkClassifier,
     fiction_genres,
     nonfiction_genres,
@@ -131,6 +132,16 @@ class TestClassifier(object):
         m = SetsNameForOneIdentifier.scrub_identifier_and_name
         eq_(("A", "USE THIS NAME!"), m("A", "name a"))
         eq_(("B", "NAME B"), m("B", "name b"))
+
+    def test_scrub_identifier(self):
+        m = Classifier.scrub_identifier
+        eq_(None, m(None))
+        eq_(Lowercased("Foo"), m("Foo"))
+
+    def test_scrub_name(self):
+        m = Classifier.scrub_name
+        eq_(None, m(None))
+        eq_(Lowercased("Foo"), m("Foo"))
 
 
 class TestClassifierLookup(object):
@@ -327,7 +338,7 @@ class TestDewey(object):
         young_adult = Classifier.AUDIENCE_YOUNG_ADULT
 
         def aud(identifier):
-            return DDC.audience(DDC.scrub_identifier(identifier), None)
+            return DDC.audience(*DDC.scrub_identifier(identifier))
 
         eq_(child, aud("JB"))
         eq_(child, aud("J300"))
@@ -343,7 +354,7 @@ class TestDewey(object):
     def test_is_fiction(self):
 
         def fic(identifier):
-            return DDC.is_fiction(DDC.scrub_identifier(identifier), None)
+            return DDC.is_fiction(*DDC.scrub_identifier(identifier))
 
         eq_(True, fic("FIC"))
         eq_(True, fic("E"))
@@ -358,7 +369,8 @@ class TestDewey(object):
 
     def test_classification(self):
         def c(identifier):
-            i = DDC.scrub_identifier(identifier)
+            i, name = DDC.scrub_identifier(identifier)
+            eq_(name, None)
             return DDC.genre(i, None)
 
         eq_(classifier.Folklore, c("398"))

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -50,7 +50,7 @@ from metadata_layer import (
     ReplacementPolicy,
     SubjectData,
 )
-from s3 import DummyS3Uploader
+from s3 import MockS3Uploader
 from coverage import (
     BaseCoverageProvider,
     BibliographicCoverageProvider,
@@ -1284,7 +1284,7 @@ class TestCollectionCoverageProvider(CoverageProviderTest):
         )
         
         # ..and will then be uploaded to this 'mirror'.
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
 
         class Tripwire(PresentationCalculationPolicy):
             # This class sets a variable if one of its properties is

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -43,7 +43,7 @@ from . import (
     DummyHTTPClient,
 )
 
-from s3 import DummyS3Uploader
+from s3 import MockS3Uploader
 from classifier import NO_VALUE, NO_NUMBER
 
 class TestIdentifierData(object):
@@ -287,7 +287,7 @@ class TestMetadataImporter(DatabaseTest):
         # However, updated tests passing does not guarantee that all code now 
         # correctly calls on CirculationData, too.  This is a risk.
 
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         edition, pool = self._edition(with_license_pool=True)
         content = open(self.sample_cover_path("test-book-cover.png")).read()
         l1 = LinkData(
@@ -342,7 +342,7 @@ class TestMetadataImporter(DatabaseTest):
 
     def test_mirror_thumbnail_only(self):
         # Make sure a thumbnail image is mirrored when there's no cover image.
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         edition, pool = self._edition(with_license_pool=True)
         thumbnail_content = open(self.sample_cover_path("tiny-image-cover.png")).read()
         l = LinkData(
@@ -368,7 +368,7 @@ class TestMetadataImporter(DatabaseTest):
         data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)
         m = Metadata(data_source=data_source)
 
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         h = DummyHTTPClient()
 
         policy = ReplacementPolicy(mirror=mirror, http_get=h.do_get)
@@ -406,7 +406,7 @@ class TestMetadataImporter(DatabaseTest):
         eq_(None, pool.license_exception)
 
     def test_mirror_404_error(self):
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         h = DummyHTTPClient()
         h.queue_response(404)
         policy = ReplacementPolicy(mirror=mirror, http_get=h.do_get)
@@ -441,7 +441,7 @@ class TestMetadataImporter(DatabaseTest):
         data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)
         m = Metadata(data_source=data_source)
 
-        mirror = DummyS3Uploader(fail=True)
+        mirror = MockS3Uploader(fail=True)
         h = DummyHTTPClient()
 
         policy = ReplacementPolicy(mirror=mirror, http_get=h.do_get)
@@ -494,7 +494,7 @@ class TestMetadataImporter(DatabaseTest):
         data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)
         m = Metadata(data_source=data_source)
 
-        mirror = DummyS3Uploader(fail=True)
+        mirror = MockS3Uploader(fail=True)
         h = DummyHTTPClient()
 
         policy = ReplacementPolicy(mirror=mirror, http_get=h.do_get)
@@ -531,7 +531,7 @@ class TestMetadataImporter(DatabaseTest):
         data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)
         m = Metadata(data_source=data_source)
 
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         def dummy_content_modifier(representation):
             representation.content = "Replaced Content"
         h = DummyHTTPClient()

--- a/tests/test_mirror_uploader.py
+++ b/tests/test_mirror_uploader.py
@@ -1,17 +1,98 @@
 import datetime
-from nose.tools import eq_
+from nose.tools import (
+    eq_,
+    assert_raises_regexp,
+)
 from . import DatabaseTest
+from config import CannotLoadConfiguration
 from util.mirror import MirrorUploader
+from model import ExternalIntegration
 
 class DummySuccessUploader(MirrorUploader):
+
+    def __init__(self):
+        pass
 
     def do_upload(self, representation):
         return None
 
 class DummyFailureUploader(MirrorUploader):
 
+    def __init__(self):
+        pass
+
     def do_upload(self, representation):
         return "I always fail."
+
+
+class TestInitialization(DatabaseTest):
+    """Test the ability to get a MirrorUploader for various aspects of site
+    configuration.
+    """
+
+    @property
+    def _integration(self):
+        """Helper method to make a storage ExternalIntegration."""
+        integration = self._external_integration("my protocol")
+        integration.goal = ExternalIntegration.STORAGE_GOAL
+        return integration
+
+    def test_sitewide(self):
+        # If there's no integration with goal=STORAGE,
+        # MirrorUploader.sitewide raises an exception.
+        assert_raises_regexp(
+            CannotLoadConfiguration,
+            'No storage integration is configured',
+            MirrorUploader.sitewide, self._db
+        )
+        
+        # If there's only one, sitewide() uses it to initialize a
+        # MirrorUploader.
+        integration = self._integration
+        uploader = MirrorUploader.sitewide(self._db)
+        assert isinstance(uploader, MirrorUploader)
+
+        # If there are multiple integrations with goal=STORAGE, no
+        # sitewide configuration can be determined.
+        duplicate = self._integration
+        assert_raises_regexp(
+            CannotLoadConfiguration,
+            'Multiple storage integrations are configured',
+            MirrorUploader.sitewide, self._db
+        )
+
+    def test_for_collection(self):
+        # This collection has no mirror_integration, so 
+        # there is no MirrorUploader for it.
+        collection = self._collection()
+        eq_(None, MirrorUploader.for_collection(self._db, collection))
+
+        # This collection has a properly configured mirror_integration,
+        # so it can have an MirrorUploader.
+        collection.mirror_integration = self._integration        
+        uploader = MirrorUploader.for_collection(self._db, collection)
+        assert isinstance(uploader, MirrorUploader)
+
+        # This collection has a mirror_integration but it has the
+        # wrong goal, so attempting to make an MirrorUploader for it
+        # raises an exception.
+        collection.mirror_integration.goal = ExternalIntegration.LICENSE_GOAL
+        assert_raises_regexp(
+            CannotLoadConfiguration,
+            "from an integration with goal=licenses",
+            MirrorUploader.for_collection, self._db, collection
+        )
+
+    def test_constructor(self):
+        # You can't create a MirrorUploader with an integration 
+        # that's not designed for storage.
+        integration = self._integration
+        integration.goal = ExternalIntegration.LICENSE_GOAL
+        assert_raises_regexp(
+            CannotLoadConfiguration,
+            "from an integration with goal=licenses",
+            MirrorUploader, integration
+        )
 
 
 class TestMirrorUploader(DatabaseTest):

--- a/tests/test_mirror_uploader.py
+++ b/tests/test_mirror_uploader.py
@@ -106,6 +106,7 @@ class TestInitialization(DatabaseTest):
         assert isinstance(uploader, DummyFailureUploader)
         del MirrorUploader.IMPLEMENTATION_REGISTRY["my protocol"]
 
+
 class TestMirrorUploader(DatabaseTest):
     """Test the basic workflow of MirrorUploader."""
 

--- a/tests/test_mirror_uploader.py
+++ b/tests/test_mirror_uploader.py
@@ -10,7 +10,7 @@ from model import ExternalIntegration
 
 class DummySuccessUploader(MirrorUploader):
 
-    def __init__(self):
+    def __init__(self, integration=None):
         pass
 
     def do_upload(self, representation):
@@ -18,7 +18,7 @@ class DummySuccessUploader(MirrorUploader):
 
 class DummyFailureUploader(MirrorUploader):
 
-    def __init__(self):
+    def __init__(self, integration=None):
         pass
 
     def do_upload(self, representation):
@@ -94,6 +94,17 @@ class TestInitialization(DatabaseTest):
             MirrorUploader, integration
         )
 
+    def test_implementation_registry(self):
+        """The implementation class used for a given ExternalIntegration
+        is controlled by the integration's protocol and the contents
+        of the MirrorUploader's implementation registry.
+        """
+        MirrorUploader.IMPLEMENTATION_REGISTRY["my protocol"] = DummyFailureUploader
+
+        integration = self._integration
+        uploader = MirrorUploader.sitewide(self._db)
+        assert isinstance(uploader, DummyFailureUploader)
+        del MirrorUploader.IMPLEMENTATION_REGISTRY["my protocol"]
 
 class TestMirrorUploader(DatabaseTest):
     """Test the basic workflow of MirrorUploader."""

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5079,17 +5079,6 @@ class TestRepresentation(DatabaseTest):
 
 class TestCoverResource(DatabaseTest):
 
-    def sample_cover_path(self, name):
-        base_path = os.path.split(__file__)[0]
-        resource_path = os.path.join(base_path, "files", "covers")
-        sample_cover_path = os.path.join(resource_path, name)
-        return sample_cover_path
-
-    def sample_cover_representation(self, name):
-        sample_cover_path = self.sample_cover_path(name)
-        return self._representation(
-            media_type="image/png", content=open(sample_cover_path).read())[0]
-
     def test_set_cover(self):
         edition, pool = self._edition(with_license_pool=True)
         original = self._url

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -39,7 +39,6 @@ from monitor import (
     OPDSEntryCacheMonitor,
     PermanentWorkIDRefreshMonitor,
     PresentationReadyWorkSweepMonitor,
-    SubjectAssignmentMonitor,
     SubjectSweepMonitor,
     SweepMonitor,
     WorkRandomnessUpdateMonitor,
@@ -561,18 +560,6 @@ class TestOPDSEntryCacheMonitor(DatabaseTest):
         assert work.simple_opds_entry != None
         assert work.verbose_opds_entry != None
 
-
-class TestSubjectAssignmentMonitor(DatabaseTest):
-
-    def test_process_item(self):
-        """This Monitor assigns Subjects to Genres."""
-        class Mock(SubjectAssignmentMonitor):
-            SERVICE_NAME = "Mock"
-
-        subject = self._subject(Subject.TAG, "Science Fiction")
-        eq_(None, subject.genre)
-        Mock(self._db).process_item(subject)
-        eq_("Science Fiction", subject.genre.name)
 
 class TestPermanentWorkIDRefresh(DatabaseTest):
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -29,9 +29,9 @@ class S3UploaderTest(DatabaseTest):
     def _integration(self, **settings):
         """Create and configure a simple S3 integration."""
         integration = self._external_integration(
-            ExternalIntegration.S3, settings=settings
+            ExternalIntegration.S3, ExternalIntegration.STORAGE_GOAL,
+            settings=settings
         )
-        integration.goal = ExternalIntegration.STORAGE_GOAL
         integration.username = 'username'
         integration.password = 'password'
         return integration

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -98,23 +98,22 @@ class TestS3Uploader(S3UploaderTest):
 
     def test_cover_image_root(self):
         bucket = u'test-book-covers-s3-bucket'
-        uploader = self._uploader()
+        m = S3Uploader.cover_image_root
 
         gutenberg_illustrated = DataSource.lookup(
             self._db, DataSource.GUTENBERG_COVER_GENERATOR)
         overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
 
         eq_("http://s3.amazonaws.com/test-book-covers-s3-bucket/Gutenberg%20Illustrated/",
-            uploader.cover_image_root(bucket, gutenberg_illustrated))
+            m(bucket, gutenberg_illustrated))
         eq_("http://s3.amazonaws.com/test-book-covers-s3-bucket/Overdrive/",
-            uploader.cover_image_root(bucket, overdrive))
+            m(bucket, overdrive))
         eq_("http://s3.amazonaws.com/test-book-covers-s3-bucket/scaled/300/Overdrive/",
-            uploader.cover_image_root(bucket, overdrive, 300))
+            m(bucket, overdrive, 300))
 
     def test_content_root(self):
         bucket = u'test-open-access-s3-bucket'
-        uploader = self._uploader()
-        m = uploader.content_root
+        m = S3Uploader.content_root
         eq_(
             "http://s3.amazonaws.com/test-open-access-s3-bucket/",
             m(bucket)

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -75,8 +75,7 @@ class TestS3Uploader(S3UploaderTest):
         }
         buckets_plus_irrelevant_setting = dict(buckets)
         buckets_plus_irrelevant_setting['not-a-bucket-at-all'] = "value"
-        self._integration(**buckets_plus_irrelevant_setting)
-        uploader = MirrorUploader.implementation(integration)
+        uploader = self._uploader(**buckets_plus_irrelevant_setting)
 
         # This S3Uploader knows about the configured buckets.  It
         # wasn't informed of the irrelevant 'not-a-bucket-at-all'
@@ -198,7 +197,7 @@ class TestUpload(S3UploaderTest):
             content=svg)
 
         # 'Upload' it to S3.
-        s3pool = MockS3Pool()
+        s3pool = MockS3Pool('username', 'password')
         s3 = self._uploader(s3pool)
         s3.mirror_one(hyperlink.resource.representation)
         [[filename, data, bucket, media_type, ignore]] = s3pool.uploads

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -25,37 +25,14 @@ from config import CannotLoadConfiguration
 
 class TestInitialization(DatabaseTest):
 
-    def test_sitewide(self):
-        # If there's no configuration for S3, S3Uploader.sitewide
-        # raises an exception.
-        assert_raises_regexp(
-            CannotLoadConfiguration,
-            'Required S3 integration is not configured',
-            S3Uploader.from_config, self._db
-        )
-        
-        # If there's only one, sitewide() uses it to initialize an
-        # S3Uploader.
-
-        # If there are multiple S3 configurations, no sitewide configuration
-        # can be determined.
-        duplicate = self._external_integration(ExternalIntegration.S3)
-        duplicate.goal = ExternalIntegration.STORAGE_GOAL
-        assert_raises_regexp(
-            CannotLoadConfiguration, 'Multiple S3 ExternalIntegrations configured',
-            S3Uploader.from_config, self._db
-        )
-
-
-    def test_for_collection(self):
-        # This collection has no mirror_integration, so 
-        # there is no S3Uploader for it.
-
-        # This collection has a mirror_integration but it's of the 
-        # wrong type.
-
-        # This collection has a properly configured mirror_integration,
-        # so it can have an S3Uploader.
+    @property
+    def _integration(self):
+        """Create and configure a simple S3 integration."""
+        integration = self._external_integration(ExternalIntegration.S3)
+        integration.goal = ExternalIntegration.STORAGE_GOAL
+        integration.username = 'username'
+        integration.password = 'password'
+        return integration
 
     def test_constructor(self):
         # If there is a configuration but it's misconfigured, an error
@@ -65,7 +42,7 @@ class TestInitialization(DatabaseTest):
         )
         assert_raises_regexp(
             CannotLoadConfiguration, 'without both access_key and secret_key',
-            S3Uploader.from_config, self._db
+            MirrorUploader.from_config, self._db
         )
 
         # Otherwise, it builds just fine.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2202,11 +2202,6 @@ class TestCustomListManagementScript(object):
     pass
 
 
-class TestSubjectAssignmentScript(object):
-    """TODO"""
-    pass
-
-        
 class TestNYTBestSellerListsScript(object):
     """TODO"""
     pass

--- a/util/mirror.py
+++ b/util/mirror.py
@@ -13,7 +13,7 @@ class MirrorUploader(object):
     # sitewide() or for_collection(). A subclass that wants to take
     # advantage of this should add a mapping here from its .protocol
     # to itself.
-    SUBCLASS_REGISTRY = {}
+    IMPLEMENTATION_REGISTRY = {}
 
     @classmethod
     def sitewide(cls, _db):
@@ -44,7 +44,7 @@ class MirrorUploader(object):
             )
 
         [integration] = integrations
-        return cls(integration)
+        return cls.implementation(integration)
 
     @classmethod
     def for_collection(cls, _db, collection):
@@ -58,7 +58,17 @@ class MirrorUploader(object):
         integration = collection.mirror_integration
         if not integration:
             return None
-        return cls(integration)
+        return cls.implementation(integration)
+
+    @classmethod
+    def implementation(cls, integration):
+        """Instantiate the appropriate implementation of MirrorUploader
+        for the given ExternalIntegration.
+        """
+        implementation_class = cls.IMPLEMENTATION_REGISTRY.get(
+            integration.protocol, cls
+        )
+        return implementation_class(integration)
 
     def __init__(self, integration):
         """Instantiate a MirrorUploader from an ExternalIntegration.

--- a/util/mirror.py
+++ b/util/mirror.py
@@ -106,3 +106,13 @@ class MirrorUploader(object):
 
         for representation in representations:
             self.mirror_one(representation)
+
+    def book_url(self, identifier, extension='.epub', open_access=True, 
+                 data_source=None, title=None):
+        """The path to the hosted EPUB file for the given identifier."""
+        raise NotImplementedError()
+
+    def cover_image_url(self, data_source, identifier, filename=None,
+                        scaled_size=None):
+        raise NotImplementedError()
+

--- a/util/mirror.py
+++ b/util/mirror.py
@@ -109,10 +109,20 @@ class MirrorUploader(object):
 
     def book_url(self, identifier, extension='.epub', open_access=True, 
                  data_source=None, title=None):
-        """The path to the hosted EPUB file for the given identifier."""
+        """The URL of the hosted EPUB file for the given identifier.
+
+        This does not upload anything to the URL, but it is expected
+        that calling mirror() on a certain Representation object will
+        make that representation end up at that URL.
+        """
         raise NotImplementedError()
 
     def cover_image_url(self, data_source, identifier, filename=None,
                         scaled_size=None):
-        raise NotImplementedError()
+        """The URL of the hosted cover image for the given identifier.
 
+        This does not upload anything to the URL, but it is expected
+        that calling mirror() on a certain Representation object will
+        make that representation end up at that URL.
+        """
+        raise NotImplementedError()


### PR DESCRIPTION
This branch adds a relationship between `Collection` and `ExternalIntegration` that says any open-access books or book covers discovered in the course of an OPDS import into the `Collection` should be mirrored externally as configured by the `ExternalIntegration`. As an example, you could set this up so that every time you do an OPDS import from Standard Ebooks, everything you find is mirrored to your own S3 bucket.

This makes it possible to duplicate a lot of the content server's functionality within the circulation manager.

I ripped up a lot of the S3 initialization code, which assumed there was a single S3 integration that was used site-wide and instantiated as necessary. S3Uploaders are no longer instantiated directly; you're supposed to go through `MirrorUploader.sitewide` or `MirrorUploader.for_collection`. This opens up the possibility of mirror techniques other than "upload to S3".

We still support the case where there is one sitewide integration (i.e. the metadata wrangler), but it relies on the database containing one and only one integration with GOAL="storage", so it's a little fragile.

I also made sure there was test coverage for every method in s3.py.