### PR TITLE
Allow shortened S3 URLs

### DIFF
--- a/s3.py
+++ b/s3.py
@@ -23,17 +23,48 @@ class S3Uploader(MirrorUploader):
 
     NAME = ExternalIntegration.S3
 
+    S3_HOSTNAME = "s3.amazonaws.com"
+    S3_BASE = "https://%s/" % S3_HOSTNAME
+
     BOOK_COVERS_BUCKET_KEY = u'book_covers_bucket'
     OA_CONTENT_BUCKET_KEY = u'open_access_content_bucket'
 
-    S3_HOSTNAME = "s3.amazonaws.com"
-    S3_BASE = "http://%s/" % S3_HOSTNAME
+    URL_TRANSFORM_KEY = u'bucket_name_transform'
+    URL_TRANSFORM_HTTP = u'http'
+    URL_TRANSFORM_HTTPS = u'https'
+    URL_TRANSFORM_IDENTITY = u'identity'
+
+    URL_TEMPLATES_BY_TRANSFORM = {
+        URL_TRANSFORM_HTTP: u'http://%(bucket)s/%(key)s',
+        URL_TRANSFORM_HTTPS: u'https://%(bucket)s/%(key)s',
+        URL_TRANSFORM_IDENTITY: S3_BASE + u'%(bucket)s/%(key)s',
+    }
 
     SETTINGS = [
         { "key": ExternalIntegration.USERNAME, "label": _("Access Key") },
         { "key": ExternalIntegration.PASSWORD, "label": _("Secret Key") },
-        { "key": BOOK_COVERS_BUCKET_KEY, "label": _("Book Covers Bucket"), "optional": True },
-        { "key": OA_CONTENT_BUCKET_KEY, "label": _("Open Access Content Bucket"), "optional": True },
+        { "key": BOOK_COVERS_BUCKET_KEY, "label": _("Book Covers Bucket"), "optional": True,
+          "description" : _("All book cover images encountered will be mirrored to this S3 bucket. Large images will be scaled down, and the scaled-down copies will also be uploaded to this bucket. <p>The bucket must already exist&mdash;it will not be created automatically.</p>")
+        },
+        { "key": OA_CONTENT_BUCKET_KEY, "label": _("Open Access Content Bucket"), "optional": True,
+          "description" : _("All open-access books encountered will be uploaded to this S3 bucket. <p>The bucket must already exist&mdash;it will not be created automatically.</p>")
+        },
+        { "key": URL_TRANSFORM_KEY, "label": _("Rewrite URLs to remove S3 domain?"),
+          "type": "select",
+          "options" : [
+              { "key" : URL_TRANSFORM_IDENTITY,
+                "label": _("No rewrite - Leave http://s3.amazonaws.com/{bucket}/ alone."),
+              },
+              { "key" : URL_TRANSFORM_HTTPS,
+                "label": _("HTTPS rewrite: http://s3.amazonaws.com/{bucket}/ becomes https://{bucket}/"),
+              },
+              { "key" : URL_TRANSFORM_HTTP,
+                "label": _("HTTP rewrite: http://s3.amazonaws.com/{bucket}/ becomes http://{bucket}/"),
+              },
+          ],
+          "default": URL_TRANSFORM_IDENTITY,
+          "description" : _("A file mirrored to S3 is available at <code>http://s3.amazonaws.com/{bucket}/{filename}</code>. If you've set up DNS to use the bucket name as a hostname that points to the S3 bucket, configure this S3 integration to automatically rewrite URLs to remove the S3 part of the domain. Users will see URLs that look like <code>http[s]://{bucket}/{filename}</code>.")
+        },
     ]
 
     SITEWIDE = True
@@ -65,6 +96,10 @@ class S3Uploader(MirrorUploader):
         else:
             self.client = client_class
 
+        self.url_transform = integration.setting(
+            self.URL_TRANSFORM_KEY).value_or_default(
+                self.URL_TRANSFORM_IDENTITY)
+
         # Transfer information about bucket names from the
         # ExternalIntegration to the S3Uploader object, so we don't
         # have to keep the ExternalIntegration around.
@@ -72,7 +107,6 @@ class S3Uploader(MirrorUploader):
         for setting in integration.settings:
             if setting.key.endswith('_bucket'):
                 self.buckets[setting.key] = setting.value
-
     def get_bucket(self, bucket_key):
         """Gets the bucket for a particular use based on the given key"""
         return self.buckets.get(bucket_key)
@@ -163,7 +197,23 @@ class S3Uploader(MirrorUploader):
         else:
             bucket = netloc
             filename = path[1:]
-        return bucket, filename
+        return bucket, urllib.unquote(filename)
+
+    def final_mirror_url(self, bucket, key):
+        """Determine the URL to use as Representation.mirror_url, assuming
+        that it was successfully uploaded to the given `bucket` as `key`.
+
+        Depending on ExternalIntegration configuration this may 
+        be any of the following:
+
+        https://s3.amazonaws.com/{bucket}/{key}
+        http://{bucket}/{key}
+        https://{bucket}/{key}
+        """
+        templates = self.URL_TEMPLATES_BY_TRANSFORM
+        default = templates[self.URL_TRANSFORM_IDENTITY]
+        template = templates.get(self.url_transform, default)
+        return template % dict(bucket=bucket, key=key)
 
     def mirror_one(self, representation):
         """Mirror a single representation."""
@@ -183,12 +233,21 @@ class S3Uploader(MirrorUploader):
                 representation.mirror_url)
             fh = representation.external_content()
             try:
-                self.client.upload_fileobj(
+                result = self.client.upload_fileobj(
                     Fileobj=fh,
                     Bucket=bucket,
                     Key=remote_filename,
                     ExtraArgs=dict(ContentType=media_type)
                 )
+
+                # Since upload_fileobj completed without a problem, we
+                # know the file is available at
+                # https://s3.amazonaws.com/{bucket}/{remote_filename}. But
+                # that may not be the URL we want to store.
+                representation.mirror_url = self.final_mirror_url(
+                    bucket, remote_filename
+                )
+
                 source = representation.local_content_path
                 if representation.url != representation.mirror_url:
                     source = representation.url

--- a/s3.py
+++ b/s3.py
@@ -222,6 +222,10 @@ class S3Uploader(MirrorUploader):
     def mirror_batch(self, representations):
         """Mirror a bunch of Representations at once."""
         for representation in representations:
+            # TODO: It's strange that we're setting mirror_url to the
+            # original URL when the file hasn't been mirrored and that
+            # may not end up being the final URL. We should be able to
+            # simplify this.
             if not representation.mirror_url:
                 representation.mirror_url = representation.url
             # Turn the mirror URL into an s3.amazonaws.com URL.

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -613,7 +613,7 @@ class TestMetaToModelUtility(DatabaseTest):
         # make sure the mirrored link is safely on edition
         sorted_edition_links = sorted(pool.identifier.links, key=lambda x: x.rel)
         unmirrored_representation, mirrored_representation = [edlink.resource.representation for edlink in sorted_edition_links]
-        assert mirrored_representation.mirror_url.startswith('http://s3.amazonaws.com/test.content.bucket/')
+        assert mirrored_representation.mirror_url.startswith('https://s3.amazonaws.com/test.content.bucket/')
 
         # make sure the unmirrored link is safely on edition
         eq_('http://example.com/2', unmirrored_representation.url)

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -603,7 +603,7 @@ class TestMetaToModelUtility(DatabaseTest):
 
 
         # It's been 'mirrored' to the appropriate S3 bucket.
-        assert book.mirror_url.startswith('http://s3.amazonaws.com/test.content.bucket/')
+        assert book.mirror_url.startswith('https://s3.amazonaws.com/test.content.bucket/')
         expect = '/%s/%s.epub' % (
             edition.primary_identifier.identifier,
             edition.title

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -336,11 +336,11 @@ class TestMetadataImporter(DatabaseTest):
         assert thumbnail.content != l2.content
 
         # Both images have been 'mirrored' to Amazon S3.
-        assert image.mirror_url.startswith('http://s3.amazonaws.com/test.cover.bucket/')
+        assert image.mirror_url.startswith('https://s3.amazonaws.com/test.cover.bucket/')
         assert image.mirror_url.endswith('cover.jpg')
 
         # The thumbnail image has been converted to PNG.
-        assert thumbnail.mirror_url.startswith('http://s3.amazonaws.com/test.cover.bucket/scaled/300/')
+        assert thumbnail.mirror_url.startswith('https://s3.amazonaws.com/test.cover.bucket/scaled/300/')
         assert thumbnail.mirror_url.endswith('cover.png')
 
     def test_mirror_thumbnail_only(self):
@@ -362,7 +362,7 @@ class TestMetadataImporter(DatabaseTest):
         [thumbnail] = mirror.uploaded
 
         # The image has been 'mirrored' to Amazon S3.
-        assert thumbnail.mirror_url.startswith('http://s3.amazonaws.com/test.cover.bucket/')
+        assert thumbnail.mirror_url.startswith('https://s3.amazonaws.com/test.cover.bucket/')
         assert thumbnail.mirror_url.endswith('thumb.png')
 
     def test_mirror_open_access_link_fetch_failure(self):

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -1428,10 +1428,10 @@ class TestMirroring(OPDSImporterTest):
         # The "crow" book was mirrored to a bucket corresponding to
         # the open-access content source, the default data source used
         # when no distributor was specified for a book.
-        url0 = 'http://s3.amazonaws.com/test.content.bucket/Gutenberg/Gutenberg%20ID/10441/The%20Green%20Mouse.epub.images'
-        url1 = u'http://s3.amazonaws.com/test.cover.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441/cover_10441_9.png'
-        url2 = u'http://s3.amazonaws.com/test.cover.bucket/scaled/300/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441/cover_10441_9.png'
-        url3 = 'http://s3.amazonaws.com/test.content.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10557/Johnny%20Crow%27s%20Party.epub.images'
+        url0 = 'https://s3.amazonaws.com/test.content.bucket/Gutenberg/Gutenberg%20ID/10441/The%20Green%20Mouse.epub.images'
+        url1 = u'https://s3.amazonaws.com/test.cover.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441/cover_10441_9.png'
+        url2 = u'https://s3.amazonaws.com/test.cover.bucket/scaled/300/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441/cover_10441_9.png'
+        url3 = 'https://s3.amazonaws.com/test.content.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10557/Johnny%20Crow%27s%20Party.epub.images'
         uploaded_urls = [x.mirror_url for x in s3.uploaded]
         eq_([url0, url1, url2, url3], uploaded_urls)
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -72,11 +72,11 @@ class TestS3Uploader(S3UploaderTest):
         # Otherwise, it builds just fine.
         integration.username = 'your-access-key'
         integration.password = 'your-secret-key'
-        integration.setting(S3Uploader.URL_TRANSFORM_KEY).value='a transform'
+        integration.setting(S3Uploader.URL_TEMPLATE_KEY).value='a transform'
         uploader = MirrorUploader.implementation(integration)
         eq_(True, isinstance(uploader, S3Uploader))
 
-        # The URL_TRANSFORM_KEY setting becomes the .url_transform
+        # The URL_TEMPLATE_KEY setting becomes the .url_transform
         # attribute on the S3Uploader object.
         eq_('a transform', uploader.url_transform)
 
@@ -116,15 +116,15 @@ class TestS3Uploader(S3UploaderTest):
     def test_final_mirror_url(self):
         # By default, the mirror URL is not modified.
         uploader = self._uploader()
-        eq_(S3Uploader.URL_TRANSFORM_IDENTITY, uploader.url_transform)
+        eq_(S3Uploader.URL_TEMPLATE_DEFAULT, uploader.url_transform)
         eq_(u'https://s3.amazonaws.com/bucket/key',
             uploader.final_mirror_url("bucket", "key"))
 
-        uploader.url_transform = S3Uploader.URL_TRANSFORM_HTTP
+        uploader.url_transform = S3Uploader.URL_TEMPLATE_HTTP
         eq_(u'http://bucket/key',
             uploader.final_mirror_url("bucket", "key"))
 
-        uploader.url_transform = S3Uploader.URL_TRANSFORM_HTTPS
+        uploader.url_transform = S3Uploader.URL_TEMPLATE_HTTPS
         eq_(u'https://bucket/key',
             uploader.final_mirror_url("bucket", "key"))
 


### PR DESCRIPTION
This branch introduces a new configuration for the S3 integration which controls the presentation of the URLs of items mirrored to S3. When a file is uploaded to S3 we know that it is accessible at `http://s3.amazonaws.com/bucket/file`, and that's what's been put in so far, but this isn't always the best URL to show to people, since it's possible to set up DNS so that `https://bucket/` points to the S3 bucket.

This branch introduces a configuration option that lets you choose which template to use when determining the final `mirror_url` of a resource that was mirrored to S3.

* `https://s3.amazonaws.com/bucket/file` (default)
* `https://bucket/file`
* `http://bucket/file`

This branch also changes the default S3 URL to use HTTPS instead of HTTP.

Switching to boto3 has made me aware that the S3 code needs some work, but I think the eventual system will look more like this -- based on building URLs from known pieces -- and less like parsing pieces out of URLs.