### PR TITLE
Mention a work's customlists in its search document

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -263,7 +263,7 @@ class ExternalSearchIndex(object):
         return base_works_index
 
     def query_works(self, library, query_string, media, languages, fiction, audiences,
-                    target_age, in_any_of_these_genres=[], fields=None, size=30, offset=0):
+                    target_age, in_any_of_these_genres=[], on_any_of_these_lists=[], fields=None, size=30, offset=0):
         if not self.works_alias:
             return []
 
@@ -280,7 +280,8 @@ class ExternalSearchIndex(object):
 
         filter = self.make_filter(
             collection_ids, media, languages, fiction, 
-            audiences, target_age, in_any_of_these_genres
+            audiences, target_age, in_any_of_these_genres,
+            on_any_of_these_lists
         )
         q = dict(
             filtered=dict(
@@ -532,7 +533,7 @@ class ExternalSearchIndex(object):
             }
         }
         
-    def make_filter(self, collection_ids, media, languages, fiction, audiences, target_age, genres):
+    def make_filter(self, collection_ids, media, languages, fiction, audiences, target_age, genres, customlist_ids):
         def _f(s):
             if not s:
                 return s
@@ -562,6 +563,8 @@ class ExternalSearchIndex(object):
                 # no longer happen but we'll handle it.
                 genre_ids = [genre.id for genre in genres]
             clauses.append(dict(terms={"genres.term": genre_ids}))
+        if customlist_ids:
+            clauses.append(dict(terms={"list_id": customlist_ids}))
         if media:
             media = [_f(medium) for medium in media]
             clauses.append(dict(terms=dict(medium=media)))

--- a/external_search.py
+++ b/external_search.py
@@ -263,7 +263,7 @@ class ExternalSearchIndex(object):
         return base_works_index
 
     def query_works(self, library, query_string, media, languages, fiction, audiences,
-                    target_age, in_any_of_these_genres=[], on_any_of_these_lists=[], fields=None, size=30, offset=0):
+                    target_age, in_any_of_these_genres=[], on_any_of_these_lists=None, fields=None, size=30, offset=0):
         if not self.works_alias:
             return []
 
@@ -563,7 +563,7 @@ class ExternalSearchIndex(object):
                 # no longer happen but we'll handle it.
                 genre_ids = [genre.id for genre in genres]
             clauses.append(dict(terms={"genres.term": genre_ids}))
-        if customlist_ids:
+        if customlist_ids is not None:
             clauses.append(dict(terms={"list_id": customlist_ids}))
         if media:
             media = [_f(medium) for medium in media]

--- a/lane.py
+++ b/lane.py
@@ -876,6 +876,13 @@ class WorkList(object):
         return []
 
     @property
+    def customlist_ids(self):
+        """WorkLists per se are not associated with custom lists, although
+        Lanes might be.
+        """
+        return None
+
+    @property
     def full_identifier(self):
         """A human-readable identifier for this WorkList that
         captures its position within the heirarchy.
@@ -1325,6 +1332,7 @@ class WorkList(object):
                 audiences=self.audiences,
                 target_age=target_age,
                 in_any_of_these_genres=self.genre_ids,
+                on_any_of_these_lists=self.customlist_ids,
             )
             if facets and facets.entrypoint:
                 kwargs = facets.entrypoint.modified_search_arguments(**kwargs)
@@ -1943,10 +1951,16 @@ class Lane(Base, WorkList):
                 [CustomList.id],
                 CustomList.data_source_id==self.list_datasource.id
             )
-            return [x[0] for x in _db.execute(query)]
+            ids = [x[0] for x in _db.execute(query)]
         else:
             # Find the IDs of some specific CustomLists.
-            return [x.id for x in self.customlists]
+            ids = [x.id for x in self.customlists]
+        if len(ids) == 0:
+            # Return None to make it clear that we mean "there is no
+            # custom list restriction" rather than "exclude
+            # everything".
+            return None
+        return ids
 
     @classmethod
     def affected_by_customlist(self, customlist):

--- a/lane.py
+++ b/lane.py
@@ -1921,6 +1921,17 @@ class Lane(Base, WorkList):
             )
         return genre_ids
 
+    @property
+    def customlist_ids(self):
+        """Find the database ID of every CustomList such that a Work filed
+        in that List should be in this Lane.
+
+        :return: A list of CustomList IDs, possibly empty.
+        """
+        # TODO: We need to consider the 'all custom lists for a data source'
+        # case.
+        return [x.id for x in self.customlists]
+
     @classmethod
     def affected_by_customlist(self, customlist):
         """Find all Lanes whose membership is partially derived

--- a/lane.py
+++ b/lane.py
@@ -1956,10 +1956,14 @@ class Lane(Base, WorkList):
             # Find the IDs of some specific CustomLists.
             ids = [x.id for x in self.customlists]
         if len(ids) == 0:
-            # Return None to make it clear that we mean "there is no
-            # custom list restriction" rather than "exclude
-            # everything".
-            return None
+            if self.list_datasource:
+                # We are restricted to all lists from a given data
+                # source, and there are no such lists, so we want to
+                # exclude everything.
+                return []
+            else:
+                # There is no custom list restriction at all.
+                return None
         return ids
 
     @classmethod

--- a/migration/20180419-remove-all-search-coverage.sql
+++ b/migration/20180419-remove-all-search-coverage.sql
@@ -1,0 +1,3 @@
+-- Remove all WorkCoverageRecords pertaining to the search index. This
+-- will force a complete reindex on the next run of bin/search_index_refresh.
+delete from workcoveragerecords where operation='update-search-index';

--- a/model.py
+++ b/model.py
@@ -9584,6 +9584,11 @@ class CustomList(Base):
         if was_new:
             self.updated = datetime.datetime.utcnow()
 
+        # Make sure the Work's search document is updated to reflect its new
+        # list membership.
+        if entry.work:
+            entry.work.external_index_needs_updating()
+
         return entry, was_new
 
     def remove_entry(self, work_or_edition):
@@ -9594,6 +9599,11 @@ class CustomList(Base):
 
         existing_entries = list(self.entries_for_work(work_or_edition))
         for entry in existing_entries:
+            if entry.work:
+                # Make sure the Work's search document is updated to
+                # reflect its new list membership.
+                entry.work.external_index_needs_updating()
+
             _db.delete(entry)
 
         if existing_entries:

--- a/opds.py
+++ b/opds.py
@@ -783,7 +783,7 @@ class AcquisitionFeed(OPDSFeed):
             AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, rel="previous", href=previous_url)
 
         # Add "up" link and breadcrumbs
-        AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, rel="up", href=annotator.lane_url(lane), title=str(lane.display_name))
+        AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, rel="up", href=annotator.lane_url(lane), title=unicode(lane.display_name))
         opds_feed.add_breadcrumbs(lane, annotator, include_lane=True)
 
         annotator.annotate_feed(opds_feed, lane)

--- a/tests/test_cdn.py
+++ b/tests/test_cdn.py
@@ -9,6 +9,18 @@ from config import Configuration, temp_config
 from model import ExternalIntegration
 from cdn import cdnify
 
+from core.model import Work
+
+class TestSubtransaction(DatabaseTest):
+
+    def test_subtransaction(self):
+        transaction = self._db.begin_nested()
+        work = self._work(title="out, brief candle")
+        transaction.rollback()
+        eq_([], self._db.query(Work).all())
+
+    def test_zzz(self):
+        eq_([], self._db.query(Work).all())
 
 class TestCDN(DatabaseTest):
 

--- a/tests/test_cdn.py
+++ b/tests/test_cdn.py
@@ -9,18 +9,6 @@ from config import Configuration, temp_config
 from model import ExternalIntegration
 from cdn import cdnify
 
-from core.model import Work
-
-class TestSubtransaction(DatabaseTest):
-
-    def test_subtransaction(self):
-        transaction = self._db.begin_nested()
-        work = self._work(title="out, brief candle")
-        transaction.rollback()
-        eq_([], self._db.query(Work).all())
-
-    def test_zzz(self):
-        eq_([], self._db.query(Work).all())
 
 class TestCDN(DatabaseTest):
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -334,6 +334,13 @@ class TestExternalSearchWithWorks(ExternalSearchTest):
             self.sherlock_spanish.presentation_edition.language = "es"
             self.sherlock_spanish.set_presentation_ready()
 
+            # Create a custom list that contains a few books.
+            self.presidential, ignore = self._customlist(
+                name="Nonfiction about US Presidents", num_entries=0
+            )
+            for work in [self.washington, self.lincoln, self.obama]:
+                self.presidential.add_entry(work)
+
             # Create a second collection that only contains a few books.
             self.tiny_collection = self._collection("A Tiny Collection")
             self.tiny_book = self._work(
@@ -371,7 +378,6 @@ class TestExternalSearchWithWorks(ExternalSearchTest):
             return self.search.query_works(
                 self._default_library, *args, **kwargs
             )
-        
 
         # Pagination
 
@@ -781,6 +787,15 @@ class TestExternalSearchWithWorks(ExternalSearchTest):
         hits = results["hits"]["hits"]
         eq_(2, len(hits))
 
+        # Filters on list membership.
+        # This ignores 'Abraham Lincoln, Vampire Hunter' because that
+        # book isn't on the list.
+        results = query("lincoln", None, None, None, None, None, None, on_any_of_these_lists=[self.presidential.id])
+        hits = results['hits']['hits']
+        eq_(1, len(hits))
+        eq_(unicode(self.lincoln.id), hits[0]["_id"])
+
+
         # This query does not match anything because the book in
         # question is not in a collection associated with the default
         # library.
@@ -1185,7 +1200,7 @@ class TestSearchFilterFromLane(DatabaseTest):
             collection_ids,
             lane.media, lane.languages,
             lane.fiction, list(lane.audiences), lane.target_age,
-            lane.genre_ids,
+            lane.genre_ids, lane.customlist_ids,
         )
         [collection_filter] = filter['and']
         expect = [
@@ -1203,7 +1218,7 @@ class TestSearchFilterFromLane(DatabaseTest):
             [self._default_collection.id],
             lane.media, lane.languages,
             lane.fiction, lane.audiences, lane.target_age,
-            lane.genre_ids,
+            lane.genre_ids, lane.customlist_ids,
         )
         collection_filter, medium_filter = filter['and']
         expect = dict(terms=dict(medium=[Edition.AUDIO_MEDIUM.lower()]))
@@ -1218,7 +1233,7 @@ class TestSearchFilterFromLane(DatabaseTest):
             [self._default_collection.id],
             lane.media, lane.languages,
             lane.fiction, list(lane.audiences), lane.target_age,
-            lane.genre_ids,
+            lane.genre_ids, lane.customlist_ids,
         )
 
         collection_filter, audience_filter, target_age_filter = filter['and']
@@ -1236,7 +1251,7 @@ class TestSearchFilterFromLane(DatabaseTest):
             [self._default_collection.id],
             lane.media, lane.languages,
             lane.fiction, lane.audiences, lane.target_age,
-            lane.genre_ids,
+            lane.genre_ids, lane.customlist_ids,
         )
         
         collection_filter, languages_filter = filter['and']

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -795,6 +795,11 @@ class TestExternalSearchWithWorks(ExternalSearchTest):
         eq_(1, len(hits))
         eq_(unicode(self.lincoln.id), hits[0]["_id"])
 
+        # This filters everything, since the query is restricted to
+        # an empty set of lists.
+        results = query("lincoln", None, None, None, None, None, None, on_any_of_these_lists=[])
+        hits = results['hits']['hits']
+        eq_(0, len(hits))
 
         # This query does not match anything because the book in
         # question is not in a collection associated with the default

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -2018,6 +2018,14 @@ class TestLane(DatabaseTest):
         )
         eq_(set([nyt1.id, nyt2.id]), set(has_list_source.customlist_ids))
 
+        # If there are no CustomLists from that data source, an empty
+        # list is returned.
+        has_no_lists = self._lane()
+        has_no_lists.list_datasource = DataSource.lookup(
+            self._db, DataSource.OVERDRIVE
+        )
+        eq_([], has_no_lists.customlist_ids)
+
     def test_search_target(self):
 
         # A Lane that is the root for a patron type can be

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1978,6 +1978,32 @@ class TestLane(DatabaseTest):
         assert len(no_inclusive_genres.genre_ids) > 10
         assert science_fiction.id not in no_inclusive_genres.genre_ids
 
+    def test_customlist_ids(self):
+        # When you add a CustomList to a Lane, you are saying that works
+        # from that CustomList can appear in the Lane.
+        nyt1, ignore = self._customlist(
+            num_entries=0, data_source_name=DataSource.NYT
+        )
+        nyt2, ignore = self._customlist(
+            num_entries=0, data_source_name=DataSource.NYT
+        )
+
+        no_lists = self._lane()
+        eq_([], no_lists.customlist_ids)
+
+        has_list = self._lane()
+        has_list.customlists.append(nyt1)
+        eq_([nyt1.id], has_list.customlist_ids)
+
+        # When you set a Lane's list_datasource, you're saying that
+        # works appear in the Lane if they are on _any_ CustomList from
+        # that data source.
+        has_list_source = self._lane()
+        has_list_source.list_datasource = DataSource.lookup(
+            self._db, DataSource.NYT
+        )
+        eq_(set([nyt1.id, nyt2.id]), set(has_list_source.customlist_ids))
+
     def test_search_target(self):
 
         # A Lane that is the root for a patron type can be


### PR DESCRIPTION
This branch implements https://github.com/NYPL-Simplified/server_core/issues/852 by making a Work's list memberships part of its search document. When a Lane is searched, the CustomLists associated with that lane are passed into the search engine, a work must be on one of those lists to match the search query.

This makes it possible to search within lanes based on custom lists.

When a list is added to or removed from a custom list, it is flagged for reindexing.

I would especially value a close look at my changes to `make_filter`.