### PR TITLE
Change the Explain script to include information about CoverageRecords, WorkCoverageRecords, and the Collection of every LicensePool associated with the work.

### DIFF
--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2363,6 +2363,8 @@ class TestExplain(DatabaseTest):
         [pool] = work.license_pools
         edition = work.presentation_edition
         identifier = pool.identifier
+        source = DataSource.lookup(self._db, DataSource.OCLC_LINKED_DATA)
+        CoverageRecord.add_for(identifier, source, "an operation")
         input = StringIO()
         output = StringIO()
         args = ["--identifier-type", "Database ID", str(identifier.id)]
@@ -2378,6 +2380,14 @@ class TestExplain(DatabaseTest):
         assert "Science Fiction" in output
         for contributor in edition.contributors:
             assert contributor.sort_name in output
+
+        # CoverageRecords associated with the primary identifier were
+        # printed out.
+        assert 'OCLC Linked Data | an operation | success' in output
+
+        # WorkCoverageRecords associated with the work were
+        # printed out.
+        assert 'generate-opds | success' in output
 
         # There is an active LicensePool that is fulfillable and has
         # copies owned.


### PR DESCRIPTION
This branch puts information in the output of explain() that is useful when debugging problems on the metadata wrangler. This is as part of my work on https://jira.nypl.org/browse/SIMPLY-314 but it's very far removed from actually solving any problems -- I'm just trying to improve my visibility into the problems.