### PR TITLE
Only one local analytics provider can exist on the site.

### DIFF
--- a/local_analytics_provider.py
+++ b/local_analytics_provider.py
@@ -6,6 +6,9 @@ class LocalAnalyticsProvider(object):
 
     DESCRIPTION = _("Store analytics events in the 'circulationevents' database table.")
 
+    # A given site can only have one analytics provider.
+    CARDINALITY = 1
+
     def __init__(self, integration, library=None):
         self.integration_id = integration.id
         if library:

--- a/opds_import.py
+++ b/opds_import.py
@@ -124,6 +124,7 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup):
 
     PROTOCOL = ExternalIntegration.METADATA_WRANGLER
     NAME = _("Library Simplified Metadata Wrangler")
+    CARDINALITY = 1
 
     SETTINGS = [
         { "key": ExternalIntegration.URL, "label": _("URL"), "default": "http://metadata.librarysimplified.org/" },


### PR DESCRIPTION
This branch takes advantage of https://github.com/NYPL-Simplified/circulation/pull/865 to say that only one local analytics provider can be created on a given site. This fixes https://github.com/NYPL-Simplified/circulation/issues/864.