### PR TITLE
Extra entrypoint for search

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -90,6 +90,16 @@ class EntryPoint(object):
         """
         return kwargs
 
+    @classmethod
+    def apply(cls, qu):
+        """Default behavior is to not change a query at all."""
+        return qu
+
+    @classmethod
+    def modified_search_arguments(cls, **kwargs):
+        """Default behavior is to not change search arguments at all."""
+        return kwargs
+
 
 class EverythingEntryPoint(EntryPoint):
     """An entry point that has everything."""

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -91,6 +91,12 @@ class EntryPoint(object):
         return kwargs
 
 
+class EverythingEntryPoint(EntryPoint):
+    """An entry point that has everything."""
+    INTERNAL_NAME = "All"
+EntryPoint.register(EverythingEntryPoint, "All")
+
+
 class MediumEntryPoint(EntryPoint):
     """A entry point that creates a view on one specific medium.
 

--- a/lane.py
+++ b/lane.py
@@ -630,6 +630,9 @@ class SearchFacets(FacetsWithEntryPoint):
 
     @classmethod
     def available_entrypoints(cls, worklist):
+        """If the WorkList has more than one facet, an 'everything' facet
+        is added for search purposes.
+        """
         if not worklist:
             return []
         entrypoints = list(worklist.entrypoints)

--- a/lane.py
+++ b/lane.py
@@ -620,13 +620,12 @@ class SearchFacets(FacetsWithEntryPoint):
     @classmethod
     def available_entrypoints(cls, worklist):
         if not worklist:
-            return None
+            return []
         entrypoints = list(worklist.entrypoints)
         if len(entrypoints) < 2:
             return entrypoints
         if EverythingEntryPoint not in entrypoints:
             entrypoints.insert(0, EverythingEntryPoint)
-        set_trace()
         return entrypoints
 
 

--- a/lane.py
+++ b/lane.py
@@ -105,6 +105,15 @@ class FacetsWithEntryPoint(FacetConstants):
             input, but the default implementation is to ignore them.
         """
         self.entrypoint = entrypoint
+        self.constructor_kwargs = kwargs
+
+    def navigate(self, entrypoint):
+        """Create a very similar FacetsWithEntryPoint that points to
+        a different EntryPoint.
+        """
+        return self.__class__(
+            entrypoint=entrypoint, **self.constructor_kwargs
+        )
 
     @classmethod
     def from_request(
@@ -315,15 +324,17 @@ class Facets(FacetsWithEntryPoint):
     def navigate(self, collection=None, availability=None, order=None,
                  entrypoint=None):
         """Create a slightly different Facets object from this one."""
-        return Facets(self.library,
-                      collection or self.collection,
-                      availability or self.availability,
-                      order or self.order,
-                      enabled_facets=self.facets_enabled_at_init,
-                      entrypoint=(entrypoint or self.entrypoint)
+        return self.__class__(self.library,
+                              collection or self.collection,
+                              availability or self.availability,
+                              order or self.order,
+                              enabled_facets=self.facets_enabled_at_init,
+                              entrypoint=(entrypoint or self.entrypoint)
         )
 
     def items(self):
+        for k,v in super(Facets, self).items():
+            yield k, v
         if self.order:
             yield (self.ORDER_FACET_GROUP_NAME, self.order)
         if self.availability:
@@ -536,7 +547,7 @@ class FeaturedFacets(FacetsWithEntryPoint):
         if uses_customlists is None:
             uses_customlists = self.uses_customlists
         entrypoint = entrypoint or self.entrypoint
-        return FeaturedFacets(
+        return self.__class__(
             minimum_featured_quality, uses_customlists, entrypoint
         )
 

--- a/opds.py
+++ b/opds.py
@@ -537,17 +537,18 @@ class AcquisitionFeed(OPDSFeed):
 
         # A grouped feed may link to alternate entry points into
         # the data.
-        if lane.entrypoints:
+        entrypoints = facets.available_entrypoints(lane)
+        if entrypoints:
             def make_link(ep, is_default):
                 if is_default:
                     # No need to clutter up the URL with the default
                     # entry point.
                     ep = None
                 return annotator.groups_url(
-                    lane, facets=FacetsWithEntryPoint(ep)
+                    lane, facets=facets.navigate(entrypoint=ep)
                 )
             cls.add_entrypoint_links(
-                feed, make_link, lane.entrypoints, facets.entrypoint
+                feed, make_link, entrypoints, facets.entrypoint
             )
 
         cls.add_breadcrumb_links(feed, lane, annotator)
@@ -602,7 +603,8 @@ class AcquisitionFeed(OPDSFeed):
             pagination.this_page_size = len(works)
         feed = cls(_db, title, url, works, annotator)
 
-        if lane.entrypoints:
+        entrypoints = facets.available_entrypoints(lane)
+        if entrypoints:
             # A paginated feed may have multiple entry points into the
             # same dataset.
             def make_link(ep, is_default):
@@ -611,10 +613,10 @@ class AcquisitionFeed(OPDSFeed):
                     # entry point.
                     ep = None
                 return annotator.feed_url(
-                    lane, facets=FacetsWithEntryPoint(ep)
+                    lane, facets=facets.navigate(entrypoint=entrypoint)
                 )
             cls.add_entrypoint_links(
-                feed, make_link, lane.entrypoints, facets.entrypoint
+                feed, make_link, entrypoints, facets.entrypoint
             )
 
         # Add URLs to change faceted views of the collection.
@@ -752,16 +754,17 @@ class AcquisitionFeed(OPDSFeed):
 
         # A feed of search results may link to alternate entry points
         # into those results.
-        if lane.entrypoints:
+        entrypoints = facets.available_entrypoints(lane)
+        if entrypoints:
             def make_link(ep, is_default):
                 if is_default:
                     ep = None
                 return annotator.search_url(
                     lane, query, pagination=None,
-                    facets=FacetsWithEntryPoint(ep)
+                    facets=facets.navigate(entrypoint=ep)
                 )
             cls.add_entrypoint_links(
-                opds_feed, make_link, lane.entrypoints, facets.entrypoint
+                opds_feed, make_link, entrypoints, facets.entrypoint
             )
 
         if len(results) > 0:

--- a/opds.py
+++ b/opds.py
@@ -471,6 +471,7 @@ class AcquisitionFeed(OPDSFeed):
         """
         cached = None
         use_cache = cache_type != cls.NO_CACHE
+        facets = facets or lane.default_featured_facets(_db)
         if use_cache:
             cache_type = cache_type or CachedFeed.GROUPS_TYPE
             cached, usable = CachedFeed.fetch(
@@ -613,7 +614,7 @@ class AcquisitionFeed(OPDSFeed):
                     # entry point.
                     ep = None
                 return annotator.feed_url(
-                    lane, facets=facets.navigate(entrypoint=entrypoint)
+                    lane, facets=facets.navigate(entrypoint=ep)
                 )
             cls.add_entrypoint_links(
                 feed, make_link, entrypoints, facets.entrypoint

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -11,14 +11,16 @@ from model import (
 from entrypoint import (
     EntryPoint,
     EbooksEntryPoint,
+    EverythingEntryPoint,
     AudiobooksEntryPoint,
     MediumEntryPoint,
 )
 
-class TestEntryPoint(object):
+class TestEntryPoint(DatabaseTest):
 
     def test_defaults(self):
-        ebooks, audiobooks = EntryPoint.ENTRY_POINTS
+        everything, ebooks, audiobooks = EntryPoint.ENTRY_POINTS
+        eq_(EverythingEntryPoint, everything)
         eq_(EbooksEntryPoint, ebooks)
         eq_(AudiobooksEntryPoint, audiobooks)
 
@@ -28,6 +30,13 @@ class TestEntryPoint(object):
 
         eq_(Edition.BOOK_MEDIUM, EbooksEntryPoint.INTERNAL_NAME)
         eq_(Edition.AUDIO_MEDIUM, AudiobooksEntryPoint.INTERNAL_NAME)
+
+    def test_no_changes(self):
+        # EntryPoint doesn't modify queries or searches.
+        qu = self._db.query(Edition)
+        eq_(qu, EntryPoint.apply(qu))
+        args = dict(arg="value")
+        eq_(args, EverythingEntryPoint.modified_search_arguments(**args))
 
     def test_register(self):
 
@@ -68,6 +77,18 @@ class TestEntryPoint(object):
             ValueError, "Duplicate entry point display name: Mock!",
             EntryPoint.register, Mock2, "Mock!"
         )
+
+
+class TestEverythingEntryPoint(DatabaseTest):
+
+    def test_no_changes(self):
+        # EverythingEntryPoint doesn't modify queries or searches
+        # beyond the default behavior for any entry point.
+        qu = self._db.query(Edition)
+        eq_(qu, EntryPoint.apply(qu))
+        args = dict(arg="value")
+        eq_(args, EverythingEntryPoint.modified_search_arguments(**args))
+        eq_("All", EverythingEntryPoint.INTERNAL_NAME)
 
 
 class TestMediumEntryPoint(DatabaseTest):

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -332,8 +332,8 @@ class TestFacets(DatabaseTest):
         )
         eq_([
             ('available', Facets.AVAILABLE_ALL),
-            ('collection', Facets.COLLECTION_MAIN)
-            ('entrypoint', AudiobooksEntryPoint.NAME),
+            ('collection', Facets.COLLECTION_MAIN),
+            ('entrypoint', AudiobooksEntryPoint.INTERNAL_NAME),
             ('order', Facets.ORDER_TITLE)],
             sorted(facets.items())
         )

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -76,6 +76,23 @@ class TestFacetsWithEntryPoint(DatabaseTest):
         f.apply(_db, qu)
         eq_(qu, ep.called_with)
 
+    def test_navigate(self):
+        old_entrypoint = object()
+        kwargs = dict(extra_key="extra_value")
+        facets = FacetsWithEntryPoint(old_entrypoint, **kwargs)
+        new_entrypoint = object()
+        new_facets = facets.navigate(new_entrypoint)
+
+        # A new FacetsWithEntryPoint was created.
+        assert isinstance(new_facets, FacetsWithEntryPoint)
+
+        # It has the new entry point.
+        eq_(new_entrypoint, new_facets.entrypoint)
+
+        # The keyword arguments used to create the origina faceting
+        # object were propagated to its constructor.
+        eq_(kwargs, new_facets.constructor_kwargs)
+
     def test_from_request(self):
         """from_request just calls _from_request."""
         expect = object()
@@ -303,6 +320,23 @@ class TestFacets(DatabaseTest):
         all_groups = list(facets.facet_groups)
         expect = [['order', 'author', False], ['order', 'title', True]]
         eq_(expect, sorted([list(x[:2]) + [x[-1]] for x in all_groups]))
+
+    def test_items(self):
+        """Verify that Facets.items() returns all information necessary
+        to recreate the Facets object.
+        """
+        facets = Facets(
+            self._default_library,
+            Facets.COLLECTION_MAIN, Facets.AVAILABLE_ALL, Facets.ORDER_TITLE,
+            entrypoint=AudiobooksEntryPoint
+        )
+        eq_([
+            ('available', Facets.AVAILABLE_ALL),
+            ('collection', Facets.COLLECTION_MAIN)
+            ('entrypoint', AudiobooksEntryPoint.NAME),
+            ('order', Facets.ORDER_TITLE)],
+            sorted(facets.items())
+        )
 
     def test_order_facet_to_database_field(self):
         from model import MaterializedWorkWithGenre as mwg
@@ -813,6 +847,23 @@ class TestSearchFacets(DatabaseTest):
         worklist.entrypoints = [ep1, ep2]
         eq_([EverythingEntryPoint, ep1, ep2], m(worklist))
 
+        # If EverythingEntryPoint is already in the list, it's not
+        # added twice.
+        worklist.entrypoints = [ep1, EverythingEntryPoint, ep2]
+        eq_(worklist.entrypoints, m(worklist))
+
+    def test_navigation(self):
+        """Navigating from one SearchFacets to another
+        gives a new SearchFacets object, even though SearchFacets doesn't
+        define navigate().
+
+        I.e. this is really a test of FacetsWithEntryPoint.navigate().
+        """
+        facets = SearchFacets(object())
+        new_ep = object()
+        new_facets = facets.navigate(new_ep)
+        assert isinstance(new_facets, SearchFacets)
+        eq_(new_ep, new_facets.entrypoint)
 
 class TestPagination(DatabaseTest):
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -18,8 +18,9 @@ from sqlalchemy import (
 from classifier import Classifier
 
 from entrypoint import (
-    EbooksEntryPoint,
     AudiobooksEntryPoint,
+    EbooksEntryPoint,
+    EverythingEntryPoint,
 )
 
 from external_search import (
@@ -168,6 +169,21 @@ class TestFacetsWithEntryPoint(DatabaseTest):
         # Same behavior if for some reason you try to load an
         # entrypoint but don't provide a associated WorkList.
         eq_(None, m(audio.INTERNAL_NAME, None))
+
+    def test_available_entrypoints(self):
+        """The default implementation of available_entrypoints just returns
+        the worklist's entrypoints.
+        """
+        class MockWorkList(object):
+            def __init__(self, entrypoints):
+                self.entrypoints = entrypoints
+
+        mock_entrypoints = object()
+        worklist = MockWorkList(mock_entrypoints)
+
+        m = FacetsWithEntryPoint.available_entrypoints
+        eq_(mock_entrypoints, m(worklist))
+        eq_([], m(None))
 
 
 class TestFacets(DatabaseTest):
@@ -768,6 +784,34 @@ class TestFeaturedFacets(DatabaseTest):
         eq_(
             work_model.works_id, distinct_query._distinct[-1]
         )
+
+
+class TestSearchFacets(DatabaseTest):
+
+    def test_available_entrypoints(self):
+        """If the WorkList has more than one facet, an 'everything' facet
+        is added for search purposes.
+        """
+        class MockWorkList(object):
+            def __init__(self):
+                self.entrypoints = None
+
+        ep1 = object()
+        ep2 = object()
+        worklist = MockWorkList()
+
+        # No WorkList, no EntryPoints.
+        m = SearchFacets.available_entrypoints
+        eq_([], m(None))
+
+        # If there is one EntryPoint, it is returned as-is.
+        worklist.entrypoints = [ep1]
+        eq_([ep1], m(worklist))
+
+        # If there are multiple EntryPoints, EverythingEntryPoint
+        # shows up at the beginning.
+        worklist.entrypoints = [ep1, ep2]
+        eq_([EverythingEntryPoint, ep1, ep2], m(worklist))
 
 
 class TestPagination(DatabaseTest):


### PR DESCRIPTION
The overall goal of this branch is to add an 'All' entry point that puts no extra restrictions on which part of a lane is shown. You can turn on this entry point and show it everywhere, but it's not on by default, and even if it's off, it will show up in search results.

The centerpiece of this branch is `FacetsWithEntryPoint.available_entrypoints`, which allows a faceting object to modify the list of EntryPoints. The OPDS generation code uses `available_entrypoints` everywhere it used to look at `worklist.entrypoints`.

To make sure all relevant URL arguments are propagated, the OPDS generation code now relies more heavily on `navigate` and less on explicitly calling the constructor with different arguments. The `navigate` implementations have been changed to be more careful about creating a new object of the same class and passing in all information that was passed in to the previous faceting object.