### PR TITLE
EPUB_MEDIA_TYPE/BEARER_TOKEN is now supported.

### DIFF
--- a/migration/20180427-bearer-token-supported-by-default.sql
+++ b/migration/20180427-bearer-token-supported-by-default.sql
@@ -1,0 +1,1 @@
+update deliverymechanisms set default_client_can_fulfill=true where content_type='application/epub+zip' and drm_scheme='application/vnd.librarysimplified.bearer-token+json';

--- a/model.py
+++ b/model.py
@@ -9331,6 +9331,7 @@ class DeliveryMechanism(Base, HasFullTableCache):
     default_client_can_fulfill_lookup = set([
         (Representation.EPUB_MEDIA_TYPE, NO_DRM),
         (Representation.EPUB_MEDIA_TYPE, ADOBE_DRM),
+        (Representation.EPUB_MEDIA_TYPE, BEARER_TOKEN),
     ])
 
     license_pool_delivery_mechanisms = relationship(


### PR DESCRIPTION
This branch changes the database to reflect the fact that SimplyE now supports EPUBs delivered through bearer token exchange.

Bizarrely, this does not seem to have any effect on whether books with these delivery mechanisms show up in the materialized view or search results, so even without this change, these titles can be seen and fulfilled by SimplyE. It does change the behavior of `LicensePool.deliverable` but I'm not sure where that's called.