### PR TITLE
 Compare a query against None rather than trying to determine its boolean value

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -848,7 +848,7 @@ class WorkList(object):
         qu, bibliographic_clause = self.bibliographic_filter_clause(
             _db, qu, featured
         )
-        if not qu:
+        if qu is None:
             # bibliographic_filter_clause() may return a null query to
             # indicate that the WorkList should not exist at all.
             return None

--- a/lane.py
+++ b/lane.py
@@ -803,6 +803,7 @@ class WorkList(object):
         """Create the appearance of having called works(),
         but return the specific MaterializedWorks identified by `work_ids`.
         """
+
         # Get a list of MaterializedWorkWithGenre objects as though we
         # had called works().
         from model import MaterializedWorkWithGenre as mw

--- a/lane.py
+++ b/lane.py
@@ -803,7 +803,6 @@ class WorkList(object):
         """Create the appearance of having called works(),
         but return the specific MaterializedWorks identified by `work_ids`.
         """
-
         # Get a list of MaterializedWorkWithGenre objects as though we
         # had called works().
         from model import MaterializedWorkWithGenre as mw


### PR DESCRIPTION
I exposed this problem with some code I wrote by mistake, but it is a problem. This code was treating a SQLAlchemy query as a boolean when it should have been checking that the query was non-null. A SQLAlchemy query can evaluate false if it contains a contradiction.