### PR TITLE
If a superclass of OPDSImportMonitor specifies a different value for Accept or Authorization, don't overwrite that value.

### DIFF
--- a/opds_import.py
+++ b/opds_import.py
@@ -1449,6 +1449,7 @@ class OPDSImporter(object):
         series_position = attr.get('{http://schema.org/}position', None)
         return series_name, series_position
 
+
 class OPDSImportMonitor(CollectionMonitor):
 
     """Periodically monitor a Collection's OPDS archive feed and import
@@ -1501,21 +1502,26 @@ class OPDSImportMonitor(CollectionMonitor):
 
         Long timeout, raise error on anything but 2xx or 3xx.
         """
-        headers = dict(headers or {})
-        if self.username and self.password:
-            auth_header = "Basic %s" % base64.b64encode("%s:%s" % (self.username, self.password))
-            headers['Authorization'] = auth_header
-
-        types = dict(
-            opds_acquisition=OPDSFeed.ACQUISITION_FEED_TYPE,
-            atom="application/atom+xml",
-            xml="application/xml",
-            anything="*/*",
-        )
-        headers['Accept'] = "%(opds_acquisition)s, %(atom)s;q=0.9, %(xml)s;q=0.8, %(anything)s;q=0.1" % types
+        headers = self._update_headers(headers)
         kwargs = dict(timeout=120, allowed_response_codes=['2xx', '3xx'])
         response = HTTP.get_with_timeout(url, headers=headers, **kwargs)
         return response.status_code, response.headers, response.content
+
+    def _update_headers(self, headers):
+        dict(headers or {})
+        if self.username and self.password and not 'Authorization' in headers:
+            auth_header = "Basic %s" % base64.b64encode("%s:%s" % (self.username, self.password))
+            headers['Authorization'] = auth_header
+
+        if not 'Accept' in headers:
+            types = dict(
+                opds_acquisition=OPDSFeed.ACQUISITION_FEED_TYPE,
+                atom="application/atom+xml",
+                xml="application/xml",
+                anything="*/*",
+            )
+            headers['Accept'] = "%(opds_acquisition)s, %(atom)s;q=0.9, %(xml)s;q=0.8, %(anything)s;q=0.1" % types
+        return headers
 
     def opds_url(self, collection):
         """Returns the OPDS import URL for the given collection.

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -1789,3 +1789,31 @@ class TestOPDSImportMonitor(OPDSImporterTest):
 
         # Feeds are imported in reverse order
         eq_(["last page", "second page", "first page"], monitor.imports)
+
+    def test_update_headers(self):
+        """Test the _update_headers helper method."""
+        monitor = OPDSImportMonitor(
+            self._db, collection=self._default_collection,
+            import_class=OPDSImporter
+        )
+
+        # By default, only an Accept header is added.
+        headers = {}
+        monitor._update_headers(headers)
+        eq_(['Accept'], headers.keys())
+
+        # If the monitor has a username and password, an Authorization
+        # header using HTTP Basic Authentication is also added.
+        monitor.username = "a user"
+        monitor.password = "a password"
+        headers = {}
+        monitor._update_headers(headers)
+        assert headers['Authorization'].startswith('Basic')
+
+        # However, if the Authorization and/or Accept headers have been
+        # filled in by some other piece of code, _update_headers does
+        # not touch them.
+        expect = dict(Accept="text/html", Authorization="Bearer abc")
+        headers = dict(expect)
+        monitor._update_headers(headers)
+        eq_(headers, expect)


### PR DESCRIPTION
The OPDS for Distributors import monitor uses the `username` and `password` values to create an `Authorization` header using a bearer token. But this work is destroyed by the superclass `_get` method, which uses the `username` and `password` values to create an `Authorization` header using Basic Auth.

This branch creates a separate helper method for the code that changes the headers, and makes that code not replace the value of an existing header.