### PR TITLE
Corrected the name of the Web Publication Manifest field used to list authors.

### DIFF
--- a/tests/test_util_web_publication_manifest.py
+++ b/tests/test_util_web_publication_manifest.py
@@ -91,7 +91,7 @@ class TestUpdateBibliographicMetadata(DatabaseTest):
 
         # The author's sort name is used because they have no display
         # name.
-        eq_([author.sort_name], metadata['authors'])
+        eq_([author.sort_name], metadata['author'])
 
         # The language has been converted from ISO-3166-1-alpha-3 to
         # ISO-3166-1-alpha-2.
@@ -106,7 +106,7 @@ class TestUpdateBibliographicMetadata(DatabaseTest):
         author.display_name = "a display name"
         manifest = Manifest()
         manifest.update_bibliographic_metadata(pool)
-        eq_(["a display name"], manifest.metadata['authors'])
+        eq_(["a display name"], manifest.metadata['author'])
 
         # If the pool has no presentation edition, the only information
         # we get is the identifier.
@@ -114,7 +114,7 @@ class TestUpdateBibliographicMetadata(DatabaseTest):
         manifest = Manifest()
         manifest.update_bibliographic_metadata(pool)
         eq_(pool.identifier.urn, metadata['identifier'])
-        for missing in ['title', 'language', 'authors']:
+        for missing in ['title', 'language', 'author']:
             assert missing not in manifest.metadata
         eq_([], manifest.links)
 

--- a/util/web_publication_manifest.py
+++ b/util/web_publication_manifest.py
@@ -100,7 +100,7 @@ class Manifest(JSONable):
                    for author in edition.author_contributors
                    if author.display_name or author.sort_name]
         if authors:
-            self.metadata['authors'] = authors
+            self.metadata['author'] = authors
 
         if edition.cover_thumbnail_url:
             self.add_link(edition.cover_thumbnail_url, 'cover')


### PR DESCRIPTION
Our Findaway-specific variant of the Web Publication Manifest document used "authors" to give the list of authors, but the actual spec (http://readium.org/webpub-manifest/schema/publication.schema.json) uses "author" for the same purpose. (Despite the name, it's allowable for "author" to be a list.)

Our variant document is still not a valid Web Publication Manifest, and it never will be, because its spine items don't have `href`s, but there's no reason to have random deviations from the spec like this.

This addresses https://jira.nypl.org/browse/SIMPLY-1028