### PR TITLE
Reduce the number of times the site configuration needs to change, and avoid contention when it does need to change

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -1908,7 +1908,7 @@ lanes_customlists = Table(
 
 @event.listens_for(Lane, 'after_insert')
 @event.listens_for(Lane, 'after_delete')
-# @event.listens_for(Lane, 'after_update')
+@event.listens_for(Lane, 'after_update')
 @event.listens_for(LaneGenre, 'after_insert')
 @event.listens_for(LaneGenre, 'after_delete')
 @event.listens_for(LaneGenre, 'after_update')

--- a/lane.py
+++ b/lane.py
@@ -1908,7 +1908,7 @@ lanes_customlists = Table(
 
 @event.listens_for(Lane, 'after_insert')
 @event.listens_for(Lane, 'after_delete')
-@event.listens_for(Lane, 'after_update')
+# @event.listens_for(Lane, 'after_update')
 @event.listens_for(LaneGenre, 'after_insert')
 @event.listens_for(LaneGenre, 'after_delete')
 @event.listens_for(LaneGenre, 'after_update')

--- a/lane.py
+++ b/lane.py
@@ -1912,7 +1912,6 @@ lanes_customlists = Table(
 @event.listens_for(LaneGenre, 'after_insert')
 @event.listens_for(LaneGenre, 'after_delete')
 def configuration_relevant_lifecycle_event(mapper, connection, target):
-    logging.error("CONFIGURATION RELEVANT LIFECYCLE EVENT: %r", target)
     site_configuration_has_changed(target)
 
 
@@ -1920,5 +1919,4 @@ def configuration_relevant_lifecycle_event(mapper, connection, target):
 @event.listens_for(LaneGenre, 'after_update')
 def configuration_relevant_update(mapper, connection, target):
     if directly_modified(target):
-        logging.error("CONFIGURATION RELEVANT UPDATE: %r", target)
         site_configuration_has_changed(target)

--- a/lane.py
+++ b/lane.py
@@ -44,6 +44,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.sql.expression import literal
 
 from model import (
+    directly_modified,
     get_one_or_create,
     numericrange_to_tuple,
     site_configuration_has_changed,
@@ -1908,9 +1909,14 @@ lanes_customlists = Table(
 
 @event.listens_for(Lane, 'after_insert')
 @event.listens_for(Lane, 'after_delete')
-@event.listens_for(Lane, 'after_update')
 @event.listens_for(LaneGenre, 'after_insert')
 @event.listens_for(LaneGenre, 'after_delete')
-@event.listens_for(LaneGenre, 'after_update')
 def configuration_relevant_lifecycle_event(mapper, connection, target):
     site_configuration_has_changed(target)
+
+
+@event.listens_for(Lane, 'after_update')
+@event.listens_for(LaneGenre, 'after_update')
+def configuration_relevant_update(mapper, connection, target):
+    if directly_modified(target):
+        site_configuration_has_changed(target)

--- a/lane.py
+++ b/lane.py
@@ -1912,6 +1912,7 @@ lanes_customlists = Table(
 @event.listens_for(LaneGenre, 'after_insert')
 @event.listens_for(LaneGenre, 'after_delete')
 def configuration_relevant_lifecycle_event(mapper, connection, target):
+    logging.error("CONFIGURATION RELEVANT LIFECYCLE EVENT: %r", target)
     site_configuration_has_changed(target)
 
 
@@ -1919,4 +1920,5 @@ def configuration_relevant_lifecycle_event(mapper, connection, target):
 @event.listens_for(LaneGenre, 'after_update')
 def configuration_relevant_update(mapper, connection, target):
     if directly_modified(target):
+        logging.error("CONFIGURATION RELEVANT UPDATE: %r", target)
         site_configuration_has_changed(target)

--- a/model.py
+++ b/model.py
@@ -11418,7 +11418,7 @@ def _site_configuration_has_changed(_db, timeout=1):
 
         # Update the timestamp.
         now = datetime.datetime.utcnow()
-        earlier = now-datetime.timedelta(seconds=1)
+        earlier = now-datetime.timedelta(seconds=timeout)
         sql = "UPDATE timestamps SET timestamp=:timestamp WHERE service=:service AND collection_id IS NULL AND timestamp<=:earlier;"
         _db.execute(
             text(sql),

--- a/model.py
+++ b/model.py
@@ -11521,6 +11521,7 @@ def directly_modified(obj):
 @event.listens_for(Library.settings, 'append')
 @event.listens_for(Library.settings, 'remove')
 def configuration_relevant_collection_change(target, value, initiator):
+    logging.error("CONFIGURATION RELEVANT COLLECTION CHANGE: %r, %r, %r", target, value, initiator)
     site_configuration_has_changed(target)
 
 @event.listens_for(Library, 'after_insert')
@@ -11532,6 +11533,7 @@ def configuration_relevant_collection_change(target, value, initiator):
 @event.listens_for(ConfigurationSetting, 'after_insert')
 @event.listens_for(ConfigurationSetting, 'after_delete')
 def configuration_relevant_lifecycle_event(mapper, connection, target):
+    logging.error("CONFIGURATION RELEVANT LIFECYCLE EVENT: %r", target)
     site_configuration_has_changed(target)
 
 @event.listens_for(Library, 'after_update')
@@ -11540,6 +11542,7 @@ def configuration_relevant_lifecycle_event(mapper, connection, target):
 @event.listens_for(ConfigurationSetting, 'after_update')
 def configuration_relevant_update(mapper, connection, target):
     if directly_modified(target):
+        logging.error("CONFIGURATION RELEVANT UPDATE: %r", target)
         site_configuration_has_changed(target)
 
 @event.listens_for(Collection, 'after_insert')

--- a/model.py
+++ b/model.py
@@ -11420,11 +11420,12 @@ def _site_configuration_has_changed(_db, timeout=1):
 
         # Update the timestamp.
         now = datetime.datetime.utcnow()
-        sql = "UPDATE timestamps SET timestamp=:timestamp WHERE service=:service AND collection_id IS NULL;"
+        earlier = now-datetime.timedelta(seconds=1)
+        sql = "UPDATE timestamps SET timestamp=:timestamp WHERE service=:service AND collection_id IS NULL AND timestamp<=:earlier;"
         _db.execute(
             text(sql),
             dict(service=Configuration.SITE_CONFIGURATION_CHANGED,
-                 timestamp=now)
+                 timestamp=now, earlier=earlier)
         )
 
         # Update the Configuration's record of when the configuration

--- a/model.py
+++ b/model.py
@@ -19,6 +19,7 @@ import os
 import random
 import re
 import requests
+from threading import RLock
 import time
 import traceback
 import urllib
@@ -11373,8 +11374,6 @@ def tuple_to_numericrange(t):
         return None
     return NumericRange(t[0], t[1], '[]')
 
-
-from threading import RLock
 site_configuration_has_changed_lock = RLock()
 def site_configuration_has_changed(_db, timeout=1):
     """Call this whenever you want to indicate that the site configuration
@@ -11396,7 +11395,6 @@ def site_configuration_has_changed(_db, timeout=1):
         # Another thread is updating site configuration right now.
         # There is no need to do anything--the timestamp will still be
         # accurate.
-        logging.error("BAILING OUT!")
         return
 
     try:
@@ -11521,7 +11519,6 @@ def directly_modified(obj):
 @event.listens_for(Library.settings, 'append')
 @event.listens_for(Library.settings, 'remove')
 def configuration_relevant_collection_change(target, value, initiator):
-    logging.error("CONFIGURATION RELEVANT COLLECTION CHANGE: %r, %r, %r", target, value, initiator)
     site_configuration_has_changed(target)
 
 @event.listens_for(Library, 'after_insert')
@@ -11533,7 +11530,6 @@ def configuration_relevant_collection_change(target, value, initiator):
 @event.listens_for(ConfigurationSetting, 'after_insert')
 @event.listens_for(ConfigurationSetting, 'after_delete')
 def configuration_relevant_lifecycle_event(mapper, connection, target):
-    logging.error("CONFIGURATION RELEVANT LIFECYCLE EVENT: %r", target)
     site_configuration_has_changed(target)
 
 @event.listens_for(Library, 'after_update')
@@ -11542,7 +11538,6 @@ def configuration_relevant_lifecycle_event(mapper, connection, target):
 @event.listens_for(ConfigurationSetting, 'after_update')
 def configuration_relevant_update(mapper, connection, target):
     if directly_modified(target):
-        logging.error("CONFIGURATION RELEVANT UPDATE: %r", target)
         site_configuration_has_changed(target)
 
 @event.listens_for(Collection, 'after_insert')


### PR DESCRIPTION
This branch fixes a bug that caused the site configuration timestamp to change a lot more than it needed to. It also introduces safeguards to stop different threads in a process from all changing that timestamp at once, and to reduce the risk that multiple different processes will try to change the timestamp at once.