### PR TITLE
Use a Work's cached OPDS feed for any LicensePool whose Identifier matches that of the active LicensePool, not only for the active LicensePool itself.

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -1416,12 +1416,13 @@ class LookupAcquisitionFeed(AcquisitionFeed):
 
         # A cached OPDS entry contains information keyed to a specific
         # Work and Identifier, but not to a specific LicensePool.
-        # Assuming the identifiers match (and there is already a
-        # cached entry), we can avoid the expense of creating a new
-        # one.
+        # Assuming the identifier of the active licensepool matches
+        # the identifier of the default licensepool (and there is
+        # already a cached entry), we can avoid the expense of
+        # creating a new one.
         use_cache = (
-            active_licensepool and identifier
-            and active_licensepool.identifier == identifier
+            active_licensepool and default_licensepool
+            and active_licensepool.identifier == default_licensepool.identifier
         )
 
         error_status = error_message = None

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1742,12 +1742,16 @@ class TestAcquisitionFeed(DatabaseTest):
 
 class TestLookupAcquisitionFeed(DatabaseTest):
 
-    def entry(self, identifier, work, annotator=VerboseAnnotator, **kwargs):
-        """Helper method to create an entry."""
-        feed = LookupAcquisitionFeed(
+    def feed(self, annotator=VerboseAnnotator, **kwargs):
+        """Helper method to create a LookupAcquisitionFeed."""
+        return LookupAcquisitionFeed(
             self._db, u"Feed Title", "http://whatever.io", [],
             annotator=annotator, **kwargs
         )
+
+    def entry(self, identifier, work, annotator=VerboseAnnotator, **kwargs):
+        """Helper method to create an entry."""
+        feed = self.feed(annotator, **kwargs)
         entry = feed.create_entry((identifier, work))
         if isinstance(entry, OPDSMessage):
             return feed, entry
@@ -1835,6 +1839,54 @@ class TestLookupAcquisitionFeed(DatabaseTest):
             "I know about this work but can offer no way of fulfilling it."
         )
         eq_(expect, entry)
+
+    def test_create_entry_uses_cache_for_all_licensepools_with_identifier(self):
+        """A Work's cached OPDS entries are based on a specific identifier,
+        but they can be reused by all LicensePools with that identifier,
+        even LicensePools not directly associated with that Work.
+        """
+        class InstrumentableActiveLicensePool(VerboseAnnotator):
+            """A mock class that lets us control the output of
+            active_license_pool.
+            """
+
+            ACTIVE = None
+
+            @classmethod
+            def active_licensepool_for(cls, work):
+                return cls.ACTIVE
+        feed = self.feed(annotator=InstrumentableActiveLicensePool)
+
+        # Here are two completely different LicensePools for the same
+        # identifier.
+        work = self._work(with_license_pool=True)
+        work.verbose_opds_entry = "<entry>Cached</entry>"
+        [pool1] = work.license_pools
+        identifier = pool1.identifier
+
+        collection2 = self._collection()
+        edition2 = self._edition(
+            identifier_type=identifier.type,
+            identifier_id=identifier.identifier
+        )
+        pool2 = self._licensepool(edition=edition2, collection=collection2)
+
+        # Regardless of which LicensePool the annotator thinks is
+        # 'active', passing in (identifier, work) will use the cache.
+        m = feed.create_entry
+        annotator = feed.annotator
+
+        annotator.ACTIVE = pool1
+        eq_("Cached", m((identifier, work)).text)
+
+        annotator.ACTIVE = pool2
+        eq_("Cached", m((identifier, work)).text)
+
+        # If for some reason we pass in an identifier that is not
+        # associated with the active license pool, the cache is not used.
+        identifier2 = self._identifier()
+        result = m((identifier2, work))
+        assert isinstance(result, OPDSMessage)
 
 
 class TestEntrypointLinkInsertion(DatabaseTest):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -238,10 +238,10 @@ class TestAnnotators(DatabaseTest):
         # Although the default 'cutoff' for
         # recursively_equivalent_identifier_ids is null, when we are
         # generating subjects as part of an OPDS feed, the cutoff is
-        # set to 500. This gives us reasonable worst-case performance
+        # set to 100. This gives us reasonable worst-case performance
         # at the cost of not showing every single random subject under
         # which an extremely popular book is filed.
-        eq_(500, MockIdentifier.called_with_cutoff)
+        eq_(100, MockIdentifier.called_with_cutoff)
 
         ddc_uri = Subject.uri_lookup[Subject.DDC]
         rating_value = '{http://schema.org/}ratingValue'
@@ -1772,12 +1772,12 @@ class TestLookupAcquisitionFeed(DatabaseTest):
         # We can generate two different OPDS feeds for a single work
         # depending on which identifier we look up.
         ignore, e1 = self.entry(original_pool.identifier, work)
-        ignore, e2 = self.entry(new_pool.identifier, work)
         assert original_pool.identifier.urn in e1
         assert original_pool.presentation_edition.title in e1
         assert new_pool.identifier.urn not in e1
         assert new_pool.presentation_edition.title not in e1
 
+        ignore, e2 = self.entry(new_pool.identifier, work)
         assert new_pool.identifier.urn in e2
         assert new_pool.presentation_edition.title in e2
         assert original_pool.identifier.urn not in e2


### PR DESCRIPTION
This branch makes additional changes to improve the performance of the metadata wrangler.

The first is pretty simple -- I change the `identifier_cutoff` for `VerboseAnnotator.categories` from 500 to 100. This will have some effect on the quality of subject-based searches, but without this change, looking up a bunch of popular open-access works will still kill the server.

If we could use the cached OPDS entry for a lookup, we wouldn't have this problem, because those have a full list of subjects attached. And in a lot of cases we can use the cached OPDS entry -- we weren't, on the metadata wrangler, because `LookupAcquisitionFeed.create_entry` was only using the cached entry for a Work if the active LicensePool is the default one used to create the Work. This generally is the case on the circulation manager, but it's almost never the case on the metadata wrangler, because the active LicensePool is associated with a specific collection, and the LicensePool used to create the Work is a dummy not associated with any collection.

This isn't necessary. The cached OPDS entry includes information about the Identifier, but no information specific to the LicensePool -- that's added afterwards. So I changed `create_entry` to use the cache if the _identifier_ of the active LicensePool matches the _identifier_ of the one used to create the Work.

If the cached OPDS entry _only_ included information about the Work, with Identifier information being added at runtime by the annotator (just as LicensePool information is now), then even lookups of open access works would use the cache, and we could bump up the `identifier_cutoff` quite a bit (because it would almost never be necessary). But that's a really big project; I filed https://jira.nypl.org/browse/SIMPLY-273 to handle it.