### PR TITLE
Added a method to check if a collection is visible to an admin.

### DIFF
--- a/model.py
+++ b/model.py
@@ -10574,13 +10574,10 @@ class Admin(Base, HasFullTableCache):
         return False
 
     def can_see_collection(self, collection):
+        if self.is_system_admin():
+            return True
         for library in collection.libraries:
             if self.is_librarian(library):
-                return True
-        if not collection.libraries:
-            # If the collection's not associated with any libraries, only system
-            # admins can see it.
-            if self.is_system_admin():
                 return True
         return False
 

--- a/model.py
+++ b/model.py
@@ -10573,6 +10573,17 @@ class Admin(Base, HasFullTableCache):
             return True
         return False
 
+    def can_see_collection(self, collection):
+        for library in collection.libraries:
+            if self.is_librarian(library):
+                return True
+        if not collection.libraries:
+            # If the collection's not associated with any libraries, only system
+            # admins can see it.
+            if self.is_system_admin():
+                return True
+        return False
+
     def add_role(self, role, library=None):
         _db = Session.object_session(self)
         role, is_new = get_one_or_create(_db, AdminRole, admin=self, role=role, library=library)


### PR DESCRIPTION
This helps with some changes I'm making to the dashboard statistics where the totals will only include collections from libraries the admin has access to.