### PR TITLE
Add a script to mirror unmirrored items if possible

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -552,7 +552,7 @@ class MetaToModelUtility(object):
         if edition and edition.title:
             title = edition.title
         else:
-            title = self.title or None
+            title = getattr(self, 'title', None) or None
 
         if ((not identifier) or (link_obj.identifier and identifier != link_obj.identifier)):
             # insanity found

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -500,6 +500,8 @@ class MetaToModelUtility(object):
     Contains functionality common to both CirculationData and Metadata.
     """
 
+    log = logging.getLogger("Abstract metadata layer - mirror code")
+
     def mirror_link(self, model_object, data_source, link, link_obj, policy):
         """Retrieve a copy of the given link and make sure it gets
         mirrored. If it's a full-size image, create a thumbnail and

--- a/model.py
+++ b/model.py
@@ -5833,9 +5833,8 @@ class Resource(Base):
         """If this Resource is used in a LicensePoolDeliveryMechanism for the
         given LicensePool, return that LicensePoolDeliveryMechanism.
         """
-        for lpdm in licensepooldeliverymechanisms:
-            if (lpdm.identifier == licensepool.identifier
-                and lpdm.data_source == licensepool.data_source):
+        for lpdm in licensepool.delivery_mechanisms:
+            if lpdm.resource == self:
                 return lpdm
 
     def set_mirrored_elsewhere(self, media_type):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5137,8 +5137,12 @@ class TestHyperlink(DatabaseTest):
         c1 = self._default_collection
         c1.data_source = ds
 
-        i1 = self._identifier()
-        c1.catalog_identifier(i1)
+        # Here's an Identifier associated with a collection.
+        work = self._work(with_license_pool=True, collection=c1)
+        [pool] = work.license_pools
+        i1 = pool.identifier
+
+        # This is a random identifier not associated with the collection.
         i2 = self._identifier()
 
         def m():
@@ -5153,8 +5157,8 @@ class TestHyperlink(DatabaseTest):
         wrong_type.resource.set_mirrored_elsewhere("text/plain")
         eq_([], m())
 
-        # Hyperlink has no associated representation -- mirroring will
-        # create one!
+        # Hyperlink has no associated representation -- it needs to be
+        # mirrored, which will create one!
         hyperlink, ignore = i1.add_link(Hyperlink.IMAGE, self._url, ds)
         eq_([hyperlink], m())
 
@@ -5169,7 +5173,7 @@ class TestHyperlink(DatabaseTest):
         eq_([hyperlink], m())
 
         # Hyperlink is associated with a data source other than the
-        # data source of the collection. It should be mirrored, but
+        # data source of the collection. It ought to be mirrored, but
         # this collection isn't responsible for mirroring it.
         hyperlink.data_source = overdrive
         eq_([], m())

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5190,7 +5190,8 @@ class TestResource(DatabaseTest):
         # If there's no relationship between the Resource and 
         # the LicensePoolDeliveryMechanism, as_delivery_mechanism_for
         # returns None.
-        unrelated = self._licensepool()
+        w2 = self._work(with_license_pool=True)
+        [unrelated] = w2.license_pools
         eq_(None, lpdm.resource.as_delivery_mechanism_for(unrelated))
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5175,6 +5175,25 @@ class TestHyperlink(DatabaseTest):
         eq_([], m())
 
 
+class TestResource(DatabaseTest):
+
+    def test_as_delivery_mechanism_for(self):
+
+        # Calling as_delivery_mechanism_for on a Resource that is used
+        # to deliver a specific LicensePool returns the appropriate
+        # LicensePoolDeliveryMechanism.
+        work = self._work(with_open_access_download=True)
+        [pool] = work.license_pools
+        [lpdm] = pool.delivery_mechanisms
+        eq_(lpdm, lpdm.resource.as_delivery_mechanism_for(pool))
+
+        # If there's no relationship between the Resource and 
+        # the LicensePoolDeliveryMechanism, as_delivery_mechanism_for
+        # returns None.
+        unrelated = self._licensepool()
+        eq_(None, lpdm.resource.as_delivery_mechanism_for(unrelated))
+
+
 class TestRepresentation(DatabaseTest):
 
     def test_normalized_content_path(self):


### PR DESCRIPTION
This branch adds a script that, after the fact,  goes through unmirrored Resources that were not mirrored on initial import, and mirrors them.

It's not perfect because it doesn't capture the entire context in which we heard about the item that needs mirroring. In particular, it doesn't always work with FeedBooks books, because we might need to unzip the books and replace the CSS files, but outside of a FeedbooksImporter we don't know if we do, in fact, have to do this. But we do check the rights status of the books we're mirroring to make sure we have the rights to mirror them.

Sometimes Feedbooks OPDS feeds show a rights status that are incorrect from a US perspective, but by the time the information gets into the database (which is where this script works), the information has been translated to the US copyright regime.

A larger underlying problem is https://github.com/NYPL-Simplified/server_core/issues/848, which makes many resources look "mirrored" when they actually haven't been.