### PR TITLE
Define a common self-test interface for third-party integration classes

### DIFF
--- a/config.py
+++ b/config.py
@@ -14,6 +14,9 @@ from entrypoint import EntryPoint
 from sqlalchemy.exc import ArgumentError
 
 from util import LanguageCodes
+
+# It's convenient for other modules import IntegrationException
+# from this module, alongside CannotLoadConfiguration.
 from util.http import IntegrationException
 
 

--- a/config.py
+++ b/config.py
@@ -14,8 +14,37 @@ from entrypoint import EntryPoint
 
 from sqlalchemy.exc import ArgumentError
 
-class CannotLoadConfiguration(Exception):
+
+class IntegrationException(Exception):
+    """There was a problem in the setup or usage of an external integration.
+    """
+    def __init__(self, message, diagnostic=None):
+        """Constructor.
+
+        :param message: The normal message passed to any Exception
+        constructor.
+
+        :param diagnostic: An extra human-readable explanation of the
+        problem.  This may include instructions on what bits of the
+        integration configuration might need to be changed.
+
+        For example, an API key might be wrong, or the API key might
+        be correct but the API provider might not have granted that
+        key enough permissions.
+        """
+        super(IntegrationSetupException, self).__init__(message)
+        self.diagnostic = diagnostic
+
+
+class CannotLoadConfiguration(IntegrationException):
+    """The current configuration of an external integration, or of the
+    site as a whole, is in an incomplete or inconsistent state.
+
+    This is more specific than an IntegrationException because it assumes the
+    problem is evident just by looking at the current configuration.
+    """
     pass
+
 
 @contextlib.contextmanager
 def temp_config(new_config=None, replacement_classes=None):

--- a/config.py
+++ b/config.py
@@ -5,7 +5,6 @@ import os
 import json
 import logging
 import copy
-from util import LanguageCodes
 from sqlalchemy.engine.url import make_url
 from flask_babel import lazy_gettext as _
 
@@ -14,34 +13,18 @@ from entrypoint import EntryPoint
 
 from sqlalchemy.exc import ArgumentError
 
-
-class IntegrationException(Exception):
-    """There was a problem in the setup or usage of an external integration.
-    """
-    def __init__(self, message, diagnostic=None):
-        """Constructor.
-
-        :param message: The normal message passed to any Exception
-        constructor.
-
-        :param diagnostic: An extra human-readable explanation of the
-        problem.  This may include instructions on what bits of the
-        integration configuration might need to be changed.
-
-        For example, an API key might be wrong, or the API key might
-        be correct but the API provider might not have granted that
-        key enough permissions.
-        """
-        super(IntegrationException, self).__init__(message)
-        self.diagnostic = diagnostic
+from util import LanguageCodes
+from util.http import IntegrationException
 
 
 class CannotLoadConfiguration(IntegrationException):
     """The current configuration of an external integration, or of the
     site as a whole, is in an incomplete or inconsistent state.
 
-    This is more specific than an IntegrationException because it assumes the
-    problem is evident just by looking at the current configuration.
+    This is more specific than a base IntegrationException because it
+    assumes the problem is evident just by looking at the current
+    configuration, with no need to actually talk to the foreign
+    server.
     """
     pass
 

--- a/config.py
+++ b/config.py
@@ -32,7 +32,7 @@ class IntegrationException(Exception):
         be correct but the API provider might not have granted that
         key enough permissions.
         """
-        super(IntegrationSetupException, self).__init__(message)
+        super(IntegrationException, self).__init__(message)
         self.diagnostic = diagnostic
 
 

--- a/external_integration.py
+++ b/external_integration.py
@@ -20,7 +20,7 @@ class SelfTestResult(object):
 
         # The return value of the test method, assuming it ran to
         # completion.
-        self.result = result
+        self.result = None
 
         # Start time of the test.
         self.start = datetime.datetime.utcnow()
@@ -30,7 +30,7 @@ class SelfTestResult(object):
 
     def __repr__(self):
         if self.exception:
-            if (isinstance(self.exception, IntegrationSetupException)
+            if (isinstance(self.exception, IntegrationException)
                 and self.exception.diagnostic):
                 exception = " exception=%r diagnostic=%r" % (
                     self.exception.message, self.exception.diagnostic
@@ -50,7 +50,7 @@ class HasSelfTest(object):
     self-test.
     """
 
-    def self_test(self):
+    def self_test(self, _db):
         """Verify that this integration is properly configured and working.
 
         :return: A list of SelfTestResult objects.
@@ -70,9 +70,9 @@ class HasSelfTest(object):
         """
         result = SelfTestResult(name)
         try:
-            result = method(*args, **kwargs)
+            return_value = method(*args, **kwargs)
             result.success = True
-            result.result = result
+            result.result = return_value
         except Exception, e:
             result.exception = e
             result.success = False

--- a/external_integration.py
+++ b/external_integration.py
@@ -1,0 +1,83 @@
+"""A module to support the classes that implement the code
+configured by various ExternalIntegrations.
+"""
+from nose.tools import set_trace
+from config import IntegrationException
+import datetime
+
+
+class SelfTestResult(object):
+
+    def __init__(self, name):
+        # Name of the test.
+        self.name = name
+
+        # The test ran without raising an exception.
+        self.success = False
+
+        # The exception raised, if any.
+        self.exception = None
+
+        # The return value of the test method, assuming it ran to
+        # completion.
+        self.result = result
+
+        # Start time of the test.
+        self.start = datetime.datetime.utcnow()
+
+        # End time of the test.
+        self.end = None
+
+    def __repr__(self):
+        if self.exception:
+            if (isinstance(self.exception, IntegrationSetupException)
+                and self.exception.diagnostic):
+                exception = " exception=%r diagnostic=%r" % (
+                    self.exception.message, self.exception.diagnostic
+                )
+            else:
+                exception = " exception=%r" % self.exception
+        else:
+            exception = ""
+        return "<SelfTestResult: name=%r timing=%.2fsec success=%r%s>" % (
+            self.name, (self.end-self.start).total_seconds(), self.success,
+            exception
+        )
+
+
+class HasSelfTest(object):
+    """An object capable of verifying its own configuration by running a
+    self-test.
+    """
+
+    def self_test(self):
+        """Verify that this integration is properly configured and working.
+
+        :return: A list of SelfTestResult objects.
+        """
+        raise NotImplementedError()
+
+    def run_test(self, name, method, *args, **kwargs):
+        """Run a test method, record any exception that happens, and keep
+        track of how long the test takes to run.
+
+        :param name: The name of the test to be run.
+        :param method: A method to call to run the test.
+        :param args: Position arguments to `method`.
+        :param kwargs: Keyword arguments to `method`.
+
+        :return: A filled-in SelfTestResult.
+        """
+        result = SelfTestResult(name)
+        try:
+            result = method(*args, **kwargs)
+            result.success = True
+            result.result = result
+        except Exception, e:
+            result.exception = e
+            result.success = False
+            result.result = None
+        finally:
+            if not result.end:
+                result.end = datetime.datetime.utcnow()
+        return result

--- a/model.py
+++ b/model.py
@@ -8407,6 +8407,7 @@ class Representation(Base):
     EPUB_MEDIA_TYPE = u"application/epub+zip"
     PDF_MEDIA_TYPE = u"application/pdf"
     MOBI_MEDIA_TYPE = u"application/x-mobipocket-ebook"
+    AMAZON_KF8_MEDIA_TYPE = u"application/x-mobi8-ebook"
     TEXT_XML_MEDIA_TYPE = u"text/xml"
     TEXT_HTML_MEDIA_TYPE = u"text/html"
     APPLICATION_XML_MEDIA_TYPE = u"application/xml"
@@ -8428,6 +8429,7 @@ class Representation(Base):
         PDF_MEDIA_TYPE,
         MOBI_MEDIA_TYPE,
         MP3_MEDIA_TYPE,
+        AMAZON_KF8_MEDIA_TYPE,
     ]
 
     # These media types are in the order we would prefer to use them.

--- a/overdrive.py
+++ b/overdrive.py
@@ -320,10 +320,7 @@ class OverdriveAPI(object):
         """Get IDs for every book in the system, with the most recently added
         ones at the front.
         """
-        params = dict(collection_token=self.collection_token,
-                      sort="dateAdded:desc")
-        next_link = self.make_link_safe(
-            self.ALL_PRODUCTS_ENDPOINT % params)
+        next_link = self._all_products_link
         while next_link:
             page_inventory, next_link = self._get_book_list_page(
                 next_link, 'next'
@@ -331,6 +328,12 @@ class OverdriveAPI(object):
 
             for i in page_inventory:
                 yield i
+
+    @property
+    def _all_products_link(self):
+        params = dict(collection_token=self.collection_token,
+                      sort="dateAdded:desc")
+        return self.make_link_safe(self.ALL_PRODUCTS_ENDPOINT % params)
 
     def _get_book_list_page(self, link, rel_to_follow='next'):
         """Process a page of inventory whose circulation we need to check.

--- a/selftest.py
+++ b/selftest.py
@@ -25,6 +25,10 @@ class SelfTestResult(object):
         # completion.
         self.result = None
 
+        # Any extra diagnostic information that's useful for
+        # understanding the test results.
+        self.diagnostic = None
+
         # Start time of the test.
         self.start = datetime.datetime.utcnow()
 
@@ -42,9 +46,9 @@ class SelfTestResult(object):
                 exception = " exception=%r" % self.exception
         else:
             exception = ""
-        return "<SelfTestResult: name=%r timing=%.2fsec success=%r%s>" % (
+        return "<SelfTestResult: name=%r timing=%.2fsec success=%r%s result=%s>" % (
             self.name, (self.end-self.start).total_seconds(), self.success,
-            exception
+            exception, self.result
         )
 
 
@@ -83,4 +87,16 @@ class HasSelfTests(object):
         finally:
             if not result.end:
                 result.end = datetime.datetime.utcnow()
+        return result
+
+    def test_failure(self, name, message, diagnostic=None):
+        """Create a SelfTestResult for a known failure."""
+        result = SelfTestResult(name)
+        result.end = result.start
+        result.success = False
+        if isinstance(message, Exception):
+            exception = message
+        else:
+            exception = IntegrationException(message, diagnostic)
+        result.exception = exception
         return result

--- a/selftest.py
+++ b/selftest.py
@@ -15,7 +15,7 @@ class SelfTestResult(object):
         # Name of the test.
         self.name = name
 
-        # The test ran without raising an exception.
+        # Set to True when the test runs without raising an exception.
         self.success = False
 
         # The exception raised, if any.
@@ -54,7 +54,7 @@ class HasSelfTests(object):
     """
 
     def run_self_tests(self, _db):
-        """Run a series of self tests. 
+        """Run a series of self-tests.
 
         :return: A list of SelfTestResult objects.
         """

--- a/selftest.py
+++ b/selftest.py
@@ -1,7 +1,7 @@
 """Define the interfaces used by ExternalIntegration self-tests.
 """
 from nose.tools import set_trace
-from config import IntegrationException
+from util.http import IntegrationException
 import datetime
 
 
@@ -25,10 +25,6 @@ class SelfTestResult(object):
         # completion.
         self.result = None
 
-        # Any extra diagnostic information that's useful for
-        # understanding the test results.
-        self.diagnostic = None
-
         # Start time of the test.
         self.start = datetime.datetime.utcnow()
 
@@ -38,9 +34,9 @@ class SelfTestResult(object):
     def __repr__(self):
         if self.exception:
             if (isinstance(self.exception, IntegrationException)
-                and self.exception.diagnostic):
+                and self.exception.debug_message):
                 exception = " exception=%r diagnostic=%r" % (
-                    self.exception.message, self.exception.diagnostic
+                    self.exception.message, self.exception.debug_message
                 )
             else:
                 exception = " exception=%r" % self.exception

--- a/selftest.py
+++ b/selftest.py
@@ -58,11 +58,14 @@ class HasSelfTests(object):
         """Instantiate this class and call _run_self_tests on it.
 
         :param _db: A database connection. Will be passed into
-        _run_self_tests as well as the first argument of the constructor
-        method.
+        _run_self_tests. This connection may need to be used again
+        in *args, if the constructor needs it.
 
         :param constructor_method: Method to use to instantiate the
         class, if different from the default constructor.
+
+        :param args: Positional arguments to pass into the constructor.
+        :param kwargs: Keyword arguments to pass into the constructor.
 
         :return: An iterator of SelfTestResult objects, starting with
         the attempt to instantiate the test class in the first place.
@@ -71,7 +74,7 @@ class HasSelfTests(object):
         result = SelfTestResult("Initial setup.")
         instance = None
         try:
-            instance = constructor_method(_db, *args, **kwargs)
+            instance = constructor_method(*args, **kwargs)
             result.success = True
             result.result = instance
         except Exception, e:

--- a/selftest.py
+++ b/selftest.py
@@ -35,7 +35,7 @@ class SelfTestResult(object):
         if self.exception:
             if (isinstance(self.exception, IntegrationException)
                 and self.exception.debug_message):
-                exception = " exception=%r diagnostic=%r" % (
+                exception = " exception=%r debug=%r" % (
                     self.exception.message, self.exception.debug_message
                 )
             else:
@@ -85,7 +85,7 @@ class HasSelfTests(object):
                 result.end = datetime.datetime.utcnow()
         return result
 
-    def test_failure(self, name, message, diagnostic=None):
+    def test_failure(self, name, message, debug_message=None):
         """Create a SelfTestResult for a known failure."""
         result = SelfTestResult(name)
         result.end = result.start
@@ -93,6 +93,6 @@ class HasSelfTests(object):
         if isinstance(message, Exception):
             exception = message
         else:
-            exception = IntegrationException(message, diagnostic)
+            exception = IntegrationException(message, debug_message)
         result.exception = exception
         return result

--- a/selftest.py
+++ b/selftest.py
@@ -69,7 +69,6 @@ class HasSelfTests(object):
         """
         constructor_method = constructor_method or cls
         result = SelfTestResult("Initial setup.")
-        result.start = datetime.datetime.utcnow()
         instance = None
         try:
             instance = constructor_method(_db, *args, **kwargs)

--- a/selftest.py
+++ b/selftest.py
@@ -1,5 +1,4 @@
-"""A module to support the classes that implement the code
-configured by various ExternalIntegrations.
+"""Define the interfaces used by ExternalIntegration self-tests.
 """
 from nose.tools import set_trace
 from config import IntegrationException
@@ -7,6 +6,10 @@ import datetime
 
 
 class SelfTestResult(object):
+    """The result of running a single self-test.
+
+    HasSelfTest.run_self_tests() returns a list of these
+    """
 
     def __init__(self, name):
         # Name of the test.
@@ -45,13 +48,13 @@ class SelfTestResult(object):
         )
 
 
-class HasSelfTest(object):
-    """An object capable of verifying its own configuration by running a
-    self-test.
+class HasSelfTests(object):
+    """An object capable of verifying its own setup by running a
+    series of self-tests.
     """
 
-    def self_test(self, _db):
-        """Verify that this integration is properly configured and working.
+    def run_self_tests(self, _db):
+        """Run a series of self tests. 
 
         :return: A list of SelfTestResult objects.
         """
@@ -63,7 +66,7 @@ class HasSelfTest(object):
 
         :param name: The name of the test to be run.
         :param method: A method to call to run the test.
-        :param args: Position arguments to `method`.
+        :param args: Positional arguments to `method`.
         :param kwargs: Keyword arguments to `method`.
 
         :return: A filled-in SelfTestResult.

--- a/selftest.py
+++ b/selftest.py
@@ -53,7 +53,40 @@ class HasSelfTests(object):
     series of self-tests.
     """
 
-    def run_self_tests(self, _db):
+    @classmethod
+    def run_self_tests(cls, _db, constructor_method=None, *args, **kwargs):
+        """Instantiate this class and call _run_self_tests on it.
+
+        :param _db: A database connection. Will be passed into
+        _run_self_tests as well as the first argument of the constructor
+        method.
+
+        :param constructor_method: Method to use to instantiate the
+        class, if different from the default constructor.
+
+        :return: An iterator of SelfTestResult objects, starting with
+        the attempt to instantiate the test class in the first place.
+        """
+        constructor_method = constructor_method or cls
+        result = SelfTestResult("Initial setup.")
+        result.start = datetime.datetime.utcnow()
+        instance = None
+        try:
+            instance = constructor_method(_db, *args, **kwargs)
+            result.success = True
+            result.result = instance
+        except Exception, e:
+            result.exception = e
+            result.success = False
+        finally:
+            result.end = datetime.datetime.utcnow()
+        yield result
+
+        if instance:
+            for result in instance._run_self_tests(_db):
+                yield result
+
+    def _run_self_tests(self, _db):
         """Run a series of self-tests.
 
         :return: A list of SelfTestResult objects.
@@ -85,7 +118,8 @@ class HasSelfTests(object):
                 result.end = datetime.datetime.utcnow()
         return result
 
-    def test_failure(self, name, message, debug_message=None):
+    @classmethod
+    def test_failure(cls, name, message, debug_message=None):
         """Create a SelfTestResult for a known failure.
 
         This is useful when you can't even get the data necessary to

--- a/selftest.py
+++ b/selftest.py
@@ -42,7 +42,7 @@ class SelfTestResult(object):
                 exception = " exception=%r" % self.exception
         else:
             exception = ""
-        return "<SelfTestResult: name=%r timing=%.2fsec success=%r%s result=%s>" % (
+        return "<SelfTestResult: name=%r timing=%.2fsec success=%r%s result=%r>" % (
             self.name, (self.end-self.start).total_seconds(), self.success,
             exception, self.result
         )

--- a/selftest.py
+++ b/selftest.py
@@ -86,7 +86,11 @@ class HasSelfTests(object):
         return result
 
     def test_failure(self, name, message, debug_message=None):
-        """Create a SelfTestResult for a known failure."""
+        """Create a SelfTestResult for a known failure.
+
+        This is useful when you can't even get the data necessary to
+        run a test method.
+        """
         result = SelfTestResult(name)
         result.end = result.start
         result.success = False

--- a/tests/test_selftest.py
+++ b/tests/test_selftest.py
@@ -1,0 +1,53 @@
+"""Test the self-test functionality.
+
+Self-tests are not unit tests -- they are executed at runtime on a
+specific installation. They verify that that installation is properly
+configured, not that the code is correct.
+"""
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+
+import datetime
+
+from selftest import (
+    SelfTestResult,
+    HasSelfTests,
+)
+
+from util.http import IntegrationException
+
+class TestSelfTestResult(object):
+
+    now = datetime.datetime.utcnow()
+    future = now + datetime.timedelta(seconds=5)
+    
+    def test_repr_success(self):
+        """Show the string representation of a successful test result."""
+        # A successful result
+        result = SelfTestResult("success1")
+        result.start = self.now
+        result.end = self.future
+        result.result = "The result"
+        result.success = True
+        eq_(
+            "<SelfTestResult: name='success1' timing=5.00sec success=False result='The result'>", 
+            repr(result)
+        )
+
+    def test_repr_success(self):
+        """Show the string representation of a successful test result."""
+
+        exception = IntegrationException("basic info", "debug info")
+
+        result = SelfTestResult("failure1")
+        result.start = self.now
+        result.end = self.future
+        result.exception = exception
+        result.result = "The result"
+        eq_(
+            "<SelfTestResult: name='failure1' timing=5.00sec success=False exception='basic info' debug='debug info' result='The result'>", 
+            repr(result)
+        )
+

--- a/tests/test_selftest.py
+++ b/tests/test_selftest.py
@@ -59,19 +59,19 @@ class TestHasSelfTests(object):
         object and run its self-tests.
         """
         class Tester(HasSelfTests):
-            def __init__(self, _db, extra_arg=None):
+            def __init__(self, extra_arg=None):
                 """This constructor works."""
-                self.invoked_with = (_db, extra_arg)
+                self.invoked_with = (extra_arg)
 
             @classmethod
-            def good_alternate_constructor(self, _db, another_extra_arg=None):
+            def good_alternate_constructor(self, another_extra_arg=None):
                 """This alternate constructor works."""
-                tester = Tester(_db)
+                tester = Tester()
                 tester.another_extra_arg = another_extra_arg
                 return tester
 
             @classmethod
-            def bad_alternate_constructor(self, _db):
+            def bad_alternate_constructor(self):
                 """This constructor doesn't work."""
                 raise Exception("I don't work!")
 
@@ -85,12 +85,13 @@ class TestHasSelfTests(object):
         [setup, test] = list(
             Tester.run_self_tests(mock_db, extra_arg="a value")
         )
+        eq_(mock_db, setup.result._run_self_tests_called_with)
 
         # There are two results -- one from the initial setup
         # and one from the _run_self_tests call.
         eq_("Initial setup.", setup.name)
         eq_(True, setup.success)
-        eq_((mock_db, "a value"), setup.result.invoked_with)
+        eq_("a value", setup.result.invoked_with)
 
         eq_("a result", test)
 
@@ -103,7 +104,7 @@ class TestHasSelfTests(object):
         )
         eq_("Initial setup.", setup.name)
         eq_(True, setup.success)
-        eq_((mock_db, None), setup.result.invoked_with)
+        eq_(None, setup.result.invoked_with)
         eq_("another value", setup.result.another_extra_arg)
         eq_("a result", test)
 

--- a/tests/test_selftest.py
+++ b/tests/test_selftest.py
@@ -22,7 +22,7 @@ class TestSelfTestResult(object):
 
     now = datetime.datetime.utcnow()
     future = now + datetime.timedelta(seconds=5)
-    
+
     def test_repr_success(self):
         """Show the string representation of a successful test result."""
         # A successful result
@@ -32,7 +32,7 @@ class TestSelfTestResult(object):
         result.result = "The result"
         result.success = True
         eq_(
-            "<SelfTestResult: name='success1' timing=5.00sec success=False result='The result'>", 
+            "<SelfTestResult: name='success1' timing=5.00sec success=False result='The result'>",
             repr(result)
         )
 
@@ -47,7 +47,58 @@ class TestSelfTestResult(object):
         result.exception = exception
         result.result = "The result"
         eq_(
-            "<SelfTestResult: name='failure1' timing=5.00sec success=False exception='basic info' debug='debug info' result='The result'>", 
+            "<SelfTestResult: name='failure1' timing=5.00sec success=False exception='basic info' debug='debug info' result='The result'>",
             repr(result)
         )
 
+
+class TestHasSelfTests(object):
+
+    def test_run_test_success(self):
+        o = HasSelfTests()
+        # This self-test method will succeed.
+        def successful_test(arg, kwarg):
+            return arg, kwarg
+        result = o.run_test(
+            "A successful test", successful_test, "arg1", kwarg="arg2"
+        )
+        eq_(True, result.success)
+        eq_("A successful test", result.name)
+        eq_(("arg1", "arg2"), result.result)
+        assert (result.end-result.start).total_seconds() < 1
+
+    def test_run_test_failure(self):
+        o = HasSelfTests()
+        # This self-test method will fail.
+        def unsuccessful_test(arg, kwarg):
+            raise IntegrationException(arg, kwarg)
+        result = o.run_test(
+            "An unsuccessful test", unsuccessful_test, "arg1", kwarg="arg2"
+        )
+        eq_(False, result.success)
+        eq_("An unsuccessful test", result.name)
+        eq_(None, result.result)
+        eq_("arg1", result.exception.message)
+        eq_("arg2", result.exception.debug_message)
+        assert (result.end-result.start).total_seconds() < 1
+
+    def test_test_failure(self):
+        o = HasSelfTests()
+
+        # You can pass in an Exception...
+        exception = Exception("argh")
+        now = datetime.datetime.utcnow()
+        result = o.test_failure("a failure", exception)
+        eq_("a failure", result.name)
+        eq_(exception, result.exception)
+        assert (result.start-now).total_seconds() < 1
+
+        # ... or you can pass in arguments to an IntegrationException
+        result = o.test_failure("another failure", "message", "debug")
+        assert isinstance(result.exception, IntegrationException)
+        eq_("message", result.exception.message)
+        eq_("debug", result.exception.debug_message)
+
+        # Since no test code actually ran, the end time is the
+        # same as the start time.
+        eq_(result.start, result.end)

--- a/util/http.py
+++ b/util/http.py
@@ -15,11 +15,39 @@ INTEGRATION_ERROR = pd(
       _("A third-party service has failed."),
 )
 
-class RemoteIntegrationException(Exception):
+class IntegrationException(Exception):
+    """An exception that happens when the site's connection to a
+    third-party service is broken.
 
-    """An exception that happens when communicating with a third-party
-    service over HTTP.
+    This may be because communication failed
+    (RemoteIntegrationException), or because local configuration is
+    missing or obviously wrong (CannotLoadConfiguration).
     """
+
+    def __init__(self, message, debug_message=None):
+        """Constructor.
+
+        :param message: The normal message passed to any Exception
+        constructor.
+
+        :param debug_message: An extra human-readable explanation of the
+        problem, shown to admins but not to patrons. This may include
+        instructions on what bits of the integration configuration might need
+        to be changed.
+
+        For example, an API key might be wrong, or the API key might
+        be correct but the API provider might not have granted that
+        key enough permissions.
+        """
+        super(IntegrationException, self).__init__(message)
+        self.debug_message = debug_message
+
+
+class RemoteIntegrationException(Exception):
+    """An exception that happens when we try and fail to communicate
+    with a third-party service over HTTP.
+    """
+
     title = _("Failure contacting external service")
     detail = _("The server tried to access %(service)s but the third-party service experienced an error.")
     internal_message = "Error accessing %s: %s"

--- a/util/http.py
+++ b/util/http.py
@@ -43,7 +43,7 @@ class IntegrationException(Exception):
         self.debug_message = debug_message
 
 
-class RemoteIntegrationException(Exception):
+class RemoteIntegrationException(IntegrationException):
     """An exception that happens when we try and fail to communicate
     with a third-party service over HTTP.
     """

--- a/util/http.py
+++ b/util/http.py
@@ -58,14 +58,15 @@ class RemoteIntegrationException(IntegrationException):
         `param url_or_service` The name of the service that failed
            (e.g. "Overdrive"), or the specific URL that had the problem.
         """
-        super(RemoteIntegrationException, self).__init__(message)
         if (url_or_service and
             any(url_or_service.startswith(x) for x in ('http:', 'https:'))):
             self.url = url_or_service
             self.service = urlparse.urlparse(url_or_service).netloc
         else:
             self.url = self.service = url_or_service
-        self.debug_message = debug_message
+        if not debug_message:
+            debug_message = self.internal_message % (self.url, message)
+        super(RemoteIntegrationException, self).__init__(message, debug_message)
 
     def __str__(self):
         return self.internal_message % (self.url, self.message)

--- a/util/http.py
+++ b/util/http.py
@@ -18,7 +18,7 @@ INTEGRATION_ERROR = pd(
 class RemoteIntegrationException(Exception):
 
     """An exception that happens when communicating with a third-party
-    service.
+    service over HTTP.
     """
     title = _("Failure contacting external service")
     detail = _("The server tried to access %(service)s but the third-party service experienced an error.")
@@ -233,7 +233,9 @@ class HTTP(object):
         """
         if allowed_response_codes:
             allowed_response_codes = map(str, allowed_response_codes)
-            status_code_not_in_allowed = "Got status code %%s from external server, but can only continue on: %s." % ", ".join(sorted(allowed_response_codes))
+            status_code_not_in_allowed = "Got status code %%s from external server at %s, but can only continue on: %s." % (
+                url, ", ".join(sorted(allowed_response_codes)),
+            )
         if disallowed_response_codes:
             disallowed_response_codes = map(str, disallowed_response_codes)
         else:

--- a/util/http.py
+++ b/util/http.py
@@ -262,8 +262,8 @@ class HTTP(object):
         """
         if allowed_response_codes:
             allowed_response_codes = map(str, allowed_response_codes)
-            status_code_not_in_allowed = "Got status code %%s from external server at %s, but can only continue on: %s." % (
-                url, ", ".join(sorted(allowed_response_codes)),
+            status_code_not_in_allowed = "Got status code %%s from external server, but can only continue on: %s." % (
+                ", ".join(sorted(allowed_response_codes)),
             )
         if disallowed_response_codes:
             disallowed_response_codes = map(str, disallowed_response_codes)


### PR DESCRIPTION
This branch defines a class called `HasSelfTests` which implements a class method `run_self_tests`. The job of this method is to instantiate the class and run a suite of self tests. The results are a sequence of `SelfTestResult` objects. Each `SelfTestResult` records how long some code took to run, whether it raised an exception, and what the return value was.

The overall idea is that the circulation manager's admin interface will eventually feature a self-test button for each configured integration. Clicking the self-test button will call `run_self_tests` on the appropriate class, and the `SelfTestResult` objects will be displayed to the user.

This is how self-tests differ from unit tests and integration tests -- they test that a running site is configured to communicate with a foreign server, not the correctness of the underlying code.

A new class, `IntegrationException`, represents a problem with a third-party integration. It's the new superclass of `RemoteIntegrationException`, which is used primarily for problems that happen during HTTP requests, and `CannotLoadConfiguration`, which is used for obviously missing data in an `ExternalIntegration`'s configuration. (In circulation, it's also the new superclass of `CirculationException`). The fundamental thing about an `IntegrationException` is that it has a `message`, like any Exception, but it also has a `debug_message`, which gives more specific information about the problem, including--potentially--how to fix the problem.

Although any `Exception` raised during a self-test will be understood as the reason why the test failed, using `IntegrationExceptions` instead and gradually improving their `debug_message`s will let us make the process of debugging a circulation manager configuration easier over time.