### PR TITLE
Annotate OPDS <feed> tags with a URI for the currently selected EntryPoint.

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -28,6 +28,10 @@ class EntryPoint(object):
     DISPLAY_TITLES = {}
     BY_INTERNAL_NAME = {}
 
+    # A distinctive URI designating the sort of thing found through this
+    # EntryPoint.
+    URI = None
+
     @classmethod
     def register(cls, entrypoint_class, display_title, default_enabled=False):
         """Register the given subclass with the master registry
@@ -104,6 +108,7 @@ class EntryPoint(object):
 class EverythingEntryPoint(EntryPoint):
     """An entry point that has everything."""
     INTERNAL_NAME = "All"
+    URI = "http://schema.org/CreativeWork"
 EntryPoint.register(EverythingEntryPoint, "All")
 
 
@@ -111,6 +116,9 @@ class MediumEntryPoint(EntryPoint):
     """A entry point that creates a view on one specific medium.
 
     The medium is expected to be the entry point's INTERNAL_NAME.
+
+    The URI is expected to be the one in
+    Edition.schema_to_additional_type[INTERNAL_NAME]
     """
 
     @classmethod
@@ -132,8 +140,10 @@ class MediumEntryPoint(EntryPoint):
 
 class EbooksEntryPoint(MediumEntryPoint):
     INTERNAL_NAME = "Book"
+    URI = u"http://schema.org/EBook"
 EntryPoint.register(EbooksEntryPoint, "Books", default_enabled=True)
 
 class AudiobooksEntryPoint(MediumEntryPoint):
     INTERNAL_NAME = "Audio"
+    URI = u"http://bib.schema.org/Audiobook"
 EntryPoint.register(AudiobooksEntryPoint, "Audio")

--- a/opds.py
+++ b/opds.py
@@ -558,7 +558,7 @@ class AcquisitionFeed(OPDSFeed):
                 feed, make_link, entrypoints, facets.entrypoint
             )
 
-        cls.add_breadcrumb_links(feed, lane, facets.entrypoint)
+        feed.add_breadcrumb_links(lane, facets.entrypoint)
         annotator.annotate_feed(feed, lane)
 
         content = unicode(feed)

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -31,6 +31,10 @@ class TestEntryPoint(DatabaseTest):
         eq_(Edition.BOOK_MEDIUM, EbooksEntryPoint.INTERNAL_NAME)
         eq_(Edition.AUDIO_MEDIUM, AudiobooksEntryPoint.INTERNAL_NAME)
 
+        eq_("http://schema.org/CreativeWork", everything.URI)
+        for ep in (EbooksEntryPoint, AudiobooksEntryPoint):
+            eq_(ep.URI, Edition.medium_to_additional_type[ep.INTERNAL_NAME])
+
     def test_no_changes(self):
         # EntryPoint doesn't modify queries or searches.
         qu = self._db.query(Edition)


### PR DESCRIPTION
This branch adds a `simplified:entryPoint` attribute to the `<atom:feed>` tag when an EntryPoint is selected.

I added test coverage for add_breadcrumb_links, which previously had no standalone test coverage. I was able to simplify the signature by making it an instance method -- previously it was a class method that took an instance as its first argument, so it was effectively an instance method already.