### PR TITLE
Resource derivatives

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -46,6 +46,7 @@ from model import (
     PresentationCalculationPolicy,
     RightsStatus,
     Representation,
+    Resource,
     Work,
 )
 from classifier import NO_VALUE, NO_NUMBER
@@ -411,7 +412,8 @@ class IdentifierData(object):
 
 class LinkData(object):
     def __init__(self, rel, href=None, media_type=None, content=None,
-                 thumbnail=None, rights_uri=None):
+                 thumbnail=None, rights_uri=None, rights_explanation=None,
+                 original=None, derivation_settings=None):
         if not rel:
             raise ValueError("rel is required")
 
@@ -423,8 +425,13 @@ class LinkData(object):
         self.content = content
         self.thumbnail = thumbnail
         # This handles content sources like unglue.it that have rights for each link
-        # rather than each edition.
+        # rather than each edition, and rights for cover images.
         self.rights_uri = rights_uri
+        self.rights_explanation = rights_explanation
+        # If this LinkData is a derivative, it may also contain the original link
+        # and the settings used to derive it.
+        self.original = original
+        self.derivation_settings = derivation_settings or {}
 
     @property
     def guessed_media_type(self):
@@ -1556,10 +1563,27 @@ class Metadata(MetaToModelUtility):
 
         for link in self.links:
             if link.rel in Hyperlink.METADATA_ALLOWED:
+                original_resource = None
+                if link.original:
+                    rights_status = RightsStatus.lookup(_db, link.original.rights_uri)
+                    original_resource, ignore = get_one_or_create(
+                        _db, Resource, url=link.original.href,
+                    )
+                    original_resource.data_source = data_source
+                    original_resource.rights_status = rights_status
+                    original_resource.rights_explanation = link.original.rights_explanation
+                    if link.original.content:
+                        original_resource.set_fetched_content(
+                            link.original.guessed_media_type,
+                            link.original.content, None)
+
                 link_obj, ignore = identifier.add_link(
                     rel=link.rel, href=link.href, data_source=data_source, 
                     media_type=link.guessed_media_type,
-                    content=link.content
+                    content=link.content, rights_status_uri=link.rights_uri,
+                    rights_explanation=link.rights_explanation,
+                    original_resource=original_resource,
+                    derivation_settings=link.derivation_settings,
                 )
             link_objects[link] = link_obj
             if link.thumbnail:
@@ -1597,13 +1621,6 @@ class Metadata(MetaToModelUtility):
                 measurement.value, measurement.weight,
                 measurement.taken_at
             )
-
-        # Make sure the work we just did shows up.
-        made_changes = edition.calculate_presentation(
-            policy=replace.presentation_calculation_policy
-        )
-        if made_changes:
-            made_core_changes = True
 
         if not edition.sort_author:
             # This may be a situation like the NYT best-seller list where
@@ -1647,6 +1664,14 @@ class Metadata(MetaToModelUtility):
                 # to make sure that its thumbnail exists locally and
                 # is associated with the original image.
                 self.make_thumbnail(data_source, link, link_obj)
+
+        # Make sure the work we just did shows up. This needs to happen after mirroring
+        # so mirror urls are available.
+        made_changes = edition.calculate_presentation(
+            policy=replace.presentation_calculation_policy
+        )
+        if made_changes:
+            made_core_changes = True
 
         # The metadata wrangler doesn't need information from these data sources.
         # We don't need to send it information it originally provided, and

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -413,7 +413,7 @@ class IdentifierData(object):
 class LinkData(object):
     def __init__(self, rel, href=None, media_type=None, content=None,
                  thumbnail=None, rights_uri=None, rights_explanation=None,
-                 original=None, derivation_settings=None):
+                 original=None, transformation_settings=None):
         if not rel:
             raise ValueError("rel is required")
 
@@ -429,9 +429,9 @@ class LinkData(object):
         self.rights_uri = rights_uri
         self.rights_explanation = rights_explanation
         # If this LinkData is a derivative, it may also contain the original link
-        # and the settings used to derive it.
+        # and the settings used to transform the original into the derivative.
         self.original = original
-        self.derivation_settings = derivation_settings or {}
+        self.transformation_settings = transformation_settings or {}
 
     @property
     def guessed_media_type(self):
@@ -1569,7 +1569,8 @@ class Metadata(MetaToModelUtility):
                     original_resource, ignore = get_one_or_create(
                         _db, Resource, url=link.original.href,
                     )
-                    original_resource.data_source = data_source
+                    if not original_resource.data_source:
+                        original_resource.data_source = data_source
                     original_resource.rights_status = rights_status
                     original_resource.rights_explanation = link.original.rights_explanation
                     if link.original.content:
@@ -1583,7 +1584,7 @@ class Metadata(MetaToModelUtility):
                     content=link.content, rights_status_uri=link.rights_uri,
                     rights_explanation=link.rights_explanation,
                     original_resource=original_resource,
-                    derivation_settings=link.derivation_settings,
+                    transformation_settings=link.transformation_settings,
                 )
             link_objects[link] = link_obj
             if link.thumbnail:

--- a/migration/20180528-add-resource-rights-status-and-derivatives.sql
+++ b/migration/20180528-add-resource-rights-status-and-derivatives.sql
@@ -1,0 +1,16 @@
+DO $$
+  BEGIN
+    BEGIN
+      ALTER TABLE resources ADD COLUMN rights_status_id integer;
+      ALTER TABLE resources ADD CONSTRAINT resources_rightsstatus_id_fkey FOREIGN KEY (rights_status_id) REFERENCES rightsstatus(id);
+    EXCEPTION
+      WHEN duplicate_column THEN RAISE NOTICE 'column resources.rights_status_id already exists, not creating it.';
+    END;
+
+    BEGIN
+      ALTER TABLE resources ADD COLUMN rights_explanation varchar;
+    EXCEPTION
+      WHEN duplicate_column THEN RAISE NOTICE 'column resources.rights_explanation already exists, not creating it.';
+    END;
+  END;
+$$;

--- a/model.py
+++ b/model.py
@@ -2178,7 +2178,8 @@ class Identifier(Base):
                 return lp
 
     def add_link(self, rel, href, data_source, media_type=None, content=None,
-                 content_path=None):
+                 content_path=None, rights_status_uri=None, rights_explanation=None,
+                 original_resource=None, derivation_settings=None):
         """Create a link between this Identifier and a (potentially new)
         Resource.
 
@@ -2191,9 +2192,14 @@ class Identifier(Base):
         # Find or create the Resource.
         if not href:
             href = Hyperlink.generic_uri(data_source, self, rel, content)
+        rights_status = None
+        if rights_status_uri:
+            rights_status = RightsStatus.lookup(_db, rights_status_uri)
         resource, new_resource = get_one_or_create(
             _db, Resource, url=href,
-            create_method_kwargs=dict(data_source=data_source)
+            create_method_kwargs=dict(data_source=data_source, 
+                                      rights_status=rights_status,
+                                      rights_explanation=rights_explanation)
         )
 
         # Find or create the Hyperlink.
@@ -2211,6 +2217,9 @@ class Identifier(Base):
             resource.representation, is_new = get_one_or_create(
                 _db, Representation, url=resource.url, media_type=media_type
             )
+
+        if original_resource:
+            original_resource.add_derivative(link.resource, derivation_settings)
 
         # TODO: This is where we would mirror the resource if we
         # wanted to.
@@ -5795,6 +5804,32 @@ class Resource(Base):
     representation_id = Column(
         Integer, ForeignKey('representations.id'), index=True)
 
+    # The rights status of this Resource.
+    rights_status_id = Column(Integer, ForeignKey('rightsstatus.id'))
+
+    # An optional explanation of the rights status.
+    rights_explanation = Column(Unicode)
+
+    # Many derivatives may be derived from a Resource.
+    derivative_derivations = relationship(
+        'ResourceDerivation',
+        primaryjoin="ResourceDerivation.original_id==Resource.id",
+        foreign_keys=id,
+        lazy="joined",
+        backref=backref('original', uselist=False),
+        uselist=True,
+    )
+
+    # A derivative resource may have one original.
+    derivation = relationship(
+        'ResourceDerivation',
+        primaryjoin="ResourceDerivation.derivative_id==Resource.id",
+        foreign_keys=id,
+        backref=backref('derivative', uselist=False),
+        lazy="joined",
+        uselist=False,
+    )
+
     # A calculated value for the quality of this resource, based on an
     # algorithmic treatment of its content.
     estimated_quality = Column(Float)
@@ -6032,6 +6067,32 @@ class Resource(Base):
         self.set_estimated_quality(quality)
         return quality
 
+    def add_derivative(self, derivative_resource, settings=None):
+        _db = Session.object_session(self)
+
+        derivation, ignore = get_one_or_create(
+            _db, ResourceDerivation, derivative_id=derivative_resource.id)
+        derivation.original_id = self.id
+        derivation.settings = settings or {}
+        return derivation
+
+class ResourceDerivation(Base):
+    """A record that a resource is a derivative of another resource,
+    and the settings that were used to derive it.
+    """
+
+    __tablename__ = 'resourcederivations'
+
+    # The derivative resource. A resource can only be derived from one other resource.
+    derivative_id = Column(
+        Integer, ForeignKey('resources.id'), index=True, primary_key=True)
+
+    # The original resource that was used to create the derivative.
+    original_id = Column(
+        Integer, ForeignKey('resources.id'), index=True)
+
+    # The settings used to create the derivative.
+    settings = Column(MutableDict.as_mutable(JSON), default={})
 
 class Genre(Base, HasFullTableCache):
     """A subject-matter classification for a book.
@@ -7083,7 +7144,10 @@ class LicensePool(Base):
         )
 
     def add_link(self, rel, href, data_source, media_type=None,
-                 content=None, content_path=None):
+                 content=None, content_path=None, 
+                 rights_status_uri=None, rights_explanation=None,
+                 original_resource=None, derivation_settings=None,
+                 ):
         """Add a link between this LicensePool and a Resource.
 
         :param rel: The relationship between this LicensePool and the resource
@@ -7095,9 +7159,17 @@ class LicensePool(Base):
                resource.
         :param content_path: Path (relative to DATA_DIRECTORY) of the
                representation associated with the resource.
+        :param rights_status_uri: The URI of the RightsStatus for this resource.
+        :param rights_explanation: A free text explanation of why the RightsStatus
+               applies.
+        :param original_resource: Another resource that this resource was derived from.
+        :param derivation_settings: The settings used to derive this resource from
+               the original resource.
         """
         return self.identifier.add_link(
-            rel, href, data_source, media_type, content, content_path)
+            rel, href, data_source, media_type, content, content_path,
+            rights_status_uri, rights_explanation, original_resource,
+            derivation_settings)
 
     def needs_update(self):
         """Is it time to update the circulation info for this license pool?"""
@@ -7818,6 +7890,16 @@ class RightsStatus(Base):
         GENERIC_OPEN_ACCESS,
     ]
 
+    ALLOWS_DERIVATIVES = [
+        PUBLIC_DOMAIN_USA,
+        CC0,
+        CC_BY,
+        CC_BY_SA,
+        CC_BY_NC,
+        CC_BY_NC_SA,
+        GENERIC_OPEN_ACCESS,
+    ]
+
     NAMES = {
         IN_COPYRIGHT: "In Copyright",
         PUBLIC_DOMAIN_USA: "Public domain in the USA",
@@ -7855,6 +7937,9 @@ class RightsStatus(Base):
 
     # One RightsStatus may apply to many LicensePoolDeliveryMechanisms.
     licensepooldeliverymechanisms = relationship("LicensePoolDeliveryMechanism", backref="rights_status")
+
+    # One RightsStatus may apply to many Resources.
+    resources = relationship("Resource", backref="rights_status")
 
     @classmethod
     def lookup(cls, _db, uri):

--- a/opds.py
+++ b/opds.py
@@ -141,7 +141,7 @@ class Annotator(object):
                     availability_tag = AtomFeed.makeelement("published")
                     # TODO: convert to local timezone.
                     availability_tag.text = AtomFeed._strftime(avail)
-                entry.extend([availability_tag])
+                    entry.extend([availability_tag])
 
         # If this OPDS entry is being used as part of a grouped feed
         # (which is up to the Annotator subclass), we need to add a

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -166,7 +166,7 @@ class TestMetadataImporter(DatabaseTest):
                               rights_uri=RightsStatus.PUBLIC_DOMAIN_USA,
                               rights_explanation="This image is from 1922",
                               original=original,
-                              derivation_settings=dict(position='top')
+                              transformation_settings=dict(position='top')
                               )
 
         metadata = Metadata(links=[derivative], data_source=data_source)
@@ -178,14 +178,14 @@ class TestMetadataImporter(DatabaseTest):
         eq_(RightsStatus.PUBLIC_DOMAIN_USA, image.resource.rights_status.uri)
         eq_("This image is from 1922", image.resource.rights_explanation)
 
-        eq_([], image.resource.derivative_derivations)
-        derivation = image.resource.derivation
-        eq_(image.resource, derivation.derivative)
+        eq_([], image.resource.transformations)
+        transformation = image.resource.derived_through
+        eq_(image.resource, transformation.derivative)
 
-        eq_("http://example.com/", derivation.original.url)
-        eq_(RightsStatus.PUBLIC_DOMAIN_USA, derivation.original.rights_status.uri)
-        eq_("This image is from 1922", derivation.original.rights_explanation)
-        eq_("top", derivation.settings.get("position"))
+        eq_("http://example.com/", transformation.original.url)
+        eq_(RightsStatus.PUBLIC_DOMAIN_USA, transformation.original.rights_status.uri)
+        eq_("This image is from 1922", transformation.original.rights_explanation)
+        eq_("top", transformation.settings.get("position"))
 
     def test_image_and_thumbnail(self):
         edition = self._edition()

--- a/tests/test_mirror_uploader.py
+++ b/tests/test_mirror_uploader.py
@@ -67,6 +67,13 @@ class TestInitialization(DatabaseTest):
         collection = self._collection()
         eq_(None, MirrorUploader.for_collection(collection))
 
+        # We can tell the method that we're okay with a sitewide
+        # integration instead of an integration specifically for this
+        # collection.
+        sitewide_integration = self._integration
+        uploader = MirrorUploader.for_collection(collection, use_sitewide=True)
+        assert isinstance(uploader, MirrorUploader)
+
         # This collection has a properly configured mirror_integration,
         # so it can have an MirrorUploader.
         collection.mirror_integration = self._integration

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5129,15 +5129,25 @@ class TestHyperlink(DatabaseTest):
         edition, pool = self._edition(with_license_pool=True)
         identifier = edition.primary_identifier
         data_source = pool.data_source
+        original, ignore = create(self._db, Resource, url="http://bar.com")
         hyperlink, is_new = pool.add_link(
             Hyperlink.DESCRIPTION, "http://foo.com/", data_source, 
-            "text/plain", "The content")
+            "text/plain", "The content", None, RightsStatus.CC_BY,
+            "The rights explanation", original,
+            derivation_settings=dict(setting="a setting"))
         eq_(True, is_new)
         rep = hyperlink.resource.representation
         eq_("text/plain", rep.media_type)
         eq_("The content", rep.content)
         eq_(Hyperlink.DESCRIPTION, hyperlink.rel)
         eq_(identifier, hyperlink.identifier)
+        eq_(RightsStatus.CC_BY, hyperlink.resource.rights_status.uri)
+        eq_("The rights explanation", hyperlink.resource.rights_explanation)
+        derivation = hyperlink.resource.derivation
+        eq_(hyperlink.resource, derivation.derivative)
+        eq_(original, derivation.original)
+        eq_("a setting", derivation.settings.get("setting"))
+        eq_([derivation], original.derivative_derivations)
 
     def test_default_filename(self):
         m = Hyperlink._default_filename

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5134,7 +5134,7 @@ class TestHyperlink(DatabaseTest):
             Hyperlink.DESCRIPTION, "http://foo.com/", data_source, 
             "text/plain", "The content", None, RightsStatus.CC_BY,
             "The rights explanation", original,
-            derivation_settings=dict(setting="a setting"))
+            transformation_settings=dict(setting="a setting"))
         eq_(True, is_new)
         rep = hyperlink.resource.representation
         eq_("text/plain", rep.media_type)
@@ -5143,11 +5143,11 @@ class TestHyperlink(DatabaseTest):
         eq_(identifier, hyperlink.identifier)
         eq_(RightsStatus.CC_BY, hyperlink.resource.rights_status.uri)
         eq_("The rights explanation", hyperlink.resource.rights_explanation)
-        derivation = hyperlink.resource.derivation
-        eq_(hyperlink.resource, derivation.derivative)
-        eq_(original, derivation.original)
-        eq_("a setting", derivation.settings.get("setting"))
-        eq_([derivation], original.derivative_derivations)
+        transformation = hyperlink.resource.derived_through
+        eq_(hyperlink.resource, transformation.derivative)
+        eq_(original, transformation.original)
+        eq_("a setting", transformation.settings.get("setting"))
+        eq_([transformation], original.transformations)
 
     def test_default_filename(self):
         m = Hyperlink._default_filename


### PR DESCRIPTION
This branch introduces the concept of a "resource derivation" which is when a resource is used to create another resource based on some settings. It also adds rights status and a free text explanation of rights to resources.

This is currently used for adding a title and author to an open-access image to create a cover. It would also make sense to use for thumbnails, but I didn't do that in this branch.