### PR TITLE
Removing default variable when generating facet entrypoint links.

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -55,7 +55,7 @@ class EntryPoint(object):
         if display_title in cls.DISPLAY_TITLES.values():
             raise ValueError(
                 "Duplicate entry point display name: %s" % display_title
-            )            
+            )
         cls.DISPLAY_TITLES[entrypoint_class] = display_title
         cls.BY_INTERNAL_NAME[value] = entrypoint_class
         cls.ENTRY_POINTS.append(entrypoint_class)
@@ -141,9 +141,9 @@ class MediumEntryPoint(EntryPoint):
 class EbooksEntryPoint(MediumEntryPoint):
     INTERNAL_NAME = "Book"
     URI = u"http://schema.org/EBook"
-EntryPoint.register(EbooksEntryPoint, "Books", default_enabled=True)
+EntryPoint.register(EbooksEntryPoint, "eBooks", default_enabled=True)
 
 class AudiobooksEntryPoint(MediumEntryPoint):
     INTERNAL_NAME = "Audio"
     URI = u"http://bib.schema.org/Audiobook"
-EntryPoint.register(AudiobooksEntryPoint, "Audio")
+EntryPoint.register(AudiobooksEntryPoint, "Audio Books")

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -146,4 +146,4 @@ EntryPoint.register(EbooksEntryPoint, "eBooks", default_enabled=True)
 class AudiobooksEntryPoint(MediumEntryPoint):
     INTERNAL_NAME = "Audio"
     URI = u"http://bib.schema.org/Audiobook"
-EntryPoint.register(AudiobooksEntryPoint, "Audio Books")
+EntryPoint.register(AudiobooksEntryPoint, "Audiobooks")

--- a/opds.py
+++ b/opds.py
@@ -715,11 +715,7 @@ class AcquisitionFeed(OPDSFeed):
         if entrypoints:
             # A paginated feed may have multiple entry points into the
             # same dataset.
-            def make_link(ep, is_default):
-                if is_default:
-                    # No need to clutter up the URL with the default
-                    # entry point.
-                    ep = None
+            def make_link(ep):
                 return annotator.feed_url(
                     lane, facets=facets.navigate(entrypoint=ep)
                 )
@@ -889,9 +885,7 @@ class AcquisitionFeed(OPDSFeed):
         # into those results.
         entrypoints = facets.selectable_entrypoints(lane)
         if entrypoints:
-            def make_link(ep, is_default):
-                if is_default:
-                    ep = None
+            def make_link(ep):
                 return annotator.search_url(
                     lane, query, pagination=None,
                     facets=facets.navigate(entrypoint=ep)

--- a/opds.py
+++ b/opds.py
@@ -652,11 +652,7 @@ class AcquisitionFeed(OPDSFeed):
         # the data.
         entrypoints = facets.selectable_entrypoints(lane)
         if entrypoints:
-            def make_link(ep, is_default):
-                # if is_default:
-                #     # No need to clutter up the URL with the default
-                #     # entry point.
-                #     ep = None
+            def make_link(ep):
                 return annotator.groups_url(
                     lane, facets=facets.navigate(entrypoint=ep)
                 )
@@ -819,7 +815,7 @@ class AcquisitionFeed(OPDSFeed):
             # Shouldn't happen.
             return
 
-        url = url_generator(entrypoint, is_default)
+        url = url_generator(entrypoint)
         is_selected = entrypoint is selected_entrypoint
         link = cls.facet_link(url, display_title, group_name, is_selected)
 

--- a/opds.py
+++ b/opds.py
@@ -653,10 +653,10 @@ class AcquisitionFeed(OPDSFeed):
         entrypoints = facets.selectable_entrypoints(lane)
         if entrypoints:
             def make_link(ep, is_default):
-                if is_default:
-                    # No need to clutter up the URL with the default
-                    # entry point.
-                    ep = None
+                # if is_default:
+                #     # No need to clutter up the URL with the default
+                #     # entry point.
+                #     ep = None
                 return annotator.groups_url(
                     lane, facets=facets.navigate(entrypoint=ep)
                 )

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -26,7 +26,7 @@ class TestEntryPoint(DatabaseTest):
 
         display = EntryPoint.DISPLAY_TITLES
         eq_("eBooks", display[ebooks])
-        eq_("Audio Books", display[audiobooks])
+        eq_("Audiobooks", display[audiobooks])
 
         eq_(Edition.BOOK_MEDIUM, EbooksEntryPoint.INTERNAL_NAME)
         eq_(Edition.AUDIO_MEDIUM, AudiobooksEntryPoint.INTERNAL_NAME)

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -25,8 +25,8 @@ class TestEntryPoint(DatabaseTest):
         eq_(AudiobooksEntryPoint, audiobooks)
 
         display = EntryPoint.DISPLAY_TITLES
-        eq_("Books", display[ebooks])
-        eq_("Audio", display[audiobooks])
+        eq_("eBooks", display[ebooks])
+        eq_("Audio Books", display[audiobooks])
 
         eq_(Edition.BOOK_MEDIUM, EbooksEntryPoint.INTERNAL_NAME)
         eq_(Edition.AUDIO_MEDIUM, AudiobooksEntryPoint.INTERNAL_NAME)

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1473,7 +1473,7 @@ class TestAcquisitionFeed(DatabaseTest):
         l = m(g, AudiobooksEntryPoint, AudiobooksEntryPoint, True, "Grupe")
 
         # This may affect the URL generated for the facet link.
-        eq_(l['href'], g(AudiobooksEntryPoint, True))
+        eq_(l['href'], g(AudiobooksEntryPoint))
 
         # Here, the entry point for which we're generating the link is
         # not the selected one -- EbooksEntryPoint is.

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -2229,7 +2229,7 @@ class TestEntrypointLinkInsertion(DatabaseTest):
         # TestAnnotator.feed_url() when passed an EntryPoint. The
         # Facets object's other facet groups are propagated in this URL.
         first_page_url = "http://wl/?available=all&collection=main&entrypoint=Book&order=author"
-        eq_(first_page_url, make_link(EbooksEntryPoint, False))
+        eq_(first_page_url, make_link(EbooksEntryPoint))
 
         # Pagination information is not propagated through entry point links
         # -- you always start at the beginning of the list.
@@ -2237,7 +2237,7 @@ class TestEntrypointLinkInsertion(DatabaseTest):
         feed, make_link, entrypoints, selected = run(
             self.wl, facets, pagination
         )
-        eq_(first_page_url, make_link(EbooksEntryPoint, False))
+        eq_(first_page_url, make_link(EbooksEntryPoint))
 
     def test_search(self):
         """When AcquisitionFeed.search() generates the first page of
@@ -2287,7 +2287,7 @@ class TestEntrypointLinkInsertion(DatabaseTest):
         # The make_link function that was passed in calls
         # TestAnnotator.search_url() when passed an EntryPoint.
         first_page_url = 'http://wl/?entrypoint=Book'
-        eq_(first_page_url, make_link(EbooksEntryPoint, False))
+        eq_(first_page_url, make_link(EbooksEntryPoint))
 
         # Pagination information is not propagated through entry point links
         # -- you always start at the beginning of the list.
@@ -2295,4 +2295,4 @@ class TestEntrypointLinkInsertion(DatabaseTest):
         feed, make_link, entrypoints, selected = run(
             self.wl, facets, pagination
         )
-        eq_(first_page_url, make_link(EbooksEntryPoint, False))
+        eq_(first_page_url, make_link(EbooksEntryPoint))

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1462,7 +1462,7 @@ class TestAcquisitionFeed(DatabaseTest):
         eq_('true', l['{http://opds-spec.org/2010/catalog}activeFacet'])
 
         # The URL generator was invoked to create the href.
-        eq_(l['href'], g(AudiobooksEntryPoint, False))
+        eq_(l['href'], g(AudiobooksEntryPoint))
 
         # The facet title identifies it as a way to look at audiobooks.
         eq_(EntryPoint.DISPLAY_TITLES[AudiobooksEntryPoint], l['title'])

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1441,9 +1441,9 @@ class TestAcquisitionFeed(DatabaseTest):
         attributes for <link> tags.
         """
         m = AcquisitionFeed._entrypoint_link
-        def g(entrypoint, is_default):
+        def g(entrypoint):
             """A mock URL generator."""
-            return "%s - %s" % (entrypoint.INTERNAL_NAME, is_default)
+            return "%s" % (entrypoint.INTERNAL_NAME)
 
         # If the entry point is not registered, None is returned.
         eq_(None, m(g, object(), object(), True, "group"))
@@ -2191,7 +2191,7 @@ class TestEntrypointLinkInsertion(DatabaseTest):
 
         # The make_link function that was passed in calls
         # TestAnnotator.groups_url() when passed an EntryPoint.
-        eq_("http://groups/?entrypoint=Book", make_link(EbooksEntryPoint, False))
+        eq_("http://groups/?entrypoint=Book", make_link(EbooksEntryPoint))
 
     def test_page(self):
         """When AcquisitionFeed.page() generates the first page of a paginated


### PR DESCRIPTION
I believe this fixes the issue where the "All" default entrypoint facet link picks up the same facet link as what is currently selected. So, like the image below, when "Audio Books" was selected, the "All" tab link had `?entrypoint=Audio` in the url.

![samelink](https://user-images.githubusercontent.com/1280564/42466024-b5e449c4-837b-11e8-9d0b-b3df819a6161.png)

I noticed that down the line in `lane.py`, FeatureFacets.navigate line 560 is where the entrypoint would be passed as `None` if the value is a default. In that case, `self.entrypoint` is the value of the entrypoint facet from the url. I think there's a better way to fix this but I don't know where `FeatureFacets` is instantiated with its initial value of entrypoint to better fix this.