### PR TITLE
Update the scripts that explain why books are or aren't available.

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -2872,6 +2872,15 @@ class Explain(IdentifierInputScript):
 
     def explain_license_pool(self, pool):
         self.write("Licensepool info:")
+        if pool.collection:
+            self.write(" Collection: %r" % pool.collection)
+        else:
+            self.write(" Not in any collection!")
+        libraries = [library.name for library in pool.collection.libraries]
+        if libraries:
+            self.write(" Available to libraries: %s" % ", ".join(libraries))
+        else:
+            self.write("Not available to any libraries!")
         self.write(" Delivery mechanisms:")
         if pool.delivery_mechanisms:
             for lpdm in pool.delivery_mechanisms:

--- a/scripts.py
+++ b/scripts.py
@@ -2874,13 +2874,13 @@ class Explain(IdentifierInputScript):
         self.write("Licensepool info:")
         if pool.collection:
             self.write(" Collection: %r" % pool.collection)
+            libraries = [library.name for library in pool.collection.libraries]
+            if libraries:
+                self.write(" Available to libraries: %s" % ", ".join(libraries))
+            else:
+                self.write("Not available to any libraries!")
         else:
             self.write(" Not in any collection!")
-        libraries = [library.name for library in pool.collection.libraries]
-        if libraries:
-            self.write(" Available to libraries: %s" % ", ".join(libraries))
-        else:
-            self.write("Not available to any libraries!")
         self.write(" Delivery mechanisms:")
         if pool.delivery_mechanisms:
             for lpdm in pool.delivery_mechanisms:

--- a/scripts.py
+++ b/scripts.py
@@ -3033,7 +3033,35 @@ class FixInvisibleWorksScript(CollectionInputScript):
         self.output.write(
             "I would now expect you to be able to find %d works.\n" % mv_works_count
         )
+        self.check_libraries()
 
+    def check_libraries(self):
+        """Assuming that works are properly in the materialized view,
+        make sure the libraries are equipped to show them.
+        """
+        # Now check each library.
+        libraries = self._db.query(Library).all()
+        if libraries:
+            for library in libraries:
+                self.check_library(library)
+        else:
+            self.output.write("There are no libraries in the system -- that's a problem.\n")
+
+    def check_library(self, library):
+        self.output.write("Checking library %s\n" % library.name)
+
+        # Make sure it has collections.
+        if not library.collections:
+            self.output.write(" This library has no collections -- that's a problem.\n")
+        else:
+            for collection in library.collections:
+                self.output.write(" Associated with collection %s.\n" % collection.name)
+
+        # Make sure it has lanes.
+        if not library.lanes:
+            self.output.write(" This library has no lanes -- that's a problem.\n")
+        else:
+            self.output.write(" Associated with %s lanes.\n" % len(library.lanes))
 
 class ListCollectionMetadataIdentifiersScript(CollectionInputScript):
     """List the metadata identifiers for Collections in the database.

--- a/scripts.py
+++ b/scripts.py
@@ -2923,6 +2923,7 @@ class FixInvisibleWorksScript(CollectionInputScript):
         self.do_run(parsed.collections)
 
     def do_run(self, collections=None):
+        self.check_libraries()
         if collections:
             collection_ids = [c.id for c in collections]
 
@@ -3033,21 +3034,21 @@ class FixInvisibleWorksScript(CollectionInputScript):
         self.output.write(
             "I would now expect you to be able to find %d works.\n" % mv_works_count
         )
-        self.check_libraries()
 
     def check_libraries(self):
-        """Assuming that works are properly in the materialized view,
-        make sure the libraries are equipped to show them.
+        """Make sure the libraries are equipped to show works.
         """
-        # Now check each library.
+        # Check each library.
         libraries = self._db.query(Library).all()
         if libraries:
             for library in libraries:
                 self.check_library(library)
         else:
             self.output.write("There are no libraries in the system -- that's a problem.\n")
+        self.output.write("\n")
 
     def check_library(self, library):
+        """Make sure a library is properly set up to show works."""
         self.output.write("Checking library %s\n" % library.name)
 
         # Make sure it has collections.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2154,6 +2154,8 @@ Here's your problem: your works aren't open access and have no licenses owned.
         output = StringIO()
         search = DummyExternalSearchIndex()
 
+        lane = self._lane()
+
         # Let's add a work that's not presentation-ready for a stupid
         # reason.
         work = self._work(with_license_pool=True)
@@ -2179,6 +2181,9 @@ Refreshing the materialized views.
 1 page-type feeds in cachedfeeds table.
 Deleting them all.
 I would now expect you to be able to find 1 works.
+Checking library default
+ Associated with collection Default Collection.
+ Associated with 1 lanes.
 """, output.getvalue())
 
         # The Work was made presentation-ready
@@ -2189,6 +2194,20 @@ I would now expect you to be able to find 1 works.
 
         # The materialized view was refreshed.
         eq_(1, mw_query.count())
+
+    def test_no_library(self):
+        output = StringIO()
+        search = DummyExternalSearchIndex()
+        FixInvisibleWorksScript(self._db, output, search=search).do_run()
+        assert "There are no libraries in the system -- that's a problem" in output.getvalue()
+
+    def test_no_collections_in_library(self):
+        library = self._default_library
+        output = StringIO()
+        search = DummyExternalSearchIndex()
+        FixInvisibleWorksScript(self._db, output, search=search).do_run()
+        set_trace()
+        assert "There are no libraries in the system -- that's a problem" in output.getvalue()
 
     def test_with_collections(self):
         search = DummyExternalSearchIndex()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2260,7 +2260,7 @@ Here's your problem: there are no presentation-ready works.
         output = StringIO()
 
         # But running it with the right collection fixes the work.
-        Mock(self._db, output, search=search).do_run(collections=[c2])
+        self.MockScript(self._db, output, search=search).do_run(collections=[c2])
         eq_("""0 presentation-ready works.
 1 works not presentation-ready.
 Attempting to make 1 works presentation-ready based on their metadata.
@@ -2372,6 +2372,8 @@ class TestExplain(DatabaseTest):
         # The script ran. Spot-check that it provided various
         # information about the work, without testing the exact
         # output.
+        assert pool.collection.name in output
+        assert "Available to libraries: default" in output
         assert work.title in output
         assert "Science Fiction" in output
         for contributor in edition.contributors:


### PR DESCRIPTION
This fixes https://github.com/NYPL-Simplified/circulation/issues/687.