### PR TITLE
Dont store identifier in cached opds entry

### DIFF
--- a/model.py
+++ b/model.py
@@ -4746,11 +4746,11 @@ class Work(Base):
         )
         _db = Session.object_session(self)
         simple = AcquisitionFeed.single_entry(
-            _db, self, Annotator(), force_create=True
+            _db, self, Annotator, force_create=True
         )
         if verbose is True:
             verbose = AcquisitionFeed.single_entry(
-                _db, self, VerboseAnnotator(), force_create=True
+                _db, self, VerboseAnnotator, force_create=True
             )
         WorkCoverageRecord.add_for(
             self, operation=WorkCoverageRecord.GENERATE_OPDS_OPERATION

--- a/model.py
+++ b/model.py
@@ -4746,11 +4746,11 @@ class Work(Base):
         )
         _db = Session.object_session(self)
         simple = AcquisitionFeed.single_entry(
-            _db, self, Annotator, force_create=True
+            _db, self, Annotator(), force_create=True
         )
         if verbose is True:
             verbose = AcquisitionFeed.single_entry(
-                _db, self, VerboseAnnotator, force_create=True
+                _db, self, VerboseAnnotator(), force_create=True
             )
         WorkCoverageRecord.add_for(
             self, operation=WorkCoverageRecord.GENERATE_OPDS_OPERATION

--- a/opds.py
+++ b/opds.py
@@ -421,11 +421,15 @@ class VerboseAnnotator(Annotator):
 
     def annotate_work_entry(self, work, active_license_pool, edition,
                             identifier, feed, entry):
-        """Add a quality rating to the work.
-        """
         super(VerboseAnnotator, self).annotate_work_entry(
             work, active_license_pool, edition, identifier, feed, entry
         )
+        self.add_ratings(work, entry)
+
+    @classmethod
+    def add_ratings(cls, work):
+        """Add a quality rating to the work.
+        """
         for type_uri, value in [
                 (Measurement.QUALITY, work.quality),
                 (None, work.rating),

--- a/opds.py
+++ b/opds.py
@@ -1531,27 +1531,15 @@ class LookupAcquisitionFeed(AcquisitionFeed):
         """
         identifier, work = work
 
-        # Most of the time we can use the cached OPDS entry for the
-        # Work. However, that cached OPDS feed is designed around one
-        # specific Identifier, and it's possible that the client is
-        # asking for a lookup centered around a different edition of the
-        # same book.
+        # Unless the client is asking for something impossible
+        # (e.g. the Identifier is not really associated with the
+        # Work), we should be able to use the cached OPDS entry for
+        # the Work.
         default_licensepool = self.annotator.active_licensepool_for(work)
         if identifier.licensed_through:
             active_licensepool = identifier.licensed_through[0]
         else:
             active_licensepool = default_licensepool
-
-        # A cached OPDS entry contains information keyed to a specific
-        # Work and Identifier, but not to a specific LicensePool.
-        # Assuming the identifier of the active licensepool matches
-        # the identifier of the default licensepool (and there is
-        # already a cached entry), we can avoid the expense of
-        # creating a new one.
-        use_cache = (
-            active_licensepool and default_licensepool
-            and active_licensepool.identifier == default_licensepool.identifier
-        )
 
         error_status = error_message = None
         if not active_licensepool:
@@ -1570,8 +1558,7 @@ class LookupAcquisitionFeed(AcquisitionFeed):
             edition = work.presentation_edition
         try:
             return self._create_entry(
-                work, active_licensepool, edition, identifier,
-                use_cache=use_cache
+                work, active_licensepool, edition, identifier
             )
         except UnfulfillableWork, e:
             logging.info(

--- a/opds.py
+++ b/opds.py
@@ -429,7 +429,6 @@ class Annotator(object):
                 active_license_pool = p
         return active_license_pool
 
-    @classmethod
     def sort_works_for_groups_feed(self, works, **kwargs):
         return works
 
@@ -560,6 +559,10 @@ class AcquisitionFeed(OPDSFeed):
 
         :return: CachedFeed (if use_cache is True) or unicode
         """
+        if not annotator:
+            annotator = Annotator
+        if callable(annotator):
+            annotator = annotator()
         cached = None
         use_cache = cache_type != cls.NO_CACHE
         facets = facets or lane.default_featured_facets(_db)

--- a/opds.py
+++ b/opds.py
@@ -1679,6 +1679,5 @@ class TestAnnotatorWithGroup(TestAnnotator):
 class TestUnfulfillableAnnotator(TestAnnotator):
     """Raise an UnfulfillableWork exception when asked to annotate an entry."""
 
-    @classmethod
     def annotate_work_entry(self, *args, **kwargs):
         raise UnfulfillableWork()

--- a/opds.py
+++ b/opds.py
@@ -114,7 +114,7 @@ class Annotator(object):
         permalink_uri = self.permalink_for(
             work, active_license_pool, identifier
         )
-        if permalink:
+        if permalink_uri:
             OPDSFeed.add_link_to_entry(
                 entry, rel='alternate', href=permalink_uri
             )

--- a/opds.py
+++ b/opds.py
@@ -111,12 +111,13 @@ class Annotator(object):
             entry.append(AtomFeed.id(identifier.urn))
 
         # Add a permalink if one is available.
-        permalink_uri = self.permalink_for(
+        permalink_uri, permalink_type = self.permalink_for(
             work, active_license_pool, identifier
         )
         if permalink_uri:
             OPDSFeed.add_link_to_entry(
-                entry, rel='alternate', href=permalink_uri
+                entry, rel='alternate', href=permalink_uri,
+                type=permalink_type
             )
 
         if active_license_pool:
@@ -355,13 +356,19 @@ class Annotator(object):
 
     @classmethod
     def permalink_for(cls, work, license_pool, identifier):
-        """In the absence of any specific controllers,
-        there is no permalink.
+        """Generate a permanent link a client can follow for information about
+        this entry, and only this entry.
 
         Note that permalink is distinct from the Atom <id>,
         which is always the identifier's URN.
+
+        :return: A 2-tuple (URL, media type). If a single value is
+        returned, the media type will be presumed to be that of an
+        OPDS entry.
         """
-        return None
+        # In the absence of any specific controllers, there is no
+        # permalink. This method must be defined in a subclass.
+        return None, None
 
     @classmethod
     def lane_url(cls, lane, facets=None):

--- a/opds.py
+++ b/opds.py
@@ -111,7 +111,9 @@ class Annotator(object):
             entry.append(AtomFeed.id(identifier.urn))
 
         # Add a permalink if one is available.
-        permalink = self.permalink_for(work, active_license_pool, identifier)
+        permalink_uri = self.permalink_for(
+            work, active_license_pool, identifier
+        )
         if permalink:
             OPDSFeed.add_link_to_entry(
                 entry, rel='alternate', href=permalink_uri

--- a/opds.py
+++ b/opds.py
@@ -405,6 +405,7 @@ class Annotator(object):
                 active_license_pool = p
         return active_license_pool
 
+    @classmethod
     def sort_works_for_groups_feed(self, works, **kwargs):
         return works
 

--- a/opds.py
+++ b/opds.py
@@ -958,7 +958,9 @@ class AcquisitionFeed(OPDSFeed):
         into a feed.
         """
         if not annotator:
-            annotator = Annotator()
+            annotator = Annotator
+        if callable(annotator):
+            annotator = annotator()
         self.annotator = annotator
 
         super(AcquisitionFeed, self).__init__(title, url)

--- a/opds.py
+++ b/opds.py
@@ -79,10 +79,7 @@ class Annotator(object):
 
     opds_cache_field = Work.simple_opds_entry.name
 
-    # TODO: it's a pain to make this an instance method but I think it
-    # needs to happen.
-    @classmethod
-    def annotate_work_entry(cls, work, active_license_pool, edition,
+    def annotate_work_entry(self, work, active_license_pool, edition,
                             identifier, feed, entry, updated=None):
         """Make any custom modifications necessary to integrate this
         OPDS entry into the application's workflow.
@@ -101,7 +98,7 @@ class Annotator(object):
         :param entry: An lxml Element object, the entry that will be added
            to the feed.
         """
-        permalink = cls.permalink_for(work, active_license_pool, identifier)
+        permalink = self.permalink_for(work, active_license_pool, identifier)
         entry.append(AtomFeed.id(permalink))
 
         if active_license_pool:
@@ -130,11 +127,11 @@ class Annotator(object):
         # If this OPDS entry is being used as part of a grouped feed
         # (which is up to the Annotator subclass), we need to add a
         # group link.
-        group_uri, group_title = cls.group_uri(
+        group_uri, group_title = self.group_uri(
             work, active_license_pool, identifier
         )
         if group_uri:
-            cls.add_link_to_entry(
+            OPDSFeed.add_link_to_entry(
                 entry, rel=OPDSFeed.GROUP_REL, href=group_uri,
                 title=unicode(group_title)
             )
@@ -343,6 +340,10 @@ class Annotator(object):
         """In the absence of any specific URLs, the best we can do
         is a URN.
         """
+        if not license_pool and not identifier:
+            return None
+        if not identifier:
+            identifier = license_pool.identifier
         return identifier.urn
 
     @classmethod
@@ -1094,6 +1095,8 @@ class AcquisitionFeed(OPDSFeed):
 
         # Now add the stuff specific to the selected Identifier
         # and LicensePool.
+        if not isinstance(self.annotator, Annotator):
+            set_trace()
         self.annotator.annotate_work_entry(
             work, active_license_pool, edition, identifier, self, xml)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8719,6 +8719,15 @@ class TestCollection(DatabaseTest):
         self.collection.catalog_identifier(w1.license_pools[0].identifier)
         self.collection.catalog_identifier(w2.license_pools[0].identifier)
 
+        # This Work is catalogued in another catalog and will never show up.
+        collection2 = self._collection()
+        in_other_catalog = self._work(
+            with_license_pool=True, collection=collection2
+        )
+        collection2.catalog_identifier(
+            in_other_catalog.license_pools[0].identifier
+        )
+
         # When no timestamp is passed, all works in the catalog are returned.
         # in order of their WorkCoverageRecord timestamp.
         t1, t2 = self.collection.works_updated_since(self._db, None).all()
@@ -8730,14 +8739,10 @@ class TestCollection(DatabaseTest):
         # CollectionIdentifier). This gives the caller all the information
         # necessary to understand the path by which a given Work belongs to
         # a given Collection.
-        _w1, lp1, i1, wc1, ci1 = t1
+        _w1, lp1, i1 = t1
         [pool] = w1.license_pools
         eq_(pool, lp1)
         eq_(pool.identifier, i1)
-        eq_(w1, wc1.work)
-        eq_(WorkCoverageRecord.GENERATE_OPDS_OPERATION, wc1.operation)
-        eq_(self.collection.id, ci1.collection_id)
-        eq_(pool.identifier.id, ci1.identifier_id)
 
         # When a timestamp is passed, only works that have been updated
         # since then will be returned

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1801,8 +1801,6 @@ class TestLookupAcquisitionFeed(DatabaseTest):
 
     def entry(self, identifier, work, annotator=VerboseAnnotator, **kwargs):
         """Helper method to create an entry."""
-        if callable(annotator):
-            annotator = annotator()
         feed = self.feed(annotator, **kwargs)
         entry = feed.create_entry((identifier, work))
         if isinstance(entry, OPDSMessage):
@@ -1821,7 +1819,7 @@ class TestLookupAcquisitionFeed(DatabaseTest):
         )
         work.license_pools.append(new_pool)
 
-        # We can generate two different OPDS feeds for a single work
+        # We can generate two different OPDS entries for a single work
         # depending on which identifier we look up.
         ignore, e1 = self.entry(original_pool.identifier, work)
         assert original_pool.identifier.urn in e1
@@ -1829,11 +1827,16 @@ class TestLookupAcquisitionFeed(DatabaseTest):
         assert new_pool.identifier.urn not in e1
         assert new_pool.presentation_edition.title not in e1
 
-        ignore, e2 = self.entry(new_pool.identifier, work)
+        # Passing in the other identifier gives an OPDS entry with the
+        # same bibliographic data (taken from the original pool's
+        # presentation edition) but with different identifier
+        # information.
+        i = new_pool.identifier
+        ignore, e2 = self.entry(i, work)
         assert new_pool.identifier.urn in e2
-        assert new_pool.presentation_edition.title in e2
+        assert new_pool.presentation_edition.title not in e2
+        assert original_pool.presentation_edition.title in e2
         assert original_pool.identifier.urn not in e2
-        assert original_pool.presentation_edition.title not in e2
 
     def test_error_on_mismatched_identifier(self):
         """We get an error if we try to make it look like an Identifier lookup

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -158,7 +158,7 @@ class TestBaseAnnotator(DatabaseTest):
         edition.add_contributor(
             "Jonathan Frakes", Contributor.NARRATOR_ROLE
         )
-        author, contributor = Annotator.authors(None, None, edition, None)
+        author, contributor = Annotator.authors(None, edition)
 
         # The <author> tag indicates a role of 'author', so there's no
         # need for an explicitly specified role property.
@@ -305,9 +305,7 @@ class TestAnnotators(DatabaseTest):
         work = self._work(authors=[], with_license_pool=True)
         work.presentation_edition.add_contributor(c, Contributor.PRIMARY_AUTHOR_ROLE)
 
-        [same_tag] = VerboseAnnotator.authors(
-            work, work.license_pools[0], work.presentation_edition,
-            work.presentation_edition.primary_identifier)
+        [same_tag] = VerboseAnnotator.authors(work, work.presentation_edition)
         eq_(tag_string, etree.tostring(same_tag))
 
     def test_duplicate_author_names_are_ignored(self):
@@ -319,9 +317,7 @@ class TestAnnotators(DatabaseTest):
         edition = work.presentation_edition
         edition.add_contributor(duplicate, Contributor.AUTHOR_ROLE)
 
-        eq_(1, len(Annotator.authors(
-            work, work.license_pools[0], edition, edition.primary_identifier
-        )))
+        eq_(1, len(Annotator.authors(work, edition)))
 
     def test_all_annotators_mention_every_relevant_author(self):
         work = self._work(authors=[], with_license_pool=True)
@@ -351,10 +347,7 @@ class TestAnnotators(DatabaseTest):
         ]
 
         for annotator in Annotator, VerboseAnnotator:
-            tags = Annotator.authors(
-                work, work.license_pools[0], edition,
-                edition.primary_identifier
-            )
+            tags = Annotator.authors(work, edition)
             # We made two <author> tags and one <contributor>
             # tag, for the illustrator.
             eq_(['author', 'author', 'contributor'],

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -364,7 +364,7 @@ class TestAnnotators(DatabaseTest):
         work.rating = 0.6
         work.calculate_opds_entries(verbose=True)
         feed = AcquisitionFeed(
-            self._db, self._str, self._url, [work], VerboseAnnotator()
+            self._db, self._str, self._url, [work], VerboseAnnotator
         )
         url = self._url
         tag = feed.create_entry(work, None)
@@ -386,7 +386,7 @@ class TestAnnotators(DatabaseTest):
         work.calculate_opds_entries()
 
         raw_feed = unicode(AcquisitionFeed(
-            self._db, self._str, self._url, [work], Annotator()
+            self._db, self._str, self._url, [work], Annotator
         ))
         assert "schema:alternativeHeadline" in raw_feed
         assert work.presentation_edition.subtitle in raw_feed
@@ -399,7 +399,7 @@ class TestAnnotators(DatabaseTest):
         work.presentation_edition.subtitle = None
         work.calculate_opds_entries()
         raw_feed = unicode(AcquisitionFeed(
-            self._db, self._str, self._url, [work], Annotator()
+            self._db, self._str, self._url, [work], Annotator
         ))
 
         assert "schema:alternativeHeadline" not in raw_feed
@@ -414,7 +414,7 @@ class TestAnnotators(DatabaseTest):
         work.calculate_opds_entries()
 
         raw_feed = unicode(AcquisitionFeed(
-            self._db, self._str, self._url, [work], Annotator()
+            self._db, self._str, self._url, [work], Annotator
         ))
         assert "schema:Series" in raw_feed
         assert work.presentation_edition.series in raw_feed
@@ -429,7 +429,7 @@ class TestAnnotators(DatabaseTest):
         work.calculate_opds_entries()
 
         raw_feed = unicode(AcquisitionFeed(
-            self._db, self._str, self._url, [work], Annotator()
+            self._db, self._str, self._url, [work], Annotator
         ))
         assert "schema:Series" in raw_feed
         assert work.presentation_edition.series in raw_feed
@@ -443,7 +443,7 @@ class TestAnnotators(DatabaseTest):
         work.presentation_edition.series = None
         work.calculate_opds_entries()
         raw_feed = unicode(AcquisitionFeed(
-            self._db, self._str, self._url, [work], Annotator()
+            self._db, self._str, self._url, [work], Annotator
         ))
 
         assert "schema:Series" not in raw_feed
@@ -584,7 +584,7 @@ class TestOPDS(DatabaseTest):
 
         cached_feed = AcquisitionFeed.page(
             self._db, "title", "http://the-url.com/",
-            lane, TestAnnotator(), facets=facets
+            lane, TestAnnotator, facets=facets
         )
 
         u = unicode(cached_feed)
@@ -670,7 +670,7 @@ class TestOPDS(DatabaseTest):
         self._db.commit()
         works = self._db.query(Work)
         with_times = AcquisitionFeed(
-            self._db, "test", "url", works, TestAnnotator())
+            self._db, "test", "url", works, TestAnnotator)
         u = unicode(with_times)
         assert 'dcterms:issued' in u
 
@@ -720,7 +720,7 @@ class TestOPDS(DatabaseTest):
 
         works = self._db.query(Work)
         with_publisher = AcquisitionFeed(
-            self._db, "test", "url", works, TestAnnotator())
+            self._db, "test", "url", works, TestAnnotator)
         with_publisher = feedparser.parse(unicode(with_publisher))
         entries = sorted(with_publisher['entries'], key = lambda x: x['title'])
         eq_('The Publisher', entries[0]['dcterms_publisher'])
@@ -964,7 +964,7 @@ class TestOPDS(DatabaseTest):
 
         def make_page(pagination):
             return AcquisitionFeed.page(
-                self._db, "test", self._url, lane, TestAnnotator(),
+                self._db, "test", self._url, lane, TestAnnotator,
                 pagination=pagination
             )
         cached_works = make_page(pagination)
@@ -1012,7 +1012,7 @@ class TestOPDS(DatabaseTest):
         # CachedFeeds aren't used.
         old_cache_count = self._db.query(CachedFeed).count()
         raw_page = AcquisitionFeed.page(
-            self._db, "test", self._url, lane, TestAnnotator(),
+            self._db, "test", self._url, lane, TestAnnotator,
             pagination=pagination.next_page, cache_type=AcquisitionFeed.NO_CACHE
         )
 
@@ -1038,7 +1038,7 @@ class TestOPDS(DatabaseTest):
 
         def make_page(pagination):
             return AcquisitionFeed.page(
-                self._db, "test", self._url, lane, TestAnnotator(),
+                self._db, "test", self._url, lane, TestAnnotator,
                 pagination=pagination
             )
         cached_works = make_page(pagination)
@@ -1075,7 +1075,7 @@ class TestOPDS(DatabaseTest):
         # CachedFeeds aren't used.
         old_cache_count = self._db.query(CachedFeed).count()
         raw_page = AcquisitionFeed.page(
-            self._db, "test", self._url, lane, TestAnnotator(),
+            self._db, "test", self._url, lane, TestAnnotator,
             pagination=pagination.next_page, cache_type=AcquisitionFeed.NO_CACHE
         )
 
@@ -1224,7 +1224,7 @@ class TestOPDS(DatabaseTest):
                 self._db, "test", self._url, fantasy_lane, search_client,
                 "fantasy",
                 pagination=pagination,
-                annotator=TestAnnotator(),
+                annotator=TestAnnotator,
             )
         feed = make_page(pagination)
         parsed = feedparser.parse(feed)
@@ -1276,7 +1276,7 @@ class TestOPDS(DatabaseTest):
 
         def make_page():
             return AcquisitionFeed.page(
-                self._db, "test", self._url, fantasy_lane, TestAnnotator(),
+                self._db, "test", self._url, fantasy_lane, TestAnnotator,
                 pagination=Pagination.default()
             )
 
@@ -1454,7 +1454,7 @@ class TestAcquisitionFeed(DatabaseTest):
         facets = object()
 
         AcquisitionFeed.groups(
-            self._db, "title", "url", lane, TestAnnotator(), facets=facets
+            self._db, "title", "url", lane, TestAnnotator, facets=facets
         )
         # We called CachedFeed.fetch with the given facets object.
         eq_(facets, mock.fetch_called_with)
@@ -1560,7 +1560,7 @@ class TestAcquisitionFeed(DatabaseTest):
         # This is the edition used when we create an <entry> tag for
         # this Work.
         entry = AcquisitionFeed.single_entry(
-            self._db, work, TestAnnotator()
+            self._db, work, TestAnnotator
         )
         entry = etree.tostring(entry)
         assert original_pool.presentation_edition.title in entry
@@ -1574,7 +1574,7 @@ class TestAcquisitionFeed(DatabaseTest):
             datetime.datetime.utcnow() - five_hundred_years
         )
 
-        entry = AcquisitionFeed.single_entry(self._db, work, TestAnnotator())
+        entry = AcquisitionFeed.single_entry(self._db, work, TestAnnotator)
 
         expected = str(work.presentation_edition.issued.date())
         assert expected in etree.tostring(entry)
@@ -1601,7 +1601,7 @@ class TestAcquisitionFeed(DatabaseTest):
         # The entry is retrieved from cache and the appropriate
         # namespace inserted.
         entry = AcquisitionFeed.single_entry(
-            self._db, work, AddDRMTagAnnotator()
+            self._db, work, AddDRMTagAnnotator
         )
         eq_('<entry xmlns:drm="http://librarysimplified.org/terms/drm"><foo>bar</foo><drm:licensor/></entry>',
             etree.tostring(entry)
@@ -1615,14 +1615,14 @@ class TestAcquisitionFeed(DatabaseTest):
         work.license_pools[0].identifier = None
         work.presentation_edition.primary_identifier = None
         entry = AcquisitionFeed.single_entry(
-            self._db, work, TestAnnotator()
+            self._db, work, TestAnnotator
         )
         eq_(entry, None)
 
     def test_error_when_work_has_no_licensepool(self):
         work = self._work()
         feed = AcquisitionFeed(
-            self._db, self._str, self._url, [], annotator=Annotator()
+            self._db, self._str, self._url, [], annotator=Annotator
         )
         entry = feed.create_entry(work)
         expect = AcquisitionFeed.error_message(
@@ -1640,7 +1640,7 @@ class TestAcquisitionFeed(DatabaseTest):
         work.license_pools[0].presentation_edition = None
         work.presentation_edition = None
         feed = AcquisitionFeed(
-            self._db, self._str, self._url, [], annotator=Annotator()
+            self._db, self._str, self._url, [], annotator=Annotator
         )
         entry = feed.create_entry(work)
         eq_(None, entry)
@@ -1648,7 +1648,7 @@ class TestAcquisitionFeed(DatabaseTest):
     def test_cache_usage(self):
         work = self._work(with_open_access_download=True)
         feed = AcquisitionFeed(
-            self._db, self._str, self._url, [], annotator=Annotator()
+            self._db, self._str, self._url, [], annotator=Annotator
         )
 
         # Set the Work's cached OPDS entry to something that's clearly wrong.
@@ -1700,7 +1700,7 @@ class TestAcquisitionFeed(DatabaseTest):
             def _create_entry(self, *args, **kwargs):
                 raise Exception("I'm doomed!")
         feed = DoomedFeed(
-            self._db, self._str, self._url, [], annotator=Annotator()
+            self._db, self._str, self._url, [], annotator=Annotator
         )
         work = self._work(with_open_access_download=True)
 
@@ -1713,7 +1713,7 @@ class TestAcquisitionFeed(DatabaseTest):
         work = self._work(with_open_access_download=True)
         [pool] = work.license_pools
         entry = AcquisitionFeed.single_entry(
-            self._db, work, TestUnfulfillableAnnotator()
+            self._db, work, TestUnfulfillableAnnotator
         )
         expect = AcquisitionFeed.error_message(
             pool.identifier, 403,
@@ -1751,7 +1751,7 @@ class TestAcquisitionFeed(DatabaseTest):
             def show_current_entrypoint(self, entrypoint):
                 self.current_entrypoint = entrypoint
 
-        annotator = TestAnnotator()
+        annotator = TestAnnotator
         feed = MockFeed(self._db, "title", "url", [], annotator=annotator)
 
         lane = self._lane()
@@ -1885,7 +1885,7 @@ class TestLookupAcquisitionFeed(DatabaseTest):
         work = self._work(with_open_access_download=True)
         [pool] = work.license_pools
         feed, entry = self.entry(pool.identifier, work,
-                                 TestUnfulfillableAnnotator())
+                                 TestUnfulfillableAnnotator)
         expect = AcquisitionFeed.error_message(
             pool.identifier, 403,
             "I know about this work but can offer no way of fulfilling it."
@@ -1977,7 +1977,7 @@ class TestEntrypointLinkInsertion(DatabaseTest):
         self.no_eps.works = works
         self.wl.works = works
 
-        self.annotator = TestAnnotator()
+        self.annotator = TestAnnotator
         self.old_add_entrypoint_links = AcquisitionFeed.add_entrypoint_links
         AcquisitionFeed.add_entrypoint_links = self.mock.add_entrypoint_links
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -185,7 +185,7 @@ class TestBaseAnnotator(DatabaseTest):
         [pool] = work.license_pools
 
         entry = []
-        Annotator.annotate_work_entry(work, pool, None, None, None, entry)
+        Annotator().annotate_work_entry(work, pool, None, None, None, entry)
         eq_(2, len(entry))
         [distributor, updated] = entry
         assert 'ProviderName="Gutenberg"' in etree.tostring(distributor)
@@ -364,7 +364,7 @@ class TestAnnotators(DatabaseTest):
         work.rating = 0.6
         work.calculate_opds_entries(verbose=True)
         feed = AcquisitionFeed(
-            self._db, self._str, self._url, [work], VerboseAnnotator
+            self._db, self._str, self._url, [work], VerboseAnnotator()
         )
         url = self._url
         tag = feed.create_entry(work, None)
@@ -386,7 +386,7 @@ class TestAnnotators(DatabaseTest):
         work.calculate_opds_entries()
 
         raw_feed = unicode(AcquisitionFeed(
-            self._db, self._str, self._url, [work], Annotator
+            self._db, self._str, self._url, [work], Annotator()
         ))
         assert "schema:alternativeHeadline" in raw_feed
         assert work.presentation_edition.subtitle in raw_feed
@@ -399,7 +399,7 @@ class TestAnnotators(DatabaseTest):
         work.presentation_edition.subtitle = None
         work.calculate_opds_entries()
         raw_feed = unicode(AcquisitionFeed(
-            self._db, self._str, self._url, [work], Annotator
+            self._db, self._str, self._url, [work], Annotator()
         ))
 
         assert "schema:alternativeHeadline" not in raw_feed
@@ -414,7 +414,7 @@ class TestAnnotators(DatabaseTest):
         work.calculate_opds_entries()
 
         raw_feed = unicode(AcquisitionFeed(
-            self._db, self._str, self._url, [work], Annotator
+            self._db, self._str, self._url, [work], Annotator()
         ))
         assert "schema:Series" in raw_feed
         assert work.presentation_edition.series in raw_feed
@@ -429,7 +429,7 @@ class TestAnnotators(DatabaseTest):
         work.calculate_opds_entries()
 
         raw_feed = unicode(AcquisitionFeed(
-            self._db, self._str, self._url, [work], Annotator
+            self._db, self._str, self._url, [work], Annotator()
         ))
         assert "schema:Series" in raw_feed
         assert work.presentation_edition.series in raw_feed
@@ -443,7 +443,7 @@ class TestAnnotators(DatabaseTest):
         work.presentation_edition.series = None
         work.calculate_opds_entries()
         raw_feed = unicode(AcquisitionFeed(
-            self._db, self._str, self._url, [work], Annotator
+            self._db, self._str, self._url, [work], Annotator()
         ))
 
         assert "schema:Series" not in raw_feed
@@ -584,7 +584,7 @@ class TestOPDS(DatabaseTest):
 
         cached_feed = AcquisitionFeed.page(
             self._db, "title", "http://the-url.com/",
-            lane, TestAnnotator, facets=facets
+            lane, TestAnnotator(), facets=facets
         )
 
         u = unicode(cached_feed)
@@ -670,7 +670,7 @@ class TestOPDS(DatabaseTest):
         self._db.commit()
         works = self._db.query(Work)
         with_times = AcquisitionFeed(
-            self._db, "test", "url", works, TestAnnotator)
+            self._db, "test", "url", works, TestAnnotator())
         u = unicode(with_times)
         assert 'dcterms:issued' in u
 
@@ -720,7 +720,7 @@ class TestOPDS(DatabaseTest):
 
         works = self._db.query(Work)
         with_publisher = AcquisitionFeed(
-            self._db, "test", "url", works, TestAnnotator)
+            self._db, "test", "url", works, TestAnnotator())
         with_publisher = feedparser.parse(unicode(with_publisher))
         entries = sorted(with_publisher['entries'], key = lambda x: x['title'])
         eq_('The Publisher', entries[0]['dcterms_publisher'])
@@ -964,7 +964,7 @@ class TestOPDS(DatabaseTest):
 
         def make_page(pagination):
             return AcquisitionFeed.page(
-                self._db, "test", self._url, lane, TestAnnotator,
+                self._db, "test", self._url, lane, TestAnnotator(),
                 pagination=pagination
             )
         cached_works = make_page(pagination)
@@ -1012,7 +1012,7 @@ class TestOPDS(DatabaseTest):
         # CachedFeeds aren't used.
         old_cache_count = self._db.query(CachedFeed).count()
         raw_page = AcquisitionFeed.page(
-            self._db, "test", self._url, lane, TestAnnotator,
+            self._db, "test", self._url, lane, TestAnnotator(),
             pagination=pagination.next_page, cache_type=AcquisitionFeed.NO_CACHE
         )
 
@@ -1038,7 +1038,7 @@ class TestOPDS(DatabaseTest):
 
         def make_page(pagination):
             return AcquisitionFeed.page(
-                self._db, "test", self._url, lane, TestAnnotator,
+                self._db, "test", self._url, lane, TestAnnotator(),
                 pagination=pagination
             )
         cached_works = make_page(pagination)
@@ -1075,7 +1075,7 @@ class TestOPDS(DatabaseTest):
         # CachedFeeds aren't used.
         old_cache_count = self._db.query(CachedFeed).count()
         raw_page = AcquisitionFeed.page(
-            self._db, "test", self._url, lane, TestAnnotator,
+            self._db, "test", self._url, lane, TestAnnotator(),
             pagination=pagination.next_page, cache_type=AcquisitionFeed.NO_CACHE
         )
 
@@ -1224,7 +1224,7 @@ class TestOPDS(DatabaseTest):
                 self._db, "test", self._url, fantasy_lane, search_client,
                 "fantasy",
                 pagination=pagination,
-                annotator=TestAnnotator,
+                annotator=TestAnnotator(),
             )
         feed = make_page(pagination)
         parsed = feedparser.parse(feed)
@@ -1276,7 +1276,7 @@ class TestOPDS(DatabaseTest):
 
         def make_page():
             return AcquisitionFeed.page(
-                self._db, "test", self._url, fantasy_lane, TestAnnotator,
+                self._db, "test", self._url, fantasy_lane, TestAnnotator(),
                 pagination=Pagination.default()
             )
 
@@ -1560,7 +1560,7 @@ class TestAcquisitionFeed(DatabaseTest):
         # This is the edition used when we create an <entry> tag for
         # this Work.
         entry = AcquisitionFeed.single_entry(
-            self._db, work, TestAnnotator
+            self._db, work, TestAnnotator()
         )
         entry = etree.tostring(entry)
         assert original_pool.presentation_edition.title in entry
@@ -1574,7 +1574,7 @@ class TestAcquisitionFeed(DatabaseTest):
             datetime.datetime.utcnow() - five_hundred_years
         )
 
-        entry = AcquisitionFeed.single_entry(self._db, work, TestAnnotator)
+        entry = AcquisitionFeed.single_entry(self._db, work, TestAnnotator())
 
         expected = str(work.presentation_edition.issued.date())
         assert expected in etree.tostring(entry)
@@ -1601,7 +1601,7 @@ class TestAcquisitionFeed(DatabaseTest):
         # The entry is retrieved from cache and the appropriate
         # namespace inserted.
         entry = AcquisitionFeed.single_entry(
-            self._db, work, AddDRMTagAnnotator
+            self._db, work, AddDRMTagAnnotator()
         )
         eq_('<entry xmlns:drm="http://librarysimplified.org/terms/drm"><foo>bar</foo><drm:licensor/></entry>',
             etree.tostring(entry)
@@ -1615,14 +1615,14 @@ class TestAcquisitionFeed(DatabaseTest):
         work.license_pools[0].identifier = None
         work.presentation_edition.primary_identifier = None
         entry = AcquisitionFeed.single_entry(
-            self._db, work, TestAnnotator
+            self._db, work, TestAnnotator()
         )
         eq_(entry, None)
 
     def test_error_when_work_has_no_licensepool(self):
         work = self._work()
         feed = AcquisitionFeed(
-            self._db, self._str, self._url, [], annotator=Annotator
+            self._db, self._str, self._url, [], annotator=Annotator()
         )
         entry = feed.create_entry(work)
         expect = AcquisitionFeed.error_message(
@@ -1640,7 +1640,7 @@ class TestAcquisitionFeed(DatabaseTest):
         work.license_pools[0].presentation_edition = None
         work.presentation_edition = None
         feed = AcquisitionFeed(
-            self._db, self._str, self._url, [], annotator=Annotator
+            self._db, self._str, self._url, [], annotator=Annotator()
         )
         entry = feed.create_entry(work)
         eq_(None, entry)
@@ -1648,7 +1648,7 @@ class TestAcquisitionFeed(DatabaseTest):
     def test_cache_usage(self):
         work = self._work(with_open_access_download=True)
         feed = AcquisitionFeed(
-            self._db, self._str, self._url, [], annotator=Annotator
+            self._db, self._str, self._url, [], annotator=Annotator()
         )
 
         # Set the Work's cached OPDS entry to something that's clearly wrong.
@@ -1664,7 +1664,8 @@ class TestAcquisitionFeed(DatabaseTest):
         # run through `Annotator.annotate_work_entry`.
         [pool] = work.license_pools
         xml = etree.fromstring(work.simple_opds_entry)
-        Annotator.annotate_work_entry(
+        annotator = Annotator()
+        annotator.annotate_work_entry(
             work, pool, pool.presentation_edition, pool.identifier, feed,
             xml
         )
@@ -1686,7 +1687,7 @@ class TestAcquisitionFeed(DatabaseTest):
         # Again, we got entry_string by running the (new) cached value
         # through `Annotator.annotate_work_entry`.
         full_entry = etree.fromstring(work.simple_opds_entry)
-        Annotator.annotate_work_entry(
+        annotator.annotate_work_entry(
             work, pool, pool.presentation_edition, pool.identifier, feed,
             full_entry
         )
@@ -1699,7 +1700,7 @@ class TestAcquisitionFeed(DatabaseTest):
             def _create_entry(self, *args, **kwargs):
                 raise Exception("I'm doomed!")
         feed = DoomedFeed(
-            self._db, self._str, self._url, [], annotator=Annotator
+            self._db, self._str, self._url, [], annotator=Annotator()
         )
         work = self._work(with_open_access_download=True)
 
@@ -1712,7 +1713,7 @@ class TestAcquisitionFeed(DatabaseTest):
         work = self._work(with_open_access_download=True)
         [pool] = work.license_pools
         entry = AcquisitionFeed.single_entry(
-            self._db, work, TestUnfulfillableAnnotator
+            self._db, work, TestUnfulfillableAnnotator()
         )
         expect = AcquisitionFeed.error_message(
             pool.identifier, 403,
@@ -1800,6 +1801,8 @@ class TestLookupAcquisitionFeed(DatabaseTest):
 
     def entry(self, identifier, work, annotator=VerboseAnnotator, **kwargs):
         """Helper method to create an entry."""
+        if callable(annotator):
+            annotator = annotator()
         feed = self.feed(annotator, **kwargs)
         entry = feed.create_entry((identifier, work))
         if isinstance(entry, OPDSMessage):
@@ -1882,7 +1885,7 @@ class TestLookupAcquisitionFeed(DatabaseTest):
         work = self._work(with_open_access_download=True)
         [pool] = work.license_pools
         feed, entry = self.entry(pool.identifier, work,
-                                 TestUnfulfillableAnnotator)
+                                 TestUnfulfillableAnnotator())
         expect = AcquisitionFeed.error_message(
             pool.identifier, 403,
             "I know about this work but can offer no way of fulfilling it."
@@ -1904,7 +1907,7 @@ class TestLookupAcquisitionFeed(DatabaseTest):
             @classmethod
             def active_licensepool_for(cls, work):
                 return cls.ACTIVE
-        feed = self.feed(annotator=InstrumentableActiveLicensePool)
+        feed = self.feed(annotator=InstrumentableActiveLicensePool())
 
         # Here are two completely different LicensePools for the same
         # identifier.


### PR DESCRIPTION
This branch does the core work of https://jira.nypl.org/browse/SIMPLY-273. The OPDS entry that is cached under Work.simple_opds_entry or Work.verbose_opds_entry no longer contains any information that can be derived from a particular Identifier or LicensePool, only Work and Edition. This means the cached OPDS entry can be reused for any Identifier or LicensePool associated with that Work.