### PR TITLE
Make it possible to collect an analytics event not associated with any particular library.

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -37,5 +37,8 @@ class Analytics(object):
     def collect_event(self, library, license_pool, event_type, time=None, **kwargs):
         if not time:
             time = datetime.datetime.utcnow()
-        for provider in (self.sitewide_providers + self.library_providers[library.id]):
+        providers = list(self.sitewide_providers)
+        if library:
+            providers.extend(self.library_providers[library.id])
+        for provider in providers:
             provider.collect_event(library, license_pool, event_type, time, **kwargs)

--- a/local_analytics_provider.py
+++ b/local_analytics_provider.py
@@ -18,7 +18,7 @@ class LocalAnalyticsProvider(object):
 
     def collect_event(self, library, license_pool, event_type, time, 
         old_value=None, new_value=None, **kwargs):
-        _db = Session.object_session(library)
+        _db = Session.object_session(license_pool)
         if library and self.library_id and library.id != self.library_id:
             return
         

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -111,3 +111,11 @@ class TestAnalytics(DatabaseTest):
         eq_(2, sitewide_provider.count)
         eq_(1, library_provider.count)
         eq_(CirculationEvent.DISTRIBUTOR_CHECKIN, library_provider.event_type)
+
+        # Here's an event that we couldn't associate with any
+        # particular library.
+        analytics.collect_event(None, lp, CirculationEvent.DISTRIBUTOR_CHECKOUT, None)
+
+        # It's counted as a sitewide event, but not as a library event.
+        eq_(3, sitewide_provider.count)
+        eq_(1, library_provider.count)


### PR DESCRIPTION
Currently, if a CirculationEvent comes through not associated with any library, the event handling code will crash. Although ideally every incoming event would be associated with a library, this branch avoids the crash and makes sure the event is at least passed into any global event handlers.

The real-world event that causes this problem is when a title is fulfilled anonymously, with no underlying loan (the subject of https://github.com/NYPL-Simplified/circulation/pull/953). We derive the affected library from the Patron object, so when there is no Patron object we don't know which library is affected. We can fix this later by changing some method signatures to also pass in a Library object, but I don't think it matters very much.