### PR TITLE
Work.from_identifiers can filter against an ID other than Identifier.id

### DIFF
--- a/migration/20180313-add-identifier-id-to-materialized-view.sql
+++ b/migration/20180313-add-identifier-id-to-materialized-view.sql
@@ -1,0 +1,9 @@
+DO $$
+    BEGIN
+        BEGIN
+	    create index mv_works_for_lanes_identifier_id on mv_works_for_lanes (identifier_id);
+        EXCEPTION
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: mv_works_for_lanes_identifier_id already exists.';
+        END;
+    END
+$$;

--- a/model.py
+++ b/model.py
@@ -4237,7 +4237,7 @@ class Work(Base):
         return q
 
     @classmethod
-    def from_identifiers(cls, _db, identifiers, base_query=None):
+    def from_identifiers(cls, _db, identifiers, base_query=None, identifier_id_field=Identifier.id):
         """Returns all of the works that have one or more license_pools
         associated with either an identifier in the given list or an
         identifier considered equivalent to one of those listed
@@ -4256,7 +4256,7 @@ class Work(Base):
             Identifier.id, levels=1, threshold=0.999)
         identifier_ids_subquery = identifier_ids_subquery.where(Identifier.id.in_(identifier_ids))
 
-        query = base_query.filter(Identifier.id.in_(identifier_ids_subquery))
+        query = base_query.filter(identifier_id_field.in_(identifier_ids_subquery))
         return query
 
     @classmethod

--- a/model.py
+++ b/model.py
@@ -9511,11 +9511,28 @@ class CustomList(Base):
             edition = work_or_edition
             work = edition.work
 
-        equivalents = edition.equivalent_editions().all()
+        equivalent_ids = [x.id for x in edition.equivalent_editions()]
 
-        for entry in self.entries:
-            if (work and entry.work == work) or entry.edition in equivalents:
-                yield entry
+        clauses = []
+        if equivalent_ids:
+            clauses.append(CustomListEntry.edition_id.in_(equivalent_ids))
+        if work:
+            clauses.append(CustomListEntry.work==work)
+        if len(clauses) == 0:
+            # This shouldn't happen, but if it does, there can be
+            # no matching results.
+            return
+        elif len(clauses) == 1:
+            clause = clauses[0]
+        else:
+            clause = or_(*clauses)
+
+        _db = Session.object_session(work_or_edition)
+        qu = _db.query(CustomListEntry).filter(
+            CustomListEntry.customlist==self).filter(
+                clause
+            )
+        return qu
 
 
 class CustomListEntry(Base):

--- a/model.py
+++ b/model.py
@@ -9513,6 +9513,7 @@ class CustomList(Base):
 
         equivalent_ids = [x.id for x in edition.equivalent_editions()]
 
+        _db = Session.object_session(work_or_edition)
         clauses = []
         if equivalent_ids:
             clauses.append(CustomListEntry.edition_id.in_(equivalent_ids))
@@ -9521,13 +9522,12 @@ class CustomList(Base):
         if len(clauses) == 0:
             # This shouldn't happen, but if it does, there can be
             # no matching results.
-            return
+            return _db.query(CustomListEntry).filter(False)
         elif len(clauses) == 1:
             clause = clauses[0]
         else:
             clause = or_(*clauses)
 
-        _db = Session.object_session(work_or_edition)
         qu = _db.query(CustomListEntry).filter(
             CustomListEntry.customlist==self).filter(
                 clause

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2650,6 +2650,19 @@ class TestWork(DatabaseTest):
         # Because the work's license_pool isn't suppressed, it isn't returned.
         eq_([], result)
 
+        # It's possible to filter a field other than Identifier.id.
+        # Here, we filter based on the value of
+        # mv_works_for_lanes.identifier_id.
+        from model import MaterializedWorkWithGenre as mw
+        qu = self._db.query(mw)
+        m = lambda: Work.from_identifiers(
+            self._db, [lp.identifier], base_query=qu,
+            identifier_id_field=mw.identifier_id
+        ).all()
+        eq_([], m())
+        self.add_to_materialized_view([work, ignored_work])
+        eq_([work.id], [x.works_id for x in m()])
+
     def test_calculate_presentation(self):
         # Test that:
         # - work coverage records are made on work creation and primary edition selection.


### PR DESCRIPTION
This branch is the core fix to https://github.com/NYPL-Simplified/circulation/issues/884. It makes it possible for Work.from_identifiers to filter against a field other than Identifier.id, such as the materialized view's `identifier_id`.