### PR TITLE
Improve materialized view performance

### DIFF
--- a/files/materialized_view_for_lanes.sql
+++ b/files/materialized_view_for_lanes.sql
@@ -52,6 +52,13 @@ as
   ORDER BY (editions.sort_title, editions.sort_author, licensepools.availability_time)
   WITH NO DATA;
 
+-- Put an index on all foreign keys.
+create index ix_mv_works_for_lanes_works_id on mv_works_for_lanes (works_id);
+create index ix_mv_works_for_lanes_license_pool_id on mv_works_for_lanes (license_pool_id);
+create index ix_mv_works_for_lanes_workgenres_id on mv_works_for_lanes (workgenres_id);
+create index ix_mv_works_for_lanes_list_id on mv_works_for_lanes (list_id);
+create index ix_mv_works_for_lanes_list_edition_id on mv_works_for_lanes (list_edition_id);
+
 -- First create an index that allows work/genre lookup. It's unique and incorporates license_pool_id so that the materialized view can be refreshed CONCURRENTLY.
 -- NOTE: All fields mentioned here also need to be part of the primary key
 -- for the model object defined in model.py.

--- a/lane.py
+++ b/lane.py
@@ -810,8 +810,9 @@ class WorkList(object):
         qu = _db.query(mw).join(
             LicensePool, mw.license_pool_id==LicensePool.id
         ).filter(
-            mw.works_id.in_(work_ids)
-        )
+            mw.works_id.in_(work_ids),
+            LicensePool.work_id.in_(work_ids),
+        ).enable_eagerloads(False)
         qu = self._lazy_load(qu)
         qu = self._defer_unused_fields(qu)
         qu = self.only_show_ready_deliverable_works(_db, qu)

--- a/migration/20180228-improve-materialized-view-performance.sql
+++ b/migration/20180228-improve-materialized-view-performance.sql
@@ -1,0 +1,53 @@
+DO $$
+    BEGIN
+        -- Create indices for foreign keys on materialized views.
+        BEGIN
+            create index ix_mv_works_for_lanes_works_id on
+                mv_works_for_lanes (works_id);
+        EXCEPTION
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: ix_mv_works_for_lanes_works_id already exists.';
+        END;
+
+        BEGIN
+            create index ix_mv_works_for_lanes_license_pool_id on
+                mv_works_for_lanes (license_pool_id);
+        EXCEPTION
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: ix_mv_works_for_lanes_license_pool_id already exists.';
+        END;
+
+        BEGIN
+            create index ix_mv_works_for_lanes_workgenres_id on
+                mv_works_for_lanes (workgenres_id);
+        EXCEPTION
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: ix_mv_works_for_lanes_workgenres_id already exists.';
+        END;
+
+        BEGIN
+            create index ix_mv_works_for_lanes_list_id on
+                mv_works_for_lanes (list_id);
+        EXCEPTION
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: ix_mv_works_for_lanes_list_id already exists.';
+        END;
+
+        BEGIN
+            create index ix_mv_works_for_lanes_list_edition_id on
+                mv_works_for_lanes (list_edition_id);
+        EXCEPTION
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: ix_mv_works_for_lanes_list_edition_id already exists.';
+        END;
+
+        BEGIN
+            create index ix_licensepools_collection_id on
+                licensepools (collection_id);
+        EXCEPTION
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: ix_licensepools_collection_id already exists.';
+        END;
+
+        BEGIN
+            create index ix_licensepools_licenses_owned on
+                licensepools (licenses_owned);
+        EXCEPTION
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: ix_licensepools_licenses_owned already exists.';
+        END;
+    END;
+$$;

--- a/model.py
+++ b/model.py
@@ -403,16 +403,19 @@ class SessionManager(object):
                 __table__ = Table(
                     cls.MATERIALIZED_VIEW_LANES,
                     Base.metadata,
-                    Column('works_id', Integer, primary_key=True),
-                    Column('workgenres_id', Integer, primary_key=True),
+                    Column('works_id', Integer, primary_key=True, index=True),
+                    Column('workgenres_id', Integer, primary_key=True, index=True),
                     Column('list_id', Integer, ForeignKey('customlists.id'),
-                           primary_key=True),
+                           primary_key=True, index=True),
                     Column(
                         'list_edition_id', Integer, ForeignKey('editions.id'),
-                        primary_key=True
+                        primary_key=True, index=True
                     ),
-                    Column('license_pool_id', Integer,
-                           ForeignKey('licensepools.id'), primary_key=True),
+                    Column(
+                        'license_pool_id', Integer,
+                        ForeignKey('licensepools.id'), primary_key=True,
+                        index=True
+                    ),
                     autoload=True,
                     autoload_with=engine
                 )
@@ -6641,7 +6644,7 @@ class LicensePool(Base):
 
     open_access = Column(Boolean, index=True)
     last_checked = Column(DateTime, index=True)
-    licenses_owned = Column(Integer,default=0)
+    licenses_owned = Column(Integer, default=0, index=True)
     licenses_available = Column(Integer,default=0, index=True)
     licenses_reserved = Column(Integer,default=0)
     patrons_in_hold_queue = Column(Integer,default=0)


### PR DESCRIPTION
This branch improves materialized view performance for search queries using indices and an improved join condition. Against the production database, these changes decrease query execution time from the 40-80 second range to a half-second or less. Planning time also decreases.

The foreign key indices were added at an earlier stage and may be unnecessary with the unique `mv_works_for_lanes_unique` index, but I saw slight performance improvements by adding the `mv_works_for_lanes_works_id` index. I also think it's a good practice to put an index on all foreign keys. I'm open to other thoughts on this, though.

Resolves NYPL-Simplified/circulation#872.