### PR TITLE
Entry point is a facet group

### DIFF
--- a/facets.py
+++ b/facets.py
@@ -2,6 +2,11 @@ from flask_babel import lazy_gettext as _
 
 class FacetConstants(object):
 
+    # A special constant, basically an additional rel, indicating that
+    # an OPDS facet group represents different entry points into a
+    # collection.
+    ENTRY_POINT_REL = 'http://librarysimplified.org/terms/rel/entrypoint'
+
     # Subset the collection, roughly, by quality.
     COLLECTION_FACET_GROUP_NAME = 'collection'
     COLLECTION_FULL = "full"

--- a/facets.py
+++ b/facets.py
@@ -4,7 +4,7 @@ class FacetConstants(object):
 
     # A special constant, basically an additional rel, indicating that
     # an OPDS facet group represents different entry points into a
-    # collection.
+    # WorkList.
     ENTRY_POINT_REL = 'http://librarysimplified.org/terms/rel/entrypoint'
 
     # Subset the collection, roughly, by quality.

--- a/facets.py
+++ b/facets.py
@@ -6,6 +6,7 @@ class FacetConstants(object):
     # an OPDS facet group represents different entry points into a
     # WorkList.
     ENTRY_POINT_REL = 'http://librarysimplified.org/terms/rel/entrypoint'
+    ENTRY_POINT_FACET_GROUP_NAME = 'entrypoint'
 
     # Subset the collection, roughly, by quality.
     COLLECTION_FACET_GROUP_NAME = 'collection'

--- a/lane.py
+++ b/lane.py
@@ -129,13 +129,7 @@ class Facets(FacetsWithEntryPoint):
 
     Despite the generic name, this is only used in 'page' type OPDS
     feeds that list all the works in some WorkList.
-
-    The currently selected EntryPoint (if any) is propagated through
-    all generated URLs, but no functionality is provided for
-    navigating _between_ EntryPoints.
-
     """
-
     @classmethod
     def default(cls, library):
         return cls(

--- a/lane.py
+++ b/lane.py
@@ -548,7 +548,7 @@ class WorkList(object):
 
     def initialize(self, library, display_name=None, genres=None,
                    audiences=None, languages=None, media=None,
-                   children=None, priority=None):
+                   children=None, priority=None, entrypoints=None):
         """Initialize with basic data.
 
         This is not a constructor, to avoid conflicts with `Lane`, an
@@ -579,6 +579,9 @@ class WorkList(object):
         :param priority: A number indicating where this WorkList should
         show up in relation to its siblings when it is the child of
         some other WorkList.
+
+        :param entrypoints: A list of EntryPoint objects representing
+        different facets of this WorkList.
         """
         self.library_id = None
         self.collection_ids = []
@@ -604,6 +607,11 @@ class WorkList(object):
 
         self.children = children or []
         self.priority = priority or 0
+
+        if entrypoints:
+            self.entrypoints = list(entrypoints)
+        else:
+            self.entrypoints = []
 
     def get_library(self, _db):
         """Find the Library object associated with this WorkList."""
@@ -1514,6 +1522,11 @@ class Lane(Base, WorkList):
         i.e. how many times do we have to follow .parent before we get None?
         """
         return len(list(self.parentage))
+
+    @property
+    def entrypoints(self):
+        """Lanes cannot currently have EntryPoints."""
+        return []
 
     @hybrid_property
     def visible(self):

--- a/lane.py
+++ b/lane.py
@@ -120,12 +120,14 @@ class FacetsWithEntryPoint(FacetConstants):
 class Facets(FacetsWithEntryPoint):
     """A full-fledged facet class that supports complex navigation between
     multiple facet groups.
-    
-    This is only used in paginated OPDS feeds.
+
+    Despite the generic name, this is only used in 'page' type OPDS
+    feeds that list all the works in some WorkList.
 
     The currently selected EntryPoint (if any) is propagated through
     all generated URLs, but no functionality is provided for
     navigating _between_ EntryPoints.
+
     """
 
     @classmethod
@@ -826,7 +828,7 @@ class WorkList(object):
             library.minimum_featured_quality,
             self.uses_customlists
         )
-        
+
         query = self.works(_db, facets=facets)
         if not query:
             # works() may return None, indicating that the whole
@@ -1125,7 +1127,7 @@ class WorkList(object):
 
     def search(self, _db, query, search_client, media=None, pagination=None, languages=None, facets=None):
         """Find works in this WorkList that match a search query.
-        
+
         :param facets: A faceting object, probably a SearchFacets.
         """
         if not pagination:

--- a/lane.py
+++ b/lane.py
@@ -92,14 +92,17 @@ class FacetsWithEntryPoint(FacetConstants):
     selected EntryPoint.
     """
     def __init__(self, entrypoint=None):
-        """Prepare a query to focus on a specific EntryPoint.
+        """Constructor.
 
         :param entrypoint: An EntryPoint (optional).
         """
         self.entrypoint = entrypoint
 
     def items(self):
-        """Yields a 2-tuple for every active facet setting."""
+        """Yields a 2-tuple for every active facet setting.
+
+        In this class that just means the entrypoint.
+        """
         if self.entrypoint:
             yield (self.ENTRY_POINT_FACET_GROUP_NAME,
                    self.entrypoint.INTERNAL_NAME)
@@ -112,8 +115,11 @@ class FacetsWithEntryPoint(FacetConstants):
         return "&".join("=".join(x) for x in sorted(self.items()))
 
     def apply(self, _db, qu):
+        """Modify the given query based on the EntryPoint associated
+        with this object.
+        """
         if self.entrypoint:
-            qu = self.entrypoint.apply(qu)
+            qu = self.entrypoint.apply(_db, qu)
         return qu
 
 

--- a/lane.py
+++ b/lane.py
@@ -119,7 +119,7 @@ class FacetsWithEntryPoint(FacetConstants):
         with this object.
         """
         if self.entrypoint:
-            qu = self.entrypoint.apply(_db, qu)
+            qu = self.entrypoint.apply(qu)
         return qu
 
 
@@ -410,7 +410,8 @@ class FeaturedFacets(FacetsWithEntryPoint):
         one.
         """
         minimum_featured_quality = minimum_featured_quality or self.minimum_featured_quality
-        uses_customlists = uses_customlists or self.uses_customlists
+        if uses_customlists is None:
+            uses_customlists = self.uses_customlists
         entrypoint = entrypoint or self.entrypoint
         return FeaturedFacets(
             minimum_featured_quality, uses_customlists, entrypoint
@@ -831,8 +832,8 @@ class WorkList(object):
 
         facets = facets or FeaturedFacets()
         facets = facets.navigate(
-            library.minimum_featured_quality,
-            self.uses_customlists
+            minimum_featured_quality=library.minimum_featured_quality,
+            uses_customlists=self.uses_customlists
         )
 
         query = self.works(_db, facets=facets)

--- a/model.py
+++ b/model.py
@@ -6593,6 +6593,7 @@ class CachedFeed(Base):
         if isinstance(max_age, int):
             max_age = datetime.timedelta(seconds=max_age)
 
+        unique_key = None
         if lane and isinstance(lane, Lane):
             lane_id = lane.id
         else:

--- a/model.py
+++ b/model.py
@@ -6593,18 +6593,11 @@ class CachedFeed(Base):
         if isinstance(max_age, int):
             max_age = datetime.timedelta(seconds=max_age)
 
-        entrypoint = facets.entrypoint
         if lane and isinstance(lane, Lane):
             lane_id = lane.id
-            if entrypoint:
-                unique_key = entrypoint.INTERNAL_NAME
-            else:
-                unique_key = None
         else:
             lane_id = None
             unique_key = "%s-%s-%s" % (lane.display_name, lane.language_key, lane.audience_key)
-            if entrypoint:
-                unique_key += '-' + entrypoint.INTERNAL_NAME
         work = None
         if lane:
             work = getattr(lane, 'work', None)
@@ -6669,7 +6662,7 @@ class CachedFeed(Base):
                 return cls.fetch(
                     _db, lane, CachedFeed.PAGE_TYPE, facets, pagination,
                     annotator, force_refresh, max_age=None,
-                    entrypoint=entrypoint
+                    facets=facets
                 )
         else:
             # This feed is cheap enough to generate on the fly.

--- a/model.py
+++ b/model.py
@@ -6662,8 +6662,7 @@ class CachedFeed(Base):
                 )
                 return cls.fetch(
                     _db, lane, CachedFeed.PAGE_TYPE, facets, pagination,
-                    annotator, force_refresh, max_age=None,
-                    facets=facets
+                    annotator, force_refresh, max_age=None
                 )
         else:
             # This feed is cheap enough to generate on the fly.

--- a/model.py
+++ b/model.py
@@ -6578,7 +6578,7 @@ class CachedFeed(Base):
 
     @classmethod
     def fetch(cls, _db, lane, type, facets, pagination, annotator,
-              force_refresh=False, max_age=None, entrypoint=None):
+              force_refresh=False, max_age=None):
         from opds import AcquisitionFeed
         from lane import Lane, WorkList
         if max_age is None:
@@ -6592,6 +6592,8 @@ class CachedFeed(Base):
                 max_age = 0
         if isinstance(max_age, int):
             max_age = datetime.timedelta(seconds=max_age)
+
+        entrypoint = facets.entrypoint
         if lane and isinstance(lane, Lane):
             lane_id = lane.id
             if entrypoint:

--- a/opds.py
+++ b/opds.py
@@ -476,7 +476,7 @@ class AcquisitionFeed(OPDSFeed):
                 _db,
                 lane=lane,
                 type=cache_type,
-                facets=None,
+                facets=facets,
                 pagination=None,
                 annotator=annotator,
                 force_refresh=force_refresh,
@@ -497,6 +497,7 @@ class AcquisitionFeed(OPDSFeed):
                 _db, title, url, lane, annotator,
                 cache_type=cache_type,
                 force_refresh=force_refresh,
+                facets=facets,
             )
             return cached
 

--- a/opds.py
+++ b/opds.py
@@ -665,7 +665,7 @@ class AcquisitionFeed(OPDSFeed):
 
     @classmethod
     def add_entrypoint_links(cls, feed, url_generator, entrypoints,
-                             selected_entrypoint, group_name='Start here'):
+                             selected_entrypoint, group_name='Formats'):
         """Add links to a feed forming an OPDS facet group for a set of
         EntryPoints.
 

--- a/opds.py
+++ b/opds.py
@@ -602,9 +602,9 @@ class AcquisitionFeed(OPDSFeed):
             pagination.this_page_size = len(works)
         feed = cls(_db, title, url, works, annotator)
 
-        if lane.entrypoints and (not pagination or pagination.offset == 0):
-            # On the first page of a paginated feed there may be
-            # multiple entry points into the same dataset.
+        if lane.entrypoints:
+            # A paginated feed may have multiple entry points into the
+            # same dataset.
             def make_link(ep, is_default):
                 if is_default:
                     # No need to clutter up the URL with the default
@@ -742,14 +742,15 @@ class AcquisitionFeed(OPDSFeed):
         opds_feed = AcquisitionFeed(_db, title, url, results, annotator=annotator)
         AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, rel='start', href=annotator.default_lane_url(), title=annotator.top_level_title())
 
-        # The first page of a feed of search results may link to
-        # alternate entry points into those results.
-        if lane.entrypoints and (not pagination or pagination.offset == 0):
+        # A feed of search results may link to alternate entry points
+        # into those results.
+        if lane.entrypoints:
             def make_link(ep, is_default):
                 if is_default:
                     ep = None
                 return annotator.search_url(
-                    lane, query, pagination, facets=FacetsWithEntryPoint(ep)
+                    lane, query, pagination=None,
+                    facets=FacetsWithEntryPoint(ep)
                 )
             cls.add_entrypoint_links(
                 opds_feed, make_link, lane.entrypoints, facets.entrypoint

--- a/opds.py
+++ b/opds.py
@@ -485,7 +485,7 @@ class AcquisitionFeed(OPDSFeed):
             if usable:
                 return cached
 
-        works_and_lanes = lane.groups(_db, facets)
+        works_and_lanes = lane.groups(_db, facets=facets)
         if not works_and_lanes:
             # We did not find enough works for a groups feed.
             # Instead we need to display a flat feed--the

--- a/opds.py
+++ b/opds.py
@@ -52,6 +52,7 @@ from lane import (
     Facets,
     Lane,
     Pagination,
+    SearchFacets,
     WorkList,
 )
 from util.opds_writer import (

--- a/opds.py
+++ b/opds.py
@@ -1471,7 +1471,9 @@ class TestAnnotator(Annotator):
             base += sep + pagination.query_string
             sep = '&'
         if facets:
-            base += sep + facets.query_string
+            facet_query_string = facets.query_string
+            if facet_query_string:
+                base += sep + facet_query_string
         return base
 
     @classmethod

--- a/opds.py
+++ b/opds.py
@@ -50,6 +50,7 @@ from model import (
 )
 from lane import (
     Facets,
+    FacetsWithEntryPoint,
     Lane,
     Pagination,
     SearchFacets,
@@ -604,7 +605,15 @@ class AcquisitionFeed(OPDSFeed):
         if lane.entrypoints and (not pagination or pagination.offset == 0):
             # On the first page of a paginated feed there may be
             # multiple entry points into the same dataset.
-            self.add_entrypoint_links(
+            def make_link(ep, is_default):
+                if is_default:
+                    # No need to clutter up the URL with the default
+                    # entry point.
+                    ep = None
+                return annotator.feed_url(
+                    lane, facets=FacetsWithEntryPoint(ep)
+                )
+            cls.add_entrypoint_links(
                 feed, make_link, lane.entrypoints, facets.entrypoint
             )
 

--- a/opds.py
+++ b/opds.py
@@ -546,7 +546,7 @@ class AcquisitionFeed(OPDSFeed):
                 return annotator.groups_url(
                     lane, facets=FacetsWithEntryPoint(ep)
                 )
-            self.add_entrypoint_links(
+            cls.add_entrypoint_links(
                 feed, make_link, lane.entrypoints, facets.entrypoint
             )
 
@@ -735,6 +735,7 @@ class AcquisitionFeed(OPDSFeed):
                annotator=None, languages=None, facets=None
     ):
         facets = facets or SearchFacets()
+        pagination = pagination or Pagination.default()
         results = lane.search(
             _db, query, search_engine, media, pagination=pagination, languages=languages, facets=facets
         )
@@ -750,8 +751,8 @@ class AcquisitionFeed(OPDSFeed):
                 return annotator.search_url(
                     lane, query, pagination, facets=FacetsWithEntryPoint(ep)
                 )
-            self.add_entrypoint_links(
-                feed, make_link, lane.entrypoints, facets
+            cls.add_entrypoint_links(
+                opds_feed, make_link, lane.entrypoints, facets.entrypoint
             )
 
         if len(results) > 0:
@@ -1480,7 +1481,7 @@ class TestAnnotator(Annotator):
         else:
             identifier = ""
         if facets:
-            facet_string = '&' + facets.query_string
+            facet_string = '?' + facets.query_string
         else:
             facet_string = ''
 

--- a/tests/test_facets.py
+++ b/tests/test_facets.py
@@ -8,6 +8,7 @@ from . import DatabaseTest
 from facets import (
     FacetConstants as Facets,
     FacetConfig,
+    FacetsWithEntryPoint,
 )
 
 class TestFacetConfig(DatabaseTest):

--- a/tests/test_facets.py
+++ b/tests/test_facets.py
@@ -8,8 +8,8 @@ from . import DatabaseTest
 from facets import (
     FacetConstants as Facets,
     FacetConfig,
-    FacetsWithEntryPoint,
 )
+
 
 class TestFacetConfig(DatabaseTest):
    

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -244,6 +244,29 @@ class TestFacets(DatabaseTest):
         actual = order(Facets.ORDER_ADDED_TO_COLLECTION, None)
         compare(expect, actual)
 
+
+
+class TestFacetsWithEntryPoint(object):
+
+    def test_items(self):
+        ep = AudiobooksEntryPoint
+        f = FacetsWithEntryPoint(ep)
+        expect_items = (f.ENTRY_POINT_FACET_GROUP_NAME, ep.INTERNAL_NAME)
+        eq_([expect_items], list(f.items()))
+        eq_("%s=%s" % expect_items, f.query_string)
+
+    def test_apply(self):
+        class MockEntryPoint(object):
+            def apply(self, _db, qu):
+                self.called_with = (_db, qu)
+
+        ep = MockEntryPoint()
+        f = FacetsWithEntryPoint(ep)
+        _db = object()
+        qu = object()
+        f.apply(_db, qu)
+        eq_((_db, qu), ep.called_with)
+
 class TestFacetsApply(DatabaseTest):
 
     def test_apply(self):

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -661,7 +661,7 @@ class TestWorkList(DatabaseTest):
         # Create a WorkList that's associated with a Library, two genres,
         # and a child WorkList.
         wl.initialize(self._default_library, children=[child],
-                      genres=[sf, romance])
+                      genres=[sf, romance], entrypoints=[1,2,3])
 
         # Access the Library.
         eq_(self._default_library, wl.get_library(self._db))
@@ -678,6 +678,10 @@ class TestWorkList(DatabaseTest):
 
         # The WorkList's child is the WorkList passed in to the constructor.
         eq_([child], wl.visible_children)
+
+        # The Worklist's .entrypoints is whatever was passed in
+        # to the constructor.
+        eq_([1,2,3], wl.entrypoints)
 
     def test_initialize_without_library(self):
         wl = WorkList()
@@ -1484,6 +1488,10 @@ class TestLane(DatabaseTest):
     def test_display_name_for_all(self):
         lane = self._lane("Fantasy / Science Fiction")
         eq_("All Fantasy / Science Fiction", lane.display_name_for_all)
+
+    def test_entrypoints(self):
+        """Currently a Lane can never have entrypoints."""
+        eq_([], self._lane().entrypoints)
 
     def test_affected_by_customlist(self):
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -64,15 +64,15 @@ class TestFacetsWithEntryPoint(object):
 
     def test_apply(self):
         class MockEntryPoint(object):
-            def apply(self, _db, qu):
-                self.called_with = (_db, qu)
+            def apply(self, qu):
+                self.called_with = qu
 
         ep = MockEntryPoint()
         f = FacetsWithEntryPoint(ep)
         _db = object()
         qu = object()
         f.apply(_db, qu)
-        eq_((_db, qu), ep.called_with)
+        eq_(qu, ep.called_with)
 
 
 class TestFacets(DatabaseTest):
@@ -416,19 +416,17 @@ class TestFeaturedFacets(DatabaseTest):
         entrypoint = EbooksEntryPoint
         f = FeaturedFacets(1, True, entrypoint)
 
-        different_entrypoint = f.navigate_to(
-            entrypoint=AudiobooksEntryPoint
-        )
-        eq_(1, different_quality.minimum_featured_quality)
-        eq_(True, different_quality.uses_customlists)
-        eq_(AudiobooksEntryPoint, different_quality.entrypoint)
+        different_entrypoint = f.navigate(entrypoint=AudiobooksEntryPoint)
+        eq_(1, different_entrypoint.minimum_featured_quality)
+        eq_(True, different_entrypoint.uses_customlists)
+        eq_(AudiobooksEntryPoint, different_entrypoint.entrypoint)
 
-        different_quality = f.navigate_to(minimum_featured_quality=2)
+        different_quality = f.navigate(minimum_featured_quality=2)
         eq_(2, different_quality.minimum_featured_quality)
         eq_(True, different_quality.uses_customlists)
         eq_(entrypoint, different_quality.entrypoint)
 
-        not_a_list = f.navigate_to(uses_customlist)
+        not_a_list = f.navigate(uses_customlists=False)
         eq_(1, not_a_list.minimum_featured_quality)
         eq_(False, not_a_list.uses_customlists)
         eq_(entrypoint, not_a_list.entrypoint)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -28,8 +28,10 @@ from external_search import (
 
 from lane import (
     Facets,
+    FacetsWithEntryPoint,
     FeaturedFacets,
     Pagination,
+    SearchFacets,
     WorkList,
     Lane,
 )
@@ -634,8 +636,8 @@ class MockWorks(WorkList):
         """Set the next return value for works()."""
         self._works.append(works)
 
-    def works(self, _db, facets=None, pagination=None, featured=False, entrypoint=None):
-        self.works_calls.append((facets, pagination, featured, entrypoint))
+    def works(self, _db, facets=None, pagination=None, featured=False):
+        self.works_calls.append((facets, pagination, featured))
         try:
             return self._works.pop(0)
         except IndexError:
@@ -824,28 +826,28 @@ class TestWorkList(DatabaseTest):
         eq_((w2, child2), wwl2)
         eq_((w1, child2), wwl3)
 
-    def test_groups_propagates_entrypoint(self):
-        """Verify that the EntryPoint passed into groups() is
+    def test_groups_propagates_facets(self):
+        """Verify that the Facets object passed into groups() is
         propagated to the methods called by groups().
         """
         class MockWorkList(WorkList):
 
-            def featured_works(self, _db, entrypoint):
-                self.featured_called_with = entrypoint
+            def featured_works(self, _db, facets):
+                self.featured_called_with = facets
                 return []
 
-            def _groups_for_lanes(self, _db, relevant_children, relevant_lanes, entrypoint):
-                self.groups_called_with = entrypoint
+            def _groups_for_lanes(self, _db, relevant_children, relevant_lanes, facets):
+                self.groups_called_with = facets
                 return []
 
         mock = MockWorkList()
         mock.initialize(library=self._default_library)
-        entrypoint = object()
-        [x for x in mock.groups(self._db, entrypoint=entrypoint)]
-        eq_(entrypoint, mock.groups_called_with)
+        facets = object()
+        [x for x in mock.groups(self._db, facets=facets)]
+        eq_(facets, mock.groups_called_with)
 
-        [x for x in mock.groups(self._db, entrypoint=entrypoint, include_sublanes=False)]
-        eq_(entrypoint, mock.featured_called_with)
+        [x for x in mock.groups(self._db, facets=facets, include_sublanes=False)]
+        eq_(facets, mock.featured_called_with)
 
     def test_featured_works(self):
         wl = MockWorks()
@@ -868,10 +870,10 @@ class TestWorkList(DatabaseTest):
         eq_([w1], featured)
 
         # We created a FeaturedFacets object and passed it in to works().
-        [(facets, pagination, featured, entrypoint)] = wl.works_calls
+        [(facets, pagination, featured)] = wl.works_calls
         eq_(self._default_library.minimum_featured_quality,
             facets.minimum_featured_quality)
-        eq_(featured, facets.uses_customlists)
+        eq_(False, facets.uses_customlists)
 
         # We then called random_sample() on the results.
         [(query, target_size)] = wl.random_sample_calls
@@ -879,12 +881,13 @@ class TestWorkList(DatabaseTest):
         eq_(self._default_library.featured_lane_size, target_size)
 
     def test_methods_that_call_works_propagate_entrypoint(self):
-        """Verify that the EntryPoint passed into featured_works() and
-        works_in_window() is propagated when those methods call works().
+        """Verify that the EntryPoint mentioned in the Facets object passed
+        into featured_works() and works_in_window() is propagated when
+        those methods call works().
         """
         class Mock(WorkList):
             def works(self, _db, *args, **kwargs):
-                self.works_called_with = kwargs['entrypoint']
+                self.works_called_with = kwargs['facets']
                 # This query won't work, but we need to return some
                 # kind of query so works_in_window can complete.
                 return _db.query(Work)
@@ -894,15 +897,20 @@ class TestWorkList(DatabaseTest):
 
         wl = Mock()
         wl.initialize(library=self._default_library)
-        entrypoint = object()
+        audio = AudiobooksEntryPoint
+        facets = FeaturedFacets(entrypoint=audio)
 
-        wl.featured_works(self._db, entrypoint=entrypoint)
-        eq_(entrypoint, wl.works_called_with)
+        # The Facets object passed in to works() is different from the
+        # one we passed in -- it's got some settings for
+        # minimum_featured_quality and uses_customlists which we
+        # didn't bother to provide -- but the EntryPoint we did provide
+        # is propagated.
+        wl.featured_works(self._db, facets=facets)
+        eq_(audio, wl.works_called_with.entrypoint)
 
         wl.works_called_with = None
-        wl.works_in_window(self._db, None, 10, entrypoint=entrypoint)
-        eq_(entrypoint, wl.works_called_with)
-
+        wl.works_in_window(self._db, facets, 10)
+        eq_(audio, wl.works_called_with.entrypoint)
 
     def test_works(self):
         """Verify that WorkList.works() correctly locates works
@@ -955,18 +963,18 @@ class TestWorkList(DatabaseTest):
         wl.collection_ids = [self._default_collection.id]
         eq_(2, wl.works(self._db).count())
 
-    def test_works_propagates_entrypoint(self):
-        """Verify that the EntryPoint passed into works() is
+    def test_works_propagates_facets(self):
+        """Verify that the Facets object passed into works() is
         propagated to the methods called by works().
         """
         class Mock(WorkList):
-            def apply_filters(self, *args, **kwargs):
-                self.apply_filters_called_with = kwargs['entrypoint']
+            def apply_filters(self, _db, qu, facets, pagination):
+                self.apply_filters_called_with = facets
         wl = Mock()
         wl.initialize(self._default_library)
-        entrypoint = object()
-        wl.works(self._db, entrypoint=entrypoint)
-        eq_(entrypoint, wl.apply_filters_called_with)
+        facets = FacetsWithEntryPoint()
+        wl.works(self._db, facets=facets)
+        eq_(facets, wl.apply_filters_called_with)
 
     def test_works_for_specific_ids(self):
         # Create two works and put them in the materialized view.
@@ -1059,20 +1067,18 @@ class TestWorkList(DatabaseTest):
         assert 'facets.apply' not in called
         assert 'pagination.apply' not in called
 
-        # If an EntryPoint is passed into apply_filters, the query
-        # is passed into the EntryPoint's apply() method.
-        class MockEntryPoint(object):
-            def apply(self, qu):
+        # If a Facets is passed into apply_filters, the query
+        # is passed into the Facets.apply() method.
+        class MockFacets(object):
+            def apply(self, _db, qu):
                 self.called_with = qu
                 return qu
-        entrypoint = MockEntryPoint()
-        wl.apply_filters(
-            self._db, original_qu, None, None, entrypoint=entrypoint
-        )
+        facets = MockFacets()
+        wl.apply_filters(self._db, original_qu, facets, None)
         # The query was modified by the time it was passed in, so it's
         # not the same as original_qu, but all we need to check is that
         # _some_ query was passed in.
-        assert isinstance(entrypoint.called_with, type(original_qu))
+        assert isinstance(facets.called_with, type(original_qu))
 
     def test_apply_bibliographic_filters_short_circuits_apply_filters(self):
         class MockWorkList(WorkList):
@@ -1370,14 +1376,16 @@ class TestWorkList(DatabaseTest):
         [fixed, kw] = third_query
         eq_(None, kw["media"])
 
-        # If an EntryPoint is passed into search(), a subset of search
-        # arguments are passed into EntryPoint.modified_search_arguments().
+        # If a Facets object is passed into search(), and the Facets
+        # object has an EntryPoint set, a subset of search arguments
+        # are passed into EntryPoint.modified_search_arguments().
         class MockEntryPoint(object):
             def modified_search_arguments(self, **kwargs):
                 self.called_with = dict(kwargs)
                 return kwargs
         entrypoint = MockEntryPoint()
-        wl.search(self._db, work.title, search_client, entrypoint=entrypoint)
+        facets = SearchFacets(entrypoint=entrypoint)
+        wl.search(self._db, work.title, search_client, facets=facets)
 
         # Arguments relevant to the EntryPoint's view of the
         # collection were passed in...
@@ -1757,30 +1765,30 @@ class TestLane(DatabaseTest):
         )
         eq_(results, target_results)
 
-    def test_search_propagates_entrypoint(self):
-        """Lane.search propagates entrypoint when calling search() on
+    def test_search_propagates_facets(self):
+        """Lane.search propagates facets when calling search() on
         its search target.
         """
         class Mock(object):
             def search(self, *args, **kwargs):
-                self.called_with = kwargs['entrypoint']
+                self.called_with = kwargs['facets']
         mock = Mock()
         lane = self._lane()
 
         old_lane_search_target = Lane.search_target
         old_wl_search = WorkList.search
         Lane.search_target = mock
-        entrypoint = object()
-        lane.search(self._db, "query", None, entrypoint=entrypoint)
-        eq_(entrypoint, mock.called_with)
+        facets = SearchFacets()
+        lane.search(self._db, "query", None, facets=facets)
+        eq_(facets, mock.called_with)
 
         # Now try the case where a lane is its own search target.  The
-        # entrypoint is propagated to the WorkList.search().
+        # Facets object is propagated to the WorkList.search().
         mock.called_with = None
         Lane.search_target = lane
         WorkList.search = mock.search
-        lane.search(self._db, "query", None, entrypoint=entrypoint)
-        eq_(entrypoint, mock.called_with)
+        lane.search(self._db, "query", None, facets=facets)
+        eq_(facets, mock.called_with)
 
         # Restore methods that were mocked.
         Lane.search_target = old_lane_search_target
@@ -2157,19 +2165,19 @@ class TestLane(DatabaseTest):
             data
         )
 
-    def test_groups_propagates_entrypoint(self):
-        """Lane.groups propagates a received EntryPoint into
+    def test_groups_propagates_facets(self):
+        """Lane.groups propagates a received Facets object into
         _groups_for_lanes.
         """
-        def mock(self, _db, relevant_lanes, queryable_lanes, entrypoint):
-            self.called_with = entrypoint
+        def mock(self, _db, relevant_lanes, queryable_lanes, facets):
+            self.called_with = facets
             return []
         old_value = Lane._groups_for_lanes
         Lane._groups_for_lanes = mock
         lane = self._lane()
-        entrypoint = object()
-        lane.groups(self._db, entrypoint=entrypoint)
-        eq_(entrypoint, lane.called_with)
+        facets = FeaturedFacets()
+        lane.groups(self._db, facets=facets)
+        eq_(facets, lane.called_with)
         Lane._groups_for_lanes = old_value
 
 
@@ -2406,9 +2414,11 @@ class TestWorkListGroups(DatabaseTest):
         # Let's see how entry points affect the feeds.
         #
 
-        # There are no audiobooks in the system, so passing in the
-        # AudiobooksEntryPoint excludes everything.
-        eq_([], list(fiction.groups(self._db, entrypoint=AudiobooksEntryPoint)))
+        # There are no audiobooks in the system, so passing in a
+        # FeaturedFacets scoped to the AudiobooksEntryPoint excludes everything.
+        facets = FeaturedFacets(entrypoint=AudiobooksEntryPoint)
+        _db = self._db
+        eq_([], list(fiction.groups(self._db, facets=facets)))
 
         # Here's an entry point that ignores everything except one
         # specific book.
@@ -2417,8 +2427,9 @@ class TestWorkListGroups(DatabaseTest):
             def apply(cls, qu):
                 from model import MaterializedWorkWithGenre as mv
                 return qu.filter(mv.sort_title=='LQ Romance')
+        facets = FeaturedFacets(entrypoint=LQRomanceEntryPoint)
         assert_contents(
-            fiction.groups(self._db, entrypoint=LQRomanceEntryPoint),
+            fiction.groups(self._db, facets=facets),
             [
                 # The single recognized book shows up in both lanes
                 # that can show it.
@@ -2437,7 +2448,7 @@ class TestWorkListGroups(DatabaseTest):
             visible = True
             priority = 2
 
-            def groups(self, _db, include_sublanes, entrypoint=None):
+            def groups(self, _db, include_sublanes, facets=None):
                 yield lq_litfic, self
 
         mock = MockWorkList()
@@ -2459,17 +2470,17 @@ class TestWorkListGroups(DatabaseTest):
             ]
         )
 
-    def test_groups_for_lanes_propagates_entrypoint(self):
+    def test_groups_for_lanes_propagates_facets(self):
         class Mock(WorkList):
             def _featured_works_with_lanes(self, *args, **kwargs):
-                self.featured_called_with = kwargs['entrypoint']
+                self.featured_called_with = kwargs['facets']
                 return []
 
         wl = Mock()
         wl.initialize(library=self._default_library)
-        entrypoint = object()
-        groups = list(wl._groups_for_lanes(self._db, [], [], entrypoint))
-        eq_(entrypoint, wl.featured_called_with)
+        facets = FeaturedFacets()
+        groups = list(wl._groups_for_lanes(self._db, [], [], facets))
+        eq_(facets, wl.featured_called_with)
 
     def test_featured_works_with_lanes(self):
         """_featured_works_with_lanes calls works_in_window on every lane
@@ -2481,17 +2492,17 @@ class TestWorkListGroups(DatabaseTest):
             def __init__(self, mock_works):
                 self.mock_works = mock_works
 
-            def works_in_window(self, _db, facets, target_size, entrypoint):
-                self.called_with = [_db, facets, target_size, entrypoint]
+            def works_in_window(self, _db, facets, target_size):
+                self.called_with = [_db, facets, target_size]
                 return [self.mock_works]
 
         mock1 = Mock(("mw1","quality1"))
         mock2 = Mock(("mw2","quality2"))
 
         lane = self._lane()
-        mock_entrypoint = object()
+        facets = FeaturedFacets()
         results = lane._featured_works_with_lanes(
-            self._db, [mock1, mock2], mock_entrypoint
+            self._db, [mock1, mock2], facets
         )
 
         # The results of works_in_window were annotated with the
@@ -2502,7 +2513,7 @@ class TestWorkListGroups(DatabaseTest):
         # Each Mock's works_in_window was called with the same
         # arguments.
         eq_(mock1.called_with, mock2.called_with)
-        _db, facets, target_size, entrypoint = mock1.called_with
+        _db, facets, target_size = mock1.called_with
 
         # Those arguments came from the configuration of the Library
         # associated with the (non-mock) Lane on which _groups_query
@@ -2510,7 +2521,7 @@ class TestWorkListGroups(DatabaseTest):
         eq_(self._db, _db)
         eq_(lane.library.minimum_featured_quality, facets.minimum_featured_quality)
         eq_(lane.library.featured_lane_size, target_size)
-        eq_(mock_entrypoint, entrypoint)
+        eq_(facets, facets)
 
     def test_featured_window(self):
         lane = self._lane()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7355,13 +7355,6 @@ class TestCachedFeed(DatabaseTest):
         eq_("", feed.pagination)
         eq_("", feed.facets)
 
-        # If an EntryPoint is provided, the EntryPoint's internal name
-        # is used as the unique key.
-        audio, usable = m(self._db, lane, page, None, None, annotator,
-                          entrypoint=AudiobooksEntryPoint)
-        eq_(AudiobooksEntryPoint.INTERNAL_NAME, audio.unique_key)
-
-
         # Now let's introduce some pagination and facet information.
         facets = Facets.default(self._default_library)
         pagination = Pagination.default()
@@ -7388,17 +7381,9 @@ class TestCachedFeed(DatabaseTest):
             self._db, worklist, page, None, None, annotator
         )
         # The unique key incorporates the WorkList's display name,
-        # its languages, and its audiences.
+        # its languages, its audiences, and the currently selected
+        # EntryPoint.
         eq_("aworklist-eng,spa-Children", feed.unique_key)
-
-        # If an EntryPoint is employed, the unique key also incorporates
-        # The EntryPoint's internal name.
-        feed, fresh = m(
-            self._db, worklist, page, None, None, annotator,
-            entrypoint=AudiobooksEntryPoint
-        )
-        eq_("aworklist-eng,spa-Children-" + AudiobooksEntryPoint.INTERNAL_NAME,
-            feed.unique_key)
 
     def test_fetch_group_feeds(self):
         # Group feeds don't need to worry about facets or pagination,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7428,13 +7428,6 @@ class TestCachedFeed(DatabaseTest):
                          force_refresh=True)
         eq_(False, usable)
 
-        # A group feed's unique_key is always empty unless an EntryPoint
-        # is in play, in which case the unique_key is the internal name of
-        # the EntryPoint.
-        feed, usable = m(self._db, lane, groups, None, None, annotator,
-                         entrypoint=AudiobooksEntryPoint)
-        eq_(AudiobooksEntryPoint.INTERNAL_NAME, feed.unique_key)
-
 
 class TestLibrary(DatabaseTest):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7381,8 +7381,7 @@ class TestCachedFeed(DatabaseTest):
             self._db, worklist, page, None, None, annotator
         )
         # The unique key incorporates the WorkList's display name,
-        # its languages, its audiences, and the currently selected
-        # EntryPoint.
+        # its languages, and its audiences.
         eq_("aworklist-eng,spa-Children", feed.unique_key)
 
     def test_fetch_group_feeds(self):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1789,7 +1789,8 @@ class TestLookupAcquisitionFeed(DatabaseTest):
 
 class TestEntrypointLinkInsertion(DatabaseTest):
     """Verify that the three main types of OPDS feeds -- grouped,
-    paginated, and search results -- will all
+    paginated, and search results -- will all include links to the same
+    feed but through a different entry point.
     """
 
     def setup(self):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1298,6 +1298,7 @@ class TestAcquisitionFeed(DatabaseTest):
                 return self.attrs
 
         mock = Mock()
+        old_entrypoint_link = AcquisitionFeed._entrypoint_link
         AcquisitionFeed._entrypoint_link = mock
 
         feed = etree.fromstring("<feed/>")
@@ -1326,6 +1327,7 @@ class TestAcquisitionFeed(DatabaseTest):
         for l in l1, l2:
             eq_("link", l.tag)
             eq_(mock.attrs, l.attrib)
+        AcquisitionFeed._entrypoint_link = old_entrypoint_link
 
     def test_entrypoint_link(self):
         """Test the _entrypoint_link method's ability to create

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1898,12 +1898,16 @@ class TestEntrypointLinkInsertion(DatabaseTest):
 
         # The make_link function that was passed in calls
         # TestAnnotator.feed_url() when passed an EntryPoint.
-        eq_("http://wl/?entrypoint=Book", make_link(EbooksEntryPoint, False))
+        first_page_url = "http://wl/?entrypoint=Book"
+        eq_(first_page_url, make_link(EbooksEntryPoint, False))
 
-        # The entry point links are only created at the beginning of a
-        # list.
+        # Pagination information is not propagated through entry point links
+        # -- you always start at the beginning of the list.
         pagination = Pagination(offset=100)
-        eq_(None, run(self.wl, facets, pagination))
+        feed, make_link, entrypoints, selected = run(
+            self.wl, facets, pagination
+        )
+        eq_(first_page_url, make_link(EbooksEntryPoint, False))
 
     def test_search(self):
         """When AcquisitionFeed.search() generates the first page of
@@ -1946,12 +1950,13 @@ class TestEntrypointLinkInsertion(DatabaseTest):
 
         # The make_link function that was passed in calls
         # TestAnnotator.search_url() when passed an EntryPoint.
-        eq_(
-            'http://wl/?after=0&size=50&entrypoint=Book',
-            make_link(EbooksEntryPoint, False)
-        )
+        first_page_url = 'http://wl/?entrypoint=Book'
+        eq_(first_page_url, make_link(EbooksEntryPoint, False))
 
-        # The entry point links are only created at the beginning of a
-        # list.
+        # Pagination information is not propagated through entry point links
+        # -- you always start at the beginning of the list.
         pagination = Pagination(offset=100)
-        eq_(None, run(self.wl, facets, pagination))
+        feed, make_link, entrypoints, selected = run(
+            self.wl, facets, pagination
+        )
+        eq_(first_page_url, make_link(EbooksEntryPoint, False))

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -43,6 +43,7 @@ from facets import FacetConstants
 
 from lane import (
     Facets,
+    FeaturedFacets,
     Pagination,
     Lane,
     WorkList,
@@ -1374,6 +1375,55 @@ class TestAcquisitionFeed(DatabaseTest):
 
         # This means the 'activeFacet' attribute is not present.
         assert '{http://opds-spec.org/2010/catalog}activeFacet' not in l
+
+    def test_groups_propagates_facets(self):
+        """AcquisitionFeed.groups() might call several different
+        methods that each need a facet object.
+        """
+        class Mock(object):
+            """Contains all the mock methods used by this test."""
+            def fetch(self, *args, **kwargs):
+                self.fetch_called_with = kwargs['facets']
+                return None, False
+
+            def groups(self, _db, facets):
+                self.groups_called_with = facets
+                return []
+
+            def page(self, *args, **kwargs):
+                self.page_called_with = facets
+                return []
+
+        mock = Mock()
+        old_cachedfeed_fetch = CachedFeed.fetch
+        CachedFeed.fetch = mock.fetch
+
+        lane = self._lane()
+        lane.groups = mock.groups
+
+        old_acquisitionfeed_page = AcquisitionFeed.page
+        AcquisitionFeed.page = mock.page
+
+        # Here's the MacGuffin -- watch it!
+        facets = object()
+
+        AcquisitionFeed.groups(
+            self._db, "title", "url", lane, TestAnnotator(), facets=facets
+        )
+        # We called CachedFeed.fetch with the given facets object.
+        eq_(facets, mock.fetch_called_with)
+
+        # That didn't return anything usable, so we passed the
+        # facets into lane.groups().
+        eq_(facets, mock.groups_called_with)
+
+        # That didn't return anything either, so as a last ditch
+        # effort we passed the facets into AcquisitionFeed.page().
+        eq_(facets, mock.page_called_with)
+
+        # Un-mock the methods that we mocked.
+        CachedFeed.fetch = old_cachedfeed_fetch
+        AcquisitionFeed.page = old_acquisitionfeed_page
 
     def test_license_tags_no_loan_or_hold(self):
         edition, pool = self._edition(with_license_pool=True)


### PR DESCRIPTION
This is for https://github.com/NYPL-Simplified/server_core/issues/844.

This branch gives OPDS feeds the ability to add links to a different entry point into the same feed. These links can be present in grouped feeds, search results and paginated feeds. (To start with, we will only be actually using this with grouped feeds and search results.)

The entry points available to a feed are determined by the WorkList associated with that feed. Currently there is no actual way to associate entry points with a WorkList, but the circulation manager will take care of that.

"Entry point" is treated as a special kind of facet group and the currently selected entry point is the active facet of that group. An extra attribute on the facet group link signals to the client that this particular facet group is an entry point (e.g. so it can be rendered as a set of tabs instead of a drop-down).

It might be easier to review this branch by comparing it against master. The `tab-configuration` branch added a lot of 'entrypoint' arguments to methods which this branch either removes or replaces with 'facets' arguments. By themselves these changes aren't large but I found it confusing to check whether I needed to achieve test coverage of a given method by porting a test from `tab-configuration` or by adding a new test.

The underlying rationale for that change is to reduce the number of times we have to change the method signatures. The methods that took facets before don't change signature, and the methods that didn't take facets now take a fully general object for adding additional filters to the database or search query.