### PR TITLE
Dont persist identifier mapping between pages

### DIFF
--- a/opds_import.py
+++ b/opds_import.py
@@ -616,11 +616,13 @@ class OPDSImporter(object):
     def build_identifier_mapping(self, external_urns):
         """Uses the given Collection and a list of URNs to reverse
         engineer an identifier mapping.
+
+        NOTE: It would be better if .identifier_mapping weren't
+        instance data, since a single OPDSImporter might import
+        multiple pages of a feed. However, the code as written should
+        work.
         """
-        if self.identifier_mapping or not self.collection:
-            # NOTE: This is problematic, because a single OPDSImporter
-            # may be used to import a multi-page OPDS feed, and the
-            # identifier mapping will be different on each page.
+        if not self.collection:
             return
 
         mapping = dict()
@@ -654,13 +656,6 @@ class OPDSImporter(object):
         xml_data_meta, xml_failures = self.extract_metadata_from_elementtree(
             feed, data_source=data_source, feed_url=feed_url
         )
-
-        # Clear out any old identifier mapping, so the second page of
-        # an import doesn't use the mapping from the first page.
-        #
-        # NOTE: Obviously this is a hack and it would be better if the
-        # identifier mapping wasn't instance data.
-        self.identifier_mapping = None
 
         if self.map_from_collection:
             # Build the identifier_mapping based on the Collection.

--- a/opds_import.py
+++ b/opds_import.py
@@ -618,6 +618,9 @@ class OPDSImporter(object):
         engineer an identifier mapping.
         """
         if self.identifier_mapping or not self.collection:
+            # NOTE: This is problematic, because a single OPDSImporter
+            # may be used to import a multi-page OPDS feed, and the
+            # identifier mapping will be different on each page.
             return
 
         mapping = dict()
@@ -651,6 +654,13 @@ class OPDSImporter(object):
         xml_data_meta, xml_failures = self.extract_metadata_from_elementtree(
             feed, data_source=data_source, feed_url=feed_url
         )
+
+        # Clear out any old identifier mapping, so the second page of
+        # an import doesn't use the mapping from the first page.
+        #
+        # NOTE: Obviously this is a hack and it would be better if the
+        # identifier mapping wasn't instance data.
+        self.identifier_mapping = None
 
         if self.map_from_collection:
             # Build the identifier_mapping based on the Collection.

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -274,15 +274,9 @@ class TestOPDSImporter(OPDSImporterTest):
         importer = OPDSImporter(
             self._db, collection=None, data_source_name=data_source_name
         )
-
-        importer.identifier_mapping = object()
-
         metadata, failures = importer.extract_feed_data(
             self.content_server_mini_feed
         )
-
-        # Any identifier mapping left over from a prior import was cleared out.
-        eq_(None, importer.identifier_mapping)
 
         m1 = metadata['http://www.gutenberg.org/ebooks/10441']
         m2 = metadata['http://www.gutenberg.org/ebooks/10557']
@@ -1174,11 +1168,10 @@ class TestOPDSImporter(OPDSImporterTest):
         expected = { isbn1 : lp.identifier }
         eq_(expected, importer.identifier_mapping)
 
-        # If we already have one, it isn't overwritten.
+        # If we already have one, it's overwritten.
         importer.build_identifier_mapping([isbn2.urn])
         overwrite = { isbn2 : lp.identifier }
-        eq_(False, importer.identifier_mapping==overwrite)
-        eq_(expected, importer.identifier_mapping)
+        eq_(importer.identifier_mapping, overwrite)
 
         # If the importer doesn't have a collection, we can't build
         # its mapping.

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -274,9 +274,15 @@ class TestOPDSImporter(OPDSImporterTest):
         importer = OPDSImporter(
             self._db, collection=None, data_source_name=data_source_name
         )
+
+        importer.identifier_mapping = object()
+
         metadata, failures = importer.extract_feed_data(
             self.content_server_mini_feed
         )
+
+        # Any identifier mapping left over from a prior import was cleared out.
+        eq_(None, importer.identifier_mapping)
 
         m1 = metadata['http://www.gutenberg.org/ebooks/10441']
         m2 = metadata['http://www.gutenberg.org/ebooks/10557']


### PR DESCRIPTION
`OPDSImporter.identifier_mapping` caches its results so that the second time it's called, it doesn't have to parse the feed again. The problem with this is that we use the same OPDSImporter object to import every page of a multi-page feed. In this case we _do_ need to parse the feed every time, because every page of the feed has a different identifier mapping.

Without this fix in place, the first page of an OPDS import that uses an identifier mapping will succeed, but subsequent pages will import as though the mapping didn't exist, and the information imported probably won't be used.

The simplest solution is to remove the caching. I'm worried that will have negative side-effects so I've implemented a solution that invalidates the cache when we know that's necessary. But I would prefer to be comfortable with removing the caching.

*Update:* I removed the caching. extract_feed_data() was only being called by the code that was clearing the cache, and the failure mode is that an OPDS feed gets parsed more times than it should be.