### PR TITLE
Make LicensePoolDeliveryMechanism.set more robust

### DIFF
--- a/model.py
+++ b/model.py
@@ -5422,10 +5422,11 @@ class LicensePoolDeliveryMechanism(Base):
             a freely redistributable form.
         :param autocommit: Commit the database session immediately if
             anything changes in the database. If you're already inside
-            a nested session, pass in False here, but understand that if 
-            a LicensePool's open-access status changes as a result of 
-            calling this method, the change may not be properly reflected
-            in LicensePool.open_access.
+            a nested transaction, pass in False here to avoid
+            committing prematurely, but understand that if a
+            LicensePool's open-access status changes as a result of
+            calling this method, the change may not be properly
+            reflected in LicensePool.open_access.
         """
         _db = Session.object_session(data_source)
         delivery_mechanism, ignore = DeliveryMechanism.lookup(


### PR DESCRIPTION
This is a support branch for https://github.com/NYPL-Simplified/circulation/pull/862

This branch makes it possible to avoid the `_db.commit()` call when calling `LicensePoolDeliveryMechanism.set()`, which will cause a problem if you call it from within a nested transaction.

The downside of doing this is that if you call `set(autocommit=False)`, it's possible that a `LicensePool`'s open-access status will change but `LicensePool.open_access` won't be updated. This isn't currently a problem with the code I've added to call `set(autocommit=False)`, since Overdrive is the only real-world distributor that will currently cause this code to run, and I don't think it will be a problem in general, but I'd really like to get rid of that _db.commit() call altogether.