### PR TITLE
Fix URLs generated by OpenSearch

### DIFF
--- a/opensearch.py
+++ b/opensearch.py
@@ -26,7 +26,11 @@ class OpenSearchDocument(object):
 
     @classmethod
     def for_lane(cls, lane, base_url):
+        if '?' in base_url:
+            query = '&'
+        else:
+            query = '?'
         info = cls.search_info(lane)
-        info['url_template'] = base_url + "?q={searchTerms}"
+        info['url_template'] = base_url + query + "q={searchTerms}"
 
         return cls.TEMPLATE % info

--- a/opensearch.py
+++ b/opensearch.py
@@ -25,12 +25,16 @@ class OpenSearchDocument(object):
         return d
 
     @classmethod
-    def for_lane(cls, lane, base_url):
+    def url_template(self, base_url):
+        """Turn a base URL into an OpenSearch URL template."""
         if '?' in base_url:
             query = '&'
         else:
             query = '?'
-        info = cls.search_info(lane)
-        info['url_template'] = base_url + query + "q={searchTerms}"
+        return base_url + query + "q={searchTerms}"
 
+    @classmethod
+    def for_lane(cls, lane, base_url):
+        info = cls.search_info(lane)
+        info['url_template'] = cls.url_template(base_url)
         return cls.TEMPLATE % info

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -40,3 +40,34 @@ class TestOpenSearchDocument(DatabaseTest):
         eq_("Search Science Fiction &amp; Fantasy", info['description'])
         eq_("science-fiction-&amp;-fantasy", info['tags'])
     
+    def test_url_template(self):
+        """Verify that url_template generates sensible URL templates."""
+        m = OpenSearchDocument.url_template
+        eq_("http://url/?q={searchTerms}", m("http://url/"))
+        eq_("http://url/?key=val&q={searchTerms}", m("http://url/?key=val"))
+
+    def test_for_lane(self):
+
+        class Mock(OpenSearchDocument):
+            """Mock methods called by for_lane."""
+            @classmethod
+            def search_info(cls, lane):
+                return dict(
+                    name="name",
+                    description="description",
+                    tags=["tag"],
+                )
+
+            @classmethod
+            def url_template(cls, base_url):
+                return "http://template/"
+
+        # Here's the search document.
+        doc = Mock.for_lane(object(), object())
+
+        # It's just the result of calling search_info() and url_template(),
+        # and using the resulting dict as arguments into TEMPLATE.
+        expect = Mock.search_info(object())
+        expect['url_template'] = Mock.url_template(object())
+        eq_(Mock.TEMPLATE % expect, doc)
+


### PR DESCRIPTION
This branch prevents a situation where the URL template in an OpenSearch document contains two question marks.

This branch adds test coverage for OpenSearchDocument.for_lane, which was previously missing.