### PR TITLE
Small changes to media type handling and OPDS feed return values

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -566,6 +566,13 @@ class MetaToModelUtility(object):
             # hasn't changed, we'll keep using the one we have.
             max_age = 0
 
+        # If we don't have any information about this link's media type, but the
+        # the file extension is a mirrorable media type, assume that's correct.
+        if not link.media_type:
+            media_type_from_extension = Representation.guess_media_type(link.href)
+            if media_type_from_extension in Representation.MIRRORABLE_MEDIA_TYPES:
+                link.media_type = media_type_from_extension
+
         # This will fetch a representation of the original and 
         # store it in the database.
         representation, is_new = Representation.get(
@@ -611,15 +618,23 @@ class MetaToModelUtility(object):
             policy.content_modifier(representation)
 
         # The metadata may have some idea about the media type for this
-        # LinkObject, but the media type we actually just saw takes 
-        # precedence.
-        if representation.media_type:
+        # LinkObject, but it could be wrong. If the representation we
+        # actually just saw is a mirrorable media type, that takes
+        # precedence. If we were expecting this link to be mirrorable
+        # but we actually saw something that's not, assume our original
+        # metadata was right and the server told us the wrong media type.
+        if representation.media_type and representation.mirrorable_media_type:
             link.media_type = representation.media_type
 
         if not representation.mirrorable_media_type:
-            self.log.info("Not mirroring %s: unsupported media type %s",
-                          representation.url, representation.media_type)
-            return
+            if link.media_type:
+                self.log.info("Saw unsupported media type for %s: %s. Assuming original media type %s is correct",
+                              representation.url, representation.media_type, link.media_type)
+                representation.media_type = link.media_type
+            else:
+                self.log.info("Not mirroring %s: unsupported media type %s",
+                              representation.url, representation.media_type)
+                return
 
         # Determine the best URL to use when mirroring this
         # representation.

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -566,13 +566,6 @@ class MetaToModelUtility(object):
             # hasn't changed, we'll keep using the one we have.
             max_age = 0
 
-        # If we don't have any information about this link's media type, but the
-        # the file extension is a mirrorable media type, assume that's correct.
-        if not link.media_type:
-            media_type_from_extension = Representation.guess_media_type(link.href)
-            if media_type_from_extension in Representation.MIRRORABLE_MEDIA_TYPES:
-                link.media_type = media_type_from_extension
-
         # This will fetch a representation of the original and 
         # store it in the database.
         representation, is_new = Representation.get(

--- a/model.py
+++ b/model.py
@@ -8331,9 +8331,6 @@ class Representation(Base):
     # to stick with A.
     GENERIC_MEDIA_TYPES = [OCTET_STREAM_MEDIA_TYPE]
 
-    # These media types are the kind of thing we mirror.
-    MIRRORABLE_MEDIA_TYPES = BOOK_MEDIA_TYPES + IMAGE_MEDIA_TYPES
-
     FILE_EXTENSIONS = {
         EPUB_MEDIA_TYPE: "epub",
         MOBI_MEDIA_TYPE: "mobi",
@@ -8750,7 +8747,9 @@ class Representation(Base):
         Basically, images and books.
         """
         return any(
-            self.media_type in x for x in Representation.MIRRORABLE_MEDIA_TYPES
+            self.media_type in x for x in
+            (Representation.BOOK_MEDIA_TYPES,
+             Representation.IMAGE_MEDIA_TYPES)
         )
 
     def update_image_size(self):

--- a/model.py
+++ b/model.py
@@ -8331,6 +8331,9 @@ class Representation(Base):
     # to stick with A.
     GENERIC_MEDIA_TYPES = [OCTET_STREAM_MEDIA_TYPE]
 
+    # These media types are the kind of thing we mirror.
+    MIRRORABLE_MEDIA_TYPES = BOOK_MEDIA_TYPES + IMAGE_MEDIA_TYPES
+
     FILE_EXTENSIONS = {
         EPUB_MEDIA_TYPE: "epub",
         MOBI_MEDIA_TYPE: "mobi",
@@ -8745,9 +8748,7 @@ class Representation(Base):
         Basically, images and books.
         """
         return any(
-            self.media_type in x for x in
-            (Representation.BOOK_MEDIA_TYPES,
-             Representation.IMAGE_MEDIA_TYPES)
+            self.media_type in x for x in Representation.MIRRORABLE_MEDIA_TYPES
         )
 
     def update_image_size(self):

--- a/opds.py
+++ b/opds.py
@@ -490,7 +490,7 @@ class AcquisitionFeed(OPDSFeed):
                 force_refresh=force_refresh,
             )
             if usable:
-                return cached
+                return cached.content
 
         works_and_lanes = lane.groups(_db, facets=facets)
         if not works_and_lanes:
@@ -564,7 +564,6 @@ class AcquisitionFeed(OPDSFeed):
         content = unicode(feed)
         if cached and use_cache:
             cached.update(_db, content)
-            return cached
         return content
 
     @classmethod
@@ -599,7 +598,7 @@ class AcquisitionFeed(OPDSFeed):
                 force_refresh=force_refresh,
             )
             if usable:
-                return cached
+                return cached.content
 
         works_q = lane.works(_db, facets, pagination)
         if not works_q:
@@ -648,7 +647,6 @@ class AcquisitionFeed(OPDSFeed):
         content = unicode(feed)
         if cached and use_cache:
             cached.update(_db, content)
-            return cached
         return content
 
     @classmethod

--- a/scripts.py
+++ b/scripts.py
@@ -73,6 +73,7 @@ from model import (
     LicensePoolDeliveryMechanism,
     Patron,
     PresentationCalculationPolicy,
+    Representation,
     SessionManager,
     Subject,
     Timestamp,
@@ -1900,7 +1901,8 @@ class MirrorResourcesScript(CollectionInputScript):
         """
         return ReplacementPolicy(
             mirror=uploader, link_content=True,
-            even_if_not_apparently_updated=True
+            even_if_not_apparently_updated=True,
+            http_get=Representation.cautious_http_get,
         )
 
     def process_collection(self, collection, policy, unmirrored=None):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -517,8 +517,8 @@ class TestMetadataImporter(DatabaseTest):
             rel=link.rel, href=link.href, data_source=data_source,
         )
 
-        # But for some reason the remote server says it's XML.
-        h.queue_response(200, media_type=Representation.APPLICATION_XML_MEDIA_TYPE, content=content)
+        # The remote server told us a generic media type.
+        h.queue_response(200, media_type=Representation.OCTET_STREAM_MEDIA_TYPE, content=content)
         
         m.mirror_link(edition, data_source, link, link_obj, policy)
         representation = link_obj.resource.representation
@@ -543,7 +543,7 @@ class TestMetadataImporter(DatabaseTest):
         link_obj, ignore = edition.primary_identifier.add_link(
             rel=link.rel, href=link.href, data_source=data_source,
         )
-        h.queue_response(200, media_type=Representation.APPLICATION_XML_MEDIA_TYPE, content=content)
+        h.queue_response(200, media_type=Representation.OCTET_STREAM_MEDIA_TYPE, content=content)
         m.mirror_link(edition, data_source, link, link_obj, policy)
         representation = link_obj.resource.representation
 
@@ -567,7 +567,7 @@ class TestMetadataImporter(DatabaseTest):
         link_obj, ignore = edition.primary_identifier.add_link(
             rel=link.rel, href=link.href, data_source=data_source,
         )
-        h.queue_response(200, media_type=Representation.APPLICATION_XML_MEDIA_TYPE, content=content)
+        h.queue_response(200, media_type=Representation.OCTET_STREAM_MEDIA_TYPE, content=content)
         m.mirror_link(edition, data_source, link, link_obj, policy)
         representation = link_obj.resource.representation
 
@@ -577,7 +577,7 @@ class TestMetadataImporter(DatabaseTest):
         assert representation.fetched_at != None
         eq_(None, representation.mirror_exception)
         eq_(None, representation.mirrored_at)
-        eq_(Representation.APPLICATION_XML_MEDIA_TYPE, representation.media_type)
+        eq_(Representation.OCTET_STREAM_MEDIA_TYPE, representation.media_type)
         eq_(link.href, representation.url)
         eq_(None, representation.mirror_url)
 


### PR DESCRIPTION
#873 did most of what I needed for media types, but I also changed the mirroring code in the metadata layer to handle the case when we don't have a file extension and we get an unmirrorable media type, but the original link specified a mirrorable media type.

I also changed the methods that create OPDS feeds to consistently return feed content rather than CachedFeed objects. Before, the search feed did this and other feeds did it when caching was disabled, but all controller methods except search expected a CachedFeed, so they didn't work when caching was disabled.