### PR TITLE
Support for Feedbooks import

### DIFF
--- a/migration/20180129-collection-mirror-integration.sql
+++ b/migration/20180129-collection-mirror-integration.sql
@@ -1,0 +1,4 @@
+-- Add collections.mirror_integration_id, a foreign key
+-- against externalintegrations.id
+alter table collections add column mirror_integration_id integer;
+alter table collections add constraint collections_mirror_integration_id_fkey FOREIGN KEY (mirror_integration_id) REFERENCES externalintegrations(id);

--- a/model.py
+++ b/model.py
@@ -10039,6 +10039,8 @@ class ExternalIntegration(Base, HasFullTableCache):
     ONE_CLICK = RB_DIGITAL
     OPDS_FOR_DISTRIBUTORS = u'OPDS for Distributors'
     ENKI = DataSource.ENKI
+    FEEDBOOKS = DataSource.FEEDBOOKS
+    UNGLUEIT = DataSource.UNGLUEIT
 
     # These protocols are only used on the Content Server when mirroring
     # content from a given directory or directly from Project

--- a/model.py
+++ b/model.py
@@ -10040,7 +10040,6 @@ class ExternalIntegration(Base, HasFullTableCache):
     OPDS_FOR_DISTRIBUTORS = u'OPDS for Distributors'
     ENKI = DataSource.ENKI
     FEEDBOOKS = DataSource.FEEDBOOKS
-    UNGLUEIT = DataSource.UNGLUEIT
 
     # These protocols are only used on the Content Server when mirroring
     # content from a given directory or directly from Project

--- a/opds_import.py
+++ b/opds_import.py
@@ -1456,7 +1456,7 @@ class OPDSImportMonitor(CollectionMonitor):
                 )
             )
 
-        data_source = collection.data_source
+        data_source = self.data_source(collection)
         if not data_source:
             raise ValueError(
                 "Collection %s has no associated data source." % collection.name
@@ -1494,6 +1494,14 @@ class OPDSImportMonitor(CollectionMonitor):
         subclasses may override this.
         """
         return collection.external_account_id
+
+    def data_source(self, collection):
+        """Returns the data source name for the given collection.
+
+        By default, this URL is stored as a setting on the collection, but
+        subclasses may hard-code it.
+        """
+        return collection.data_source
 
     def feed_contains_new_data(self, feed):
         """Does the given feed contain any entries that haven't been imported
@@ -1618,7 +1626,7 @@ class OPDSImportMonitor(CollectionMonitor):
         imported_editions, pools, works, failures = self.importer.import_from_feed(
             feed, even_if_no_author=True,
             immediately_presentation_ready = True,
-            feed_url=self.collection.external_account_id
+            feed_url=self.opds_url(self.collection)
         )
 
         # Create CoverageRecords for the successful imports.

--- a/opds_import.py
+++ b/opds_import.py
@@ -1462,7 +1462,7 @@ class OPDSImportMonitor(CollectionMonitor):
                 "Collection %s has no associated data source." % collection.name
             )
 
-        self.feed_url = collection.external_account_id
+        self.feed_url = self.opds_url(collection)
         self.force_reimport = force_reimport
         self.importer = import_class(
             _db, collection=collection, **import_class_kwargs
@@ -1486,6 +1486,14 @@ class OPDSImportMonitor(CollectionMonitor):
         kwargs = dict(timeout=120, allowed_response_codes=['2xx', '3xx'])
         response = HTTP.get_with_timeout(url, headers=headers, **kwargs)
         return response.status_code, response.headers, response.content
+
+    def opds_url(self, collection):
+        """Returns the OPDS import URL for the given collection.
+
+        By default, this URL is stored as the external account ID, but
+        subclasses may override this.
+        """
+        return collection.external_account_id
 
     def feed_contains_new_data(self, feed):
         """Does the given feed contain any entries that haven't been imported

--- a/scripts.py
+++ b/scripts.py
@@ -1603,7 +1603,14 @@ class OPDSImportScript(CollectionInputScript):
     IMPORTER_CLASS = OPDSImporter
     MONITOR_CLASS = OPDSImportMonitor
     PROTOCOL = ExternalIntegration.OPDS_IMPORT
-    
+
+    def __init__(self, _db=None, importer_class=None, monitor_class=None, 
+                 protocol=None, *args, **kwargs):
+        super(OPDSImportScript, self).__init__(_db, *args, **kwargs)
+        self.importer_class = importer_class or self.IMPORTER_CLASS
+        self.monitor_class = monitor_class or self.MONITOR_CLASS
+        self.protocol = protocol or self.PROTOCOL
+
     @classmethod
     def arg_parser(cls):
         parser = CollectionInputScript.arg_parser()
@@ -1616,13 +1623,13 @@ class OPDSImportScript(CollectionInputScript):
     
     def do_run(self, cmd_args=None):
         parsed = self.parse_command_line(self._db, cmd_args=cmd_args)
-        collections = parsed.collections or Collection.by_protocol(self._db, self.PROTOCOL)
+        collections = parsed.collections or Collection.by_protocol(self._db, self.protocol)
         for collection in collections:
             self.run_monitor(collection, force=parsed.force)
 
     def run_monitor(self, collection, force=None):
-        monitor = self.MONITOR_CLASS(
-            self._db, collection, import_class=self.IMPORTER_CLASS,
+        monitor = self.monitor_class(
+            self._db, collection, import_class=self.importer_class,
             force_reimport=force
         )
         monitor.run()

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -1559,6 +1559,20 @@ class TestOPDSImportMonitor(OPDSImporterTest):
             self._default_collection,
             OPDSImporter,
         )
+
+    def test_hook_methods(self):
+        """By default, the OPDS URL and data source used by the importer 
+        come from the collection configuration.
+        """
+        monitor = OPDSImportMonitor(
+            self._db, self._default_collection,
+            import_class=OPDSImporter,
+        )
+        eq_(self._default_collection.external_account_id,
+            monitor.opds_url(self._default_collection))
+
+        eq_(self._default_collection.data_source,
+            monitor.data_source(self._default_collection))
         
     def test_feed_contains_new_data(self):
         feed = self.content_server_mini_feed


### PR DESCRIPTION
This branch adds the core support for https://github.com/NYPL-Simplified/circulation/pull/844. It also adds a migration script that I created earlier but neglected to `git add` in the branch that should have had it.