### PR TITLE
Manage pagination through the size of the current page rather than the total query size

### DIFF
--- a/files/materialized_view_for_lanes.sql
+++ b/files/materialized_view_for_lanes.sql
@@ -65,12 +65,14 @@ create index ix_mv_works_for_lanes_list_edition_id on mv_works_for_lanes (list_e
 create unique index mv_works_for_lanes_unique on mv_works_for_lanes (works_id, genre_id, list_id, list_edition_id, license_pool_id);
 
 -- Create an index on everything, sorted by descending availability time, so that sync feeds are fast.
-
+-- TODO: This index might not be necessary anymore.
 create index mv_works_for_lanes_by_availability on mv_works_for_lanes (availability_time DESC, sort_author, sort_title, works_id);
 
--- Create an index on everything, sorted by the maximum of entry first appearance, license pool availability time, and work update time, so that crawlable feeds are fast.
+-- Create an index on everything, sorted by 'last update time' (the thing used by crawlable feeds).
+create index mv_works_for_lanes_by_recently_updated on mv_works_for_lanes (GREATEST(availability_time, first_appearance, last_update_time) DESC, collection_id, works_id);
 
-create index mv_works_for_lanes_by_recently_updated on mv_works_for_lanes (GREATEST(availability_time, first_appearance, last_update_time) DESC, works_id);
+-- This index quickly cuts down the number of rows considered when generating a crawlable feed for a custom list.
+create index mv_works_for_lanes_list_and_collection_id on mv_works_for_lanes (list_id, collection_id);
 
 -- Create indexes that are helpful in running the query to find featured works.
 

--- a/lane.py
+++ b/lane.py
@@ -424,9 +424,15 @@ class Pagination(object):
         return Pagination(0, cls.DEFAULT_SIZE)
 
     def __init__(self, offset=0, size=DEFAULT_SIZE):
+        """Constructor.
+
+        :param offset: Start pulling entries from the query at this index.
+        :param size: Pull no more than this number of entries from the query.
+        """
         self.offset = offset
         self.size = size
-        self.query_size = None
+        self.total_size = None
+        self.this_page_size = None
 
     def items(self):
         yield("after", self.offset)
@@ -456,18 +462,23 @@ class Pagination(object):
     def has_next_page(self):
         """Returns boolean reporting whether pagination is done for a query
 
-        This method only returns valid information _after_ self.apply
-        has been run on a query.
+        Either `total_size` or `this_page_size` must be set for this
+        method to be accurate.
         """
-        if self.query_size is None:
+        if self.this_page_size is not None:
+            # If this page was empty, we can assume there is no next
+            # page; if not, we can assume there is a next page.
+            return self.this_page_size > 0
+        if self.total_size is None:
+            # We don't know the size of the result set; assume there is more.
             return True
-        if self.query_size==0:
+        if self.total_size==0:
+            # We know the size of the result set--it's empty.
             return False
-        return self.offset + self.size < self.query_size
+        return self.offset + self.size < self.total_size
 
     def apply(self, qu):
         """Modify the given query with OFFSET and LIMIT."""
-        self.query_size = fast_query_count(qu)
         return qu.offset(self.offset).limit(self.size)
 
 
@@ -779,6 +790,13 @@ class WorkList(object):
         if self.collection_ids is not None:
             qu = qu.filter(
                 LicensePool.collection_id.in_(self.collection_ids)
+            )
+            # Also apply the filter on the materialized view --
+            # this doesn't seem to do anything, but it's possible that
+            # applying the filter here might cause the database to use
+            # an index it wouldn't have otherwise used.
+            qu = qu.filter(
+                mw.collection_id.in_(self.collection_ids)
             )
         qu = self.apply_filters(_db, qu, facets, pagination)
         if qu:

--- a/lane.py
+++ b/lane.py
@@ -465,17 +465,21 @@ class Pagination(object):
         Either `total_size` or `this_page_size` must be set for this
         method to be accurate.
         """
+        if self.total_size is not None:
+            # We know the total size of the result set, so we know
+            # whether or not there are more results.
+            return self.offset + self.size < self.total_size
         if self.this_page_size is not None:
-            # If this page was empty, we can assume there is no next
-            # page; if not, we can assume there is a next page.
+            # We know the number of items on the current page. If this
+            # page was empty, we can assume there is no next page; if
+            # not, we can assume there is a next page. This is a little
+            # more conservative than checking whether we have a 'full'
+            # page.
             return self.this_page_size > 0
-        if self.total_size is None:
-            # We don't know the size of the result set; assume there is more.
-            return True
-        if self.total_size==0:
-            # We know the size of the result set--it's empty.
-            return False
-        return self.offset + self.size < self.total_size
+
+        # We don't know anything about this result set, so assume there is
+        # a next page.
+        return True
 
     def apply(self, qu):
         """Modify the given query with OFFSET and LIMIT."""

--- a/migration/20180212-recreate-materialized-view.sql
+++ b/migration/20180212-recreate-materialized-view.sql
@@ -65,7 +65,8 @@ create index mv_works_for_lanes_by_availability on mv_works_for_lanes (availabil
 
 -- Create an index on everything, sorted by the maximum of entry first appearance, license pool availability time, and work update time, so that crawlable feeds are fast.
 
-create index mv_works_for_lanes_by_recently_updated on mv_works_for_lanes (GREATEST(availability_time, first_appearance, last_update_time) DESC, works_id);
+-- MIGRATION NOTE: We don't create mv_works_for_lanes_by_recently_updated here
+-- because it will be created in 20180307-replace-recently-updated-index.
 
 -- Create indexes that are helpful in running the query to find featured works.
 

--- a/migration/20180307-replace-recently-updated-index.sql
+++ b/migration/20180307-replace-recently-updated-index.sql
@@ -1,0 +1,17 @@
+DO $$
+    BEGIN
+        -- Delete the index if it already exists.
+        BEGIN
+            drop index mv_works_for_lanes_by_recently_updated;
+        EXCEPTION
+            WHEN OTHERS THEN RAISE NOTICE 'mv_works_for_lanes_by_recently_updated did not previously exist.';
+        END;
+	create index mv_works_for_lanes_by_recently_updated on mv_works_for_lanes (GREATEST(availability_time, first_appearance, last_update_time) DESC, collection_id, works_id);
+
+        BEGIN
+	    create index mv_works_for_lanes_list_and_collection_id on mv_works_for_lanes (list_id, collection_id);
+        EXCEPTION
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: mv_works_for_lanes_list_and_collection_id already exists.';
+        END;
+    END
+$$;

--- a/opds.py
+++ b/opds.py
@@ -577,6 +577,7 @@ class AcquisitionFeed(OPDSFeed):
             works = []
         else:
             works = works_q.all()
+            pagination.this_page_size = len(works)
         feed = cls(_db, title, url, works, annotator)
 
         # Add URLs to change faceted views of the collection.

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -487,34 +487,54 @@ class TestFeaturedFacets(DatabaseTest):
 
 class TestPagination(DatabaseTest):
 
-    def test_has_next_page(self):
+    def test_has_next_page_total_size(self):
+        """Test the ability of Pagination.total_size to control whether there is a next page."""
         query = self._db.query(Work)
         pagination = Pagination(size=2)
 
-        # When the query is empty, pagination doesn't have a next page.
-        pagination.apply(query)
-        eq_(False, pagination.has_next_page)
-
-        # When there are more results in the query, it does.
-        for num in range(3):
-            # Create three works.
-            self._work()
+        # When total_size is not set, Pagination assumes there is a
+        # next page.
         pagination.apply(query)
         eq_(True, pagination.has_next_page)
 
-        # When we reach the end of results, there's no next page.
+        # Here, there is one more item on the next page.
+        pagination.total_size = 3
+        eq_(0, pagination.offset)
+        eq_(True, pagination.has_next_page)
+
+        # Here, the last item on this page is the last item in the dataset.
         pagination.offset = 1
         eq_(False, pagination.has_next_page)
 
-        # When the database is updated, pagination knows.
-        for num in range(3):
-            self._work()
+        # If we somehow go over the end of the dataset, there is no next page.
+        pagination.offset = 400
+        eq_(False, pagination.has_next_page)
+
+    def test_has_next_page_this_page_size(self):
+        """Test the ability of Pagination.this_page_size to control whether there is a next page."""
+        query = self._db.query(Work)
+        pagination = Pagination(size=2)
+
+        # When this_page_size is not set, Pagination assumes there is a
+        # next page.
         pagination.apply(query)
         eq_(True, pagination.has_next_page)
 
-        # Even when the query ends at the same size as a page, all is well.
-        pagination.offset = 4
+        # Here, there is nothing on the current page. There is no next page.
+        pagination.this_page_size = 0
         eq_(False, pagination.has_next_page)
+
+        # If the page is full, we can be almost certain there is a next page.
+        pagination.this_page_size = 400
+        eq_(True, pagination.has_next_page)
+
+        # Here, there is one item on the current page. Even though the
+        # current page is not full (page size is 2), we assume for
+        # safety's sake that there is a next page. The cost of getting
+        # this wrong is low, compared to the cost of saying there is no
+        # next page when there actually is.
+        pagination.this_page_size = 1
+        eq_(True, pagination.has_next_page)
 
 
 class MockFeaturedWorks(object):

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -510,6 +510,17 @@ class TestPagination(DatabaseTest):
         pagination.offset = 400
         eq_(False, pagination.has_next_page)
 
+        # If both total_size and this_page_size are set, total_size
+        # takes precedence.
+        pagination.offset = 0
+        pagination.total_size = 100
+        pagination.this_page_size = 0
+        eq_(True, pagination.has_next_page)
+
+        pagination.total_size = 0
+        pagination.this_page_size = 10
+        eq_(False, pagination.has_next_page)
+
     def test_has_next_page_this_page_size(self):
         """Test the ability of Pagination.this_page_size to control whether there is a next page."""
         query = self._db.query(Work)


### PR DESCRIPTION
This branch makes some index changes to the materialized view to improve performance of crawlable feeds. I've tested it on NYPL QA with the library-wide crawlable feed, the crawlable feed for the Overdrive collection, and the crawlable feed for NYPL's 'Staff Picks' list, which contains about 1500 books. In all cases I can now get the first page of a feed within a few seconds, which is hopefully fast enough for purposes of automated integration.

This branch also changes the way we determine whether or not a `Pagination` object represents the end of a list. Previously the act of `apply`ing the Pagination object to a query made it run a `count` query to count the total number of items in the result set. This was a slowdown in all cases and it didn't work at all for some of the crawlable feed queries, so I took it out altogether.

Now it's expected that the user of a `Pagination` object will explicitly tell the `Pagination` object either the total size of the result set that's being paginated, or the size of the current page. If the total size of the resultset is available, then "is there a next page?" works as before. Otherwise, if the total size of the current page is available, we say there's a next page if and only if the current page has items on it.

I changed `AcquisitionFeed.page` to set `this_page_size` after fetching a page of works. As far as I can tell, this is the only place `Pagination` objects are actually used, so this will eliminate the need to run a `count` query in all cases.

The performance downside of this is that sometimes we will incorrectly say there is a next page when there isn't. This can result in an extra request to the server. However the only client likely to get the last page of a feed is a client crawling a crawlable feed. On balance, clients will benefit from better performance on each page since we no longer run a `count` alongside each materialized view query.