### PR TITLE
Load entry point into faceting objects during `load_facets`

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -92,7 +92,7 @@ def _make_response(content, content_type, cache_for):
     return make_response(content, 200, {"Content-Type": content_type,
                                         "Cache-Control": cache_control})
 
-def load_facets_from_request(facet_config=None):
+def load_facets_from_request(facet_config=None, base_class=Facets):
     """Figure out which Facets object this request is asking for.
 
     The active request must have the `library` member set to a Library
@@ -114,7 +114,7 @@ def load_facets_from_request(facet_config=None):
     g = Facets.COLLECTION_FACET_GROUP_NAME
     collection = arg(g, config.default_facet(g))
     return load_facets(library, order, availability, collection,
-                       facet_config=facet_config)
+                       facet_config=facet_config, base_class=base_class)
 
 def load_pagination_from_request(default_size=Pagination.DEFAULT_SIZE):
     """Figure out which Pagination object this request is asking for."""
@@ -132,7 +132,8 @@ def load_entrypoint_from_request(worklist):
     entrypoint = flask.request.args.get(Facets.ENTRY_POINT_FACET_GROUP_NAME)
     return load_entrypoint(entrypoint, worklist)
 
-def load_facets(library, order, availability, collection, facet_config=None):
+def load_facets(library, order, availability, collection, facet_config=None,
+                base_class=Facets):
     """Turn user input into a Facets object."""
     config = facet_config or library
     order_facets = config.enabled_facets(Facets.ORDER_FACET_GROUP_NAME)
@@ -165,7 +166,7 @@ def load_facets(library, order, availability, collection, facet_config=None):
         Facets.COLLECTION_FACET_GROUP_NAME : collection_facets,
     }
 
-    return Facets(
+    return base_class(
         library=library, collection=collection, availability=availability,
         order=order, enabled_facets=enabled_facets
     )

--- a/app_server.py
+++ b/app_server.py
@@ -143,14 +143,6 @@ def load_pagination_from_request(default_size=Pagination.DEFAULT_SIZE):
     offset = arg('after', 0)
     return load_pagination(size, offset)
 
-def load_entrypoint_from_request(worklist):
-    """Load a selected EntryPoint from a request.
-
-    :param worklist: Optional WorkList. If provided, the requested
-    EntryPoint must be one of the ones available to this WorkList.
-    """
-
-    return load_entrypoint(entrypoint, worklist)
 
 def load_facets(library, order, availability, collection, facet_config=None,
                 entrypoint=None, worklist=None, base_class=Facets,

--- a/app_server.py
+++ b/app_server.py
@@ -92,14 +92,27 @@ def _make_response(content, content_type, cache_for):
     return make_response(content, 200, {"Content-Type": content_type,
                                         "Cache-Control": cache_control})
 
-def load_facets_from_request(facet_config=None, base_class=Facets):
-    """Figure out which Facets object this request is asking for.
+def load_facets_from_request(
+        facet_config=None, worklist=None, base_class=Facets,
+        base_class_constructor_kwargs=None
+):
+    """Figure out which faceting object this request is asking for.
 
     The active request must have the `library` member set to a Library
     object.
 
     :param facet_config: An object to use instead of the request Library
     when deciding which facets are enabled.
+
+    :param lane: An optional WorkList to use when checking which EntryPoints
+    are aviailable.
+
+    :param base_class: A facet class, such as FacetsWithEntryPoint or one of
+    its subclasses, to instantiate instead of Facets.
+
+    :param base_class_constructor_kwargs: A dictionary of keyword
+    arguments to the constructor of `base_class`, representing
+    extra arguments not handled by this code.
     """
     arg = flask.request.args.get
     library = flask.request.library
@@ -113,8 +126,15 @@ def load_facets_from_request(facet_config=None, base_class=Facets):
 
     g = Facets.COLLECTION_FACET_GROUP_NAME
     collection = arg(g, config.default_facet(g))
-    return load_facets(library, order, availability, collection,
-                       facet_config=facet_config, base_class=base_class)
+
+    entrypoint = arg(Facets.ENTRY_POINT_FACET_GROUP_NAME, None)
+
+    return load_facets(
+        library, order, availability, collection,
+        facet_config=facet_config, entrypoint=entrypoint,
+        worklist=worklist, base_class=base_class,
+        base_class_constructor_kwargs=base_class_constructor_kwargs
+    )
 
 def load_pagination_from_request(default_size=Pagination.DEFAULT_SIZE):
     """Figure out which Pagination object this request is asking for."""
@@ -129,12 +149,13 @@ def load_entrypoint_from_request(worklist):
     :param worklist: Optional WorkList. If provided, the requested
     EntryPoint must be one of the ones available to this WorkList.
     """
-    entrypoint = flask.request.args.get(Facets.ENTRY_POINT_FACET_GROUP_NAME)
+
     return load_entrypoint(entrypoint, worklist)
 
 def load_facets(library, order, availability, collection, facet_config=None,
-                base_class=Facets):
-    """Turn user input into a Facets object."""
+                entrypoint=None, worklist=None, base_class=Facets,
+                base_class_constructor_kwargs=None):
+    """Turn user input into a faceting object."""
     config = facet_config or library
     order_facets = config.enabled_facets(Facets.ORDER_FACET_GROUP_NAME)
     if order and not order in order_facets:
@@ -166,9 +187,13 @@ def load_facets(library, order, availability, collection, facet_config=None,
         Facets.COLLECTION_FACET_GROUP_NAME : collection_facets,
     }
 
+    entrypoint = load_entrypoint(entrypoint, worklist)
+
+    base_class_constructor_kwargs = base_class_constructor_kwargs or dict()
     return base_class(
         library=library, collection=collection, availability=availability,
-        order=order, enabled_facets=enabled_facets
+        order=order, entrypoint=entrypoint, enabled_facets=enabled_facets,
+        **base_class_constructor_kwargs
     )
 
 def load_pagination(size, offset):

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -120,4 +120,4 @@ EntryPoint.register(EbooksEntryPoint, "Books", default_enabled=True)
 
 class AudiobooksEntryPoint(MediumEntryPoint):
     INTERNAL_NAME = "Audio"
-EntryPoint.register(AudiobooksEntryPoint, "Audiobooks")
+EntryPoint.register(AudiobooksEntryPoint, "Audio")

--- a/lane.py
+++ b/lane.py
@@ -613,9 +613,10 @@ class WorkList(object):
         # This WorkList contains every title available to this library
         # in one of the media supported by the default client.
         wl = WorkList()
+
         wl.initialize(
             library, display_name=library.name, children=top_level_lanes,
-            media=Edition.FULFILLABLE_MEDIA
+            media=Edition.FULFILLABLE_MEDIA, entrypoints=library.entrypoints
         )
         return wl
 
@@ -653,7 +654,7 @@ class WorkList(object):
         show up in relation to its siblings when it is the child of
         some other WorkList.
 
-        :param entrypoints: A list of EntryPoint objects representing
+        :param entrypoints: A list of EntryPoint classes representing
         different ways of slicing up this WorkList.
         """
         self.library_id = None

--- a/lane.py
+++ b/lane.py
@@ -389,7 +389,7 @@ class FeaturedFacets(FacetsWithEntryPoint):
     AcquisitionFeed.groups().
     """
 
-    def __init__(self, minimum_featured_quality=None, uses_customlists=False,
+    def __init__(self, minimum_featured_quality, uses_customlists=False,
                  entrypoint=None):
         """Set up an object that finds featured books in a given
         WorkList.
@@ -807,6 +807,14 @@ class WorkList(object):
         ):
             yield work, worklist
 
+    def default_featured_facets(self, _db):
+        """Helper method to create a FeaturedFacets object."""
+        library = self.get_library(_db)
+        return FeaturedFacets(
+            minimum_featured_quality=library.minimum_featured_quality,
+            uses_customlists=self.uses_customlists
+        )
+
     def featured_works(self, _db, facets=None):
         """Find a random sample of featured books.
 
@@ -825,12 +833,7 @@ class WorkList(object):
         library = self.get_library(_db)
         target_size = library.featured_lane_size
 
-        facets = facets or FeaturedFacets()
-        facets = facets.navigate(
-            minimum_featured_quality=library.minimum_featured_quality,
-            uses_customlists=self.uses_customlists
-        )
-
+        facets = facets or self.default_featured_facets(_db)
         query = self.works(_db, facets=facets)
         if not query:
             # works() may return None, indicating that the whole
@@ -1299,7 +1302,7 @@ class WorkList(object):
         library = self.get_library(_db)
         target_size = library.featured_lane_size
 
-        facets = facets or FeaturedFacets()
+        facets = facets or self.default_featured_facets(_db)
         facets = facets.navigate(
             library.minimum_featured_quality,
             self.uses_customlists

--- a/lane.py
+++ b/lane.py
@@ -91,10 +91,12 @@ class FacetsWithEntryPoint(FacetConstants):
     """Basic Facets class that knows how to filter a query based on a
     selected EntryPoint.
     """
-    def __init__(self, entrypoint=None):
+    def __init__(self, entrypoint=None, **kwargs):
         """Constructor.
 
         :param entrypoint: An EntryPoint (optional).
+        :param kwargs: Other arguments may be supplied based on user
+            input, but the default implementation is to ignore them.
         """
         self.entrypoint = entrypoint
 
@@ -390,9 +392,12 @@ class FeaturedFacets(FacetsWithEntryPoint):
     """
 
     def __init__(self, minimum_featured_quality, uses_customlists=False,
-                 entrypoint=None):
+                 entrypoint=None, **kwargs):
         """Set up an object that finds featured books in a given
         WorkList.
+
+        :param kwargs: Other arguments may be supplied based on user
+            input, but the default implementation is to ignore them.
         """
         super(FeaturedFacets, self).__init__(entrypoint)
         self.minimum_featured_quality = minimum_featured_quality

--- a/lane.py
+++ b/lane.py
@@ -1308,10 +1308,6 @@ class WorkList(object):
         target_size = library.featured_lane_size
 
         facets = facets or self.default_featured_facets(_db)
-        facets = facets.navigate(
-            library.minimum_featured_quality,
-            self.uses_customlists
-        )
 
         # Pull a window of works for every lane we were given.
         for lane in lanes:

--- a/model.py
+++ b/model.py
@@ -3012,7 +3012,7 @@ class Edition(Base):
 
     # These are the media types currently fulfillable by the default
     # client.
-    FULFILLABLE_MEDIA = [BOOK_MEDIUM, AUDIO_MEDIUM]
+    FULFILLABLE_MEDIA = [BOOK_MEDIUM]
 
     medium_to_additional_type = {
         BOOK_MEDIUM : u"http://schema.org/EBook",

--- a/model.py
+++ b/model.py
@@ -3012,7 +3012,7 @@ class Edition(Base):
 
     # These are the media types currently fulfillable by the default
     # client.
-    FULFILLABLE_MEDIA = [BOOK_MEDIUM]
+    FULFILLABLE_MEDIA = [BOOK_MEDIUM, AUDIO_MEDIUM]
 
     medium_to_additional_type = {
         BOOK_MEDIUM : u"http://schema.org/EBook",

--- a/opds.py
+++ b/opds.py
@@ -1527,8 +1527,8 @@ class TestAnnotatorWithGroup(TestAnnotator):
             if isinstance(work, Work):
                 work_id = work.id
             else:
-                # MaterialivedViewWithGenre
-                work_id = work.work_id
+                # MaterialivedWorkWithGenre
+                work_id = work.works_id
             lane_name = str(work_id)
         return ("http://group/%s" % lane_name,
                 "Group Title for %s!" % lane_name)

--- a/opds.py
+++ b/opds.py
@@ -1524,7 +1524,12 @@ class TestAnnotatorWithGroup(TestAnnotator):
             if additional_lanes:
                 self.lanes_by_work[work] = additional_lanes
         else:
-            lane_name = str(work.id)
+            if isinstance(work, Work):
+                work_id = work.id
+            else:
+                # MaterialivedViewWithGenre
+                work_id = work.work_id
+            lane_name = str(work_id)
         return ("http://group/%s" % lane_name,
                 "Group Title for %s!" % lane_name)
 

--- a/opds.py
+++ b/opds.py
@@ -675,6 +675,14 @@ class AcquisitionFeed(OPDSFeed):
         :param entrypoints: A list of all EntryPoints in the facet group.
         :param selected_entrypoint: The current EntryPoint, if selected.
         """
+        if (len(entrypoints) == 1
+            and selected_entrypoint in (None, entrypoints[0])):
+            # There is only one entry point. Unless the currently
+            # selected entry point is somehow different, there's no
+            # need to put any links at all here -- a facet group with
+            # one one facet might as well not be there.
+            return
+
         is_default = True
         for entrypoint in entrypoints:
             link = cls._entrypoint_link(
@@ -682,7 +690,7 @@ class AcquisitionFeed(OPDSFeed):
                 group_name
             )
             if link:
-                cls.add_link_to_feed(feed, **link)
+                cls.add_link_to_feed(feed.feed, **link)
                 is_default = False
 
     @classmethod

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -279,6 +279,15 @@ class TestLoadMethods(DatabaseTest):
             problemdetail = load_facets_from_request()
             eq_(INVALID_INPUT.uri, problemdetail.uri)
 
+        # The caller can specify a class to instantiate other than Facets.
+        class MockFacets(object):
+            def __init__(self, *args, **kwargs):
+                pass
+        with self.app.test_request_context('/'):
+            flask.request.library = self._default_library
+            facets = load_facets_from_request(base_class=MockFacets)
+            assert isinstance(facets, MockFacets)
+
     def test_load_pagination_from_request(self):
         with self.app.test_request_context('/?size=50&after=10'):
             pagination = load_pagination_from_request()

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -24,7 +24,7 @@ class TestEntryPoint(object):
 
         display = EntryPoint.DISPLAY_TITLES
         eq_("Books", display[ebooks])
-        eq_("Audiobooks", display[audiobooks])
+        eq_("Audio", display[audiobooks])
 
         eq_(Edition.BOOK_MEDIUM, EbooksEntryPoint.INTERNAL_NAME)
         eq_(Edition.AUDIO_MEDIUM, AudiobooksEntryPoint.INTERNAL_NAME)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -2580,14 +2580,12 @@ class TestWorkListGroups(DatabaseTest):
             entrypoint=AudiobooksEntryPoint
         )
         groups = list(wl.featured_works(self._db, facets))
+        eq_(facets, wl.works_called_with)
 
-        # The Facets object passed in to Works is based on the object
-        # we passed in, but it's not the same. The entry point has
-        # been preserverd, but the worklist's uses_customlists and
-        # the library's minimum_featured_quality have replaced the
-        # fake values set earlier.
+        # If no FeaturedFacets object is specified, one is created
+        # based on default library configuration.
+        groups = list(wl.featured_works(self._db, None))
         facets2 = wl.works_called_with
-        eq_(facets.entrypoint, facets2.entrypoint)
         eq_(self._default_library.minimum_featured_quality,
             facets2.minimum_featured_quality)
         eq_(wl.uses_customlists, facets2.uses_customlists)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -980,7 +980,7 @@ class TestWorkList(DatabaseTest):
         wl = Mock()
         wl.initialize(library=self._default_library)
         audio = AudiobooksEntryPoint
-        facets = FeaturedFacets(entrypoint=audio)
+        facets = FeaturedFacets(0, entrypoint=audio)
 
         # The Facets object passed in to works() is different from the
         # one we passed in -- it's got some settings for
@@ -2257,7 +2257,7 @@ class TestLane(DatabaseTest):
         old_value = Lane._groups_for_lanes
         Lane._groups_for_lanes = mock
         lane = self._lane()
-        facets = FeaturedFacets()
+        facets = FeaturedFacets(0)
         lane.groups(self._db, facets=facets)
         eq_(facets, lane.called_with)
         Lane._groups_for_lanes = old_value
@@ -2498,7 +2498,7 @@ class TestWorkListGroups(DatabaseTest):
 
         # There are no audiobooks in the system, so passing in a
         # FeaturedFacets scoped to the AudiobooksEntryPoint excludes everything.
-        facets = FeaturedFacets(entrypoint=AudiobooksEntryPoint)
+        facets = FeaturedFacets(0, entrypoint=AudiobooksEntryPoint)
         _db = self._db
         eq_([], list(fiction.groups(self._db, facets=facets)))
 
@@ -2509,7 +2509,7 @@ class TestWorkListGroups(DatabaseTest):
             def apply(cls, qu):
                 from model import MaterializedWorkWithGenre as mv
                 return qu.filter(mv.sort_title=='LQ Romance')
-        facets = FeaturedFacets(entrypoint=LQRomanceEntryPoint)
+        facets = FeaturedFacets(0, entrypoint=LQRomanceEntryPoint)
         assert_contents(
             fiction.groups(self._db, facets=facets),
             [
@@ -2560,7 +2560,7 @@ class TestWorkListGroups(DatabaseTest):
 
         wl = Mock()
         wl.initialize(library=self._default_library)
-        facets = FeaturedFacets()
+        facets = FeaturedFacets(0)
         groups = list(wl._groups_for_lanes(self._db, [], [], facets))
         eq_(facets, wl.featured_called_with)
 
@@ -2608,7 +2608,7 @@ class TestWorkListGroups(DatabaseTest):
         mock2 = Mock(("mw2","quality2"))
 
         lane = self._lane()
-        facets = FeaturedFacets()
+        facets = FeaturedFacets(0.1)
         results = lane._featured_works_with_lanes(
             self._db, [mock1, mock2], facets
         )

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -2621,15 +2621,13 @@ class TestWorkListGroups(DatabaseTest):
         # Each Mock's works_in_window was called with the same
         # arguments.
         eq_(mock1.called_with, mock2.called_with)
-        _db, facets, target_size = mock1.called_with
 
-        # Those arguments came from the configuration of the Library
-        # associated with the (non-mock) Lane on which _groups_query
-        # was originally called.
+        # The Facets object passed in to _featured_works_with_lanes()
+        # is passed on into works_in_window().
+        _db, called_with_facets, target_size = mock1.called_with
         eq_(self._db, _db)
-        eq_(lane.library.minimum_featured_quality, facets.minimum_featured_quality)
+        eq_(facets, called_with_facets)
         eq_(lane.library.featured_lane_size, target_size)
-        eq_(facets, facets)
 
     def test_featured_window(self):
         lane = self._lane()

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1867,7 +1867,10 @@ class TestEntrypointLinkInsertion(DatabaseTest):
 
         # A WorkList with entry points does cause the mock method
         # to be called.
-        facets = FeaturedFacets(entrypoint=EbooksEntryPoint)
+        facets = FeaturedFacets(
+            minimum_featured_quality=self._default_library.minimum_featured_quality,
+            entrypoint=EbooksEntryPoint
+        )
         feed, make_link, entrypoints, selected = run(self.wl, facets)
 
         # add_entrypoint_links was passed both possible entry points

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -504,6 +504,16 @@ class TestOPDS(DatabaseTest):
         eq_(expect_uri, group_link['href'])
         eq_(expect_title, group_link['title'])
 
+        # Verify that the same group_uri is created whether a Work or
+        # a MaterializedWorkWithGenre is passed in.
+        self.add_to_materialized_view([work])
+        from model import MaterializedWorkWithGenre
+        [mw] = self._db.query(MaterializedWorkWithGenre).all()
+        
+        mw_uri, mw_title = annotator.group_uri(mw, lp, lp.identifier)
+        eq_(mw_uri, expect_uri)
+        assert str(mw.works_id) in mw_uri
+
     def test_acquisition_feed(self):
         work = self._work(with_open_access_download=True, authors="Alice")
 


### PR DESCRIPTION
This branch generalizes the `load_facets` function (used by `load_facets_from_request`) so that:

1. The caller can choose which faceting class to instantiate, and pass extra arguments into its constructor.
2. The caller can pass in a WorkList. If that WorkList has entry points, and the user requested a specific entry point, the faceting object will be instantiated with the corresponding EntryPoint class.

In a future branch we should change the `Facets` class to something like `ListFeedFacets`. Right now it sounds like a generic superclass, which isn't the case. A fair amount of `load_facets` only makes sense if the facets class being instantated is `Facets` rather than a different faceting class; we could make a faceting class more responsible for pulling its own information out of request arguments.