### PR TITLE
Extract publication date from dc:issued during OPDS import.

### DIFF
--- a/tests/files/opds/content_server.opds
+++ b/tests/files/opds/content_server.opds
@@ -29,6 +29,7 @@
     <category term="7" scheme="http://schema.org/typicalAgeRange"/>
     <dcterms:language>en</dcterms:language>
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
+    <dcterms:issued>1910</dcterms:issued>
     <link href="http://www.gutenberg.org/ebooks/10441.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
   <entry schema:additionalType="http://schema.org/EBook">
@@ -46,6 +47,7 @@
     <category term="PZ" scheme="http://purl.org/dc/terms/LCC"/>
     <dcterms:language>en</dcterms:language>
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
+    <dcterms:issued>1907-07-07</dcterms:issued>
     <link href="http://www.gutenberg.org/ebooks/10557.epub.images" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
   <entry schema:additionalType="http://schema.org/EBook">
@@ -76,6 +78,7 @@
     <category term="PN" scheme="http://purl.org/dc/terms/LCC"/>
     <dcterms:language>en</dcterms:language>
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
+    <dcterms:issued>Ignore me, but the rest of this entry should still parse</dcterms:issued>
     <link href="http://www.gutenberg.org/ebooks/10596.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
   <entry schema:additionalType="http://schema.org/EBook">
@@ -434,6 +437,7 @@
     <category term="PS" label="American Literature" scheme="http://purl.org/dc/terms/LCC" schema:ratingValue="10"/>
     <dcterms:language>en</dcterms:language>
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
+    <dcterms:issued>1862-06-01</dcterms:issued>
     <link href="http://www.gutenberg.org/ebooks/1022.epub.noimages" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
   </entry>
   <entry schema:additionalType="http://schema.org/EBook">

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -431,6 +431,8 @@ class TestOPDSImporter(OPDSImporterTest):
 
         eq_([], book['measurements'])
 
+        eq_(datetime.datetime(1862, 6, 1), book["published"])
+
         [link] = book['links']
         eq_(Hyperlink.OPEN_ACCESS_DOWNLOAD, link.rel)
         eq_("http://www.gutenberg.org/ebooks/1022.epub.noimages", link.href)
@@ -468,6 +470,8 @@ class TestOPDSImporter(OPDSImporterTest):
 
         eq_('Animal Colors', periodical['series'])
         eq_('1', periodical['series_position'])
+
+        eq_(datetime.datetime(1910, 1, 1), periodical["published"])
 
     def test_extract_metadata_from_elementtree_treats_message_as_failure(self):
         data_source = DataSource.lookup(self._db, DataSource.OA_CONTENT_SERVER)


### PR DESCRIPTION
We weren't extracting publication dates before, but now we have some OPDS feeds that have them.

See https://github.com/NYPL-Simplified/server_core/pull/769 for why this is done with elementtree instead of feedparser.