### PR TITLE
Three levels of recursive identifiers are enough

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -199,7 +199,7 @@ class BaseCoverageProvider(object):
         count_as_covered = count_as_covered or BaseCoverageRecord.DEFAULT_COUNT_AS_COVERED
         # Make it clear which class of items we're covering on this
         # run.
-        count_as_covered_message = '(counting %s as covered)' % (', '.join(count_as_covered))
+        count_as_covered_message = ' (counting %s as covered)' % (', '.join(count_as_covered))
 
         qu = self.items_that_need_coverage(count_as_covered=count_as_covered)
         self.log.info("%d items need coverage%s", qu.count(),
@@ -971,6 +971,12 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
         """
         for collection in cls.collections(_db):
             yield cls(collection, **kwargs)
+
+    def run_once(self, *args, **kwargs):
+        self.log.info("Considering collection %s", self.collection.name)
+        return super(CollectionCoverageProvider, self).run_once(
+            *args, **kwargs
+        )
 
     def items_that_need_coverage(self, identifiers=None, **kwargs):
         """Find all Identifiers associated with this Collection but lacking

--- a/model.py
+++ b/model.py
@@ -2163,7 +2163,7 @@ class Identifier(Base):
 
     @classmethod
     def recursively_equivalent_identifier_ids(
-            cls, _db, identifier_ids, levels=5, threshold=0.50, cutoff=None):
+            cls, _db, identifier_ids, levels=3, threshold=0.50, cutoff=None):
         """All Identifier IDs equivalent to the given set of Identifier
         IDs at the given confidence threshold.
 
@@ -4444,7 +4444,7 @@ class Work(Base):
         )
         return q
 
-    def all_identifier_ids(self, recursion_level=5, cutoff=None):
+    def all_identifier_ids(self, recursion_level=3, cutoff=None):
         _db = Session.object_session(self)
         primary_identifier_ids = [
             lp.identifier.id for lp in self.license_pools
@@ -7674,7 +7674,7 @@ class LicensePool(Base):
         existing_works = set([x.work for x in self.identifier.licensed_through])
         if len(existing_works) > 1:
             logging.warn(
-                "LicensePools for %r have more than one Work between them. Removing them all and starting over."
+                "LicensePools for %r have more than one Work between them. Removing them all and starting over.", self.identifier
             )
             for lp in self.identifier.licensed_through:
                 lp.work = None
@@ -7712,7 +7712,11 @@ class LicensePool(Base):
                     continue
                 if not (self.open_access and pool.open_access):
                     pool.work = None
-                    pool.calculate_work(exclude_search=exclude_search)
+                    pool.calculate_work(
+                        exclude_search=exclude_search,
+                        even_if_no_author=even_if_no_author,
+                        even_if_no_title=even_if_no_title
+                    )
                     licensepools_changed = True
 
         else:


### PR DESCRIPTION
This branch makes minor improvements to assist the metadata wrangler's Content Cafe coverage provider. The big change is I'm taking the default recursion level for determining equivalent identifiers down from 5 to 3. This dramatically speeds things up when we're calculating presentation for very popular public domain books, without noticeably affecting quality.

The 5 number was based on the idea that we would need to go from Gutenberg ID -> OCLC Number -> OCLC Work ID -> ISBN -> Related ISBN. But right now the cases we actually need to deal with go:

* Overdrive ID -> ISBN -> Related ISBN
* ISBN -> Related ISBN -> Other related ISBN
* URI -> [null]

So 3 is plenty to get a good variety of related ISBNs.

If and when we bring back the OCLC Classify interface, we can look into going to different depths for different types of books.