### PR TITLE
Upload script support

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -621,7 +621,9 @@ class MetaToModelUtility(object):
 
         # Determine the best URL to use when mirroring this
         # representation.
-        if title and link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
+        if link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
+            if not title:
+                title = identifier.identifier
             extension = representation.extension()
             mirror_url = mirror.book_url(
                 identifier, data_source=data_source, title=title,
@@ -721,6 +723,9 @@ class CirculationData(MetaToModelUtility):
             self.data_source_name = data_source
         if isinstance(primary_identifier, Identifier):
             self.primary_identifier_obj = primary_identifier
+            self._primary_identifier = IdentifierData(
+                primary_identifier.type, primary_identifier.identifier
+            )
         else:
             self.primary_identifier_obj = None
             self._primary_identifier = primary_identifier

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -622,11 +622,10 @@ class MetaToModelUtility(object):
         # Determine the best URL to use when mirroring this
         # representation.
         if link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
-            if not title:
-                title = identifier.identifier
+            url_title = title or identifier.identifier
             extension = representation.extension()
             mirror_url = mirror.book_url(
-                identifier, data_source=data_source, title=title,
+                identifier, data_source=data_source, title=url_title,
                 extension=extension
             )
         else:

--- a/mirror.py
+++ b/mirror.py
@@ -1,4 +1,6 @@
 import datetime
+from config import CannotLoadConfiguration
+from model import ExternalIntegration
 
 class MirrorUploader(object):
 
@@ -31,9 +33,9 @@ class MirrorUploader(object):
     @classmethod
     def sitewide_integration(cls, _db):
         """Find the ExternalIntegration for the site-wide mirror."""
-        from ..config import CannotLoadConfiguration
-        from ..model import ExternalIntegration as EI
-        qu = _db.query(EI).filter(EI.goal==cls.STORAGE_GOAL)
+        qu = _db.query(ExternalIntegration).filter(
+            ExternalIntegration.goal==cls.STORAGE_GOAL
+        )
         integrations = qu.all()
         if not integrations:
             raise CannotLoadConfiguration(
@@ -81,7 +83,6 @@ class MirrorUploader(object):
         :param integration: An ExternalIntegration configuring the credentials
            used to upload things.
         """
-        from ..config import CannotLoadConfiguration
         if integration.goal != self.STORAGE_GOAL:
             # This collection's 'mirror integration' isn't intended to
             # be used to mirror anything.

--- a/mirror.py
+++ b/mirror.py
@@ -1,6 +1,5 @@
 import datetime
 from config import CannotLoadConfiguration
-from model import ExternalIntegration
 
 class MirrorUploader(object):
 
@@ -33,6 +32,7 @@ class MirrorUploader(object):
     @classmethod
     def sitewide_integration(cls, _db):
         """Find the ExternalIntegration for the site-wide mirror."""
+        from model import ExternalIntegration
         qu = _db.query(ExternalIntegration).filter(
             ExternalIntegration.goal==cls.STORAGE_GOAL
         )

--- a/model.py
+++ b/model.py
@@ -10153,17 +10153,19 @@ class ExternalIntegration(Base, HasFullTableCache):
     OPDS_FOR_DISTRIBUTORS = u'OPDS for Distributors'
     ENKI = DataSource.ENKI
     FEEDBOOKS = DataSource.FEEDBOOKS
+    MANUAL = DataSource.MANUAL
 
-    # These protocols are only used on the Content Server when mirroring
+    # These protocols were used on the Content Server when mirroring
     # content from a given directory or directly from Project
-    # Gutenberg, respectively. These protocols aren't intended for use
-    # with LicensePools on the Circulation Manager.
-    DIRECTORY_IMPORT = u'Directory Import'
+    # Gutenberg, respectively. DIRECTORY_IMPORT was replaced by
+    # MANUAL.  GUTENBERG has yet to be replaced, but will eventually
+    # be moved into LICENSE_PROTOCOLS.
+    DIRECTORY_IMPORT = "Directory Import"
     GUTENBERG = DataSource.GUTENBERG
 
     LICENSE_PROTOCOLS = [
         OPDS_IMPORT, OVERDRIVE, ODILO, BIBLIOTHECA, AXIS_360, RB_DIGITAL,
-        DIRECTORY_IMPORT, GUTENBERG, ENKI,
+        GUTENBERG, ENKI, MANUAL
     ]
 
     # Some integrations with LICENSE_GOAL imply that the data and

--- a/model.py
+++ b/model.py
@@ -121,7 +121,7 @@ from util import (
     MetadataSimilarity,
     TitleProcessor,
 )
-from util.mirror import MirrorUploader
+from mirror import MirrorUploader
 from util.http import (
     HTTP,
     RemoteIntegrationException,

--- a/model.py
+++ b/model.py
@@ -8159,6 +8159,9 @@ class Representation(Base):
         SCORM_MEDIA_TYPE: "zip"
     }
 
+    COMMON_EBOOK_EXTENSIONS = ['.epub', '.pdf']
+    COMMON_IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif']
+
     # Invert FILE_EXTENSIONS and add some extra guesses.
     MEDIA_TYPE_FOR_EXTENSION = {
         ".htm" : TEXT_HTML_MEDIA_TYPE,

--- a/opds_import.py
+++ b/opds_import.py
@@ -59,7 +59,7 @@ from util.opds_writer import (
     OPDSFeed,
     OPDSMessage,
 )
-from util.mirror import MirrorUploader
+from mirror import MirrorUploader
 
 
 class AccessNotAuthenticated(Exception):

--- a/s3.py
+++ b/s3.py
@@ -5,7 +5,7 @@ import urllib
 from nose.tools import set_trace
 from sqlalchemy.orm.session import Session
 from urlparse import urlsplit
-from util.mirror import MirrorUploader
+from mirror import MirrorUploader
 
 from config import CannotLoadConfiguration
 from model import ExternalIntegration

--- a/tests/test_mirror_uploader.py
+++ b/tests/test_mirror_uploader.py
@@ -5,7 +5,7 @@ from nose.tools import (
 )
 from . import DatabaseTest
 from config import CannotLoadConfiguration
-from util.mirror import MirrorUploader
+from mirror import MirrorUploader
 from model import ExternalIntegration
 
 class DummySuccessUploader(MirrorUploader):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -21,7 +21,7 @@ from s3 import (
     S3Uploader,
     MockS3Pool,
 )
-from util.mirror import MirrorUploader
+from mirror import MirrorUploader
 from config import CannotLoadConfiguration
 
 class S3UploaderTest(DatabaseTest):

--- a/util/mirror.py
+++ b/util/mirror.py
@@ -28,6 +28,11 @@ class MirrorUploader(object):
         from config import CannotLoadConfiguration
 
         from model import ExternalIntegration as EI
+        return cls.implementation(integration)
+
+    @classmethod
+    def sitewide_integration(cls, _db):
+        """Find the ExternalIntegration for the site-wide mirror."""
         qu = _db.query(EI).filter(EI.goal==cls.STORAGE_GOAL)
         integrations = qu.all()
         if not integrations:
@@ -44,7 +49,7 @@ class MirrorUploader(object):
             )
 
         [integration] = integrations
-        return cls.implementation(integration)
+        return integration
 
     @classmethod
     def for_collection(cls, collection):

--- a/util/mirror.py
+++ b/util/mirror.py
@@ -25,14 +25,14 @@ class MirrorUploader(object):
         goal==STORAGE_GOAL is configured, or if multiple integrations
         are so configured.
         """
-        from config import CannotLoadConfiguration
-
-        from model import ExternalIntegration as EI
+        integration = cls.sitewide_integration(_db)
         return cls.implementation(integration)
 
     @classmethod
     def sitewide_integration(cls, _db):
         """Find the ExternalIntegration for the site-wide mirror."""
+        from ..config import CannotLoadConfiguration
+        from ..model import ExternalIntegration as EI
         qu = _db.query(EI).filter(EI.goal==cls.STORAGE_GOAL)
         integrations = qu.all()
         if not integrations:
@@ -81,7 +81,7 @@ class MirrorUploader(object):
         :param integration: An ExternalIntegration configuring the credentials
            used to upload things.
         """
-        from config import CannotLoadConfiguration
+        from ..config import CannotLoadConfiguration
         if integration.goal != self.STORAGE_GOAL:
             # This collection's 'mirror integration' isn't intended to
             # be used to mirror anything.


### PR DESCRIPTION
This is a small support branch for https://github.com/NYPL-Simplified/circulation/pull/852.

The biggest change is that the `util.mirror` module was moved into `mirror`. Most of the code remaining in that module dealt with the database model, and `util` is for things that don't deal with the database model.