### PR TITLE
Only set mirror_url when a Representation has actually been mirrored.

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -645,8 +645,7 @@ class MetaToModelUtility(object):
             )
 
         # Mirror it.
-        representation.mirror_url = mirror_url
-        mirror.mirror_one(representation)
+        mirror.mirror_one(representation, mirror_url)
 
         # If we couldn't mirror an open access link representation, suppress
         # the license pool until someone fixes it manually.
@@ -676,12 +675,12 @@ class MetaToModelUtility(object):
             if is_new:
                 # A thumbnail was created distinct from the original
                 # image. Mirror it as well.
-                mirror.mirror_one(thumbnail)
+                mirror.mirror_one(thumbnail, thumbnail_url)
 
         if link_obj.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
-            # If we mirrored book content successfully, don't keep it in
+            # If we mirrored book content successfully, remove it from
             # the database to save space. We do keep images in case we
-            # ever need to resize them.
+            # ever need to resize them or mirror them elsewhere.
             if representation.mirrored_at and not representation.mirror_exception:
                 representation.content = None
 

--- a/migration/20180521-not-really-mirrored.sql
+++ b/migration/20180521-not-really-mirrored.sql
@@ -5,3 +5,8 @@
 update representations set url=mirror_url where url is null and mirror_url is not null;
 
 update representations set mirror_url=null where url is not null and mirrored_at is null and mirror_url is not null;
+
+-- A representation is never 'mirrored' to its original URL.
+-- More likely Representation.set_as_mirrored() was called, but we now
+-- prefer to leave mirror_url alone.
+update representations set mirror_url=null, mirrored_at=null where url=mirror_url;

--- a/migration/20180521-not-really-mirrored.sql
+++ b/migration/20180521-not-really-mirrored.sql
@@ -1,0 +1,7 @@
+-- Some representations have mirror_url set even though they were
+-- never mirrored. Their mirror_urls should be blanked out.
+
+-- This shouldn't have happened, but just in case, so we don't lose information.
+update representations set url=mirror_url where url is null and mirror_url is not null;
+
+update representations set mirror_url=null where url is not null and mirrored_at is null and mirror_url is not null;

--- a/model.py
+++ b/model.py
@@ -2212,7 +2212,7 @@ class Identifier(Base):
                 _db, Representation, url=resource.url, media_type=media_type
             )
 
-        # TODO: This is where we would mirror the resource if we 
+        # TODO: This is where we would mirror the resource if we
         # wanted to.
         return link, new_link
 

--- a/model.py
+++ b/model.py
@@ -2209,7 +2209,7 @@ class Identifier(Base):
             # We know the type of the resource, so make a
             # Representation for it.
             resource.representation, is_new = get_one_or_create(
-                _db, Representation, url=self.url, media_type=media_type
+                _db, Representation, url=resource.url, media_type=media_type
             )
 
         # TODO: This is where we would mirror the resource if we 
@@ -5975,7 +5975,7 @@ class Resource(Base):
             # In order, our criteria are: whether we
             # mirrored the representation (which means we directly
             # control it), image quality, and media type suitability.
-            compare_key = (r.mirror_url is not None, quality, media_priority)
+            compare_key = (rep.mirror_url is not None, quality, media_priority)
             if not champion_key or (compare_key > champion_key):
                 # A new champion.
                 champions = [r]

--- a/model.py
+++ b/model.py
@@ -5950,7 +5950,7 @@ class Resource(Base):
         """Where does the given image media type rank on our list of
         preferences?
 
-        :return: A lower number is better. float('inf') means it's not an
+        :return: A lower number is better. None means it's not an
         image type or we don't care about it at all.
         """
         if media_type in Representation.IMAGE_MEDIA_TYPES:

--- a/model.py
+++ b/model.py
@@ -5969,10 +5969,9 @@ class Resource(Base):
             if not rep:
                 # A Resource with no Representation is not usable, period
                 continue
-            media_priority = (
-                cls.image_type_priority(rep.media_type) or
-                float('inf')
-            )
+            media_priority = cls.image_type_priority(rep.media_type)
+            if media_priority is None:
+                media_priority = float('inf')
 
             # This method will set the quality if it hasn't been set before.
             r.quality_as_thumbnail_image

--- a/model.py
+++ b/model.py
@@ -5983,7 +5983,11 @@ class Resource(Base):
             # In order, our criteria are: whether we
             # mirrored the representation (which means we directly
             # control it), image quality, and media type suitability.
-            compare_key = (rep.mirror_url is not None, quality, media_priority)
+            #
+            # We invert media type suitability because it's given to us
+            # as a priority (where smaller is better), but we want to compare
+            # it as a quantity (where larger is better).
+            compare_key = (rep.mirror_url is not None, quality, -media_priority)
             if not champion_key or (compare_key > champion_key):
                 # A new champion.
                 champions = [r]

--- a/model.py
+++ b/model.py
@@ -5950,7 +5950,7 @@ class Resource(Base):
         """Where does the given image media type rank on our list of
         preferences?
 
-        :return: A lower number is better. None means it's not an
+        :return: A lower number is better. float('inf') means it's not an
         image type or we don't care about it at all.
         """
         if media_type in Representation.IMAGE_MEDIA_TYPES:
@@ -5969,7 +5969,10 @@ class Resource(Base):
             if not rep:
                 # A Resource with no Representation is not usable, period
                 continue
-            media_priority = cls.image_type_priority(rep.media_type)
+            media_priority = (
+                cls.image_type_priority(rep.media_type) or
+                float('inf')
+            )
 
             # This method will set the quality if it hasn't been set before.
             r.quality_as_thumbnail_image

--- a/model.py
+++ b/model.py
@@ -8467,15 +8467,20 @@ class Representation(Base):
     def public_url(self):
         """Find the best URL to publish when referencing this Representation
         in a public space.
-        """
-        if self.mirror_url:
-            return self.mirror_url
-        if self.url:
-            return self.url
 
-        # This really shouldn't happen.
-        if self.resource:
-            return self.resource.url
+        :return: a bytestring
+        """
+        url = None
+        if self.mirror_url:
+            url = self.mirror_url
+        elif self.url:
+            url = self.url
+        elif self.resource:
+            # This really shouldn't happen.
+            url = self.resource.url
+        if isinstance(url, unicode):
+            url = url.encode("utf8")
+        return url
 
     @property
     def is_usable(self):

--- a/model.py
+++ b/model.py
@@ -3351,7 +3351,7 @@ class Edition(Base):
             and resource.representation.image_height <= self.MAX_FALLBACK_THUMBNAIL_HEIGHT):
             # The full-sized image is too large to be a thumbnail, but it's
             # not huge, and there is no other thumbnail, so use it.
-            self.cover_thumbnail_url = resource.representation.mirror_url
+            self.cover_thumbnail_url = resource.representation.public_url
         if old_cover != self.cover or old_cover_full_url != self.cover_full_url:
             logging.debug(
                 "Setting cover for %s/%s: full=%s thumb=%s",
@@ -3601,7 +3601,7 @@ class Edition(Base):
                     self.permanent_work_id, self.language
             ]
             if self.cover and self.cover.representation:
-                args.append(self.cover.representation.mirror_url)
+                args.append(self.cover.representation.public_url)
             else:
                 args.append(None)
             level(msg, *args)
@@ -7715,8 +7715,8 @@ class LicensePool(Base):
 
             if (best.data_source.name==DataSource.GUTENBERG
                 and resource.data_source.name==DataSource.GUTENBERG
-                and 'noimages' in best.representation.mirror_url
-                and not 'noimages' in resource.representation.mirror_url):
+                and 'noimages' in best.representation.public_url
+                and not 'noimages' in resource.representation.public_url):
                 # A Project Gutenberg-ism: an epub without 'noimages'
                 # in the filename is better than an epub with
                 # 'noimages' in the filename.

--- a/opds.py
+++ b/opds.py
@@ -1239,14 +1239,14 @@ class AcquisitionFeed(OPDSFeed):
             cover_representation = cover.representation
             representations.append(cover.representation)
             cover_link = AtomFeed.makeelement(
-                "link", href=cover_representation.mirror_url,
+                "link", href=cover_representation.public_url,
                 type=cover_representation.media_type, rel=Hyperlink.IMAGE)
             elements.append(cover_link)
             if cover_representation.thumbnails:
                 thumbnail = cover_representation.thumbnails[0]
                 representations.append(thumbnail)
                 thumbnail_link = AtomFeed.makeelement(
-                    "link", href=thumbnail.mirror_url,
+                    "link", href=thumbnail.public_url,
                     type=thumbnail.media_type,
                     rel=Hyperlink.THUMBNAIL_IMAGE
                 )

--- a/opds.py
+++ b/opds.py
@@ -1234,7 +1234,6 @@ class AcquisitionFeed(OPDSFeed):
     ):
         elements = []
         representations = []
-        most_recent_update = None
         if cover:
             cover_representation = cover.representation
             representations.append(cover.representation)

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -705,9 +705,8 @@ class TestMetaToModelUtility(DatabaseTest):
         eq_(link.media_type, representation.media_type)
         eq_(link.href, representation.url)
 
-        # The mirror url should still be set.
-        assert "Gutenberg" in representation.mirror_url
-        assert representation.mirror_url.endswith("%s.epub" % edition.title)
+        # The mirror url was never set.
+        eq_(None, representation.mirror_url)
 
         # Book content is still there since it wasn't mirrored.
         assert representation.content != None

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -472,15 +472,14 @@ class TestMetadataImporter(DatabaseTest):
         eq_(None, representation.fetch_exception)
         assert representation.fetched_at != None
 
-        # But mirroing failed.
+        # But mirroring failed.
         assert representation.mirror_exception != None
         eq_(None, representation.mirrored_at)
         eq_(link.media_type, representation.media_type)
         eq_(link.href, representation.url)
 
-        # The mirror url should still be set.
-        assert "Gutenberg" in representation.mirror_url
-        assert representation.mirror_url.endswith("%s/cover.jpg" % edition.primary_identifier.identifier)
+        # The mirror url is not set.
+        eq_(None, representation.mirror_url)
 
         # Book content is still there since it wasn't mirrored.
         assert representation.content != None

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -796,7 +796,7 @@ class TestIdentifier(DatabaseTest):
         eq_('http://cover', cover_link.href)
 
         # The 'updated' time is set to the latest timestamp associated
-        # with the Identifier. 
+        # with the Identifier.
         eq_([], identifier.coverage_records)
 
         # This may be the time the cover image was mirrored.
@@ -1691,11 +1691,11 @@ class TestEdition(DatabaseTest):
         # This edition has a full-sized image and a thumbnail image,
         # but there is no evidence that they are the _same_ image.
         main_image, ignore = edition.primary_identifier.add_link(
-            Hyperlink.IMAGE, self._url,
+            Hyperlink.IMAGE, "http://main/",
             edition.data_source, Representation.PNG_MEDIA_TYPE
         )
         thumbnail_image, ignore = edition.primary_identifier.add_link(
-            Hyperlink.THUMBNAIL_IMAGE, self._url,
+            Hyperlink.THUMBNAIL_IMAGE, "http://thumbnail/",
             edition.data_source, Representation.PNG_MEDIA_TYPE
         )
 
@@ -1710,10 +1710,11 @@ class TestEdition(DatabaseTest):
         # associated with the identifier is a thumbnail _of_ the
         # full-sized image...
         thumbnail_2, ignore = edition.primary_identifier.add_link(
-            Hyperlink.THUMBNAIL_IMAGE, self._url,
+            Hyperlink.THUMBNAIL_IMAGE, "http://thumbnail2/",
             edition.data_source, Representation.PNG_MEDIA_TYPE
         )
         thumbnail_2.resource.representation.thumbnail_of = main_image.resource.representation
+        set_trace()
         edition.choose_cover()
         
         # ...That thumbnail will be chosen in preference to the
@@ -5766,6 +5767,25 @@ class TestRepresentation(DatabaseTest):
                         check_for_redirect=['questionable-site.org'],
                         head_client=bad_redirect))
 
+    def test_best_thumbnail(self):
+        # This Representation has no thumbnails.
+        representation, ignore = self._representation()
+        eq_(None, representation.best_thumbnail)
+
+        # Now it has two thumbnails, neither of which is mirrored.
+        t1, ignore = self._representation()
+        t2, ignore = self._representation()
+        for i in t1, t2:
+            representation.thumbnails.append(i)
+        
+        # There's no distinction between the thumbnails, so the first one
+        # is selected as 'best'.
+        eq_(t1, representation.best_thumbnail)
+        
+        # If one of the thumbnails is mirrored, it becomes the 'best'
+        # thumbnail.
+        t2.set_as_mirrored(self._url)
+        eq_(t2, representation.best_thumbnail)
 
 class TestCoverResource(DatabaseTest):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1714,7 +1714,6 @@ class TestEdition(DatabaseTest):
             edition.data_source, Representation.PNG_MEDIA_TYPE
         )
         thumbnail_2.resource.representation.thumbnail_of = main_image.resource.representation
-        set_trace()
         edition.choose_cover()
         
         # ...That thumbnail will be chosen in preference to the

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5855,7 +5855,7 @@ class TestCoverResource(DatabaseTest):
         thumbnail, is_new = cover.scale(300, 600, url, "image/png")
         eq_(True, is_new)
         eq_(url, thumbnail.url)
-        eq_(url, thumbnail.mirror_url)
+        eq_(None, thumbnail.mirror_url)
         eq_(None, thumbnail.mirrored_at)
         eq_(cover, thumbnail.thumbnail_of)
         eq_("image/png", thumbnail.media_type)
@@ -5870,7 +5870,7 @@ class TestCoverResource(DatabaseTest):
         eq_(False, is_new)
 
         # Let's say the thumbnail has been mirrored.
-        thumbnail.mirrored_at = datetime.datetime.utcnow()
+        thumbnail.set_as_mirrored(self._url)
 
         old_content = thumbnail.content
         # With the force argument we can forcibly re-scale an image,

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -225,7 +225,6 @@ class TestS3Uploader(S3UploaderTest):
             content=content
         )
         cover_rep = cover.resource.representation
-        cover_rep.mirror_url = "http://covers-go/here.png"
         eq_(None, cover_rep.mirrored_at)
 
         original_epub_location = "https://books.com/a-book.epub"
@@ -247,33 +246,39 @@ class TestS3Uploader(S3UploaderTest):
             )
         s3.final_mirror_url = mock_final_mirror_url
 
-        to_mirror = [
-            cover.resource.representation, epub.resource.representation
-        ]
-        s3.mirror_one(cover.resource.representation, self._url)
+        book_url = "http://books-go/here.epub"
+        cover_url = "http://s3.amazonaws.com/covers-go/here.png"
+        s3.mirror_one(cover.resource.representation, cover_url)
+        s3.mirror_one(epub.resource.representation, book_url)
         [[data1, bucket1, key1, args1, ignore1],
          [data2, bucket2, key2, args2, ignore2],] = s3.client.uploads
 
-        # Both representations have been mirrored to their .mirror_urls
+        # Both representations have had .mirror_url set and been
+        # mirrored to those URLs.
         assert data1.startswith(b'\x89')
         eq_("covers-go", bucket1)
         eq_("here.png", key1)
         eq_(Representation.PNG_MEDIA_TYPE, args1['ContentType'])
         assert (datetime.datetime.utcnow() - cover_rep.mirrored_at).seconds < 10
 
-        # Since the epub_rep didn't have a .mirror_url, the .url was used
-        # to determine which bucket to mirror to. The .mirror_url was then
-        # set to the result of calling final_mirror_url on the bucket
-        # and filename.
+        eq_("i'm an epub", data2)
+        eq_("books-go", bucket2)
+        eq_("here.epub", key2)
+        eq_(Representation.EPUB_MEDIA_TYPE, args2['ContentType'])
+
+        # In both cases, mirror_url was set to the result of final_mirror_url.
         eq_(
-            u'final_mirror_url was called with bucket books.com, key a-book.epub',
+            u'final_mirror_url was called with bucket books-go, key here.epub',
             epub_rep.mirror_url
         )
-        eq_("i'm an epub", data2)
-        eq_("books.com", bucket2)
-        eq_("a-book.epub", key2)
-        eq_(Representation.EPUB_MEDIA_TYPE, args2['ContentType'])
-        assert (datetime.datetime.utcnow() - epub_rep.mirrored_at).seconds < 10
+        eq_(
+            u'final_mirror_url was called with bucket covers-go, key here.png',
+            cover_rep.mirror_url
+        )
+
+        # mirrored-at was set when the representation was 'mirrored'
+        for rep in epub_rep, cover_rep:
+            assert (datetime.datetime.utcnow() - rep.mirrored_at).seconds < 10
 
     def test_mirror_failure(self):
         edition, pool = self._edition(with_license_pool=True)


### PR DESCRIPTION
This is part of the work for https://jira.nypl.org/browse/SIMPLY-297. The goal is to stop using mirror_url as 'the URL that should go into OPDS feeds for this Representation' and only have it mean 'the URL to which this specific installation personally mirrored to S3'.

To this end, methods that mirror representations, or mark them as mirrored, now manage `mirror_url`. In general, other code is not supposed to touch `mirror_url`, unless (as in Representation.best_thumbnail) it needs to enforce a policy like 'a Representation that we mirrored is better than one we didn't.'

A new property, `Representation.public_url`, is designed to mean 'the URL that should go into OPDS feeds for this Representation'.

I'm working on a corresponding circulation branch.