### PR TITLE
Collecting a local event requires a library _or_ a license pool

### DIFF
--- a/local_analytics_provider.py
+++ b/local_analytics_provider.py
@@ -18,6 +18,8 @@ class LocalAnalyticsProvider(object):
 
     def collect_event(self, library, license_pool, event_type, time, 
         old_value=None, new_value=None, **kwargs):
+        if not library and not license_pool:
+            raise ValueError("Either library or license_pool must be provided.")
         if library:
             _db = Session.object_session(library)
         else:

--- a/local_analytics_provider.py
+++ b/local_analytics_provider.py
@@ -18,7 +18,10 @@ class LocalAnalyticsProvider(object):
 
     def collect_event(self, library, license_pool, event_type, time, 
         old_value=None, new_value=None, **kwargs):
-        _db = Session.object_session(license_pool)
+        if library:
+            _db = Session.object_session(library)
+        else:
+            _db = Session.object_session(license_pool)
         if library and self.library_id and library.id != self.library_id:
             return
         

--- a/tests/test_local_analytics_provider.py
+++ b/tests/test_local_analytics_provider.py
@@ -1,4 +1,5 @@
 from nose.tools import (
+    assert_raises_regexp,
     eq_,
 )
 from local_analytics_provider import LocalAnalyticsProvider
@@ -12,14 +13,19 @@ import datetime
 
 class TestLocalAnalyticsProvider(DatabaseTest):
 
-    def test_collect_event(self):
-        library2 = self._library()
-
-        integration, ignore = create(
+    def setup(self):
+        super(TestLocalAnalyticsProvider, self).setup()
+        self.integration, ignore = create(
             self._db, ExternalIntegration,
             goal=ExternalIntegration.ANALYTICS_GOAL,
             protocol="core.local_analytics_provider")
-        la = LocalAnalyticsProvider(integration, self._default_library)
+        self.la = LocalAnalyticsProvider(
+            self.integration, self._default_library
+        )
+
+    def test_collect_event(self):
+        library2 = self._library()
+
         work = self._work(
             title="title", authors="author", fiction=True,
             audience="audience", language="lang",
@@ -27,7 +33,7 @@ class TestLocalAnalyticsProvider(DatabaseTest):
         )
         [lp] = work.license_pools
         now = datetime.datetime.utcnow()
-        la.collect_event(
+        self.la.collect_event(
             self._default_library, lp, CirculationEvent.DISTRIBUTOR_CHECKIN, now,
             old_value=None, new_value=None)
 
@@ -44,14 +50,14 @@ class TestLocalAnalyticsProvider(DatabaseTest):
         # The LocalAnalyticsProvider will not handle an event intended
         # for a different library.
         now = datetime.datetime.now()
-        la.collect_event(
+        self.la.collect_event(
             library2, lp, CirculationEvent.DISTRIBUTOR_CHECKIN, now,
             old_value=None, new_value=None)
         eq_(1, qu.count())
 
         # It's possible to instantiate the LocalAnalyticsProvider
         # without a library.
-        la = LocalAnalyticsProvider(integration)
+        la = LocalAnalyticsProvider(self.integration)
 
         # In that case, it will process events for any library.
         for library in [self._default_library, library2]:
@@ -61,3 +67,19 @@ class TestLocalAnalyticsProvider(DatabaseTest):
                              old_value=None, new_value=None
             )
         eq_(3, qu.count())
+
+    def test_collect_with_missing_information(self):
+        """A circulation event may be collected with either the
+        library or the license pool missing, but not both.
+        """
+        now = datetime.datetime.now()
+        self.la.collect_event(self._default_library, None, "event", now)
+
+        pool = self._licensepool(None)
+        self.la.collect_event(None, pool, "event", now)
+
+        assert_raises_regexp(
+            ValueError,
+            "Either library or license_pool must be provided.",
+            self.la.collect_event, None, None, "event", now
+        )


### PR DESCRIPTION
https://github.com/NYPL-Simplified/server_core/pull/862 made it possible to collect local circulation events associated with a license pool but not a library. But there are also circulation events (like 'new patron') which are associated with a library but no license pool. This branch makes collect_event work if either the library or the license pool is not present. However, at least one of them must be present.