### PR TITLE
Properly set licenses_owned and licenses_available when discovering a new RBdigital book.

### DIFF
--- a/oneclick.py
+++ b/oneclick.py
@@ -403,8 +403,14 @@ class OneClickAPI(object):
                     # NOTE:  TODO later:  For the 4 out of 2000 libraries that chose to display 
                     # books they don't own, we'd need to call the search endpoint to get 
                     # the interest field, and then deal with licenses_owned. 
-                    if result.licensed_through:
-                        result.licensed_through.licenses_owned = 1
+                    for lp in result.licensed_through:
+                        if lp.collection == self.collection:
+                            lp.licenses_owned = 1
+
+                            # Start off by assuming the book is available.
+                            # If it's not, we'll hear differently the
+                            # next time we use the collection delta API.
+                            lp.licenses_available = 1
             if not items_created % 100:
                 # Periodically commit the work done so that if there's
                 # a failure, the subsequent run through this code will

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -402,12 +402,17 @@ class TestOneClickSyncMonitor(DatabaseTest):
             self._db, DataSource.ONECLICK, Identifier.ONECLICK_ID,
             "9780062231727", collection=self.collection
         )
+        eq_(1, pool.licenses_owned)
+        eq_(1, pool.licenses_available)
+
         eq_(False, made_new)
         pool, made_new = LicensePool.for_foreign_id(
             self._db, DataSource.ONECLICK, Identifier.ONECLICK_ID,
             "9781615730186", collection=self.collection
         )
         eq_(False, made_new)
+        eq_(1, pool.licenses_owned)
+        eq_(1, pool.licenses_available)
 
         # make sure there are 8 LicensePools
         pools = self._db.query(LicensePool).all()


### PR DESCRIPTION
This bug was caused when `Identifier.licensed_through` stopped being a single LicensePool and became an InstrumentedList. You can set .licenses_owned on an InstrumentedList but that won't do anything to the database. The upshot is that RBdigital titles were coming into the database as not having any licenses owned.