### PR TITLE
Crawlable acquisition feeds for lists

### DIFF
--- a/files/materialized_view_for_lanes.sql
+++ b/files/materialized_view_for_lanes.sql
@@ -52,7 +52,7 @@ as
   WITH NO DATA;
 
 -- First create an index that allows work/genre lookup. It's unique and incorporates license_pool_id so that the materialized view can be refreshed CONCURRENTLY.
-create unique index mv_works_for_lanes_unique on mv_works_for_lanes (works_id, genre_id, license_pool_id, list_id);
+create unique index mv_works_for_lanes_unique on mv_works_for_lanes (works_id, genre_id, list_id, license_pool_id);
 
 -- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
 

--- a/lane.py
+++ b/lane.py
@@ -42,7 +42,6 @@ from sqlalchemy.orm import (
     relationship,
 )
 from sqlalchemy.sql.expression import literal
-from sqlalchemy.sql.functions import Function
 
 from model import (
     get_one_or_create,
@@ -301,7 +300,7 @@ class Facets(FacetConstants):
         ]
     
         primary_order_by = self.order_facet_to_database_field(self.order)
-        if isinstance(primary_order_by, Function) or primary_order_by:
+        if primary_order_by is not None:
             # Promote the field designated by the sort facet to the top of
             # the order-by list.
             order_by = [primary_order_by]

--- a/lane.py
+++ b/lane.py
@@ -42,6 +42,7 @@ from sqlalchemy.orm import (
     relationship,
 )
 from sqlalchemy.sql.expression import literal
+from sqlalchemy.sql.functions import Function
 
 from model import (
     get_one_or_create,
@@ -300,7 +301,7 @@ class Facets(FacetConstants):
         ]
     
         primary_order_by = self.order_facet_to_database_field(self.order)
-        if primary_order_by:
+        if isinstance(primary_order_by, Function) or primary_order_by:
             # Promote the field designated by the sort facet to the top of
             # the order-by list.
             order_by = [primary_order_by]

--- a/migration/20180207-1-change-custom-list-name-constraint.sql
+++ b/migration/20180207-1-change-custom-list-name-constraint.sql
@@ -1,0 +1,2 @@
+alter table customlists drop constraint if exists "customlists_data_source_id_name_library_id_key";
+alter table customlists add constraint "customlists_name_library_id_key" unique (name, library_id);

--- a/migration/20180207-2-recreate-materialized-view.sql
+++ b/migration/20180207-2-recreate-materialized-view.sql
@@ -52,7 +52,7 @@ as
   WITH NO DATA;
 
 -- First create an index that allows work/genre lookup. It's unique and incorporates license_pool_id so that the materialized view can be refreshed CONCURRENTLY.
-create unique index mv_works_for_lanes_unique on mv_works_for_lanes (works_id, genre_id, license_pool_id, list_id);
+create unique index mv_works_for_lanes_unique on mv_works_for_lanes (works_id, genre_id, list_id, license_pool_id);
 
 -- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
 

--- a/migration/20180207-2-recreate-materialized-view.sql
+++ b/migration/20180207-2-recreate-materialized-view.sql
@@ -129,5 +129,6 @@ create index mv_works_for_lanes_ya_nonfiction_by_title on mv_works_for_lanes (so
 
 create index mv_works_for_lanes_ya_nonfiction_by_availability on mv_works_for_lanes (availability_time DESC, sort_author, sort_title, language, works_id) WHERE audience in ('Children', 'Young Adult') AND fiction = false;
 
--- The materialized view will be refreshed as part of initialization.
+-- Refresh the new materialized view.
+refresh materialized view concurrently mv_works_for_lanes;
 

--- a/migration/20180207-2-recreate-materialized-view.sql
+++ b/migration/20180207-2-recreate-materialized-view.sql
@@ -1,4 +1,4 @@
--- Create the materialized view with no data.
+drop materialized view mv_works_for_lanes;
 create materialized view mv_works_for_lanes
 as
  SELECT 

--- a/model.py
+++ b/model.py
@@ -9266,7 +9266,7 @@ class CustomList(Base):
 
     __table_args__ = (
         UniqueConstraint('data_source_id', 'foreign_identifier'),
-        UniqueConstraint('data_source_id', 'name', 'library_id'),
+        UniqueConstraint('name', 'library_id'),
     )
 
     # TODO: It should be possible to associate a CustomList with an
@@ -9290,17 +9290,21 @@ class CustomList(Base):
         return _db.query(CustomList).filter(CustomList.data_source_id.in_(ids))
 
     @classmethod
-    def find(cls, _db, source, foreign_identifier_or_name, library=None):
+    def find(cls, _db, foreign_identifier_or_name, data_source=None, library=None):
         """Finds a foreign list in the database by its foreign_identifier
         or its name.
         """
-        source_name = source
-        if isinstance(source, DataSource):
-            source_name = source.name
+        source_name = data_source
+        if isinstance(data_source, DataSource):
+            source_name = data_source.name
         foreign_identifier = unicode(foreign_identifier_or_name)
 
-        qu = _db.query(cls).join(CustomList.data_source).filter(
-            DataSource.name==unicode(source_name),
+        qu = _db.query(cls)
+        if source_name:
+            qu = qu.join(CustomList.data_source).filter(
+                DataSource.name==unicode(source_name))
+
+        qu = qu.filter(
             or_(CustomList.foreign_identifier==foreign_identifier,
                 CustomList.name==foreign_identifier))
         if library:

--- a/opds.py
+++ b/opds.py
@@ -77,7 +77,7 @@ class Annotator(object):
 
     @classmethod
     def annotate_work_entry(cls, work, active_license_pool, edition, 
-                            identifier, feed, entry):
+                            identifier, feed, entry, updated=None):
         """Make any custom modifications necessary to integrate this
         OPDS entry into the application's workflow.
         """
@@ -89,6 +89,11 @@ class Annotator(object):
                 **kwargs
             )
             entry.extend([data_source_tag])
+
+        if not updated and work.last_update_time:
+            updated = work.last_update_time
+        if updated:
+            entry.extend([AtomFeed.updated(AtomFeed._strftime(updated))])
 
     @classmethod
     def annotate_feed(cls, feed, lane):
@@ -916,9 +921,6 @@ class AcquisitionFeed(OPDSFeed):
         if content:
             entry.extend([AtomFeed.summary(content, type=content_type)])
 
-        entry.extend([
-            AtomFeed.updated(AtomFeed._strftime(datetime.datetime.utcnow())),
-        ])
 
         permanent_work_id_tag = AtomFeed.makeelement("{%s}pwid" % AtomFeed.SIMPLIFIED_NS)
         permanent_work_id_tag.text = edition.permanent_work_id

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6567,28 +6567,32 @@ class TestCustomList(DatabaseTest):
     def test_find(self):
         source = DataSource.lookup(self._db, DataSource.NYT)
         # When there's no CustomList to find, nothing is returned.
-        result = CustomList.find(self._db, source, 'my-list')
+        result = CustomList.find(self._db, 'my-list', source)
         eq_(None, result)
 
         custom_list = self._customlist(
             foreign_identifier='a-list', name='My List', num_entries=0
         )[0]
         # A CustomList can be found by its foreign_identifier.
-        result = CustomList.find(self._db, source, 'a-list')
+        result = CustomList.find(self._db, 'a-list', source)
         eq_(custom_list, result)
 
         # Or its name.
-        result = CustomList.find(self._db, source.name, 'My List')
+        result = CustomList.find(self._db, 'My List', source.name)
+        eq_(custom_list, result)
+
+        # The list can also be found by name without a data source.
+        result = CustomList.find(self._db, 'My List')
         eq_(custom_list, result)
 
         # By default, we only find lists with no associated Library.
         # If we look for a list from a library, there isn't one.
-        result = CustomList.find(self._db, source, 'My List', library=self._default_library)
+        result = CustomList.find(self._db, 'My List', source, library=self._default_library)
         eq_(None, result)
 
         # If we add the Library to the list, it's returned.
         custom_list.library = self._default_library
-        result = CustomList.find(self._db, source, 'My List', library=self._default_library)
+        result = CustomList.find(self._db, 'My List', source, library=self._default_library)
         eq_(custom_list, result)
         
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -165,6 +165,27 @@ class TestBaseAnnotator(DatabaseTest):
         eq_(Contributor.MARC_ROLE_CODES[Contributor.NARRATOR_ROLE],
             contributor.attrib[role_attrib])
 
+    def test_annotate_work_entry_adds_distributor_and_updated(self):
+        work = self._work(with_license_pool=True, 
+                          with_open_access_download=True)
+        work.last_update_time = datetime.datetime(2018, 2, 5, 7, 39, 49, 580651)
+        [pool] = work.license_pools
+
+        entry = []
+        Annotator.annotate_work_entry(work, pool, None, None, None, entry)
+        eq_(2, len(entry))
+        [distributor, updated] = entry
+        assert 'ProviderName="Gutenberg"' in etree.tostring(distributor)
+        assert 'updated' in etree.tostring(updated)
+        assert '2018-02-05' in etree.tostring(updated)
+
+        entry = []
+        Annotator.annotate_work_entry(work, None, None, None, None, entry,
+                                      updated=datetime.datetime(2017, 1, 2, 3, 39, 49, 580651))
+        eq_(1, len(entry))
+        [updated] = entry
+        assert 'updated' in etree.tostring(updated)
+        assert '2017-01-02' in etree.tostring(updated)
 
 class TestAnnotators(DatabaseTest):
 


### PR DESCRIPTION
This branch makes a few changes to facilitate crawlable acquisition feeds for lists.

The main things are:
- I added CustomListEntry.list_id and CustomListEntry.first_appearance to the materialized view, in order to sort by a combination of Work.last_update_time and CustomListEntry.first_appearance.
- I changed the way updated is added to OPDS entries.
- I changed a unique constraint on CustomList so that names must be unique per library, rather than per library and data source. This was so I could have nicer URLs for the crawlable feeds that only need the library and the list name.

I don't think anyone would already have two lists with the same library and the same name, but if they do they'll get an error.