### PR TITLE
Guess sort name based on display name in the metadata layer instead of leaving out the author.

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -44,6 +44,7 @@ from model import (
 )
 from classifier import NO_VALUE, NO_NUMBER
 from analytics import Analytics
+from util.personal_names import display_name_to_sort_name
 
 class ReplacementPolicy(object):
     """How serious should we be about overwriting old metadata with
@@ -290,6 +291,7 @@ class ContributorData(object):
 
         # Is there a contributor already in the database with this
         # exact sort name? If so, use their display name.
+        # If not, take our best guess based on the display name.
         sort_name = self.display_name_to_sort_name(_db, self.display_name)
         if sort_name:
             self.sort_name = sort_name
@@ -302,6 +304,7 @@ class ContributorData(object):
                 _db, identifiers, metadata_client
             )
             self.sort_name = sort_name
+
         return (self.sort_name is not None)
 
     @classmethod
@@ -329,7 +332,9 @@ class ContributorData(object):
                 contributors[0].sort_name
             )
             return contributors[0].sort_name
-        return None
+        # There weren't any matching contributors. Guess the sort name
+        # based on the display name instead.
+        return display_name_to_sort_name(display_name)
 
     def _display_name_to_sort_name(
             self, _db, metadata_client, identifier_obj

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -292,7 +292,8 @@ class ContributorData(object):
         # Is there a contributor already in the database with this
         # exact sort name? If so, use their display name.
         # If not, take our best guess based on the display name.
-        sort_name = self.display_name_to_sort_name(_db, self.display_name)
+        sort_name = self.display_name_to_sort_name_from_existing_contributor(
+            _db, self.display_name)
         if sort_name:
             self.sort_name = sort_name
             return True
@@ -303,12 +304,18 @@ class ContributorData(object):
             sort_name = self.display_name_to_sort_name_through_canonicalizer(
                 _db, identifiers, metadata_client
             )
-            self.sort_name = sort_name
+            if sort_name:
+                self.sort_name = sort_name
+                return True
+
+        # If there's still no sort name, take our best guess based
+        # on the display name.
+        self.sort_name = display_name_to_sort_name(self.display_name)
 
         return (self.sort_name is not None)
 
     @classmethod
-    def display_name_to_sort_name(self, _db, display_name):
+    def display_name_to_sort_name_from_existing_contributor(self, _db, display_name):
         """Find the sort name for this book's author, assuming it's easy.
 
         'Easy' means we already have an established sort name for a
@@ -332,9 +339,7 @@ class ContributorData(object):
                 contributors[0].sort_name
             )
             return contributors[0].sort_name
-        # There weren't any matching contributors. Guess the sort name
-        # based on the display name instead.
-        return display_name_to_sort_name(display_name)
+        return None
 
     def _display_name_to_sort_name(
             self, _db, metadata_client, identifier_obj

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -689,7 +689,14 @@ class TestContributorData(DatabaseTest):
         contributor_new, changed = contributor_data.apply(contributor_new)
         eq_(changed, False)
 
+    def test_display_name_to_sort_name(self):
+        # If there's an existing contributor with a matching display name,
+        # we'll use their sort name.
+        existing_contributor, ignore = self._contributor(sort_name="Sort, Name", display_name="John Doe")
+        eq_("Sort, Name", ContributorData.display_name_to_sort_name(self._db, "John Doe"))
 
+        # Otherwise, we'll guess based on the display name.
+        eq_("Doe, Jane", ContributorData.display_name_to_sort_name(self._db, "Jane Doe"))
 
 class TestLinkData(DatabaseTest):
 


### PR DESCRIPTION
When I import from an OPDS feed with no sort names and there's no metadata wrangler integration, the metadata layer should guess the sort names rather than leaving out the contributions.