### PR TITLE
Some lanes shouldn't show up in their own grouped feeds

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -1729,6 +1729,13 @@ class Lane(Base, WorkList):
     # This is almost never necessary.
     root_for_patron_type = Column(ARRAY(Unicode), nullable=True)
 
+    # When a lanes with sublanes is made into a grouped feed, that
+    # feed contains a swim lane from each sublane, plus a swim lane at
+    # the bottom for the lane itself. In some cases that final 
+    exclude_self_from_grouped_feed = Column(
+        Boolean, default=False, nullable=False
+    )
+
     # Only a visible lane will show up in the user interface.  The
     # admin interface can see all the lanes, visible or not.
     _visible = Column(Boolean, default=True, nullable=False, name="visible")

--- a/migration/20180517-add-lane-include-self-in-grouped-feeds.sql
+++ b/migration/20180517-add-lane-include-self-in-grouped-feeds.sql
@@ -1,0 +1,9 @@
+DO $$
+  BEGIN
+    BEGIN
+      ALTER TABLE lanes ADD COLUMN include_self_in_grouped_feed boolean default true not null;
+    EXCEPTION
+      WHEN duplicate_column THEN RAISE NOTICE 'column lanes.include_self_in_grouped_feed already exists, not creating it.';
+    END;
+  END;
+$$;

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -2714,6 +2714,10 @@ class TestWorkListGroups(DatabaseTest):
                     (i, expect_item, actual_item,
                      expect, actual)
                 )
+            eq_(len(expect), len(actual),
+               "Expect matches actual, but actual has extra members.\nOverall, expected:\n%r\nGot:\n%r:" %
+               (expect, actual)
+            )
 
         fiction.groups(self._db)
         assert_contents(
@@ -2774,7 +2778,7 @@ class TestWorkListGroups(DatabaseTest):
         # If we exclude 'Fiction' from its own grouped feed, we get
         # all the other books/lane combinations except for the books
         # associated directly with 'Fiction'.
-        fiction.exclude_self_from_grouped_feed = True
+        fiction.include_self_in_grouped_feed = False
         assert_contents(
             fiction.groups(self._db),
             [
@@ -2787,7 +2791,7 @@ class TestWorkListGroups(DatabaseTest):
                 (nonfiction, discredited_nonfiction),
             ]
         )
-        fiction.exclude_self_from_grouped_feed = False
+        fiction.include_self_in_grouped_feed = True
 
         # When a lane has no sublanes, its behavior is the same whether
         # it is called with include_sublanes true or false.

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -2760,7 +2760,7 @@ class TestWorkListGroups(DatabaseTest):
         )
 
         # If we ask only about 'Fiction', not including its sublanes,
-        # we get the same results.
+        # we get the same books associated with that lane.
         #
         # hq_ro shows up before hq_litfic because its .random is a
         # larger number. In the previous example, hq_ro showed up
@@ -2770,6 +2770,24 @@ class TestWorkListGroups(DatabaseTest):
             fiction.groups(self._db, include_sublanes=False),
             [(hq_ro, fiction), (hq_litfic, fiction)]
         )
+
+        # If we exclude 'Fiction' from its own grouped feed, we get
+        # all the other books/lane combinations except for the books
+        # associated directly with 'Fiction'.
+        fiction.exclude_self_from_grouped_feed = True
+        assert_contents(
+            fiction.groups(self._db),
+            [
+                (mq_sf, best_sellers),
+                (mq_sf, staff_picks),
+                (hq_sf, sf_lane),
+                (mq_sf, sf_lane),
+                (hq_ro, romance_lane),
+                (mq_ro, romance_lane),
+                (nonfiction, discredited_nonfiction),
+            ]
+        )
+        fiction.exclude_self_from_grouped_feed = False
 
         # When a lane has no sublanes, its behavior is the same whether
         # it is called with include_sublanes true or false.


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-287. It implements a boolean switch that turns the feature on or off; we can implement a custom name separately, later.