### PR TITLE
Different language means different work

### DIFF
--- a/model.py
+++ b/model.py
@@ -4071,7 +4071,9 @@ class Work(Base):
         # Work.
         licensepools_for_work = Counter()
         for lp in qu:
-            if lp.work and not licensepools_for_work[lp.work]:
+            if (lp.work
+                and lp.work.language in (None, language)
+                and not licensepools_for_work[lp.work]):
                 licensepools_for_work[lp.work] = len(lp.work.license_pools)
 
         work = None

--- a/model.py
+++ b/model.py
@@ -4065,7 +4065,7 @@ class Work(Base):
                 and lp.work.language in (None, language)
                 and not affected_licensepools_for_work[lp.work]):
                 affected_licensepools_for_work[lp.work] = len(
-                    [x for x in pools if x.work == lp.work and lp in pools]
+                    [x for x in pools if x.work == lp.work]
                 )
         return pools, affected_licensepools_for_work
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4393,16 +4393,33 @@ class TestWorkConsolidation(DatabaseTest):
         eq_(poolset, pools)
         eq_({w1 : 2}, counts)
 
-        # If the Work's language is set to a language that _conflicts_
-        # with the language passed in to
+        # If the Work's presentation edition has information that
+        # _conflicts_ with the information passed in to
         # _potential_open_access_works_for_permanent_work_id, the Work
         # does not show up in `counts`, indicating that a new Work
-        # needs to be created to hold books in the given language.
-        wrong_language = self._edition(language="fin")
-        w1.presentation_edition = wrong_language
+        # should to be created to hold those books.
+        bad_pe = self._edition()
+        bad_pe.permanent_work_id='pwid'
+        w1.presentation_edition = bad_pe
+
+        bad_pe.language = 'fin'
         pools, counts = m()
         eq_(poolset, pools)
         eq_({}, counts)
+        bad_pe.language = 'eng'
+
+        bad_pe.medium = Edition.AUDIO_MEDIUM
+        pools, counts = m()
+        eq_(poolset, pools)
+        eq_({}, counts)
+        bad_pe.medium = Edition.BOOK_MEDIUM
+
+        bad_pe.permanent_work_id = "Some other ID"
+        pools, counts = m()
+        eq_(poolset, pools)
+        eq_({}, counts)
+        bad_pe.permanent_work_id = "pwid"
+
         w1.presentation_edition = None
 
         # Now let's see what changes to a LicensePool will cause it

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4383,7 +4383,7 @@ class TestWorkConsolidation(DatabaseTest):
         eq_(poolset, pools)
         eq_({work : 2}, counts)
 
-        # Since the work was just created it has no presentation
+        # Since the work was just created, it has no presentation
         # edition and thus no language. If the presentation edition
         # were set, the result would be the same.
         work.presentation_edition = e1
@@ -4404,12 +4404,15 @@ class TestWorkConsolidation(DatabaseTest):
         work.presentation_edition = None
 
         # Now let's see what changes to a LicensePool will cause it
-        # not to be counted in the first place.
+        # not to be eligible in the first place.
         def assert_lp1_missing():
+            # A LicensePool that is not eligible will not show up in
+            # the set and will not be counted towards the total of eligible
+            # LicensePools for its Work.
             pools, counts = m(self._db, "pwid", Edition.BOOK_MEDIUM, "eng")
             eq_(set([lp2]), pools)
             eq_({work:1}, counts)
-        
+
         # It has to be open-access.
         lp1.open_access = False
         assert_lp1_missing()
@@ -4417,15 +4420,15 @@ class TestWorkConsolidation(DatabaseTest):
 
         # The presentation edition's permanent work ID must match
         # what's passed into the helper method.
-        e1.pwid = "another pwid"
+        e1.permanent_work_id = "another pwid"
         assert_lp1_missing()
-        e1.pwid = "pwid"
+        e1.permanent_work_id = "pwid"
 
         # The medium must also match.
-        e1.medium = "another medium"
+        e1.medium = Edition.AUDIO_MEDIUM
         assert_lp1_missing()
         e1.medium = Edition.BOOK_MEDIUM
-        
+
         # The language must also match.
         e1.language = "another language"
         assert_lp1_missing()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4293,9 +4293,11 @@ class TestWorkConsolidation(DatabaseTest):
 
         # Due to an error, it turns out both Works are providing the
         # exact same book.
-        lp1.presentation_edition.permanent_work_id="abcd"
-        lp2.presentation_edition.permanent_work_id="abcd"
-        lp3.presentation_edition.permanent_work_id="abcd"
+        def mock_pwid(debug=False):
+            return "abcd"
+        for lp in [lp1, lp2, lp3]:
+            lp.presentation_edition.permanent_work_id="abcd"
+            lp.presentation_edition.calculate_permanent_work_id = mock_pwid
 
         # We've also got Work #3, which provides a commercial license
         # for that book.
@@ -4329,6 +4331,8 @@ class TestWorkConsolidation(DatabaseTest):
 
         # Calling Work.open_access_for_permanent_work_id again returns the same
         # result.
+        _db = self._db
+        Work.open_access_for_permanent_work_id(_db, "abcd", Edition.BOOK_MEDIUM, "eng")
         eq_((w2, False), Work.open_access_for_permanent_work_id(
             self._db, "abcd", Edition.BOOK_MEDIUM, "eng"
         ))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4371,7 +4371,6 @@ class TestWorkConsolidation(DatabaseTest):
         for lp in [lp1, lp2]:
             w1.license_pools.append(lp)
             lp.open_access = True
-        self._db.commit()
 
         def m():
             return Work._potential_open_access_works_for_permanent_work_id(
@@ -4384,7 +4383,7 @@ class TestWorkConsolidation(DatabaseTest):
         # associated with the same Work.
         poolset = set([lp1, lp2])
         eq_(poolset, pools)
-        eq_({work : 2}, counts)
+        eq_({w1 : 2}, counts)
 
         # Since the work was just created, it has no presentation
         # edition and thus no language. If the presentation edition
@@ -4392,7 +4391,7 @@ class TestWorkConsolidation(DatabaseTest):
         w1.presentation_edition = e1
         pools, counts = m()
         eq_(poolset, pools)
-        eq_({work : 2}, counts)
+        eq_({w1 : 2}, counts)
 
         # If the Work's language is set to a language that _conflicts_
         # with the language passed in to
@@ -4414,7 +4413,7 @@ class TestWorkConsolidation(DatabaseTest):
             # LicensePools for its Work.
             pools, counts = m()
             eq_(set([lp2]), pools)
-            eq_({work:1}, counts)
+            eq_({w1 : 1}, counts)
 
         # It has to be open-access.
         lp1.open_access = False


### PR DESCRIPTION
My old branch on this topic, https://github.com/NYPL-Simplified/circulation/pull/906, was an improvement but didn't fix the problem I was having. It fixed the problem when books with incompatible languages are both associated with a Work that's just been created (and thus does not yet have a presentation edition). It didn't fix the problem when a book with language A is associated with a Work whose presentation edition _is_ set and is in language B. I originally had code to fix this, but took it out because it was hard to test and didn't seem to make a difference. But it does make a difference.

This branch adds the code I should have added last time. It refactors the complex code that checks which LicensePools should be grouped into the same Work, and which Works are eligible for being 'the' work for that branch, so it can be tested separately.