### PR TITLE
Add the mv_works_for_lanes_identifier_id index when creating the materialized view for the first time, not just when migrating it.

### DIFF
--- a/files/materialized_view_for_lanes.sql
+++ b/files/materialized_view_for_lanes.sql
@@ -86,6 +86,9 @@ create index mv_works_for_lanes_by_random_fiction_audience_target_age on mv_work
 
 create index mv_works_for_lanes_by_modification on mv_works_for_lanes (last_update_time DESC, sort_author, sort_title, works_id);
 
+-- This index is useful when building feeds of recommended titles.
+create index mv_works_for_lanes_identifier_id on mv_works_for_lanes (identifier_id);
+
 -- We need three versions of each index:
 --- One that orders by sort_author, sort_title, and works_id
 --- One that orders by sort_title, sort_author, and works_id


### PR DESCRIPTION
In a first, I created the migration script but forgot to change the original materialized view creation code, rather than vice versa.

Since this is purely a performance improvement, there were no failing tests to tell me this was a problem.

This SQL should be the same CREATE INDEX command as in https://github.com/NYPL-Simplified/server_core/blob/master/migration/20180313-1-add-identifier-id-to-materialized-view.sql.