### PR TITLE
Dramatically speed up CustomListEntry.entries_for_work

### DIFF
--- a/model.py
+++ b/model.py
@@ -9511,11 +9511,28 @@ class CustomList(Base):
             edition = work_or_edition
             work = edition.work
 
-        equivalents = edition.equivalent_editions().all()
+        equivalent_ids = [x.id for x in edition.equivalent_editions()]
 
-        for entry in self.entries:
-            if (work and entry.work == work) or entry.edition in equivalents:
-                yield entry
+        clauses = []
+        if equivalent_ids:
+            clauses.append(CustomListEntry.edition_id.in_(equivalent_ids))
+        if work:
+            clauses.append(CustomListEntry.work==work)
+        if len(clauses) == 0:
+            # This shouldn't happen, but if it does, there can be
+            # no matching results.
+            return
+        elif len(clauses) == 1:
+            clause = clauses[0]
+        else:
+            clause = or_(*clauses)
+
+        _db = Session.object_session(work_or_edition)
+        qu = _db.query(CustomListEntry).filter(
+            CustomListEntry.customlist==self).filter(
+                clause
+            )
+        return qu
 
 
 class CustomListEntry(Base):

--- a/model.py
+++ b/model.py
@@ -9513,6 +9513,7 @@ class CustomList(Base):
 
         equivalent_ids = [x.id for x in edition.equivalent_editions()]
 
+        _db = Session.object_session(work_or_edition)
         clauses = []
         if equivalent_ids:
             clauses.append(CustomListEntry.edition_id.in_(equivalent_ids))
@@ -9521,13 +9522,12 @@ class CustomList(Base):
         if len(clauses) == 0:
             # This shouldn't happen, but if it does, there can be
             # no matching results.
-            return
+            return _db.query(CustomListEntry).filter(False)
         elif len(clauses) == 1:
             clause = clauses[0]
         else:
             clause = or_(*clauses)
 
-        _db = Session.object_session(work_or_edition)
         qu = _db.query(CustomListEntry).filter(
             CustomListEntry.customlist==self).filter(
                 clause


### PR DESCRIPTION
Find matching entries in a CustomList using a single database query rather than pulling the entire list membership from the database and iterating over it to see which entries match.

Since `add_entry` and `remove_entry` both call `entries_for_work`, this dramatically speeds up those methods when a list is large. It doesn't even have to be that large -- I was having serious problems with the NYPL staff picks list, which only has 1400 entries.