### PR TITLE
A Collection may have a designated ExternalIntegration that's used to mirror things on OPDS import 

### DIFF
--- a/model.py
+++ b/model.py
@@ -120,6 +120,7 @@ from util import (
     MetadataSimilarity,
     TitleProcessor,
 )
+from util.mirror import MirrorUploader
 from util.http import (
     HTTP,
     RemoteIntegrationException,
@@ -10001,7 +10002,7 @@ class ExternalIntegration(Base, HasFullTableCache):
 
     # These integrations are associated with external services such as
     # S3 that provide access to book covers.
-    STORAGE_GOAL = u'storage'
+    STORAGE_GOAL = MirrorUploader.STORAGE_GOAL
 
     # These integrations are associated with external services like
     # Cloudfront or other CDNs that mirror and/or cache certain domains.
@@ -10134,6 +10135,13 @@ class ExternalIntegration(Base, HasFullTableCache):
     settings = relationship(
         "ConfigurationSetting", backref="external_integration",
         lazy="joined", cascade="all, delete-orphan",
+    )
+
+    # An ExternalIntegration may be used by many Collections
+    # to mirror book covers or other files.
+    mirror_for = relationship(
+        "Collection", backref="mirror_integration",
+        foreign_keys='Collection.mirror_integration_id',
     )
 
     def __repr__(self):
@@ -10538,6 +10546,14 @@ class Collection(Base, HasFullTableCache):
     # secret as the Overdrive collection, but it has a distinct
     # external_account_id.
     parent_id = Column(Integer, ForeignKey('collections.id'), index=True)
+
+    # Some Collections use an ExternalIntegration to mirror books and
+    # cover images they discover. Such a collection should use an
+    # ExternalIntegration to set up its mirroring technique, and keep
+    # a reference to that ExternalIntegration here.
+    mirror_integration_id = Column(
+        Integer, ForeignKey('externalintegrations.id'), nullable=True
+    )
 
     # A collection may have many child collections. For example,
     # An Overdrive collection may have many children corresponding

--- a/opds_import.py
+++ b/opds_import.py
@@ -424,7 +424,7 @@ class OPDSImporter(object):
             # If this Collection is configured to mirror the assets it
             # discovers, this will create a MirrorUploader for that
             # Collection. Otherwise, this will return None.
-            mirror = MirrorUploader.for_collection(_db, collection)
+            mirror = MirrorUploader.for_collection(collection)
         self.mirror = mirror
         self.content_modifier = content_modifier
         self.http_get = http_get

--- a/testing.py
+++ b/testing.py
@@ -915,6 +915,19 @@ class DatabaseTest(object):
             data_source=data_source, weight=weight
         )[0]
 
+    def sample_cover_path(self, name):
+        """The path to the sample cover with the given filename."""
+        base_path = os.path.split(__file__)[0]
+        resource_path = os.path.join(base_path, "tests", "files", "covers")
+        sample_cover_path = os.path.join(resource_path, name)
+        return sample_cover_path
+
+    def sample_cover_representation(self, name):
+        """A Representation of the sample cover with the given filename."""
+        sample_cover_path = self.sample_cover_path(name)
+        return self._representation(
+            media_type="image/png", content=open(sample_cover_path).read())[0]
+
 
 class MockCoverageProvider(object):
     """Mixin class for mock CoverageProviders that defines common constants."""

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -34,7 +34,7 @@ from . import (
     DummyHTTPClient,
 )
 
-from s3 import DummyS3Uploader
+from s3 import MockS3Uploader
 
 
 class TestCirculationData(DatabaseTest):
@@ -553,7 +553,7 @@ class TestMetaToModelUtility(DatabaseTest):
         # Note: Mirroring tests passing does not guarantee that all code now 
         # correctly calls on CirculationData, as well as Metadata.  This is a risk.
 
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         # Here's a book.
         edition, pool = self._edition(with_license_pool=True)
         
@@ -622,7 +622,7 @@ class TestMetaToModelUtility(DatabaseTest):
 
 
     def test_mirror_open_access_link_fetch_failure(self):
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         h = DummyHTTPClient()
 
         edition, pool = self._edition(with_license_pool=True)
@@ -665,7 +665,7 @@ class TestMetaToModelUtility(DatabaseTest):
 
 
     def test_mirror_open_access_link_mirror_failure(self):
-        mirror = DummyS3Uploader(fail=True)
+        mirror = MockS3Uploader(fail=True)
         h = DummyHTTPClient()
 
         edition, pool = self._edition(with_license_pool=True)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -50,7 +50,7 @@ from metadata_layer import (
     ReplacementPolicy,
     SubjectData,
 )
-from s3 import DummyS3Uploader
+from s3 import MockS3Uploader
 from coverage import (
     BaseCoverageProvider,
     BibliographicCoverageProvider,
@@ -1284,7 +1284,7 @@ class TestCollectionCoverageProvider(CoverageProviderTest):
         )
         
         # ..and will then be uploaded to this 'mirror'.
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
 
         class Tripwire(PresentationCalculationPolicy):
             # This class sets a variable if one of its properties is

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -43,7 +43,7 @@ from . import (
     DummyHTTPClient,
 )
 
-from s3 import DummyS3Uploader
+from s3 import MockS3Uploader
 from classifier import NO_VALUE, NO_NUMBER
 
 class TestIdentifierData(object):
@@ -287,7 +287,7 @@ class TestMetadataImporter(DatabaseTest):
         # However, updated tests passing does not guarantee that all code now 
         # correctly calls on CirculationData, too.  This is a risk.
 
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         edition, pool = self._edition(with_license_pool=True)
         content = open(self.sample_cover_path("test-book-cover.png")).read()
         l1 = LinkData(
@@ -342,7 +342,7 @@ class TestMetadataImporter(DatabaseTest):
 
     def test_mirror_thumbnail_only(self):
         # Make sure a thumbnail image is mirrored when there's no cover image.
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         edition, pool = self._edition(with_license_pool=True)
         thumbnail_content = open(self.sample_cover_path("tiny-image-cover.png")).read()
         l = LinkData(
@@ -368,7 +368,7 @@ class TestMetadataImporter(DatabaseTest):
         data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)
         m = Metadata(data_source=data_source)
 
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         h = DummyHTTPClient()
 
         policy = ReplacementPolicy(mirror=mirror, http_get=h.do_get)
@@ -406,7 +406,7 @@ class TestMetadataImporter(DatabaseTest):
         eq_(None, pool.license_exception)
 
     def test_mirror_404_error(self):
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         h = DummyHTTPClient()
         h.queue_response(404)
         policy = ReplacementPolicy(mirror=mirror, http_get=h.do_get)
@@ -441,7 +441,7 @@ class TestMetadataImporter(DatabaseTest):
         data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)
         m = Metadata(data_source=data_source)
 
-        mirror = DummyS3Uploader(fail=True)
+        mirror = MockS3Uploader(fail=True)
         h = DummyHTTPClient()
 
         policy = ReplacementPolicy(mirror=mirror, http_get=h.do_get)
@@ -494,7 +494,7 @@ class TestMetadataImporter(DatabaseTest):
         data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)
         m = Metadata(data_source=data_source)
 
-        mirror = DummyS3Uploader(fail=True)
+        mirror = MockS3Uploader(fail=True)
         h = DummyHTTPClient()
 
         policy = ReplacementPolicy(mirror=mirror, http_get=h.do_get)
@@ -531,7 +531,7 @@ class TestMetadataImporter(DatabaseTest):
         data_source = DataSource.lookup(self._db, DataSource.GUTENBERG)
         m = Metadata(data_source=data_source)
 
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         def dummy_content_modifier(representation):
             representation.content = "Replaced Content"
         h = DummyHTTPClient()

--- a/tests/test_mirror_uploader.py
+++ b/tests/test_mirror_uploader.py
@@ -1,17 +1,110 @@
 import datetime
-from nose.tools import eq_
+from nose.tools import (
+    eq_,
+    assert_raises_regexp,
+)
 from . import DatabaseTest
+from config import CannotLoadConfiguration
 from util.mirror import MirrorUploader
+from model import ExternalIntegration
 
 class DummySuccessUploader(MirrorUploader):
+
+    def __init__(self, integration=None):
+        pass
 
     def do_upload(self, representation):
         return None
 
 class DummyFailureUploader(MirrorUploader):
 
+    def __init__(self, integration=None):
+        pass
+
     def do_upload(self, representation):
         return "I always fail."
+
+
+class TestInitialization(DatabaseTest):
+    """Test the ability to get a MirrorUploader for various aspects of site
+    configuration.
+    """
+
+    @property
+    def _integration(self):
+        """Helper method to make a storage ExternalIntegration."""
+        integration = self._external_integration("my protocol")
+        integration.goal = ExternalIntegration.STORAGE_GOAL
+        return integration
+
+    def test_sitewide(self):
+        # If there's no integration with goal=STORAGE,
+        # MirrorUploader.sitewide raises an exception.
+        assert_raises_regexp(
+            CannotLoadConfiguration,
+            'No storage integration is configured',
+            MirrorUploader.sitewide, self._db
+        )
+
+        # If there's only one, sitewide() uses it to initialize a
+        # MirrorUploader.
+        integration = self._integration
+        uploader = MirrorUploader.sitewide(self._db)
+        assert isinstance(uploader, MirrorUploader)
+
+        # If there are multiple integrations with goal=STORAGE, no
+        # sitewide configuration can be determined.
+        duplicate = self._integration
+        assert_raises_regexp(
+            CannotLoadConfiguration,
+            'Multiple storage integrations are configured',
+            MirrorUploader.sitewide, self._db
+        )
+
+    def test_for_collection(self):
+        # This collection has no mirror_integration, so
+        # there is no MirrorUploader for it.
+        collection = self._collection()
+        eq_(None, MirrorUploader.for_collection(self._db, collection))
+
+        # This collection has a properly configured mirror_integration,
+        # so it can have an MirrorUploader.
+        collection.mirror_integration = self._integration
+        uploader = MirrorUploader.for_collection(self._db, collection)
+        assert isinstance(uploader, MirrorUploader)
+
+        # This collection has a mirror_integration but it has the
+        # wrong goal, so attempting to make an MirrorUploader for it
+        # raises an exception.
+        collection.mirror_integration.goal = ExternalIntegration.LICENSE_GOAL
+        assert_raises_regexp(
+            CannotLoadConfiguration,
+            "from an integration with goal=licenses",
+            MirrorUploader.for_collection, self._db, collection
+        )
+
+    def test_constructor(self):
+        # You can't create a MirrorUploader with an integration
+        # that's not designed for storage.
+        integration = self._integration
+        integration.goal = ExternalIntegration.LICENSE_GOAL
+        assert_raises_regexp(
+            CannotLoadConfiguration,
+            "from an integration with goal=licenses",
+            MirrorUploader, integration
+        )
+
+    def test_implementation_registry(self):
+        """The implementation class used for a given ExternalIntegration
+        is controlled by the integration's protocol and the contents
+        of the MirrorUploader's implementation registry.
+        """
+        MirrorUploader.IMPLEMENTATION_REGISTRY["my protocol"] = DummyFailureUploader
+
+        integration = self._integration
+        uploader = MirrorUploader.sitewide(self._db)
+        assert isinstance(uploader, DummyFailureUploader)
+        del MirrorUploader.IMPLEMENTATION_REGISTRY["my protocol"]
 
 
 class TestMirrorUploader(DatabaseTest):

--- a/tests/test_mirror_uploader.py
+++ b/tests/test_mirror_uploader.py
@@ -65,12 +65,12 @@ class TestInitialization(DatabaseTest):
         # This collection has no mirror_integration, so
         # there is no MirrorUploader for it.
         collection = self._collection()
-        eq_(None, MirrorUploader.for_collection(self._db, collection))
+        eq_(None, MirrorUploader.for_collection(collection))
 
         # This collection has a properly configured mirror_integration,
         # so it can have an MirrorUploader.
         collection.mirror_integration = self._integration
-        uploader = MirrorUploader.for_collection(self._db, collection)
+        uploader = MirrorUploader.for_collection(collection)
         assert isinstance(uploader, MirrorUploader)
 
         # This collection has a mirror_integration but it has the
@@ -80,7 +80,7 @@ class TestInitialization(DatabaseTest):
         assert_raises_regexp(
             CannotLoadConfiguration,
             "from an integration with goal=licenses",
-            MirrorUploader.for_collection, self._db, collection
+            MirrorUploader.for_collection, collection
         )
 
     def test_constructor(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2470,7 +2470,7 @@ class TestWork(DatabaseTest):
             lp3, complaint_type, "blah", "blah"
         )
 
-        eq_(set([complaint1, complaint2]), set(work.complaints))
+        eq_([complaint1, complaint2], work.complaints)
         assert complaint3 not in work.complaints
 
     def test_all_identifier_ids(self):
@@ -5078,17 +5078,6 @@ class TestRepresentation(DatabaseTest):
 
 
 class TestCoverResource(DatabaseTest):
-
-    def sample_cover_path(self, name):
-        base_path = os.path.split(__file__)[0]
-        resource_path = os.path.join(base_path, "files", "covers")
-        sample_cover_path = os.path.join(resource_path, name)
-        return sample_cover_path
-
-    def sample_cover_representation(self, name):
-        sample_cover_path = self.sample_cover_path(name)
-        return self._representation(
-            media_type="image/png", content=open(sample_cover_path).read())[0]
 
     def test_set_cover(self):
         edition, pool = self._edition(with_license_pool=True)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2206,7 +2206,7 @@ class TestSubjectAssignmentScript(object):
     """TODO"""
     pass
 
-        
+
 class TestNYTBestSellerListsScript(object):
     """TODO"""
     pass

--- a/util/mirror.py
+++ b/util/mirror.py
@@ -47,7 +47,7 @@ class MirrorUploader(object):
         return cls.implementation(integration)
 
     @classmethod
-    def for_collection(cls, _db, collection):
+    def for_collection(cls, collection):
         """Create a MirrorUploader for the given Collection.
 
         :param collection: Use the mirror configuration for this Collection.

--- a/util/mirror.py
+++ b/util/mirror.py
@@ -81,7 +81,7 @@ class MirrorUploader(object):
             # This collection's 'mirror integration' isn't intended to
             # be used to mirror anything.
             raise CannotLoadConfiguration(
-                "Cannot create an S3Uploader from an integration with goal=%s" %
+                "Cannot create an MirrorUploader from an integration with goal=%s" %
                 integration.goal
             )
 

--- a/util/mirror.py
+++ b/util/mirror.py
@@ -6,6 +6,88 @@ class MirrorUploader(object):
     a mirror that we control.
     """
 
+    STORAGE_GOAL = u'storage'
+
+    # Depending on the .protocol of an ExternalIntegration with
+    # .goal=STORAGE, a different subclass might be initialized by
+    # sitewide() or for_collection(). A subclass that wants to take
+    # advantage of this should add a mapping here from its .protocol
+    # to itself.
+    IMPLEMENTATION_REGISTRY = {}
+
+    @classmethod
+    def sitewide(cls, _db):
+        """Create a MirrorUploader from a sitewide configuration.
+
+        :return: A MirrorUploader.
+
+        :raise: CannotLoadConfiguration if no integration with
+        goal==STORAGE_GOAL is configured, or if multiple integrations
+        are so configured.
+        """
+        from config import CannotLoadConfiguration
+
+        from model import ExternalIntegration as EI
+        qu = _db.query(EI).filter(EI.goal==cls.STORAGE_GOAL)
+        integrations = qu.all()
+        if not integrations:
+            raise CannotLoadConfiguration(
+                "No storage integration is configured."
+            )
+            return None
+
+        if len(integrations) > 1:
+            # If there are multiple integrations configured, none of
+            # them can be the 'site-wide' configuration.
+            raise CannotLoadConfiguration(
+                'Multiple storage integrations are configured'
+            )
+
+        [integration] = integrations
+        return cls.implementation(integration)
+
+    @classmethod
+    def for_collection(cls, _db, collection):
+        """Create a MirrorUploader for the given Collection.
+
+        :param collection: Use the mirror configuration for this Collection.
+
+        :return: A MirrorUploader, or None if the Collection has no
+            mirror integration.
+        """
+        integration = collection.mirror_integration
+        if not integration:
+            return None
+        return cls.implementation(integration)
+
+    @classmethod
+    def implementation(cls, integration):
+        """Instantiate the appropriate implementation of MirrorUploader
+        for the given ExternalIntegration.
+        """
+        implementation_class = cls.IMPLEMENTATION_REGISTRY.get(
+            integration.protocol, cls
+        )
+        return implementation_class(integration)
+
+    def __init__(self, integration):
+        """Instantiate a MirrorUploader from an ExternalIntegration.
+
+        :param integration: An ExternalIntegration configuring the credentials
+           used to upload things.
+        """
+        from config import CannotLoadConfiguration
+        if integration.goal != self.STORAGE_GOAL:
+            # This collection's 'mirror integration' isn't intended to
+            # be used to mirror anything.
+            raise CannotLoadConfiguration(
+                "Cannot create an S3Uploader from an integration with goal=%s" %
+                integration.goal
+            )
+
+        # Subclasses will override this to further configure the client
+        # based on the credentials in the ExternalIntegration.
+
     def do_upload(self, representation):
         raise NotImplementedError()        
 
@@ -24,3 +106,23 @@ class MirrorUploader(object):
 
         for representation in representations:
             self.mirror_one(representation)
+
+    def book_url(self, identifier, extension='.epub', open_access=True,
+                 data_source=None, title=None):
+        """The URL of the hosted EPUB file for the given identifier.
+
+        This does not upload anything to the URL, but it is expected
+        that calling mirror() on a certain Representation object will
+        make that representation end up at that URL.
+        """
+        raise NotImplementedError()
+
+    def cover_image_url(self, data_source, identifier, filename=None,
+                        scaled_size=None):
+        """The URL of the hosted cover image for the given identifier.
+
+        This does not upload anything to the URL, but it is expected
+        that calling mirror() on a certain Representation object will
+        make that representation end up at that URL.
+        """
+        raise NotImplementedError()


### PR DESCRIPTION
This branch adds a relationship between Collection and ExternalIntegration that says any open-access books or book covers discovered in the course of an OPDS import into the Collection should be mirrored externally as configured by the ExternalIntegration. As an example, you could set this up so that every time you do an OPDS import from Standard Ebooks, everything you find is mirrored to your own S3 bucket.

This makes it possible to duplicate a lot of the content server's functionality within the circulation manager.

I ripped up a lot of the S3 initialization code, which assumed there was a single S3 integration that was used site-wide and instantiated as necessary. S3Uploaders are no longer instantiated directly; you're supposed to go through MirrorUploader.sitewide or MirrorUploader.for_collection. This opens up the possibility of mirror techniques other than "upload to S3".

We still support the case where there is one sitewide integration (i.e. the metadata wrangler), but it relies on the database containing one and only one integration with GOAL="storage", so it's a little fragile.

I also made sure there was test coverage for every method in s3.py.

This branch is ready for review but I won't be merging it until I make any necessary changes to circulation and metadata. (I'm not sure about content -- this is the beginning of the end for that component and it might not be a good use of time to keep it compatible.)