### PR TITLE
Stop the OPDS import if the server serves a non-Atom feed while we're following 'next' links

### DIFF
--- a/opds_import.py
+++ b/opds_import.py
@@ -1639,7 +1639,17 @@ class OPDSImportMonitor(CollectionMonitor):
         """
         self.log.info("Following next link: %s", url)
         get = do_get or self._get
-        status_code, content_type, feed = get(url, {})
+        status_code, headers, feed = get(url, {})
+
+        # Make sure we got an OPDS feed, and not an error page that was
+        # sent with a 200 status code.
+        media_type = headers.get('content-type')
+        if not media_type or OPDSFeed.ATOM_TYPE not in media_type:
+            message = "Expected Atom feed, got %s" % media_type
+            raise BadResponseException(
+                url, message=message, debug_message=feed,
+                status_code=status_code
+            )
 
         new_data = self.feed_contains_new_data(feed)
 

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -8,6 +8,8 @@ from nose.tools import set_trace
 
 class AtomFeed(object):
 
+    ATOM_TYPE = 'application/atom+xml'
+
     TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ%z'
 
     ATOM_NS = 'http://www.w3.org/2005/Atom'
@@ -150,9 +152,9 @@ class AtomFeed(object):
 
 class OPDSFeed(AtomFeed):
 
-    ACQUISITION_FEED_TYPE = "application/atom+xml;profile=opds-catalog;kind=acquisition"
-    NAVIGATION_FEED_TYPE = "application/atom+xml;profile=opds-catalog;kind=navigation"
-    ENTRY_TYPE = "application/atom+xml;type=entry;profile=opds-catalog"
+    ACQUISITION_FEED_TYPE = AtomFeed.ATOM_TYPE + ";profile=opds-catalog;kind=acquisition"
+    NAVIGATION_FEED_TYPE = AtomFeed.ATOM_TYPE + ";profile=opds-catalog;kind=navigation"
+    ENTRY_TYPE = AtomFeed.ATOM_TYPE + ";type=entry;profile=opds-catalog"
 
     GROUP_REL = "collection"
     FEATURED_REL = "http://opds-spec.org/featured"


### PR DESCRIPTION
This fixes https://github.com/NYPL-Simplified/server_core/issues/858.

The problem is 'fixed' by preventing the OPDS import from starting if it appears that doing so would miss content. So, in any particular case, the underlying issue will still need to be addressed.