### PR TITLE
Give faceting classes total responsibility over their own instantiation

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -139,29 +139,6 @@ def load_pagination(size, offset):
             return INVALID_INPUT.detailed(_("Invalid offset: %(offset)s", offset=offset))
     return Pagination(offset, size)
 
-def load_entrypoint(entrypoint, worklist):
-    """Turn user input into an EntryPoint class from the EntryPoint registry.
-
-    :param worklist: A WorkList.
-
-    :return: An EntryPoint class. This will be the requested
-    EntryPoint if possible. If a nonexistent or unusable EntryPoint is
-    requested, the WorkList's default EntryPoint will be returned. If
-    the WorkList has no EntryPoints, or no WorkList is provided, None
-    will be returned.
-    """
-    if not worklist or not worklist.entrypoints:
-        # This WorkList has no EntryPoints. No EntryPoint should ever
-        # be returned from this method.
-        return None
-    default = worklist.entrypoints[0]
-    cls = EntryPoint.BY_INTERNAL_NAME.get(entrypoint)
-    if not cls:
-        return default
-    if cls not in worklist.entrypoints:
-        return default
-    return cls
-
 def returns_problem_detail(f):
     @wraps(f)
     def decorated(*args, **kwargs):

--- a/app_server.py
+++ b/app_server.py
@@ -101,39 +101,21 @@ def load_facets_from_request(
     The active request must have the `library` member set to a Library
     object.
 
-    :param facet_config: An object to use instead of the request Library
-    when deciding which facets are enabled.
-
-    :param lane: An optional WorkList to use when checking which EntryPoints
-    are aviailable.
-
-    :param base_class: A facet class, such as FacetsWithEntryPoint or one of
-    its subclasses, to instantiate instead of Facets.
-
-    :param base_class_constructor_kwargs: A dictionary of keyword
-    arguments to the constructor of `base_class`, representing
-    extra arguments not handled by this code.
+    :param worklist: The WorkList, if any, associated with the request.
+    :param facet_config: An object containing the currently configured
+        facet groups, if different from the request library.
+    :param base_class: The faceting class to instantiate.
+    :param base_class_constructor_kwargs: Keyword arguments to pass into
+        the faceting class constructor, other than those obtained from
+        the request.
+    :return: A faceting object if possible; otherwise a ProblemDetail.
     """
-    arg = flask.request.args.get
+    kwargs = base_class_constructor_kwargs or dict()
+    get_arg = flask.request.args.get
     library = flask.request.library
-    config = facet_config or library
-    
-    g = Facets.ORDER_FACET_GROUP_NAME
-    order = arg(g, config.default_facet(g))
-
-    g = Facets.AVAILABILITY_FACET_GROUP_NAME
-    availability = arg(g, config.default_facet(g))
-
-    g = Facets.COLLECTION_FACET_GROUP_NAME
-    collection = arg(g, config.default_facet(g))
-
-    entrypoint = arg(Facets.ENTRY_POINT_FACET_GROUP_NAME, None)
-
-    return load_facets(
-        library, order, availability, collection,
-        facet_config=facet_config, entrypoint=entrypoint,
-        worklist=worklist, base_class=base_class,
-        base_class_constructor_kwargs=base_class_constructor_kwargs
+    facet_config = facet_config or library
+    return base_class.from_request(
+        library, facet_config, get_arg, worklist, **kwargs
     )
 
 def load_pagination_from_request(default_size=Pagination.DEFAULT_SIZE):
@@ -142,51 +124,6 @@ def load_pagination_from_request(default_size=Pagination.DEFAULT_SIZE):
     size = arg('size', default_size)
     offset = arg('after', 0)
     return load_pagination(size, offset)
-
-
-def load_facets(library, order, availability, collection, facet_config=None,
-                entrypoint=None, worklist=None, base_class=Facets,
-                base_class_constructor_kwargs=None):
-    """Turn user input into a faceting object."""
-    config = facet_config or library
-    order_facets = config.enabled_facets(Facets.ORDER_FACET_GROUP_NAME)
-    if order and not order in order_facets:
-        return INVALID_INPUT.detailed(
-            _("I don't know how to order a feed by '%(order)s'", order=order),
-            400
-        )
-    availability_facets = config.enabled_facets(
-        Facets.AVAILABILITY_FACET_GROUP_NAME
-    )
-    if availability and not availability in availability_facets:
-        return INVALID_INPUT.detailed(
-            _("I don't understand the availability term '%(availability)s'", availability=availability),
-            400
-        )
-
-    collection_facets = config.enabled_facets(
-        Facets.COLLECTION_FACET_GROUP_NAME
-    )
-    if collection and not collection in collection_facets:
-        return INVALID_INPUT.detailed(
-            _("I don't understand what '%(collection)s' refers to.", collection=collection),
-            400
-        )
-    
-    enabled_facets = {
-        Facets.ORDER_FACET_GROUP_NAME : order_facets,
-        Facets.AVAILABILITY_FACET_GROUP_NAME : availability_facets,
-        Facets.COLLECTION_FACET_GROUP_NAME : collection_facets,
-    }
-
-    entrypoint = load_entrypoint(entrypoint, worklist)
-
-    base_class_constructor_kwargs = base_class_constructor_kwargs or dict()
-    return base_class(
-        library=library, collection=collection, availability=availability,
-        order=order, entrypoint=entrypoint, enabled_facets=enabled_facets,
-        **base_class_constructor_kwargs
-    )
 
 def load_pagination(size, offset):
     """Turn user input into a Pagination object."""

--- a/lane.py
+++ b/lane.py
@@ -150,17 +150,19 @@ class FacetsWithEntryPoint(FacetConstants):
     def load_entrypoint(cls, name, worklist):
         """Look up an EntryPoint by name, assuming it's allowed in the
         given WorkList.
+
+        :return: An EntryPoint class. This will be the requested
+        EntryPoint if possible. If a nonexistent or unusable
+        EntryPoint is requested, the WorkList's default EntryPoint
+        will be returned. If the WorkList has no EntryPoints, or no
+        WorkList is provided, None will be returned.
         """
-        if not name:
-            # No EntryPoint was requested.
+        if not name or not worklist or not worklist.entrypoints:
             return None
-        matches = [x for x in worklist.entrypoints if x.INTERNAL_NAME==name]
-        if not matches:
-            return INVALID_INPUT.detailed(
-                _("The entry point %(entrypoint)s is not available",
-                  entrypoint=name)
-            )
-        return matches[0]
+        default = worklist.entrypoints[0]
+        cls = EntryPoint.BY_INTERNAL_NAME.get(entrypoint)
+        if not cls or cls not in worklist.entrypoints
+            return default
 
     def items(self):
         """Yields a 2-tuple for every active facet setting.

--- a/lane.py
+++ b/lane.py
@@ -44,6 +44,7 @@ from sqlalchemy.orm import (
 )
 from sqlalchemy.sql.expression import literal
 
+from entrypoint import EntryPoint
 from model import (
     directly_modified,
     get_one_or_create,
@@ -125,7 +126,7 @@ class FacetsWithEntryPoint(FacetConstants):
             a problem with the input from the request.
         """
         return cls._from_request(
-            cls, facet_config, get_argument, worklist, **extra_kwargs
+            facet_config, get_argument, worklist, **extra_kwargs
         )
 
     @classmethod
@@ -157,12 +158,13 @@ class FacetsWithEntryPoint(FacetConstants):
         will be returned. If the WorkList has no EntryPoints, or no
         WorkList is provided, None will be returned.
         """
-        if not name or not worklist or not worklist.entrypoints:
+        if not worklist or not worklist.entrypoints:
             return None
         default = worklist.entrypoints[0]
-        cls = EntryPoint.BY_INTERNAL_NAME.get(entrypoint)
-        if not cls or cls not in worklist.entrypoints
+        ep = EntryPoint.BY_INTERNAL_NAME.get(name)
+        if not ep or ep not in worklist.entrypoints:
             return default
+        return ep
 
     def items(self):
         """Yields a 2-tuple for every active facet setting.

--- a/lane.py
+++ b/lane.py
@@ -67,10 +67,12 @@ from model import (
     WorkGenre,
 )
 from facets import FacetConstants
+from problem_details import *
 from util import (
     fast_query_count,
     LanguageCodes,
 )
+from util.problem_detail import ProblemDetail
 
 import elasticsearch
 
@@ -99,6 +101,66 @@ class FacetsWithEntryPoint(FacetConstants):
             input, but the default implementation is to ignore them.
         """
         self.entrypoint = entrypoint
+
+    @classmethod
+    def from_request(
+            cls, library, facet_config, get_argument, worklist, **extra_kwargs
+    ):
+        """Load a faceting object from an HTTP request.
+
+        :param facet_config: A Library (or mock of one) that knows
+           which subset of the available facets are configured.
+
+        :param get_argument: A callable that takes one argument and
+           retrieves (or pretends to retrieve) a query string
+           parameter of that name from an incoming HTTP request.
+
+        :param worklist: A WorkList associated with the current request,
+           if any.
+
+        :param extra_kwargs: A dictionary of keyword arguments to pass
+           into the constructor when a faceting object is instantiated.
+
+        :return: A FacetsWithEntryPoint, or a ProblemDetail if there's
+            a problem with the input from the request.
+        """
+        return cls._from_request(
+            cls, facet_config, get_argument, worklist, **extra_kwargs
+        )
+
+    @classmethod
+    def _from_request(
+            cls, facet_config, get_argument, worklist, **extra_kwargs
+    ):
+        """Load a faceting object from an HTTP request.
+
+        Subclasses of FacetsWithEntryPoint can override `from_request`,
+        but call this method to load the EntryPoint and actually
+        instantiate the faceting class.
+        """
+        entrypoint_name = get_argument(
+            Facets.ENTRY_POINT_FACET_GROUP_NAME, None
+        )
+        entrypoint = cls.load_entrypoint(entrypoint_name, worklist)
+        if isinstance(entrypoint, ProblemDetail):
+            return entrypoint
+        return cls(entrypoint=entrypoint, **extra_kwargs)
+
+    @classmethod
+    def load_entrypoint(cls, name, worklist):
+        """Look up an EntryPoint by name, assuming it's allowed in the
+        given WorkList.
+        """
+        if not name:
+            # No EntryPoint was requested.
+            return None
+        matches = [x for x in worklist.entrypoints if x.INTERNAL_NAME==name]
+        if not matches:
+            return INVALID_INPUT.detailed(
+                _("The entry point %(entrypoint)s is not available",
+                  entrypoint=name)
+            )
+        return matches[0]
 
     def items(self):
         """Yields a 2-tuple for every active facet setting.
@@ -141,13 +203,55 @@ class Facets(FacetsWithEntryPoint):
             order=cls.ORDER_AUTHOR
         )
 
+    @classmethod
+    def from_request(cls, library, config, get_argument, worklist, **extra):
+        """Load a faceting object from an HTTP request."""
+        g = Facets.ORDER_FACET_GROUP_NAME
+        order = get_argument(g, config.default_facet(g))
+        order_facets = config.enabled_facets(Facets.ORDER_FACET_GROUP_NAME)
+        if order and not order in order_facets:
+            return INVALID_INPUT.detailed(
+                _("I don't know how to order a feed by '%(order)s'", order=order),
+                400
+            )
+        extra['order'] = order
+
+        g = Facets.AVAILABILITY_FACET_GROUP_NAME
+        availability = get_argument(g, config.default_facet(g))
+        availability_facets = config.enabled_facets(
+            Facets.AVAILABILITY_FACET_GROUP_NAME
+        )
+        if availability and not availability in availability_facets:
+            return INVALID_INPUT.detailed(
+                _("I don't understand the availability term '%(availability)s'", availability=availability),
+                400
+            )
+        extra['availability'] = availability
+
+        g = Facets.COLLECTION_FACET_GROUP_NAME
+        collection = get_argument(g, config.default_facet(g))
+        collection_facets = config.enabled_facets(
+            Facets.COLLECTION_FACET_GROUP_NAME
+        )
+        if collection and not collection in collection_facets:
+            return INVALID_INPUT.detailed(
+                _("I don't understand what '%(collection)s' refers to.", collection=collection),
+                400
+            )
+        extra['collection'] = collection
+
+        extra['enabled_facets'] = {
+            Facets.ORDER_FACET_GROUP_NAME : order_facets,
+            Facets.AVAILABILITY_FACET_GROUP_NAME : availability_facets,
+            Facets.COLLECTION_FACET_GROUP_NAME : collection_facets,
+        }
+        extra['library'] = library
+
+        return cls._from_request(config, get_argument, worklist, **extra)
+
     def __init__(self, library, collection, availability, order,
                  order_ascending=None, enabled_facets=None, entrypoint=None):
         """Constructor.
-
-        :param library: The library's defaults will be used when creating the
-        facets. If library is None, collection, availability, order, and
-        enabled_facets must be specified.
 
         :param collection: This is not a Collection object; it's a value for
         the 'collection' facet, e.g. 'main' or 'featured'.

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -34,7 +34,6 @@ from app_server import (
     ErrorHandler,
     ComplaintController,
     load_entrypoint,
-    load_facets,
     load_facets_from_request,
     load_pagination_from_request,
 )

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -289,56 +289,6 @@ class TestLoadMethods(DatabaseTest):
             facets = load_facets_from_request(worklist=worklist)
             eq_(AudiobooksEntryPoint, facets.entrypoint)
 
-    def test_load_facets_class_instantiation(self):
-        """The caller of load_facets() can specify a class to instantiate
-        other than Facets, and arguments to pass into the class
-        constructor.
-        """
-        class MockFacets(object):
-            def __init__(self, *args, **kwargs):
-                self.called_with = kwargs
-        kwargs = dict(some_arg='some value')
-        facets = load_facets(
-            self._default_library, None, None, None,
-            base_class=MockFacets, base_class_constructor_kwargs=kwargs
-        )
-        assert isinstance(facets, MockFacets)
-        eq_('some value', facets.called_with['some_arg'])
-
-    def test_load_entrypoint(self):
-        audio = AudiobooksEntryPoint
-        ebooks = EbooksEntryPoint
-
-        # This WorkList supports two EntryPoints.
-        worklist = WorkList()
-        worklist.initialize(
-            self._default_library, entrypoints=[audio, ebooks]
-        )
-        m = load_entrypoint
-
-        # This request does not ask for any particular entrypoint,
-        # so it gets the default.
-        eq_(audio, m(None, worklist))
-
-        # This request asks for an entrypoint and gets it.
-        eq_(ebooks, m(ebooks.INTERNAL_NAME, worklist))
-
-        # This request asks for an entrypoint that is not available,
-        # and gets the default.
-        eq_(audio, m("no such entrypoint", worklist))
-
-        # This WorkList does not have any associated EntryPoints,
-        # which means the loaded Facets object will never have an
-        # .entrypoint.
-        no_entrypoints = WorkList()
-        no_entrypoints.initialize(self._default_library)
-        eq_(None, m(None, no_entrypoints))
-        eq_(None, m(audio.INTERNAL_NAME, no_entrypoints))
-
-        # Same behavior if for some reason you try to load an
-        # entrypoint but don't provide a associated WorkList.
-        eq_(None, m(audio.INTERNAL_NAME, None))
-
     def test_load_pagination_from_request(self):
         with self.app.test_request_context('/?size=50&after=10'):
             pagination = load_pagination_from_request()

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -469,11 +469,11 @@ class TestFacets(DatabaseTest):
             invalid_availability.detail)
 
         # Invalid collection
-        args = dict(available="no such collection")
+        args = dict(collection="no such collection")
         invalid_collection = m(library, library, args.get, None)
         eq_(INVALID_INPUT.uri, invalid_collection.uri)
-        eq_("I don't understand the availability term 'no such availability'",
-            invalid_availability.detail)
+        eq_("I don't understand what 'no such collection' refers to.",
+            invalid_collection.detail)
 
 
 class TestFacetsApply(DatabaseTest):

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -75,22 +75,6 @@ class TestFacetsWithEntryPoint(DatabaseTest):
         f.apply(_db, qu)
         eq_(qu, ep.called_with)
 
-    def test_load_facets_class_instantiation(self):
-        """The caller of load_facets() can specify a class to instantiate
-        other than Facets, and arguments to pass into the class
-        constructor.
-        """
-        class MockFacets(object):
-            def __init__(self, *args, **kwargs):
-                self.called_with = kwargs
-        kwargs = dict(some_arg='some value')
-        facets = load_facets(
-            self._default_library, None, None, None,
-            base_class=MockFacets, base_class_constructor_kwargs=kwargs
-        )
-        assert isinstance(facets, MockFacets)
-        eq_('some value', facets.called_with['some_arg'])
-
     def test_from_request(self):
         # from_request just calls _from_request.
         expect = object()

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -414,6 +414,67 @@ class TestFacets(DatabaseTest):
         eq_(F.ORDER_TITLE, different_entrypoint.order)
         eq_(audiobooks, different_entrypoint.entrypoint)
 
+    def test_from_request(self):
+        library = self._default_library
+        config = library
+        worklist = WorkList()
+        worklist.initialize(
+            library, entrypoints=[AudiobooksEntryPoint, EbooksEntryPoint]
+        )
+
+        m = Facets.from_request
+
+        # Valid object using the default settings.
+        default_order = config.default_facet(Facets.ORDER_FACET_GROUP_NAME)
+        default_collection = config.default_facet(
+            Facets.COLLECTION_FACET_GROUP_NAME
+        )
+        default_availability = config.default_facet(
+            Facets.AVAILABILITY_FACET_GROUP_NAME
+        )
+        args = {}
+        facets = m(library, library, args.get, worklist)
+        eq_(default_order, facets.order)
+        eq_(default_collection, facets.collection)
+        eq_(default_availability, facets.availability)
+        eq_(library, facets.library)
+        eq_(AudiobooksEntryPoint, facets.entrypoint)
+
+        # Valid object using non-default settings.
+        args = dict(
+            order=Facets.ORDER_TITLE,
+            collection=Facets.COLLECTION_FULL,
+            available=Facets.AVAILABLE_OPEN_ACCESS,
+            entrypoint=EbooksEntryPoint.INTERNAL_NAME,
+        )
+        facets = m(library, library, args.get, worklist)
+        eq_(Facets.ORDER_TITLE, facets.order)
+        eq_(Facets.COLLECTION_FULL, facets.collection)
+        eq_(Facets.AVAILABLE_OPEN_ACCESS, facets.availability)
+        eq_(library, facets.library)
+        eq_(EbooksEntryPoint, facets.entrypoint)
+
+        # Invalid order
+        args = dict(order="no such order")
+        invalid_order = m(library, library, args.get, None)
+        eq_(INVALID_INPUT.uri, invalid_order.uri)
+        eq_("I don't know how to order a feed by 'no such order'",
+            invalid_order.detail)
+
+        # Invalid availability
+        args = dict(available="no such availability")
+        invalid_availability = m(library, library, args.get, None)
+        eq_(INVALID_INPUT.uri, invalid_availability.uri)
+        eq_("I don't understand the availability term 'no such availability'",
+            invalid_availability.detail)
+
+        # Invalid collection
+        args = dict(available="no such collection")
+        invalid_collection = m(library, library, args.get, None)
+        eq_(INVALID_INPUT.uri, invalid_collection.uri)
+        eq_("I don't understand the availability term 'no such availability'",
+            invalid_availability.detail)
+
 
 class TestFacetsApply(DatabaseTest):
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -76,15 +76,13 @@ class TestFacetsWithEntryPoint(DatabaseTest):
         eq_(qu, ep.called_with)
 
     def test_from_request(self):
-        # from_request just calls _from_request.
+        """from_request just calls _from_request."""
         expect = object()
-        @classmethod
-        def mock(cls, facet_config, get_argument, worklist, **extra_kwargs):
-            return expect
-        old = FacetsWithEntryPoint._from_request
-        FacetsWithEntryPoint._from_request = mock
-        eq_(expect, FacetsWithEntryPoint.from_request(None, None, None, None))
-        FacetsWithEntryPoint._from_request = old
+        class Mock(FacetsWithEntryPoint):
+            @classmethod
+            def _from_request(cls, *args, **kwargs):
+                return expect
+        eq_(expect, Mock.from_request(None, None, None, None))
 
     def test_from_request_propagates_extra_kwargs(self):
         """Any keyword arguments passed to from_request() are propagated
@@ -97,6 +95,7 @@ class TestFacetsWithEntryPoint(DatabaseTest):
         facets = ExtraFacets.from_request(
             None, None, {}.get, None, extra="extra value"
         )
+        assert isinstance(facets, ExtraFacets)
         eq_("extra value", facets.extra)
 
     def test__from_request(self):


### PR DESCRIPTION
This branch refactors `load_facets_from_request` so that almost all of the code runs inside the appropriate faceting class's implementation of `from_request`. 

Code that was specific to the `Facets` class has been moved to that class's `from_request` implementation, and test coverage has been added where before the coverage was a little spotty.

Despite the branch name, this does not add an extra EntryPoint for search, but that should be easy to add after this refactoring