### PR TITLE
Consistently escape the pieces of S3 keys when building URLs out of them

### DIFF
--- a/s3.py
+++ b/s3.py
@@ -114,6 +114,10 @@ class S3Uploader(MirrorUploader):
     @classmethod
     def url(cls, bucket, path):
         """The URL to a resource on S3 identified by bucket and path."""
+        if isinstance(path, list):
+            # This is a list of key components that need to be quoted
+            # and assembled.
+            path = cls.key_join(path)
         if path.startswith('/'):
             path = path[1:]
         if bucket.startswith('http://') or bucket.startswith('https://'):
@@ -129,17 +133,15 @@ class S3Uploader(MirrorUploader):
         """The root URL to the S3 location of cover images for
         the given data source.
         """
+        parts = []
         if scaled_size:
-            path = "/scaled/%d/" % scaled_size
-        else:
-            path = "/"
+            parts.extend(["scaled", str(scaled_size)])
         if isinstance(data_source, str):
             data_source_name = data_source
         else:
             data_source_name = data_source.name
-        data_source_name = urllib.quote(data_source_name)
-        path += data_source_name + "/"
-        url = cls.url(bucket, path)
+        parts.append(data_source_name)
+        url = cls.url(bucket, parts)
         if not url.endswith('/'):
             url += '/'
         return url
@@ -153,6 +155,29 @@ class S3Uploader(MirrorUploader):
             raise NotImplementedError()
         return cls.url(bucket, '/')
 
+    @classmethod
+    def key_join(self, key):
+        """Quote the path portions of an S3 key while leaving the path
+        characters themselves alone.
+
+        :param key: Either a key, or a list of parts that will eventually
+        make up a key.
+
+        :return: A bytestring that can be used as an S3 key.
+        """
+        if isinstance(key, basestring):
+            parts = key.split('/')
+        else:
+            parts = key
+        new_parts = []
+        for part in parts:
+            if isinstance(part, unicode):
+                part = part.encode("utf-8")
+            else:
+                part = str(part)
+            new_parts.append(urllib.quote_plus(part))
+        return b'/'.join(new_parts)
+
     def book_url(self, identifier, extension='.epub', open_access=True,
                  data_source=None, title=None):
         """The path to the hosted EPUB file for the given identifier."""
@@ -162,30 +187,27 @@ class S3Uploader(MirrorUploader):
         if not extension.startswith('.'):
             extension = '.' + extension
 
-        if title:
-            filename = "%s/%s" % (identifier.identifier, title)
-        else:
-            filename = identifier.identifier
-
-        args = [identifier.type, filename]
-        args = [urllib.quote(x.encode('utf-8')) for x in args]
+        parts = []
         if data_source:
-            args.insert(0, urllib.quote(data_source.name))
-            template = "%s/%s/%s%s"
+            parts.append(data_source.name)
+        parts.append(identifier.type)
+        if title:
+            # e.g. DataSource/ISBN/1234/Title.epub
+            parts.append(identifier.identifier)
+            filename = title
         else:
-            template = "%s/%s%s"
-
-        return root + template % tuple(args + [extension])
+            # e.g. DataSource/ISBN/1234.epub
+            filename = identifier.identifier
+        parts.append(filename + extension)
+        return root + self.key_join(parts)
 
     def cover_image_url(self, data_source, identifier, filename,
                         scaled_size=None):
         """The path to the hosted cover image for the given identifier."""
         bucket = self.get_bucket(self.BOOK_COVERS_BUCKET_KEY)
         root = self.cover_image_root(bucket, data_source, scaled_size)
-
-        args = [identifier.type, identifier.identifier, filename]
-        args = [urllib.quote(x) for x in args]
-        return root + "%s/%s/%s" % tuple(args)
+        parts = [identifier.type, identifier.identifier, filename]
+        return root + self.key_join(parts)
 
     @classmethod
     def bucket_and_filename(cls, url):
@@ -197,7 +219,7 @@ class S3Uploader(MirrorUploader):
         else:
             bucket = netloc
             filename = path[1:]
-        return bucket, urllib.unquote(filename)
+        return bucket, urllib.unquote_plus(filename)
 
     def final_mirror_url(self, bucket, key):
         """Determine the URL to use as Representation.mirror_url, assuming
@@ -213,7 +235,7 @@ class S3Uploader(MirrorUploader):
         templates = self.URL_TEMPLATES_BY_TEMPLATE
         default = templates[self.URL_TEMPLATE_DEFAULT]
         template = templates.get(self.url_transform, default)
-        return template % dict(bucket=bucket, key=key)
+        return template % dict(bucket=bucket, key=self.key_join(key))
 
     def mirror_one(self, representation):
         """Mirror a single representation."""

--- a/s3.py
+++ b/s3.py
@@ -160,8 +160,8 @@ class S3Uploader(MirrorUploader):
         """Quote the path portions of an S3 key while leaving the path
         characters themselves alone.
 
-        :param key: Either a key, or a list of parts that will eventually
-        make up a key.
+        :param key: Either a key, or a list of parts to be
+        assembled into a key.
 
         :return: A bytestring that can be used as an S3 key.
         """

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -335,7 +335,7 @@ class TestOPDSImporter(OPDSImporterTest):
         )
 
         # The <entry> tag became a Metadata object.
-        metadata = values['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441']
+        metadata = values['urn:librarysimplified.org/terms/id/Gutenberg+ID/10441']
         eq_("The Green Mouse", metadata['title'])
         eq_("A Tale of Mousy Terror", metadata['subtitle'])
         eq_('en', metadata['language'])
@@ -372,13 +372,13 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(2, len(failures))
 
         # The first error message became a CoverageFailure.
-        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441']
+        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg+ID/10441']
         assert isinstance(failure, CoverageFailure)
         eq_(True, failure.transient)
         assert "Utter failure!" in failure.exception
 
         # The second error message became a CoverageFailure.
-        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10557']
+        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg+ID/10557']
         assert isinstance(failure, CoverageFailure)
         eq_(True, failure.transient)
         assert "Utter failure!" in failure.exception
@@ -399,7 +399,7 @@ class TestOPDSImporter(OPDSImporterTest):
         # We're going to do spot checks on a book and a periodical.
 
         # First, the book.
-        book_id = 'urn:librarysimplified.org/terms/id/Gutenberg%20ID/1022'
+        book_id = 'urn:librarysimplified.org/terms/id/Gutenberg+ID/1022'
         book = data[book_id]
         eq_(Edition.BOOK_MEDIUM, book['medium'])
 
@@ -430,7 +430,7 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(Representation.EPUB_MEDIA_TYPE, link.media_type)
 
         # And now, the periodical.
-        periodical_id = 'urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441'
+        periodical_id = 'urn:librarysimplified.org/terms/id/Gutenberg+ID/10441'
         periodical = data[periodical_id]
         eq_(Edition.PERIODICAL_MEDIUM, periodical['medium'])
 
@@ -667,12 +667,12 @@ class TestOPDSImporter(OPDSImporterTest):
 
         # The other entries became generic CoverageFailures due to the failure
         # of extract_metadata_from_elementtree.
-        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441']
+        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg+ID/10441']
         assert isinstance(failure, CoverageFailure)
         eq_(True, failure.transient)
         assert "Utter failure!" in failure.exception
 
-        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10557']
+        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg+ID/10557']
         assert isinstance(failure, CoverageFailure)
         eq_(True, failure.transient)
         assert "Utter failure!" in failure.exception
@@ -1428,10 +1428,10 @@ class TestMirroring(OPDSImporterTest):
         # The "crow" book was mirrored to a bucket corresponding to
         # the open-access content source, the default data source used
         # when no distributor was specified for a book.
-        url0 = 'https://s3.amazonaws.com/test.content.bucket/Gutenberg/Gutenberg%20ID/10441/The%20Green%20Mouse.epub.images'
-        url1 = u'https://s3.amazonaws.com/test.cover.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441/cover_10441_9.png'
-        url2 = u'https://s3.amazonaws.com/test.cover.bucket/scaled/300/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10441/cover_10441_9.png'
-        url3 = 'https://s3.amazonaws.com/test.content.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg%20ID/10557/Johnny%20Crow%27s%20Party.epub.images'
+        url0 = 'https://s3.amazonaws.com/test.content.bucket/Gutenberg/Gutenberg+ID/10441/The%20Green%20Mouse.epub.images'
+        url1 = u'https://s3.amazonaws.com/test.cover.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg+ID/10441/cover_10441_9.png'
+        url2 = u'https://s3.amazonaws.com/test.cover.bucket/scaled/300/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg+ID/10441/cover_10441_9.png'
+        url3 = 'https://s3.amazonaws.com/test.content.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg+ID/10557/Johnny%20Crow%27s%20Party.epub.images'
         uploaded_urls = [x.mirror_url for x in s3.uploaded]
         eq_([url0, url1, url2, url3], uploaded_urls)
 
@@ -1752,7 +1752,7 @@ class TestOPDSImportMonitor(OPDSImporterTest):
             sorted([x.status for x in coverage_records])
         )
     
-        identifier, ignore = Identifier.parse_urn(self._db, "urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441")
+        identifier, ignore = Identifier.parse_urn(self._db, "urn:librarysimplified.org/terms/id/Gutenberg+ID/10441")
         failure = CoverageRecord.lookup(
             identifier, data_source,
             operation=CoverageRecord.IMPORT_OPERATION

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -335,7 +335,7 @@ class TestOPDSImporter(OPDSImporterTest):
         )
 
         # The <entry> tag became a Metadata object.
-        metadata = values['urn:librarysimplified.org/terms/id/Gutenberg+ID/10441']
+        metadata = values['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441']
         eq_("The Green Mouse", metadata['title'])
         eq_("A Tale of Mousy Terror", metadata['subtitle'])
         eq_('en', metadata['language'])
@@ -372,13 +372,13 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(2, len(failures))
 
         # The first error message became a CoverageFailure.
-        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg+ID/10441']
+        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441']
         assert isinstance(failure, CoverageFailure)
         eq_(True, failure.transient)
         assert "Utter failure!" in failure.exception
 
         # The second error message became a CoverageFailure.
-        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg+ID/10557']
+        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10557']
         assert isinstance(failure, CoverageFailure)
         eq_(True, failure.transient)
         assert "Utter failure!" in failure.exception
@@ -399,7 +399,7 @@ class TestOPDSImporter(OPDSImporterTest):
         # We're going to do spot checks on a book and a periodical.
 
         # First, the book.
-        book_id = 'urn:librarysimplified.org/terms/id/Gutenberg+ID/1022'
+        book_id = 'urn:librarysimplified.org/terms/id/Gutenberg%20ID/1022'
         book = data[book_id]
         eq_(Edition.BOOK_MEDIUM, book['medium'])
 
@@ -430,7 +430,7 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(Representation.EPUB_MEDIA_TYPE, link.media_type)
 
         # And now, the periodical.
-        periodical_id = 'urn:librarysimplified.org/terms/id/Gutenberg+ID/10441'
+        periodical_id = 'urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441'
         periodical = data[periodical_id]
         eq_(Edition.PERIODICAL_MEDIUM, periodical['medium'])
 
@@ -667,12 +667,12 @@ class TestOPDSImporter(OPDSImporterTest):
 
         # The other entries became generic CoverageFailures due to the failure
         # of extract_metadata_from_elementtree.
-        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg+ID/10441']
+        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441']
         assert isinstance(failure, CoverageFailure)
         eq_(True, failure.transient)
         assert "Utter failure!" in failure.exception
 
-        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg+ID/10557']
+        failure = failures['urn:librarysimplified.org/terms/id/Gutenberg%20ID/10557']
         assert isinstance(failure, CoverageFailure)
         eq_(True, failure.transient)
         assert "Utter failure!" in failure.exception
@@ -1428,10 +1428,10 @@ class TestMirroring(OPDSImporterTest):
         # The "crow" book was mirrored to a bucket corresponding to
         # the open-access content source, the default data source used
         # when no distributor was specified for a book.
-        url0 = 'https://s3.amazonaws.com/test.content.bucket/Gutenberg/Gutenberg+ID/10441/The%20Green%20Mouse.epub.images'
-        url1 = u'https://s3.amazonaws.com/test.cover.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg+ID/10441/cover_10441_9.png'
-        url2 = u'https://s3.amazonaws.com/test.cover.bucket/scaled/300/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg+ID/10441/cover_10441_9.png'
-        url3 = 'https://s3.amazonaws.com/test.content.bucket/Library%20Simplified%20Open%20Access%20Content%20Server/Gutenberg+ID/10557/Johnny%20Crow%27s%20Party.epub.images'
+        url0 = 'https://s3.amazonaws.com/test.content.bucket/Gutenberg/Gutenberg+ID/10441/The+Green+Mouse.epub.images'
+        url1 = u'https://s3.amazonaws.com/test.cover.bucket/Library+Simplified+Open+Access+Content+Server/Gutenberg+ID/10441/cover_10441_9.png'
+        url2 = u'https://s3.amazonaws.com/test.cover.bucket/scaled/300/Library+Simplified+Open+Access+Content+Server/Gutenberg+ID/10441/cover_10441_9.png'
+        url3 = 'https://s3.amazonaws.com/test.content.bucket/Library+Simplified+Open+Access+Content+Server/Gutenberg+ID/10557/Johnny+Crow%27s+Party.epub.images'
         uploaded_urls = [x.mirror_url for x in s3.uploaded]
         eq_([url0, url1, url2, url3], uploaded_urls)
 
@@ -1752,7 +1752,7 @@ class TestOPDSImportMonitor(OPDSImporterTest):
             sorted([x.status for x in coverage_records])
         )
     
-        identifier, ignore = Identifier.parse_urn(self._db, "urn:librarysimplified.org/terms/id/Gutenberg+ID/10441")
+        identifier, ignore = Identifier.parse_urn(self._db, "urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441")
         failure = CoverageRecord.lookup(
             identifier, data_source,
             operation=CoverageRecord.IMPORT_OPERATION

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import os
 import datetime
 from PIL import Image
@@ -128,6 +129,12 @@ class TestS3Uploader(S3UploaderTest):
         eq_(u'https://bucket/key',
             uploader.final_mirror_url("bucket", "key"))
 
+    def test_key_join(self):
+        """Test the code used to build S3 keys from parts."""
+        parts = ["Gutenberg", "Gutenberg ID", 1234, "Die Flügelmaus.epub"]
+        eq_('Gutenberg/Gutenberg+ID/1234/Die+Fl%C3%BCgelmaus.epub', 
+            S3Uploader.key_join(parts))
+
     def test_cover_image_root(self):
         bucket = u'test-book-covers-s3-bucket'
         m = S3Uploader.cover_image_root
@@ -136,7 +143,7 @@ class TestS3Uploader(S3UploaderTest):
             self._db, DataSource.GUTENBERG_COVER_GENERATOR)
         overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
 
-        eq_("https://s3.amazonaws.com/test-book-covers-s3-bucket/Gutenberg%20Illustrated/",
+        eq_("https://s3.amazonaws.com/test-book-covers-s3-bucket/Gutenberg+Illustrated/",
             m(bucket, gutenberg_illustrated))
         eq_("https://s3.amazonaws.com/test-book-covers-s3-bucket/Overdrive/",
             m(bucket, overdrive))
@@ -163,27 +170,27 @@ class TestS3Uploader(S3UploaderTest):
         uploader = self._uploader(**buckets)
         m = uploader.book_url
 
-        eq_(u'https://s3.amazonaws.com/thebooks/Gutenberg%20ID/ABOOK.epub',
+        eq_(u'https://s3.amazonaws.com/thebooks/Gutenberg+ID/ABOOK.epub',
             m(identifier))
 
         # The default extension is .epub, but a custom extension can
         # be specified.
-        eq_(u'https://s3.amazonaws.com/thebooks/Gutenberg%20ID/ABOOK.pdf', 
+        eq_(u'https://s3.amazonaws.com/thebooks/Gutenberg+ID/ABOOK.pdf', 
             m(identifier, extension='pdf'))
 
-        eq_(u'https://s3.amazonaws.com/thebooks/Gutenberg%20ID/ABOOK.pdf', 
+        eq_(u'https://s3.amazonaws.com/thebooks/Gutenberg+ID/ABOOK.pdf', 
             m(identifier, extension='.pdf'))
 
         # If a data source is provided, the book is stored underneath the
         # data source.
         unglueit = DataSource.lookup(self._db, DataSource.UNGLUE_IT)
-        eq_(u'https://s3.amazonaws.com/thebooks/unglue.it/Gutenberg%20ID/ABOOK.epub',
+        eq_(u'https://s3.amazonaws.com/thebooks/unglue.it/Gutenberg+ID/ABOOK.epub',
             m(identifier, data_source=unglueit))
 
         # If a title is provided, the book's filename incorporates the
         # title, for the benefit of people who download the book onto
         # their hard drive.
-        eq_(u'https://s3.amazonaws.com/thebooks/Gutenberg%20ID/ABOOK/On%20Books.epub',
+        eq_(u'https://s3.amazonaws.com/thebooks/Gutenberg+ID/ABOOK/On+Books.epub',
             m(identifier, title="On Books"))
 
         # Non-open-access content can't be stored.
@@ -197,7 +204,7 @@ class TestS3Uploader(S3UploaderTest):
 
         unglueit = DataSource.lookup(self._db, DataSource.UNGLUE_IT)
         identifier = self._identifier(foreign_id="ABOOK")
-        eq_(u'https://s3.amazonaws.com/thecovers/scaled/601/unglue.it/Gutenberg%20ID/ABOOK/filename',
+        eq_(u'https://s3.amazonaws.com/thecovers/scaled/601/unglue.it/Gutenberg+ID/ABOOK/filename',
             m(unglueit, identifier, "filename", scaled_size=601))
 
     def test_bucket_and_filename(self):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -118,12 +118,12 @@ class TestS3Uploader(S3UploaderTest):
         # By default, the mirror URL is not modified.
         uploader = self._uploader()
         eq_(S3Uploader.URL_TEMPLATE_DEFAULT, uploader.url_transform)
-        eq_(u'https://s3.amazonaws.com/bucket/key',
-            uploader.final_mirror_url("bucket", "key"))
+        eq_(u'https://s3.amazonaws.com/bucket/the+key',
+            uploader.final_mirror_url("bucket", "the key"))
 
         uploader.url_transform = S3Uploader.URL_TEMPLATE_HTTP
-        eq_(u'http://bucket/key',
-            uploader.final_mirror_url("bucket", "key"))
+        eq_(u'http://bucket/the+k%C3%ABy',
+            uploader.final_mirror_url("bucket", "the këy"))
 
         uploader.url_transform = S3Uploader.URL_TEMPLATE_HTTPS
         eq_(u'https://bucket/key',


### PR DESCRIPTION
This branch refactors the code that turns pieces of keys into URLs that will work on S3 into a new method called `key_join`, and uses that method everywhere. This ensures that we always generate valid URLs in the same style. My previous branch didn't quote the key inside `final_mirror_url`, which led to URLs with embedded spaces or non-ASCII characters.

I switched from `urllib.quote` to `urllib.quote_plus`, both to make the S3 URLs more readable, and to make it more likely that tests that relied on the old behavior would fail, so that I could check them.