### PR TITLE
Change _best_media_type to take the URL of the resource and use it to derive a default media type if none is provided.

### DIFF
--- a/model.py
+++ b/model.py
@@ -8611,7 +8611,7 @@ class Representation(Base):
                 # post response isn't worth caching.
                 response_reviewer((status_code, headers, content))
             exception = None
-            media_type = cls._best_media_type(headers, presumed_media_type)
+            media_type = cls._best_media_type(url, headers, presumed_media_type)
             if isinstance(content, unicode):
                 content = content.encode("utf8")
         except Exception, fetch_exception:
@@ -8695,15 +8695,17 @@ class Representation(Base):
         return representation, False
 
     @classmethod
-    def _best_media_type(cls, headers, default):
+    def _best_media_type(cls, url, headers, default):
         """Determine the most likely media type for the given HTTP headers.
 
         Almost all the time, this is the value of the content-type
         header, if present. However, if the content-type header has a
         really generic value like "application/octet-stream" (as often
         happens with binary files hosted on Github), we'll privilege
-        the default value.
+        the default value. If there's no default value, we'll try to
+        derive one from the URL extension.
         """
+        default = default or cls.guess_media_type(url)
         if not headers or not 'content-type' in headers:
             return default
         headers_type = headers['content-type'].lower()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5229,18 +5229,37 @@ class TestRepresentation(DatabaseTest):
 
         # If there are no headers or no content-type header, the
         # presumed media type takes precedence.
-        eq_("text/plain", m(None, "text/plain"))
-        eq_("text/plain", m({}, "text/plain"))
+        eq_("text/plain", m("http://text/all.about.jpeg", None, "text/plain"))
+        eq_("text/plain", m(None, {}, "text/plain"))
 
         # Most of the time, the content-type header takes precedence over
         # the presumed media type.
-        eq_("image/gif", m({"content-type": "image/gif"}, "text/plain"))
+        eq_("image/gif", m(None, {"content-type": "image/gif"}, "text/plain"))
 
         # Except when the content-type header is so generic as to be uselses.
         eq_("text/plain", m(
+            None,
             {"content-type": "application/octet-stream;profile=foo"}, 
             "text/plain")
         )
+
+        # If no default media type is specified, but one can be derived from
+        # the URL, that one is used as the default.
+        eq_("image/jpeg", m(
+            "http://images-galore/cover.jpeg",
+            {"content-type": "application/octet-stream;profile=foo"},
+            None)
+        )
+
+        # But a default media type doesn't override a specific
+        # Content-Type from the server, even if it superficially makes
+        # more sense.
+        eq_("image/png", m(
+            "http://images-galore/cover.jpeg",
+            {"content-type": "image/png"},
+            None)
+        )
+
 
     def test_mirrorable_media_type(self):
         representation, ignore = self._representation(self._url)


### PR DESCRIPTION
This addresses https://jira.nypl.org/browse/SIMPLY-286