### PR TITLE
Add IntegrationClient.for_url

### DIFF
--- a/opds_import.py
+++ b/opds_import.py
@@ -104,7 +104,7 @@ class SimplifiedOPDSLookup(object):
 
     def _get(self, url, **kwargs):
         """Make an HTTP request. This method is overridden in the mock class."""
-        kwargs['timeout'] = kwargs.get('timeout', 120)
+        kwargs['timeout'] = kwargs.get('timeout', 300)
         kwargs['allowed_response_codes'] = kwargs.get('allowed_response_codes', [])
         kwargs['allowed_response_codes'] += ['2xx', '3xx']
         return HTTP.get_with_timeout(url, **kwargs)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8805,6 +8805,22 @@ class TestIntegrationClient(DatabaseTest):
         super(TestIntegrationClient, self).setup()
         self.client = self._integration_client()
 
+    def test_for_url(self):
+        now = datetime.datetime.utcnow()
+        client, is_new = IntegrationClient.for_url(self._db, self._url)
+
+        # A new IntegrationClient has been created.
+        eq_(True, is_new)
+
+        # It has timestamps for created & last_accessed.
+        assert client.created and client.last_accessed
+        assert client.created > now
+        eq_(True, isinstance(client.created, datetime.datetime))
+        eq_(client.created, client.last_accessed)
+
+        # It does not have a shared secret.
+        eq_(None, client.shared_secret)
+
     def test_register(self):
         now = datetime.datetime.utcnow()
         client, is_new = IntegrationClient.register(self._db, self._url)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8807,10 +8807,14 @@ class TestIntegrationClient(DatabaseTest):
 
     def test_for_url(self):
         now = datetime.datetime.utcnow()
-        client, is_new = IntegrationClient.for_url(self._db, self._url)
+        url = self._url
+        client, is_new = IntegrationClient.for_url(self._db, url)
 
         # A new IntegrationClient has been created.
         eq_(True, is_new)
+
+        # Its .url is a normalized version of the provided URL.
+        eq_(client.url, IntegrationClient.normalize_url(url))
 
         # It has timestamps for created & last_accessed.
         assert client.created and client.last_accessed
@@ -8820,6 +8824,10 @@ class TestIntegrationClient(DatabaseTest):
 
         # It does not have a shared secret.
         eq_(None, client.shared_secret)
+
+        # Calling it again on the same URL gives the same object.
+        client2, is_new = IntegrationClient.for_url(self._db, url)
+        eq_(client, client2)
 
     def test_register(self):
         now = datetime.datetime.utcnow()


### PR DESCRIPTION
This is a support branch for https://github.com/NYPL-Simplified/metadata_wrangler/pull/167. It makes it possible to look up an existing IntegrationClient without verifying or modifying the shared secret.