### PR TITLE
Distinguish between selectable EntryPoints and valid EntryPoints

### DIFF
--- a/facets.py
+++ b/facets.py
@@ -132,9 +132,10 @@ class FacetConfig(object):
         
         return FacetConfig(enabled_facets, default_facets)
 
-    def __init__(self, enabled_facets, default_facets):
+    def __init__(self, enabled_facets, default_facets, entrypoints=[]):
         self._enabled_facets = dict(enabled_facets)
         self._default_facets = dict(default_facets)
+        self.entrypoints = entrypoints
 
     def enabled_facets(self, group_name):
         return self._enabled_facets.get(group_name)

--- a/opds.py
+++ b/opds.py
@@ -544,7 +544,7 @@ class AcquisitionFeed(OPDSFeed):
 
         # A grouped feed may link to alternate entry points into
         # the data.
-        entrypoints = facets.available_entrypoints(lane)
+        entrypoints = facets.selectable_entrypoints(lane)
         if entrypoints:
             def make_link(ep, is_default):
                 if is_default:
@@ -610,7 +610,7 @@ class AcquisitionFeed(OPDSFeed):
             pagination.this_page_size = len(works)
         feed = cls(_db, title, url, works, annotator)
 
-        entrypoints = facets.available_entrypoints(lane)
+        entrypoints = facets.selectable_entrypoints(lane)
         if entrypoints:
             # A paginated feed may have multiple entry points into the
             # same dataset.
@@ -786,7 +786,7 @@ class AcquisitionFeed(OPDSFeed):
 
         # A feed of search results may link to alternate entry points
         # into those results.
-        entrypoints = facets.available_entrypoints(lane)
+        entrypoints = facets.selectable_entrypoints(lane)
         if entrypoints:
             def make_link(ep, is_default):
                 if is_default:


### PR DESCRIPTION
We have the concept that some WorkLists have selectable EntryPoints and others do not. The WorkLists with selectable EntryPoints are the ones where you have to make a decision, e.g. between audiobooks and ebooks.

There is a similar but distinct concept of which EntryPoints are _valid_ for a given WorkList. For example, for a "Romance" lane, there are no selectable EntryPoints, but either audiobooks or ebooks are _valid_ entrypoints, because you might have navigated Audiobooks -> Fiction -> Romance or Ebooks -> Fiction -> Romance. Given that you're in Romance, there are two ways you might have gotten there.

Our code currently doesn't have a concept of "valid EntryPoint". We substitute the concept of "selectable EntryPoint" instead, which is wrong. Because of this, load_facets_from_request never loads an EntryPoint in a real situation, except at the top level (where the valid EntryPoints are also the selectable EntryPoints). The tests passed because I instrumented them to provide a list of EntryPoints that wouldn't have been provided in real life.

This branch separates the two concepts.