### PR TITLE
Allow a Work to be created in some circumstances even if no title is available.

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -997,7 +997,7 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
             p for p in identifier.licensed_through
             if self.collection==p.collection
         ]
-            
+
         if license_pools:
             # A given Collection may have at most one LicensePool for
             # a given identifier.
@@ -1023,7 +1023,7 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
         )
         return license_pool
 
-    def work(self, identifier, license_pool=None):
+    def work(self, identifier, license_pool=None, **calculate_work_kwargs):
         """Finds or creates a Work for this Identifier as licensed through
         this Collection.
 
@@ -1059,8 +1059,14 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
             )
             
         if license_pool:
+            for (v, default) in (
+                ('even_if_no_author', True),
+                ('exclude_search', self.EXCLUDE_SEARCH_INDEX)
+            ):
+                if not v in calculate_work_kwargs:
+                    calculate_work_kwargs[v] = default
             work, created = license_pool.calculate_work(
-                even_if_no_author=True, exclude_search=self.EXCLUDE_SEARCH_INDEX
+                **calculate_work_kwargs
             )
             if not work:
                 error = "Work could not be calculated"

--- a/model.py
+++ b/model.py
@@ -7550,7 +7550,8 @@ class LicensePool(Base):
 
 
     def calculate_work(
-        self, even_if_no_author=False, known_edition=None, exclude_search=False
+        self, even_if_no_author=False, known_edition=None, exclude_search=False,
+        even_if_no_title=False
     ):
         """Find or create a Work for this LicensePool.
 
@@ -7560,15 +7561,23 @@ class LicensePool(Base):
         of the LicensePool's presentation edition.
 
         :param even_if_no_author: Ordinarily this method will refuse
-        to create a Work for a LicensePool whose Edition has no title
-        or author. But sometimes a book just has no known author. If
+        to create a Work for a LicensePool whose Edition has
+        author. But sometimes a book just has no known author. If
         that's really the case, pass in even_if_no_author=True and the
         Work will be created.
+
+        :param even_if_no_title: Ordinarily this method will refuse to
+        create a Work for a LicensePool whose Edition has no title.
+        However, in components that don't present information directly
+        to readers, it's sometimes useful to create a Work even if the
+        title is unknown. In that case, pass in even_if_no_title=True
+        and the Work will be created.
 
         TODO: I think known_edition is mostly useless. We should
         either remove it or replace it with a boolean that stops us
         from calling set_presentation_edition() and assumes we've
         already done that work.
+
         """
         if not self.identifier:
             # A LicensePool with no Identifier should never have a Work.
@@ -7602,7 +7611,7 @@ class LicensePool(Base):
         if not presentation_edition.title or not presentation_edition.author:
             presentation_edition.calculate_presentation()
 
-        if not presentation_edition.title:
+        if not presentation_edition.title and not even_if_no_title:
             if presentation_edition.work:
                 logging.warn(
                     "Edition %r has no title but has a Work assigned. This will not stand.", presentation_edition
@@ -11903,6 +11912,11 @@ def add_work_to_customlists_for_collection(pool_or_work, value, oldvalue, initia
 
     if (not oldvalue or oldvalue is NO_VALUE) and value and work and work.presentation_edition:
         for pool in pools:
+            if not pool.collection:
+                # This shouldn't happen, but don't crash if it does --
+                # the correct behavior is that the work not be added to
+                # any CustomLists.
+                continue
             for list in pool.collection.customlists:
                 # Since the work was just created, we can assume that
                 # there's already a pending registration for updating the

--- a/model.py
+++ b/model.py
@@ -7561,7 +7561,7 @@ class LicensePool(Base):
         of the LicensePool's presentation edition.
 
         :param even_if_no_author: Ordinarily this method will refuse
-        to create a Work for a LicensePool whose Edition has
+        to create a Work for a LicensePool whose Edition has no
         author. But sometimes a book just has no known author. If
         that's really the case, pass in even_if_no_author=True and the
         Work will be created.

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1490,7 +1490,16 @@ class TestCollectionCoverageProvider(CoverageProviderTest):
         # is ignored.
         work3 = provider.work(identifier2, object())
         eq_(work2, work3)
-        
+
+        # Any keyword arguments passed into work() are propagated to
+        # calculate_work(). This lets use (e.g.) create a Work even
+        # when there is no title.
+        edition, pool = self._edition(with_license_pool=True)
+        edition.title = None
+        work = provider.work(pool.identifier, pool, even_if_no_title=True)
+        assert isinstance(work, Work)
+        eq_(None, work.title)
+
     def test_set_metadata_and_circulationdata(self):
         """Verify that a CollectionCoverageProvider can set both
         metadata (on an Edition) and circulation data (on a LicensePool).

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3826,6 +3826,15 @@ class TestWorkConsolidation(DatabaseTest):
         eq_(None, work)
         eq_(False, new)
 
+        # even_if_no_title means we don't need a title.
+        work, new = p.calculate_work(
+            even_if_no_author=True, even_if_no_title=True
+        )
+        assert isinstance(work, Work)
+        eq_(True, new)
+        eq_(None, work.title)
+        eq_(None, work.presentation_edition.permanent_work_id)
+
     def test_calculate_work_bails_out_if_no_author(self):
         e, p = self._edition(with_license_pool=True, authors=[])
         work, new = p.calculate_work(even_if_no_author=False)


### PR DESCRIPTION
This branch smooths out the process of creating Works for ISBNs looked up in the metadata wrangler. In some cases we have all the information necessary to create a Work for an ISBN, except for the book title. We don't actually need the book title because we're not displaying anything directly to readers. So it should be possible to create a Work with no title, just as it's possible to create a Work with no author.