### PR TITLE
Create a general "database table" reaper framework, plus reapers for CachedFeeds and Credentials

### DIFF
--- a/migration/20180321-add-timestamp-indexes.sql
+++ b/migration/20180321-add-timestamp-indexes.sql
@@ -1,0 +1,22 @@
+ DO $$
+    BEGIN
+	BEGIN
+	    create index ix_loans_start on loans (start);
+	EXCEPTION
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: is_loans_start already exists.';
+        END;
+
+	BEGIN
+	    create index ix_loans_end on loans ("end");
+	EXCEPTION
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: ix_loans_end already exists.';
+        END;
+
+	BEGIN
+	    create index ix_cachedfeeds_timestamp on cachedfeeds (timestamp);
+	EXCEPTION
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: ix_cachedfeed_timestamp already exists.';
+        END;
+    END;
+END
+$$;

--- a/migration/20180321-add-timestamp-indexes.sql
+++ b/migration/20180321-add-timestamp-indexes.sql
@@ -15,7 +15,7 @@
 	BEGIN
 	    create index ix_cachedfeeds_timestamp on cachedfeeds (timestamp);
 	EXCEPTION
-            WHEN duplicate_table THEN RAISE NOTICE 'Warning: ix_cachedfeed_timestamp already exists.';
+            WHEN duplicate_table THEN RAISE NOTICE 'Warning: ix_cachedfeeds_timestamp already exists.';
         END;
     END;
 END

--- a/model.py
+++ b/model.py
@@ -826,8 +826,8 @@ class Loan(Base, LoanAndHoldMixin):
     integration_client_id = Column(Integer, ForeignKey('integrationclients.id'), index=True)
     license_pool_id = Column(Integer, ForeignKey('licensepools.id'), index=True)
     fulfillment_id = Column(Integer, ForeignKey('licensepooldeliveries.id'))
-    start = Column(DateTime)
-    end = Column(DateTime)
+    start = Column(DateTime, index=True)
+    end = Column(DateTime, index=True)
     # Some distributors (e.g. Feedbooks) may have an identifier that can
     # be used to check the status of a specific Loan.
     external_identifier = Column(Unicode, unique=True, nullable=True)
@@ -6499,7 +6499,7 @@ class CachedFeed(Base):
         nullable=True, index=True)
 
     # Every feed has a timestamp reflecting when it was created.
-    timestamp = Column(DateTime, nullable=True)
+    timestamp = Column(DateTime, nullable=True, index=True)
 
     # A feed is of a certain type--currently either 'page' or 'groups'.
     type = Column(Unicode, nullable=False)
@@ -7931,7 +7931,7 @@ class Credential(Base):
     patron_id = Column(Integer, ForeignKey('patrons.id'), index=True)
     type = Column(String(255), index=True)
     credential = Column(String)
-    expires = Column(DateTime)
+    expires = Column(DateTime, index=True)
 
     # One Credential can have many associated DRMDeviceIdentifiers.
     drm_device_identifiers = relationship(

--- a/monitor.py
+++ b/monitor.py
@@ -89,12 +89,9 @@ class Monitor(object):
     def __init__(self, _db, collection=None):
         self._db = _db
         cls = self.__class__
-        if self.SERVICE_NAME:
-            self.service_name = self.SERVICE_NAME
-        elif cls.SERVICE_NAME:
-            self.service_name = cls.SERVICE_NAME
-        else:
+        if not self.SERVICE_NAME and not cls.SERVICE_NAME:
             raise ValueError("%s must define SERVICE_NAME." % cls.__name__)
+        self.service_name = self.SERVICE_NAME
         self.interval_seconds = cls.INTERVAL_SECONDS
         self.keep_timestamp = cls.KEEP_TIMESTAMP
         default_start_time = cls.DEFAULT_START_TIME

--- a/monitor.py
+++ b/monitor.py
@@ -692,10 +692,11 @@ class ReaperMonitor(Monitor):
         return self.timestamp_field < self.cutoff
 
     def run_once(self, *args, **kwargs):
-        rows_deleted = self._db.query(self.MODEL_CLASS).filter(
-            self.where_clause).delete(synchronize_session=False)
+        row_deleted = self.query().delete(synchronize_session=False)
         self.log.info("Deleted %d row(s)", rows_deleted)
 
+    def query(self):
+        returnself._db.query(self.MODEL_CLASS).filter(self.where_clause)
 
 # ReaperMonitors that do something specific.
 

--- a/monitor.py
+++ b/monitor.py
@@ -696,7 +696,7 @@ class ReaperMonitor(Monitor):
         self.log.info("Deleted %d row(s)", rows_deleted)
 
     def query(self):
-        returnself._db.query(self.MODEL_CLASS).filter(self.where_clause)
+        return self._db.query(self.MODEL_CLASS).filter(self.where_clause)
 
 # ReaperMonitors that do something specific.
 

--- a/monitor.py
+++ b/monitor.py
@@ -692,7 +692,7 @@ class ReaperMonitor(Monitor):
         return self.timestamp_field < self.cutoff
 
     def run_once(self, *args, **kwargs):
-        row_deleted = self.query().delete(synchronize_session=False)
+        rows_deleted = self.query().delete(synchronize_session=False)
         self.log.info("Deleted %d row(s)", rows_deleted)
 
     def query(self):

--- a/scripts.py
+++ b/scripts.py
@@ -77,6 +77,7 @@ from model import (
 from monitor import (
     SubjectAssignmentMonitor,
     CollectionMonitor,
+    ReaperMonitor,
 )
 from opds_import import (
     OPDSImportMonitor,


### PR DESCRIPTION
This branch introduces `ReaperMonitor`, an abstract class that deletes rows from a database table if a timestamp field in that row is less than a certain date. I introduce specific ReaperMonitors for removing CachedFeeds that are more than a month old, and Credentials that expired more than a day ago. Currently rows are just piling up in these two tables with no way of removing them.

Some code is refactored from `RunCollectionMonitorScript` into a new class, `RunMultipleMonitorsScript`, for any script that needs to run one monitor after another. The new class `RunReaperMonitorsScript` runs all monitors registered in `ReaperMonitor.REGISTRY`.

This branch adds some indexes on timestamp fields that are necessary for the reapers to run in a reasonable time.

Loans and holds already have reapers, in circulation. I want to bring them into this more general system, but it needs to wait for another branch, because the logic of reaping loans and holds is more complex than "delete if this field is less than this date". This branch adds some indexes on timestamp fields that will be useful when I do make this change.