### PR TITLE
Metadata support branch

### DIFF
--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -3160,6 +3160,10 @@ class WorkClassifier(object):
     def fiction(self, default_fiction=False):
         """Is it more likely this is a fiction or nonfiction book?"""
         # Default to nonfiction.
+        if not self.fiction_weights:
+            # We have absolutely no idea one way or the other, and it
+            # would be irresponsible to guess.
+            return None
         is_fiction = default_fiction
         if self.fiction_weights[True] > self.fiction_weights[False]:
             is_fiction = True
@@ -3184,6 +3188,11 @@ class WorkClassifier(object):
             return Classifier.AUDIENCE_ADULTS_ONLY
 
         w = self.audience_weights
+        if not self.audience_weights:
+            # We have absolutely no idea, and it would be
+            # irresponsible to guess.
+            return None
+
         children_weight = w.get(Classifier.AUDIENCE_CHILDREN, 0)
         ya_weight = w.get(Classifier.AUDIENCE_YOUNG_ADULT, 0)
         adult_weight = w.get(Classifier.AUDIENCE_ADULT, 0)
@@ -3248,6 +3257,11 @@ class WorkClassifier(object):
 
     def target_age(self, audience):
         """Derive a target age from the gathered data."""
+        if not audience:
+            # We have absolutely no idea, and it would be
+            # irresponsible to guess.
+            return None
+
         if audience not in (
                 Classifier.AUDIENCE_CHILDREN, Classifier.AUDIENCE_YOUNG_ADULT
         ):
@@ -3306,6 +3320,11 @@ class WorkClassifier(object):
         # science fiction. (It's probably a history of science fiction
         # or something.)
         genres = dict(self.genre_weights)
+        if not genres:
+            # We have absolutely no idea, and it would be
+            # irresponsible to guess.
+            return {}
+
         for genre in list(genres.keys()):
             if genre.default_fiction != fiction:
                 del genres[genre]

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -3321,6 +3321,11 @@ class WorkClassifier(object):
             return {}
 
         for genre in list(genres.keys()):
+            # If we have a fiction determination, that lets us eliminate
+            # possible genres that conflict with that determination.
+            #
+            # TODO: If we don't have a fiction determination, the
+            # genres we end up with may help us make one.
             if fiction is not None and (genre.default_fiction != fiction):
                 del genres[genre]
 

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -3257,11 +3257,6 @@ class WorkClassifier(object):
 
     def target_age(self, audience):
         """Derive a target age from the gathered data."""
-        if not audience:
-            # We have absolutely no idea, and it would be
-            # irresponsible to guess.
-            return None
-
         if audience not in (
                 Classifier.AUDIENCE_CHILDREN, Classifier.AUDIENCE_YOUNG_ADULT
         ):

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -3129,7 +3129,7 @@ class WorkClassifier(object):
 
         self.prepared = True
 
-    def classify(self, default_fiction=False, default_audience=Classifier.AUDIENCE_ADULT):
+    def classify(self, default_fiction=None, default_audience=None):
         # Do a little prep work.
         if not self.prepared:
             self.prepare_to_classify()
@@ -3157,13 +3157,13 @@ class WorkClassifier(object):
                 self.log.debug(" %s: %s", v, k)
         return genres, fiction, audience, target_age
 
-    def fiction(self, default_fiction=False):
+    def fiction(self, default_fiction=None):
         """Is it more likely this is a fiction or nonfiction book?"""
         # Default to nonfiction.
         if not self.fiction_weights:
             # We have absolutely no idea one way or the other, and it
             # would be irresponsible to guess.
-            return None
+            return default_fiction
         is_fiction = default_fiction
         if self.fiction_weights[True] > self.fiction_weights[False]:
             is_fiction = True
@@ -3171,7 +3171,7 @@ class WorkClassifier(object):
             is_fiction = False
         return is_fiction
 
-    def audience(self, genres=[], default_audience=Classifier.AUDIENCE_ADULT):
+    def audience(self, genres=[], default_audience=None):
         """What's the most likely audience for this book?
         :param default_audience: To avoid embarassing situations we will
         classify works as being intended for adults absent convincing
@@ -3191,7 +3191,7 @@ class WorkClassifier(object):
         if not self.audience_weights:
             # We have absolutely no idea, and it would be
             # irresponsible to guess.
-            return None
+            return default_audience
 
         children_weight = w.get(Classifier.AUDIENCE_CHILDREN, 0)
         ya_weight = w.get(Classifier.AUDIENCE_YOUNG_ADULT, 0)
@@ -3321,7 +3321,7 @@ class WorkClassifier(object):
             return {}
 
         for genre in list(genres.keys()):
-            if genre.default_fiction != fiction:
+            if fiction is not None and (genre.default_fiction != fiction):
                 del genres[genre]
 
         # Consolidate parent genres into their heaviest subgenre.

--- a/coverage.py
+++ b/coverage.py
@@ -137,10 +137,9 @@ class BaseCoverageProvider(object):
                 "%s must define SERVICE_NAME." % self.__class__.__name__
             )
         service_name = self.__class__.SERVICE_NAME
-        self.operation = self.get_operation()
-        
-        if self.operation:
-            service_name += ' (%s)' % self.operation
+        operation = self.get_operation()
+        if operation:
+            service_name += ' (%s)' % operation
         self.service_name = service_name
         if not batch_size or batch_size < 0:
             batch_size = self.DEFAULT_BATCH_SIZE
@@ -826,7 +825,7 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
         """
         qu = Identifier.missing_coverage_from(
             self._db, self.input_identifier_types, self.data_source,
-            count_as_missing_before=self.cutoff_time, operation=self.operation,
+            count_as_missing_before=self.cutoff_time, operation=self.get_operation(),
             identifiers=self.input_identifiers, collection=self.collection_or_not,
             **kwargs
         )
@@ -849,7 +848,7 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
         Edition/Identifier, as a CoverageRecord.
         """
         record, is_new = CoverageRecord.add_for(
-            item, data_source=self.data_source, operation=self.operation,
+            item, data_source=self.data_source, operation=self.get_operation(),
             collection=self.collection_or_not
         )
         record.status = CoverageRecord.SUCCESS
@@ -858,7 +857,7 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
 
     def record_failure_as_coverage_record(self, failure):
         """Turn a CoverageFailure into a CoverageRecord object."""
-        return failure.to_coverage_record(operation=self.operation)
+        return failure.to_coverage_record(operation=self.get_operation())
 
     def failure_for_ignored_item(self, item):
         """Create a CoverageFailure recording the CoverageProvider's
@@ -1242,7 +1241,7 @@ class WorkCoverageProvider(BaseCoverageProvider):
         are chosen.
         """
         qu = Work.missing_coverage_from(
-            self._db, operation=self.operation, 
+            self._db, operation=self.get_operation(),
             count_as_missing_before=self.cutoff_time,
             **kwargs
         )
@@ -1276,7 +1275,7 @@ class WorkCoverageProvider(BaseCoverageProvider):
         each of which was successful.
         """
         WorkCoverageRecord.bulk_add(
-            works, operation=self.operation
+            works, operation=self.get_operation()
         )
 
         # We can't return the specific WorkCoverageRecords that were
@@ -1288,11 +1287,11 @@ class WorkCoverageProvider(BaseCoverageProvider):
         """Record this CoverageProvider's coverage for the given
         Edition/Identifier, as a WorkCoverageRecord.
         """
-        return WorkCoverageRecord.add_for(work, operation=self.operation)
+        return WorkCoverageRecord.add_for(work, operation=self.get_operation())
 
     def record_failure_as_coverage_record(self, failure):
         """Turn a CoverageFailure into a WorkCoverageRecord object."""
-        return failure.to_work_coverage_record(operation=self.operation)
+        return failure.to_work_coverage_record(operation=self.get_operation())
 
 
 class PresentationReadyWorkCoverageProvider(WorkCoverageProvider):

--- a/coverage.py
+++ b/coverage.py
@@ -103,7 +103,7 @@ class BaseCoverageProvider(object):
 
     # In your subclass, you _may_ set this to a string that distinguishes
     # two different CoverageProviders from the same data source.
-    # (You may also override the get_operation() method, if you need 
+    # (You may also override the operation method, if you need 
     # database access to determine which operation to use.)
     OPERATION = None
     
@@ -137,7 +137,7 @@ class BaseCoverageProvider(object):
                 "%s must define SERVICE_NAME." % self.__class__.__name__
             )
         service_name = self.__class__.SERVICE_NAME
-        operation = self.get_operation()
+        operation = self.operation
         if operation:
             service_name += ' (%s)' % operation
         self.service_name = service_name
@@ -163,7 +163,8 @@ class BaseCoverageProvider(object):
             return None
         return get_one(self._db, Collection, id=self.collection_id)
 
-    def get_operation(self):
+    @property
+    def operation(self):
         """Which operation should this CoverageProvider use to
         distinguish between multiple CoverageRecords from the same data
         source?
@@ -743,7 +744,7 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
             identifier=identifier,
             collection=collection,
             data_source=self.data_source,
-            operation=self.get_operation(),
+            operation=self.operation,
             on_multiple='interchangeable',
         )
         if not force and not self.should_update(coverage_record):
@@ -825,7 +826,7 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
         """
         qu = Identifier.missing_coverage_from(
             self._db, self.input_identifier_types, self.data_source,
-            count_as_missing_before=self.cutoff_time, operation=self.get_operation(),
+            count_as_missing_before=self.cutoff_time, operation=self.operation,
             identifiers=self.input_identifiers, collection=self.collection_or_not,
             **kwargs
         )
@@ -848,7 +849,7 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
         Edition/Identifier, as a CoverageRecord.
         """
         record, is_new = CoverageRecord.add_for(
-            item, data_source=self.data_source, operation=self.get_operation(),
+            item, data_source=self.data_source, operation=self.operation,
             collection=self.collection_or_not
         )
         record.status = CoverageRecord.SUCCESS
@@ -857,7 +858,7 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
 
     def record_failure_as_coverage_record(self, failure):
         """Turn a CoverageFailure into a CoverageRecord object."""
-        return failure.to_coverage_record(operation=self.get_operation())
+        return failure.to_coverage_record(operation=self.operation)
 
     def failure_for_ignored_item(self, item):
         """Create a CoverageFailure recording the CoverageProvider's
@@ -1241,7 +1242,7 @@ class WorkCoverageProvider(BaseCoverageProvider):
         are chosen.
         """
         qu = Work.missing_coverage_from(
-            self._db, operation=self.get_operation(),
+            self._db, operation=self.operation,
             count_as_missing_before=self.cutoff_time,
             **kwargs
         )
@@ -1275,7 +1276,7 @@ class WorkCoverageProvider(BaseCoverageProvider):
         each of which was successful.
         """
         WorkCoverageRecord.bulk_add(
-            works, operation=self.get_operation()
+            works, operation=self.operation
         )
 
         # We can't return the specific WorkCoverageRecords that were
@@ -1287,11 +1288,11 @@ class WorkCoverageProvider(BaseCoverageProvider):
         """Record this CoverageProvider's coverage for the given
         Edition/Identifier, as a WorkCoverageRecord.
         """
-        return WorkCoverageRecord.add_for(work, operation=self.get_operation())
+        return WorkCoverageRecord.add_for(work, operation=self.operation)
 
     def record_failure_as_coverage_record(self, failure):
         """Turn a CoverageFailure into a WorkCoverageRecord object."""
-        return failure.to_work_coverage_record(operation=self.get_operation())
+        return failure.to_work_coverage_record(operation=self.operation)
 
 
 class PresentationReadyWorkCoverageProvider(WorkCoverageProvider):

--- a/coverage.py
+++ b/coverage.py
@@ -372,16 +372,6 @@ class BaseCoverageProvider(object):
         """
         self._db.commit()
 
-    def can_cover(self, identifier):
-        """Can this CoverageProvider do anything with the given Identifier?
-
-        This is not needed in the normal course of events, but a
-        caller may need to decide whether to pass an Identifier
-        into ensure_coverage() or register().
-        """
-        return (not self.input_identifier_types
-                or identifier.type in self.input_identifier_types)
-
     #
     # Subclasses must implement these virtual methods.
     #
@@ -669,6 +659,17 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
             transient=transient,
             collection=self.collection_or_not,
         )
+
+    def can_cover(self, identifier):
+        """Can this IdentifierCoverageProvider do anything with the given
+        Identifier?
+
+        This is not needed in the normal course of events, but a
+        caller may need to decide whether to pass an Identifier
+        into ensure_coverage() or register().
+        """
+        return (not self.input_identifier_types
+                or identifier.type in self.input_identifier_types)
     
     def run_on_specific_identifiers(self, identifiers):
         """Split a specific set of Identifiers into batches and process one

--- a/coverage.py
+++ b/coverage.py
@@ -103,7 +103,7 @@ class BaseCoverageProvider(object):
 
     # In your subclass, you _may_ set this to a string that distinguishes
     # two different CoverageProviders from the same data source.
-    # (You may also override the operation method, if you need 
+    # (You may also override the operation method, if you need
     # database access to determine which operation to use.)
     OPERATION = None
     
@@ -986,9 +986,16 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
     def license_pool(self, identifier, data_source=None):
         """Finds this Collection's LicensePool for the given Identifier,
         creating one if necessary.
+
+        :param data_source: If it's necessary to create a LicensePool,
+        the new LicensePool will have this DataSource. The default is to
+        use the DataSource associated with the CoverageProvider. This
+        should only be needed by the metadata wrangler.
         """
-        license_pools = [p for p in identifier.licensed_through
-                         if self.collection==p.collection]
+        license_pools = [
+            p for p in identifier.licensed_through
+            if self.collection==p.collection
+        ]
             
         if license_pools:
             # A given Collection may have at most one LicensePool for

--- a/model.py
+++ b/model.py
@@ -1395,6 +1395,11 @@ class CoverageRecord(Base, BaseCoverageRecord):
     )
 
     def __repr__(self):
+        template = '<CoverageRecord: %(timestamp)s identifier=%(identifier_type)s/%(identifier)s data_source="%(data_source)s"%(operation)s status="%(status)s" %(exception)s>'
+        return self.human_readable(template)
+
+    def human_readable(self, template):
+        """Interpolate data into a human-readable template."""
         if self.operation:
             operation = ' operation="%s"' % self.operation
         else:
@@ -1403,15 +1408,16 @@ class CoverageRecord(Base, BaseCoverageRecord):
             exception = ' exception="%s"' % self.exception
         else:
             exception = ''
-        template = '<CoverageRecord: identifier=%s/%s data_source="%s"%s timestamp="%s"%s>'
-        return template % (
-            self.identifier.type,
-            self.identifier.identifier,
-            self.data_source.name,
-            operation,
-            self.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
-            exception
+        return template % dict(
+            timestamp=self.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+            identifier_type=self.identifier.type,
+            identifier=self.identifier.identifier,
+            data_source=self.data_source.name,
+            operation=operation,
+            status=self.status,
+            exception=exception,
         )
+
 
     @classmethod
     def lookup(cls, edition_or_identifier, data_source, operation=None,

--- a/opds.py
+++ b/opds.py
@@ -121,13 +121,19 @@ class Annotator(object):
             )
 
         if active_license_pool:
-            provider_name_attr = "{%s}ProviderName" % AtomFeed.BIBFRAME_NS
-            kwargs = {provider_name_attr : active_license_pool.data_source.name}
-            data_source_tag = AtomFeed.makeelement(
-                "{%s}distribution" % AtomFeed.BIBFRAME_NS,
-                **kwargs
-            )
-            entry.extend([data_source_tag])
+            data_source = active_license_pool.data_source.name
+            if data_source != DataSource.INTERNAL_PROCESSING:
+                # INTERNAL_PROCESSING indicates a dummy LicensePool
+                # created as a stand-in, e.g. by the metadata wrangler.
+                # This component is not actually distributing the book,
+                # so it should not have a bibframe:distribution tag.
+                provider_name_attr = "{%s}ProviderName" % AtomFeed.BIBFRAME_NS
+                kwargs = {provider_name_attr : data_source}
+                data_source_tag = AtomFeed.makeelement(
+                    "{%s}distribution" % AtomFeed.BIBFRAME_NS,
+                    **kwargs
+                )
+                entry.extend([data_source_tag])
 
             # We use Atom 'published' for the date the book first became
             # available to people using this application.

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -815,6 +815,16 @@ class TestWorkClassifier(DatabaseTest):
         expected_genre, ignore = Genre.lookup(self._db, genre_data.name)
         return expected_genre
 
+    def test_no_assumptions(self):
+        """If we have no data whatsoever, we make no assumptions
+        about a work's classification.
+        """
+        self.classifier.weigh_metadata()
+        eq_(None, self.classifier.fiction())
+        eq_(None, self.classifier.audience())
+        eq_({}, self.classifier.genres(None))
+        eq_((None, None), self.classifier.target_age(None))
+
     def test_weight_metadata_title(self):
         self.work.presentation_edition.title = u"Star Trek: The Book"
         expected_genre = self._genre(classifier.Media_Tie_in_SF)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -948,17 +948,6 @@ class TestWorkClassifier(DatabaseTest):
         self.classifier.add(c)
         eq_(50000, self.classifier.audience_weights[Classifier.AUDIENCE_CHILDREN])
 
-    def test_default_nonfiction(self):
-        # In the absence of any information we assume a book is nonfiction.
-        eq_(False, self.classifier.fiction())
-
-        # Put a tiny bit of evidence on the scale, and the balance tips.
-        new_classifier = WorkClassifier(self.work, test_session=self._db) 
-        source = DataSource.lookup(self._db, DataSource.OCLC)
-        c = self.identifier.classify(source, Subject.TAG, u"Fiction", weight=1)
-        new_classifier.add(c)
-        eq_(True, new_classifier.fiction())
-
     def test_juvenile_classification_is_split_between_children_and_ya(self):
 
         # LCC files both children's and YA works under 'PZ'.
@@ -997,9 +986,6 @@ class TestWorkClassifier(DatabaseTest):
         # cause the work to be mistakenly classified as Adult.
         for aud in Classifier.AUDIENCES_ADULT:
             eq_(-50, weights[aud])
-
-    def test_adult_book_by_default(self):
-        eq_(Classifier.AUDIENCE_ADULT, self.classifier.audience())
 
     def test_childrens_book_when_evidence_is_overwhelming(self):
         # There is some evidence in the 'adult' and 'adults only'
@@ -1286,7 +1272,7 @@ class TestWorkClassifier(DatabaseTest):
         eq_(False, fiction)
 
     def test_classify_uses_default_audience(self):
-        genres, fiction, audience, target_age = self.classifier.classify(default_audience=None)
+        genres, fiction, audience, target_age = self.classifier.classify()
         eq_(None, audience)
         genres, fiction, audience, target_age = self.classifier.classify(default_audience=Classifier.AUDIENCE_ADULT)
         eq_(Classifier.AUDIENCE_ADULT, audience)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -158,7 +158,7 @@ class TestBaseCoverageProvider(CoverageProviderTest):
         # Class variables defined in subclasses become appropriate
         # instance variables.
         eq_("A Service (An Operation)", provider.service_name)
-        eq_("An Operation", provider.operation)
+        eq_("An Operation", provider.get_operation())
         eq_(50, provider.batch_size)
         eq_(now, provider.cutoff_time)
         
@@ -612,10 +612,12 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
         provider = AlwaysSuccessfulCollectionCoverageProvider(
             self._default_collection
         )
+        provider.OPERATION = self._str
         record = provider.ensure_coverage(self.identifier)
         assert isinstance(record, CoverageRecord)
         eq_(self.identifier, record.identifier)
         eq_(provider.data_source, record.data_source)
+        eq_(provider.OPERATION, record.operation)
         eq_(None, record.exception)
 
         # There is now one CoverageRecord -- the one returned by
@@ -989,7 +991,7 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
         # appropriate arguments.
         record2, is_new = CoverageRecord.add_for(
             identifier, data_source=provider.data_source, 
-            operation=provider.operation,
+            operation=provider.get_operation(),
             collection=provider.collection_or_not
         )
         eq_(False, is_new)
@@ -1008,7 +1010,7 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
 
         record2, is_new = CoverageRecord.add_for(
             identifier, data_source=provider.data_source, 
-            operation=provider.operation,
+            operation=provider.get_operation(),
             collection=provider.collection_or_not
         )
         eq_(False, is_new)
@@ -1696,7 +1698,7 @@ class TestWorkCoverageProvider(DatabaseTest):
         # There is now one relevant WorkCoverageRecord, for our single work.
         [record] = qu.all()
         eq_(self.work, record.work)
-        eq_(provider.operation, record.operation)
+        eq_(provider.get_operation(), record.operation)
 
         # The timestamp is now set.
         timestamp = Timestamp.value(self._db, provider.service_name, collection=None)
@@ -1709,7 +1711,7 @@ class TestWorkCoverageProvider(DatabaseTest):
             
         # We start with no relevant WorkCoverageRecords.
         qu = self._db.query(WorkCoverageRecord).filter(
-            WorkCoverageRecord.operation==provider.operation
+            WorkCoverageRecord.operation==provider.get_operation()
         )
         eq_([], qu.all())
 
@@ -1717,7 +1719,7 @@ class TestWorkCoverageProvider(DatabaseTest):
 
         # We now have a CoverageRecord for the transient failure.
         [failure] = [x for x in self.work.coverage_records if 
-                     x.operation==provider.operation]
+                     x.operation==provider.get_operation()]
         eq_(CoverageRecord.TRANSIENT_FAILURE, failure.status)
 
         # The timestamp is now set to a recent value.
@@ -1732,7 +1734,7 @@ class TestWorkCoverageProvider(DatabaseTest):
 
         # We start with no relevant WorkCoverageRecords.
         qu = self._db.query(WorkCoverageRecord).filter(
-            WorkCoverageRecord.operation==provider.operation
+            WorkCoverageRecord.operation==provider.get_operation()
         )
         eq_([], qu.all())
 
@@ -1758,7 +1760,7 @@ class TestWorkCoverageProvider(DatabaseTest):
         w3 = self._work(with_license_pool=True)
         
         # w2 has coverage, the other two do not.
-        record = self._work_coverage_record(w2, provider.operation)
+        record = self._work_coverage_record(w2, provider.get_operation())
 
         # By default, items_that_need_coverage returns the two
         # works that don't have coverage.

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -158,7 +158,7 @@ class TestBaseCoverageProvider(CoverageProviderTest):
         # Class variables defined in subclasses become appropriate
         # instance variables.
         eq_("A Service (An Operation)", provider.service_name)
-        eq_("An Operation", provider.get_operation())
+        eq_("An Operation", provider.operation)
         eq_(50, provider.batch_size)
         eq_(now, provider.cutoff_time)
         
@@ -991,7 +991,7 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
         # appropriate arguments.
         record2, is_new = CoverageRecord.add_for(
             identifier, data_source=provider.data_source, 
-            operation=provider.get_operation(),
+            operation=provider.operation,
             collection=provider.collection_or_not
         )
         eq_(False, is_new)
@@ -1010,7 +1010,7 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
 
         record2, is_new = CoverageRecord.add_for(
             identifier, data_source=provider.data_source, 
-            operation=provider.get_operation(),
+            operation=provider.operation,
             collection=provider.collection_or_not
         )
         eq_(False, is_new)
@@ -1698,7 +1698,7 @@ class TestWorkCoverageProvider(DatabaseTest):
         # There is now one relevant WorkCoverageRecord, for our single work.
         [record] = qu.all()
         eq_(self.work, record.work)
-        eq_(provider.get_operation(), record.operation)
+        eq_(provider.operation, record.operation)
 
         # The timestamp is now set.
         timestamp = Timestamp.value(self._db, provider.service_name, collection=None)
@@ -1711,7 +1711,7 @@ class TestWorkCoverageProvider(DatabaseTest):
             
         # We start with no relevant WorkCoverageRecords.
         qu = self._db.query(WorkCoverageRecord).filter(
-            WorkCoverageRecord.operation==provider.get_operation()
+            WorkCoverageRecord.operation==provider.operation
         )
         eq_([], qu.all())
 
@@ -1719,7 +1719,7 @@ class TestWorkCoverageProvider(DatabaseTest):
 
         # We now have a CoverageRecord for the transient failure.
         [failure] = [x for x in self.work.coverage_records if 
-                     x.operation==provider.get_operation()]
+                     x.operation==provider.operation]
         eq_(CoverageRecord.TRANSIENT_FAILURE, failure.status)
 
         # The timestamp is now set to a recent value.
@@ -1734,7 +1734,7 @@ class TestWorkCoverageProvider(DatabaseTest):
 
         # We start with no relevant WorkCoverageRecords.
         qu = self._db.query(WorkCoverageRecord).filter(
-            WorkCoverageRecord.operation==provider.get_operation()
+            WorkCoverageRecord.operation==provider.operation
         )
         eq_([], qu.all())
 
@@ -1760,7 +1760,7 @@ class TestWorkCoverageProvider(DatabaseTest):
         w3 = self._work(with_license_pool=True)
         
         # w2 has coverage, the other two do not.
-        record = self._work_coverage_record(w2, provider.get_operation())
+        record = self._work_coverage_record(w2, provider.operation)
 
         # By default, items_that_need_coverage returns the two
         # works that don't have coverage.

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1488,7 +1488,7 @@ class TestCollectionCoverageProvider(CoverageProviderTest):
         # Once an identifier has a work associated with it,
         # that's always the one that's used, and the value of license_pool
         # is ignored.
-        work3 = provider.work(identifier, object())
+        work3 = provider.work(identifier2, object())
         eq_(work2, work3)
         
     def test_set_metadata_and_circulationdata(self):

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -425,6 +425,28 @@ class TestBaseCoverageProvider(CoverageProviderTest):
         record.status = CoverageRecord.REGISTERED
         eq_(True, provider.should_update(record))
 
+    def test_can_cover(self):
+        """Verify that can_cover gives the correct answer when
+        asked if a BaseCoverageProvider can handle a given Identifier.
+        """
+        provider = AlwaysSuccessfulCoverageProvider(self._db)
+        identifier = self._identifier(identifier_type=Identifier.ISBN)
+        m = provider.can_cover
+
+        # This provider handles all identifier types.
+        provider.input_identifier_types = None
+        eq_(True, m(identifier))
+
+        # This provider handles ISBNs.
+        provider.input_identifier_types = [
+            Identifier.OVERDRIVE_ID, Identifier.ISBN
+        ]
+        eq_(True, m(identifier))
+
+        # This provider doesn't.
+        provider.input_identifier_types = [Identifier.OVERDRIVE_ID]
+        eq_(False, m(identifier))
+        
 
 class TestIdentifierCoverageProvider(CoverageProviderTest):
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1569,7 +1569,32 @@ class TestCollectionCoverageProvider(CoverageProviderTest):
         # as before.
         pool2 = provider.license_pool(identifier)
         eq_(pool, pool2)
-        
+
+        # It's possible for a CollectionCoverageProvider to create a
+        # LicensePool for a different DataSource than the one
+        # associated with the Collection. Only the metadata wrangler
+        # needs to do this -- it's so a CoverageProvider for a
+        # third-party DataSource can create an 'Internal Processing'
+        # LicensePool when some other part of the metadata wrangler
+        # failed to do this earlier.
+
+        # If a working pool already exists, it's returned and no new
+        # pool is created.
+        same_pool = provider.license_pool(
+            identifier, DataSource.INTERNAL_PROCESSING
+        )
+        eq_(same_pool, pool2)
+        eq_(provider.data_source, same_pool.data_source)
+
+        # A new pool is only created if no working pool can be found.
+        identifier2 = self._identifier()
+        new_pool = provider.license_pool(
+            identifier2, DataSource.INTERNAL_PROCESSING
+        )
+        eq_(new_pool.data_source.name, DataSource.INTERNAL_PROCESSING)
+        eq_(new_pool.identifier, identifier2)
+        eq_(new_pool.collection, provider.collection)
+
     def test_set_presentation_ready(self):
         """Test that a CollectionCoverageProvider can set a Work
         as presentation-ready.

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1464,6 +1464,32 @@ class TestCollectionCoverageProvider(CoverageProviderTest):
         work = provider.work(identifier)
         assert isinstance(work, Work)
         eq_(u"A title", work.title)
+
+        # If necessary, we can tell work() to use a specific
+        # LicensePool when calculating the Work. This is an extreme
+        # example in which the LicensePool to use has a different
+        # Identifier (identifier2) than the Identifier we're
+        # processing (identifier1).
+        #
+        # In a real case, this would be used by a CoverageProvider
+        # that just had to create a LicensePool using an
+        # INTERNAL_PROCESSING DataSource rather than the DataSource
+        # associated with the CoverageProvider.
+        identifier2 = self._identifier()
+        identifier.licensed_through = []
+        collection2 = self._collection()
+        edition2 = self._edition(identifier_type=identifier2.type,
+                                 identifier_id=identifier2.identifier)
+        pool2 = self._licensepool(edition=edition2, collection=collection2)
+        work2 = provider.work(identifier, pool2)
+        assert work2 != work
+        eq_([pool2], work2.license_pools)
+
+        # Once an identifier has a work associated with it,
+        # that's always the one that's used, and the value of license_pool
+        # is ignored.
+        work3 = provider.work(identifier, object())
+        eq_(work2, work3)
         
     def test_set_metadata_and_circulationdata(self):
         """Verify that a CollectionCoverageProvider can set both

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -425,28 +425,6 @@ class TestBaseCoverageProvider(CoverageProviderTest):
         record.status = CoverageRecord.REGISTERED
         eq_(True, provider.should_update(record))
 
-    def test_can_cover(self):
-        """Verify that can_cover gives the correct answer when
-        asked if a BaseCoverageProvider can handle a given Identifier.
-        """
-        provider = AlwaysSuccessfulCoverageProvider(self._db)
-        identifier = self._identifier(identifier_type=Identifier.ISBN)
-        m = provider.can_cover
-
-        # This provider handles all identifier types.
-        provider.input_identifier_types = None
-        eq_(True, m(identifier))
-
-        # This provider handles ISBNs.
-        provider.input_identifier_types = [
-            Identifier.OVERDRIVE_ID, Identifier.ISBN
-        ]
-        eq_(True, m(identifier))
-
-        # This provider doesn't.
-        provider.input_identifier_types = [Identifier.OVERDRIVE_ID]
-        eq_(False, m(identifier))
-
 
 class TestIdentifierCoverageProvider(CoverageProviderTest):
 
@@ -491,6 +469,28 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
             MockProvider,
             self._db
         )
+
+    def test_can_cover(self):
+        """Verify that can_cover gives the correct answer when
+        asked if an IdentifierCoverageProvider can handle a given Identifier.
+        """
+        provider = AlwaysSuccessfulCoverageProvider(self._db)
+        identifier = self._identifier(identifier_type=Identifier.ISBN)
+        m = provider.can_cover
+
+        # This provider handles all identifier types.
+        provider.input_identifier_types = None
+        eq_(True, m(identifier))
+
+        # This provider handles ISBNs.
+        provider.input_identifier_types = [
+            Identifier.OVERDRIVE_ID, Identifier.ISBN
+        ]
+        eq_(True, m(identifier))
+
+        # This provider doesn't.
+        provider.input_identifier_types = [Identifier.OVERDRIVE_ID]
+        eq_(False, m(identifier))
 
     def test_replacement_policy(self):
         """Unless a different replacement policy is passed in, the

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -446,7 +446,7 @@ class TestBaseCoverageProvider(CoverageProviderTest):
         # This provider doesn't.
         provider.input_identifier_types = [Identifier.OVERDRIVE_ID]
         eq_(False, m(identifier))
-        
+
 
 class TestIdentifierCoverageProvider(CoverageProviderTest):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8886,6 +8886,7 @@ class TestCollection(DatabaseTest):
         eq_(0, len(list1.entries))
         eq_(1, len(list2.entries))
 
+
 class TestCollectionForMetadataWrangler(DatabaseTest):
 
     """Tests that requirements to the metadata wrangler's use of Collection

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -578,6 +578,17 @@ class TestOPDS(DatabaseTest):
         )
         assert (1, unicode(feed).count(expect))
 
+        # If the LicensePool is a stand-in produced for internal
+        # processing purposes, it does not represent an actual license for
+        # the book, and the <bibframe:distribution> tag is not
+        # included.
+        internal = DataSource.lookup(self._db, DataSource.INTERNAL_PROCESSING)
+        work.license_pools[0].data_source = internal
+        feed = AcquisitionFeed(self._db, "test", "http://the-url.com/",
+                               [work])
+        assert '<bibframe:distribution' not in unicode(feed)
+
+
     def test_acquisition_feed_includes_author_tag_even_when_no_author(self):
         work = self._work(with_open_access_download=True)
         feed = AcquisitionFeed(self._db, "test", "http://the-url.com/",


### PR DESCRIPTION
This branch adds and fixes miscellaneous things in support of work I'm doing on the metadata wrangler for https://jira.nypl.org/browse/SIMPLY-332.

There may be another support branch before I'm done, but there are a lot of changes here already so let's get them in.

A number of the changes reflect a change in metadata wrangler strategy. We will always be creating presentation-ready works as soon as possible, even for ISBNs, and even without what the circulation manager would consider a minimal set of bibliographic information. We will then be serving the OPDS entries for those presentation-ready works rather than cobbling together a dynamically generated entry based on Resources associated with an ISBN.

* If we don't know anything about a Work's classifications, we don't say anything. Previously we assumed that a Work with absolutely no classification information was a nonfiction work for adults. This was okay for the circulation manager, since it made sure every book showed up _somewhere_, but it's misleading for ISBNs whose only coverage information comes from Content Cafe, and it turned out not to be a big problem on the circulation side.
* `CoverageProvider.get_operation` was turned into a property called `operation`, rather than `operation` being an attribute set in the constructor. This may require minor changes to circulation.
*  New method: `CoverageProvider.can_cover`, which answer the question of whether a CoverageProvider can handle a given Identifier.
* `CoverageProvider.ensure_coverage` sets the `.collection` of the newly created CoverageRecord if the CoverageProvider needs to cover the same Identifier separately for each collection.
* `CoverageProvider.license_pool` can create a LicensePool with a DataSource different from the one associated with the CoverageProvider. This is so (e.g.) the ContentCafeCoverageProvider can notice that an INTERNAL_PROCESSING LicensePool was never created for the Identifier it's processing, and create one so that it can create a Work.
* `CoverageProvider.work` can take a LicensePool to use as the basis of a Work rather than calling `license_pool` with the default arguments.
* Some code has been refactored from `CoverageRecord.__repr__` so that the same type of message can be included in an OPDS message. This will provide some visibility into "why isn't this ISBN ready?"
* If a book's LicensePool comes INTERNAL_PROCESSING, then it doesn't represent an actual copy of a book, and no <bibframe:distribution> tag will be present in the OPDS feed. (Another way to fix this would be to move this code out of core and into circulation, since circulation is the only component left that serves the actual books.)