### PR TITLE
If Overdrive sends an invalid ISBN, ignore it.

### DIFF
--- a/migration/20180712-na-is-not-an-isbn.sql
+++ b/migration/20180712-na-is-not-an-isbn.sql
@@ -1,0 +1,7 @@
+delete from equivalents where output_id in (
+ select id from identifiers where type='ISBN' and identifier='n/a'
+);
+delete from equivalents where input_id in (
+ select id from identifiers where type='ISBN' and identifier='n/a'
+);
+delete from identifiers where type='ISBN' and identifier='n/a';

--- a/overdrive.py
+++ b/overdrive.py
@@ -857,6 +857,12 @@ class OverdriveRepresentationExtractor(object):
                         type_key = Identifier.ISBN
                         if len(v) == 10:
                             v = isbnlib.to_isbn13(v)
+                        if not isbnlib.is_isbn13(v):
+                            # Overdrive sometimes uses invalid values
+                            # like "n/a" as placeholders. Ignore such
+                            # values to avoid a situation where hundreds of
+                            # books appear to have the same ISBN.
+                            continue
                     elif t == 'DOI':
                         type_key = Identifier.DOI
                     elif t == 'UPC':

--- a/tests/files/overdrive/overdrive_metadata.json
+++ b/tests/files/overdrive/overdrive_metadata.json
@@ -56,6 +56,10 @@
                 {
                     "type": "ASIN",
                     "value": ""
+                },
+                {
+                    "type": "ISBN",
+                    "value": "n/a"
                 }
             ],
             "name": "Kindle Book",

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -315,8 +315,8 @@ class TestOverdriveRepresentationExtractor(OverdriveTestWithAPI):
 
         ids = [(x.type, x.identifier) for x in metadata.identifiers]
 
-        # The original data contains a blank ASIN in addition to the
-        # actual ASIN, but it doesn't show up here.
+        # The original data contains a blank ASIN and an invalid ISBN
+        # in addition to the actual ASIN and ISBN, but they don't show up here.
         eq_(
             [
                 (Identifier.ASIN, "B000VI88N2"), 


### PR DESCRIPTION
Overdrive has started sending "ISBN": "n/a" for books where it doesn't know the ISBN, rather than omitting the 'ISBN' field. Our behavior was to treat this as a real ISBN, and we ended up with hundreds of books that all apparently had the same ISBN. This caused a variety of problems including memory errors when running fn_recursive_equivalents.

I could fix this more generally by making Identifier refuse to create an ISBN identifier for something that's not a valid ISBN but this is good enough for now.