### PR TITLE
List based lane performance improvements

### DIFF
--- a/files/materialized_view_for_lanes.sql
+++ b/files/materialized_view_for_lanes.sql
@@ -72,7 +72,7 @@ create index mv_works_for_lanes_by_availability on mv_works_for_lanes (availabil
 create index mv_works_for_lanes_by_recently_updated on mv_works_for_lanes (GREATEST(availability_time, first_appearance, last_update_time) DESC, collection_id, works_id);
 
 -- This index quickly cuts down the number of rows considered when generating a crawlable feed for a custom list.
-create index mv_works_for_lanes_list_and_collection_id on mv_works_for_lanes (list_id, collection_id);
+create index mv_works_for_lanes_list_id_collection_id_language_medium on mv_works_for_lanes (list_id, collection_id, language, medium);
 
 -- Create indexes that are helpful in running the query to find featured works.
 

--- a/files/materialized_view_for_lanes.sql
+++ b/files/materialized_view_for_lanes.sql
@@ -71,7 +71,7 @@ create index mv_works_for_lanes_by_availability on mv_works_for_lanes (availabil
 -- Create an index on everything, sorted by 'last update time' (the thing used by crawlable feeds).
 create index mv_works_for_lanes_by_recently_updated on mv_works_for_lanes (GREATEST(availability_time, first_appearance, last_update_time) DESC, collection_id, works_id);
 
--- This index quickly cuts down the number of rows considered when generating a crawlable feed for a custom list.
+-- This index quickly cuts down the number of rows considered when generating feeds for a custom list or the intersection of multiple custom lists.
 create index mv_works_for_lanes_list_id_collection_id_language_medium on mv_works_for_lanes (list_id, collection_id, language, medium);
 
 -- Create indexes that are helpful in running the query to find featured works.

--- a/lane.py
+++ b/lane.py
@@ -1910,6 +1910,8 @@ class Lane(Base, WorkList):
         else:
             customlist_ids = [x.id for x in self.customlists]
         if customlist_ids is not None:
+            if a_entry:
+                clauses.append(a_entry.list_id.in_(customlist_ids))
             clauses.append(work_model.list_id.in_(customlist_ids))
         if must_be_featured:
             clauses.append(a_entry.featured==True)

--- a/lane.py
+++ b/lane.py
@@ -1909,16 +1909,13 @@ class Lane(Base, WorkList):
         clauses = []
         customlist_ids = None
         if self.list_datasource:
-            # Use a separate query to obtain the CustomList IDs of all
+            # Use a subquery to obtain the CustomList IDs of all
             # CustomLists from this DataSource. This is significantly
-            # faster than just using the subquery as customlist_ids
-            # or adding a join against CustomList.
+            # simpler than adding a join against CustomList.
             customlist_ids = Select(
                 [CustomList.id],
                 CustomList.data_source_id==self.list_datasource.id
             )
-            _db = Session.object_session(self)
-            customlist_ids = [x[0] for x in _db.execute(customlist_ids)]
         else:
             customlist_ids = [x.id for x in self.customlists]
         if customlist_ids is not None:

--- a/lane.py
+++ b/lane.py
@@ -1889,18 +1889,7 @@ class Lane(Base, WorkList):
         # the materialized view.
         a_entry = aliased(CustomListEntry)
         clause = a_entry.work_id==work_model.works_id
-        if not already_filtered_customlist_on_materialized_view:
-            # The first time we join against CustomListEntry, the list
-            # we're talking about is the same one mentioned in the
-            # materialized view's list_id field. We only do the join
-            # in case we are filtering on some field not available in
-            # the materialized view, such as first_appearance.
-            #
-            # (Also, doing the join makes sure entries leave the lanes
-            # as soon as they are removed from the list, without
-            # needing to wait for the materialized view to be
-            # refreshed.)
-            clause = and_(clause, a_entry.list_id==work_model.list_id)
+        clause = and_(clause, a_entry.list_id==work_model.list_id)
         if outer_join:
             qu = qu.outerjoin(a_entry, clause)
         else:

--- a/lane.py
+++ b/lane.py
@@ -1891,7 +1891,15 @@ class Lane(Base, WorkList):
         # a new alias for the table every time.
         a_entry = aliased(CustomListEntry)
         clause = a_entry.work_id==work_model.works_id
-        clause = and_(clause, a_entry.list_id==work_model.list_id)
+        if not already_filtered_customlist_on_materialized_view:
+            # Since this is the first join, we're treating
+            # work_model.list_id as a stand-in for CustomListEntry.list_id,
+            # which means we should force them to be the same when joining
+            # the view to the table.
+            #
+            # For subsequent joins, this won't apply -- we want to
+            # match a _different_ list's entry for the same work.
+            clause = and_(clause, a_entry.list_id==work_model.list_id)
         if outer_join:
             qu = qu.outerjoin(a_entry, clause)
         else:

--- a/lane.py
+++ b/lane.py
@@ -1882,7 +1882,9 @@ class Lane(Base, WorkList):
         # There may already be a join against CustomListEntry, in the case 
         # of a Lane that inherits its parent's restrictions. To avoid
         # confusion, create a different join every time.
-        a_list = None
+        #
+        # Our ability to combine 'inherit parent restrictions' with
+        # CustomList restrictions is limited, but we do what we can.
         a_entry = None
         if must_be_featured or self.list_seen_in_previous_days:
             a_entry = aliased(CustomListEntry)
@@ -1896,9 +1898,9 @@ class Lane(Base, WorkList):
         clauses = []
         customlist_ids = None
         if self.list_datasource:
-            # Use a separate query to obtain the CustomList IDs of 
-            # all CustomLists from this DataSource. This is faster than
-            # using a subquery.
+            # Use a separate query to obtain the CustomList IDs of all
+            # CustomLists from this DataSource. This is significantly
+            # faster than just using the subquery as customlist_ids.
             customlist_ids = Select(
                 [CustomList.id],
                 CustomList.data_source_id==self.list_datasource.id

--- a/lane.py
+++ b/lane.py
@@ -1924,7 +1924,8 @@ class Lane(Base, WorkList):
                 clauses.append(work_model.list_id.in_(customlist_ids))
                 # Now that we've put a restriction on the materialized
                 # view's list_id, we need to signal that no future
-                # call to this method should override it this restriction.
+                # call to this method should put a restriction on the
+                # same field.
                 #
                 # Future calls will apply their restrictions
                 # solely by restricting CustomListEntry.list_id,

--- a/migration/20180307-replace-recently-updated-index.sql
+++ b/migration/20180307-replace-recently-updated-index.sql
@@ -7,11 +7,5 @@ DO $$
             WHEN OTHERS THEN RAISE NOTICE 'mv_works_for_lanes_by_recently_updated did not previously exist.';
         END;
 	create index mv_works_for_lanes_by_recently_updated on mv_works_for_lanes (GREATEST(availability_time, first_appearance, last_update_time) DESC, collection_id, works_id);
-
-        BEGIN
-	    create index mv_works_for_lanes_list_and_collection_id on mv_works_for_lanes (list_id, collection_id);
-        EXCEPTION
-            WHEN duplicate_table THEN RAISE NOTICE 'Warning: mv_works_for_lanes_list_and_collection_id already exists.';
-        END;
     END
 $$;

--- a/migration/20180315-add-performance-indexes.sql
+++ b/migration/20180315-add-performance-indexes.sql
@@ -1,0 +1,22 @@
+DO $$
+    BEGIN
+        BEGIN
+	    drop index mv_works_for_lanes_list_and_collection_id;
+        EXCEPTION
+            WHEN OTHERS THEN RAISE NOTICE 'mv_works_for_lanes_list_and_collection_id is already gone.';
+        END;
+
+	BEGIN
+	    create index mv_works_for_lanes_list_id_collection_id_language_medium on mv_works_for_lanes (list_id, collection_id, language, medium);
+	EXCEPTION
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: mv_works_for_lanes_list_id_collection_id_language_medium already exists.';
+        END;  
+
+	BEGIN
+	    create index customlistentries_work_id_list_id on customlistentries (work_id, list_id);
+	EXCEPTION
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: customlistentries_work_id_list_id already exists.';
+        END;  
+    END
+$$;
+

--- a/migration/20180315-add-performance-indexes.sql
+++ b/migration/20180315-add-performance-indexes.sql
@@ -10,13 +10,13 @@ DO $$
 	    create index mv_works_for_lanes_list_id_collection_id_language_medium on mv_works_for_lanes (list_id, collection_id, language, medium);
 	EXCEPTION
             WHEN duplicate_table THEN RAISE NOTICE 'Warning: mv_works_for_lanes_list_id_collection_id_language_medium already exists.';
-        END;  
+        END;
 
 	BEGIN
 	    create index customlistentries_work_id_list_id on customlistentries (work_id, list_id);
 	EXCEPTION
             WHEN duplicate_table THEN RAISE NOTICE 'Warning: customlistentries_work_id_list_id already exists.';
-        END;  
+        END;
     END
 $$;
 

--- a/model.py
+++ b/model.py
@@ -9685,6 +9685,10 @@ class CustomListEntry(Base):
                 _db.delete(entry)
         _db.commit
 
+# This index dramatically speeds up queries against the materialized
+# view that use custom list membership as a way to cut down on the
+# number of entries returned.
+Index("ix_customlistentries_work_id_list_id", CustomListEntry.work_id, CustomListEntry.list_id)
 
 class Complaint(Base):
     """A complaint about a LicensePool (or, potentially, something else)."""

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1681,10 +1681,6 @@ class TestLane(DatabaseTest):
         SessionManager.refresh_materialized_views(self._db)
         match_works(best_selling_classics, [childrens_fiction, nonfiction])
 
-        # NOTE: These tests have been commented out because we no
-        # longer support a lane based on lists that inherits from
-        # another lane based on lists.
-
         # When it inherits its parent's restrictions, only the
         # works that are on _both_ lists show up in the lane,
         best_selling_classics.inherit_parent_restrictions = True

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1909,10 +1909,6 @@ class TestWorkListGroups(DatabaseTest):
         lq_ro = _w(title="LQ Romance", genre="Romance", fiction=True)
         lq_ro.quality = 0.1
         nonfiction = _w(title="Nonfiction", fiction=False)
-        self.add_to_materialized_view(
-            [hq_sf, mq_sf, lq_sf, hq_ro, mq_ro, lq_ro, hq_litfic, lq_litfic,
-             nonfiction]
-        )
 
         # One of these works (mq_sf) is a best-seller and also a staff
         # pick.
@@ -1956,6 +1952,11 @@ class TestWorkListGroups(DatabaseTest):
             parent=fiction
         )
         discredited_nonfiction.inherit_parent_restrictions = False
+
+        self.add_to_materialized_view(
+            [hq_sf, mq_sf, lq_sf, hq_ro, mq_ro, lq_ro, hq_litfic, lq_litfic,
+             nonfiction]
+        )
 
         def assert_contents(g, expect):
             """Assert that a generator yields the expected

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1590,8 +1590,7 @@ class TestLane(DatabaseTest):
                 self._db, base_query, featured
             )
             
-            if (lane.uses_customlists and
-                (featured or lane.list_seen_in_previous_days)):
+            if lane.uses_customlists:
                 # bibliographic_filter_clause modifies the query (by
                 # calling customlist_filter_clauses).
                 assert base_query != new_query

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1694,11 +1694,11 @@ class TestLane(DatabaseTest):
         # Other restrictions are inherited as well. Here, a title must
         # show up on both lists _and_ be a nonfiction book. There are
         # no titles that meet all three criteria.
-        #best_sellers_lane.fiction = False
-        #match_works(best_selling_classics, [])
+        best_sellers_lane.fiction = False
+        match_works(best_selling_classics, [])
 
-        #best_sellers_lane.fiction = True
-        #match_works(best_selling_classics, [childrens_fiction])
+        best_sellers_lane.fiction = True
+        match_works(best_selling_classics, [childrens_fiction])
 
     def test_bibliographic_filter_clause_no_restrictions(self):
         """A lane that matches every single book has no bibliographic
@@ -1813,8 +1813,18 @@ class TestLane(DatabaseTest):
         gutenberg_lists_lane.list_datasource = gutenberg
         self.add_to_materialized_view([work])
 
+        from model import MaterializedWorkWithGenre as work_model
+        def _run(qu, clauses):
+            # Run a query with certain clauses and pick out the 
+            # work IDs returned.
+            from core.model import dump_query
+            modified = qu.filter(and_(*clauses)).distinct(
+                work_model.works_id
+            )
+            print dump_query(modified)
+            return [x.works_id for x in modified]
+
         def results(lane=gutenberg_lists_lane, must_be_featured=False):
-            from model import MaterializedWorkWithGenre as work_model
             qu = self._db.query(work_model)
             new_qu, clauses = lane.customlist_filter_clauses(
                 qu, must_be_featured=must_be_featured
@@ -1824,54 +1834,87 @@ class TestLane(DatabaseTest):
                 # The query comes out different than it goes in -- there's a
                 # new join against CustomListEntry.
                 assert new_qu != qu
+            return _run(new_qu, clauses)
 
-            # Run the query and see what it matches.
-            modified = new_qu.filter(and_(*clauses)).distinct(
-                work_model.works_id
-            )
-            return [x.works_id for x in modified]
-
-        # Both lanes contain the work.
-        eq_([work.id], results(gutenberg_list_lane))
-        eq_([work.id], results(gutenberg_lists_lane))
+        # # Both lanes contain the work.
+        # eq_([work.id], results(gutenberg_list_lane))
+        # eq_([work.id], results(gutenberg_lists_lane))
 
         # If there's another list with the same work on it, the
         # work only shows up once.
         gutenberg_list_2, ignore = self._customlist(num_entries=0)
         gutenberg_list_2_entry, ignore = gutenberg_list_2.add_entry(work)
         gutenberg_list_lane.customlists.append(gutenberg_list)
-        eq_([work.id], results(gutenberg_list_lane))
+        # eq_([work.id], results(gutenberg_list_lane))
 
-        # This lane gets every work on a list associated with Overdrive.
-        # There are no such lists, so the lane is empty.
-        overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
-        overdrive_lists_lane = self._lane()
-        overdrive_lists_lane.list_datasource = overdrive
-        eq_([], results(overdrive_lists_lane))
+        # # This lane gets every work on a list associated with Overdrive.
+        # # There are no such lists, so the lane is empty.
+        # overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
+        # overdrive_lists_lane = self._lane()
+        # overdrive_lists_lane.list_datasource = overdrive
+        # eq_([], results(overdrive_lists_lane))
 
-        # It's possible to restrict a lane so that only works that are
-        # _featured_ on a list show up. The work isn't featured, so it
-        # doesn't show up.
-        eq_([], results(must_be_featured=True))
+        # # It's possible to restrict a lane so that only works that are
+        # # _featured_ on a list show up. The work isn't featured, so it
+        # # doesn't show up.
+        # eq_([], results(must_be_featured=True))
 
-        # Now it's featured, and it shows up.
-        gutenberg_list_entry.featured = True
-        eq_([work.id], results(must_be_featured=True))
+        # # Now it's featured, and it shows up.
+        # gutenberg_list_entry.featured = True
+        # eq_([work.id], results(must_be_featured=True))
 
-        # It's possible to restrict a lane to works that were seen on
-        # a certain list in a given timeframe.
-        now = datetime.datetime.utcnow()
-        two_days_ago = now - datetime.timedelta(days=2)
-        gutenberg_list_entry.most_recent_appearance = two_days_ago
+        # # It's possible to restrict a lane to works that were seen on
+        # # a certain list in a given timeframe.
+        # now = datetime.datetime.utcnow()
+        # two_days_ago = now - datetime.timedelta(days=2)
+        # gutenberg_list_entry.most_recent_appearance = two_days_ago
 
-        # The lane will only show works that were seen within the last
-        # day. There are no such works.
-        gutenberg_lists_lane.list_seen_in_previous_days = 1
-        eq_([], results())
+        # # The lane will only show works that were seen within the last
+        # # day. There are no such works.
+        # gutenberg_lists_lane.list_seen_in_previous_days = 1
+        # eq_([], results())
 
-        # Now it's been loosened to three days, and the work shows up.
-        gutenberg_lists_lane.list_seen_in_previous_days = 3
-        eq_([work.id], results())
+        # # Now it's been loosened to three days, and the work shows up.
+        # gutenberg_lists_lane.list_seen_in_previous_days = 3
+        # eq_([work.id], results())
+
+        # Now let's test what happens when we chain calls to this
+        # method.
+        #
+        # We want to find books that are in *both* lists.
+        gutenberg_list_2_lane = self._lane()
+        gutenberg_list_2_lane.customlists.append(gutenberg_list_2)
+
+        qu = self._db.query(work_model)
+        list_1_qu, list_1_clauses = gutenberg_list_lane.customlist_filter_clauses(qu)
+
+        # The query has been modified to indicate that we are filtering
+        # on the materialized view's customlist_id field.
+        eq_(True, list_1_qu.customlist_id_filtered)
+        eq_([work.id], [x.works_id for x in list_1_qu])
+
+        # Now call customlist_filter_clauses again so that the query
+        # must only match books on _both_ lists. This simulates
+        # what happens when the second list is a child of the first,
+        # and inherits its restrictions.
+        both_lists_qu, list_2_clauses = gutenberg_list_2_lane.customlist_filter_clauses(
+            list_1_qu, 
+        )
+        both_lists_clauses = list_1_clauses + list_2_clauses
+        eq_([work.id], _run(both_lists_qu, both_lists_clauses))
+        
+        # If we remove `work` from either list, it stops showing up
+        # in the combined query.
+        gutenberg_list.remove_entry(work)
+        SessionManager.refresh_materialized_views(self._db)
+        eq_([], _run(both_lists_qu, both_lists_clauses))
+        gutenberg_list.add_entry(work)
+
+        gutenberg_list_2.remove_entry(work)
+        eq_([], _run(both_lists_qu, both_lists_clauses))
+        gutenberg_list_2.add_entry(work)
+        SessionManager.refresh_materialized_views(self._db)
+        
 
 class TestWorkListGroups(DatabaseTest):
     """Tests of WorkList.groups() and the helper methods."""

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1812,11 +1812,7 @@ class TestLane(DatabaseTest):
         def _run(qu, clauses):
             # Run a query with certain clauses and pick out the 
             # work IDs returned.
-            from core.model import dump_query
-            modified = qu.filter(and_(*clauses)).distinct(
-                work_model.works_id
-            )
-            print dump_query(modified)
+            modified = qu.filter(and_(*clauses))
             return [x.works_id for x in modified]
 
         def results(lane=gutenberg_lists_lane, must_be_featured=False):

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1831,7 +1831,7 @@ class TestLane(DatabaseTest):
                 assert new_qu != qu
             return _run(new_qu, clauses)
 
-        # # Both lanes contain the work.
+        # Both lanes contain the work.
         eq_([work.id], results(gutenberg_list_lane))
         eq_([work.id], results(gutenberg_lists_lane))
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1876,16 +1876,16 @@ class TestLane(DatabaseTest):
         # Now let's test what happens when we chain calls to this
         # method.
         gutenberg_list_2_lane = self._lane()
+        gutenberg_list_2_lane.customlists.append(gutenberg_list_2)
 
         # These two lines aren't necessary for the test but they
         # illustrate how this would happen in a real scenario -- When
         # determining which works belong in the child lane,
         # customlist_filter_clauses() will be called on the parent
-        # lane and then on the child.
+        # lane and then on the child. We only want books that are
+        # on _both_ gutenberg_list and gutenberg_list_2.
         gutenberg_list_2_lane.parent = gutenberg_list_lane
         gutenberg_list_2_lane.inherit_parent_restrictions = True
-
-        gutenberg_list_2_lane.customlists.append(gutenberg_list_2)
 
         qu = self._db.query(work_model)
         list_1_qu, list_1_clauses = gutenberg_list_lane.customlist_filter_clauses(qu)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1687,8 +1687,8 @@ class TestLane(DatabaseTest):
 
         # When it inherits its parent's restrictions, only the
         # works that are on _both_ lists show up in the lane,
-        #best_selling_classics.inherit_parent_restrictions = True
-        #match_works(best_selling_classics, [childrens_fiction])
+        best_selling_classics.inherit_parent_restrictions = True
+        match_works(best_selling_classics, [childrens_fiction])
 
         # Other restrictions are inherited as well. Here, a title must
         # show up on both lists _and_ be a nonfiction book. There are

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1875,9 +1875,16 @@ class TestLane(DatabaseTest):
 
         # Now let's test what happens when we chain calls to this
         # method.
-        #
-        # We want to find books that are in *both* lists.
         gutenberg_list_2_lane = self._lane()
+
+        # These two lines aren't necessary for the test but they
+        # illustrate how this would happen in a real scenario -- When
+        # determining which works belong in the child lane,
+        # customlist_filter_clauses() will be called on the parent
+        # lane and then on the child.
+        gutenberg_list_2_lane.parent = gutenberg_list_lane
+        gutenberg_list_2_lane.inherit_parent_restrictions = True
+
         gutenberg_list_2_lane.customlists.append(gutenberg_list_2)
 
         qu = self._db.query(work_model)
@@ -1890,7 +1897,7 @@ class TestLane(DatabaseTest):
 
         # Now call customlist_filter_clauses again so that the query
         # must only match books on _both_ lists. This simulates
-        # what happens when the second list is a child of the first,
+        # what happens when the second lane is a child of the first,
         # and inherits its restrictions.
         both_lists_qu, list_2_clauses = gutenberg_list_2_lane.customlist_filter_clauses(
             list_1_qu, 


### PR DESCRIPTION
This branch addresses https://github.com/NYPL-Simplified/server_core/issues/823 by improving the performance of lanes whose membership is derived from custom lists.

The basic technique is the same as other times we did this -- put a restriction on the materialized view as well as putting it on the joined table -- but it's a little more complicated because the joined table (CustomListEntry, in this case) may be joined against the materialized view multiple times, and we can only put a restriction on the materialized view once.

The solution is to apply the first restriction in both places (materialized view and CustomListEntry), and subsequent restrictions only to the aliased CustomListEntry joins.