### PR TITLE
Removed hopefully unnecessary commit that causes problems when called from an event listener.

### DIFF
--- a/model.py
+++ b/model.py
@@ -9530,7 +9530,6 @@ class CustomList(Base):
             if len(existing) > 1:
                 entry.update(_db, equivalent_entries=existing[1:])
             entry.edition = edition
-            _db.commit()
         else:
             entry, was_new = get_one_or_create(
                 _db, CustomListEntry,


### PR DESCRIPTION
`CustomList.add_entry` is sometimes called from the event listener that adds to a custom list when a work or presentation edition is created, and this commit closes the transaction prematurely. As far as I can tell the commit isn't needed for anything. Scripts that use this should be doing their own commits.