### PR TITLE
Loggly.NAME must equal ExternalIntegration.LOGGLY.

### DIFF
--- a/log.py
+++ b/log.py
@@ -153,7 +153,7 @@ class SysLogger(Logger):
 
 class Loggly(Logger):
 
-    NAME = 'loggly'
+    NAME = "Loggly"
     DEFAULT_LOGGLY_URL = "https://logs-01.loggly.com/inputs/%(token)s/tag/python/"
 
     USER = 'user'

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -52,6 +52,13 @@ class TestJSONFormatter(object):
 
 class TestLogConfiguration(DatabaseTest):
 
+    def test_configuration(self):
+        """Loggly.NAME must equal ExternalIntegration.LOGGLY.
+        Enforcing this with code would create an import loop,
+        but we can enforce it with a test.
+        """
+        eq_(Loggly.NAME, ExternalIntegration.LOGGLY)
+
     def loggly_integration(self):
         """Create an ExternalIntegration for a Loggly account."""
         integration = self._external_integration(


### PR DESCRIPTION
The protocol of a Loggly ExternalIntegration is "Loggly", but the name associated with the configuration for a Loggly integration is "loggly". This means if you create a Loggly integration, it will be used, but it won't show up in the admin interface. In fact, the entire 'logging' tab will crash, as per https://github.com/NYPL-Simplified/circulation/pull/923.