### PR TITLE
Only use the vendor value for Hold.end if it's in the future.

### DIFF
--- a/model.py
+++ b/model.py
@@ -883,8 +883,9 @@ class Hold(Base, LoanAndHoldMixin):
         this--the library's license might expire and then you'll
         _never_ get the book.)
         """
-        if self.end:
-            # Whew, the server provided its own estimate.
+        if self.end and self.end > datetime.datetime.utcnow():
+            # The license source provided their own estimate, and it's
+            # not obviously wrong, so use it.
             return self.end
 
         if default_reservation_period is None:


### PR DESCRIPTION
This stops the symptoms of https://github.com/NYPL-Simplified/server_core/issues/791. The underlying cause needs to be addressed by Bibliotheca.