### PR TITLE
Parse year from a MARC record even if it's correctly formatted

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -2037,6 +2037,16 @@ class MARCExtractor(object):
         return name
 
     @classmethod
+    def parse_year(self, value):
+        """Handle a publication year that may not be in the right format."""
+        for format in ("%Y", "%Y."):
+            try:
+                return datetime.datetime.strptime(value, format)
+            except ValueError:
+                continue
+        return None
+
+    @classmethod
     def parse(cls, file, data_source_name):
         reader = MARCReader(file)
         metadata_records = []
@@ -2045,7 +2055,7 @@ class MARCExtractor(object):
             title = record.title()
             if title.endswith(' /'):
                 title = title[:-len(' /')]
-            issued_year = datetime.datetime.strptime(record.pubyear(), "%Y.")
+            issued_year = cls.parse_year(record.pubyear())
             publisher = record.publisher()
             if publisher.endswith(','):
                 publisher = publisher[:-1]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1168,6 +1168,13 @@ class TestMARCExtractor(DatabaseTest):
         with open(os.path.join(self.resource_path, filename)) as fh:
             return fh.read()
 
+    def test_parse_year(self):
+        m = MARCExtractor.parse_year
+        nineteen_hundred = datetime.datetime.strptime("1900", "%Y")
+        eq_(nineteen_hundred, m("1900"))
+        eq_(nineteen_hundred, m("1900."))
+        eq_(None, m("not a year"))
+
     def test_parser(self):
         """Parse a MARC file into Metadata objects."""
 


### PR DESCRIPTION
This fixes https://github.com/NYPL-Simplified/content_server/issues/79. It was easier to fix the issue than to re-file it against a different project.