### PR TITLE
Target age consistency

### DIFF
--- a/model.py
+++ b/model.py
@@ -4025,8 +4025,6 @@ class Work(Base):
 
     @property
     def target_age_string(self):
-        if not self.target_age:
-            return ""
         return numericrange_to_string(self.target_age)
 
     @property
@@ -12065,6 +12063,8 @@ def tuple_to_numericrange(t):
 
 def numericrange_to_string(r):
     """Helper method to convert a NumericRange to a human-readable string."""
+    if not r:
+        return ""
     lower = r.lower
     upper = r.upper
     if lower and upper is None:

--- a/model.py
+++ b/model.py
@@ -4027,15 +4027,7 @@ class Work(Base):
     def target_age_string(self):
         if not self.target_age:
             return ""
-        lower = self.target_age.lower
-        upper = self.target_age.upper
-        if not upper and not lower:
-            return ""
-        if lower and upper is None:
-            return str(lower)
-        if upper and lower is None:
-            return str(upper)
-        return "%s-%s" % (lower,upper)
+        return numericrange_to_string(self.target_age)
 
     @property
     def has_open_access_license(self):
@@ -6342,17 +6334,7 @@ class Subject(Base):
 
     @property
     def target_age_string(self):
-        lower = self.target_age.lower
-        upper = self.target_age.upper
-        if lower and upper is None:
-            return str(lower)
-        if upper and lower is None:
-            return str(upper)
-        if not self.target_age.upper_inc:
-            upper -= 1
-        if not self.target_age.lower_inc:
-            lower += 1
-        return "%s-%s" % (lower,upper)
+        return numericrange_to_string(self.target_age)
 
     @property
     def describes_format(self):
@@ -12080,6 +12062,22 @@ def tuple_to_numericrange(t):
     if not t:
         return None
     return NumericRange(t[0], t[1], '[]')
+
+def numericrange_to_string(r):
+    """Helper method to convert a NumericRange to a human-readable string."""
+    lower = r.lower
+    upper = r.upper
+    if lower and upper is None:
+        return str(lower)
+    if upper and lower is None:
+        return str(upper)
+    if not r.upper_inc:
+        upper -= 1
+    if not r.lower_inc:
+        lower += 1
+    if upper == lower:
+        return str(lower)
+    return "%s-%s" % (lower,upper)
 
 site_configuration_has_changed_lock = RLock()
 def site_configuration_has_changed(_db, timeout=1):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3505,6 +3505,25 @@ class TestWork(DatabaseTest):
         work.target_age = NumericRange(None, 8, '[]')
         eq_("8", work.target_age_string)
 
+        work.target_age = NumericRange(7, 8, '[)')
+        eq_("7", work.target_age_string)
+
+        work.target_age = NumericRange(0, 8, '[)')
+        eq_("0-7", work.target_age_string)
+
+        work.target_age = NumericRange(7, 8, '(]')
+        eq_("8", work.target_age_string)
+
+        work.target_age = NumericRange(0, 8, '(]')
+        eq_("1-8", work.target_age_string)
+
+        work.target_age = NumericRange(7, 9, '()')
+        eq_("8", work.target_age_string)
+
+        work.target_age = NumericRange(0, 8, '()')
+        eq_("1-7", work.target_age_string)
+
+
     def test_reindex_on_availability_change(self):
         """A change in a LicensePool's availability creates a 
         WorkCoverageRecord indicating that the work needs to be

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -762,7 +762,7 @@ class TestOPDS(DatabaseTest):
         work.audience = "Young Adult"
         work2 = self._work(with_open_access_download=True)
         work2.audience = "Children"
-        work2.target_age = NumericRange(7,9)
+        work2.target_age = NumericRange(7, 9, '[]')
         work3 = self._work(with_open_access_download=True)
         work3.audience = None
         work4 = self._work(with_open_access_download=True)


### PR DESCRIPTION
This fixes a bug found by a librarian from the Curation Corps when editing the target age range from the admin interface. When you change the age range, the new OPDS entry that's generated for patrons and saved in the database contains the values you entered. However, the OPDS entry for admins that's generated on the fly has a upper bound that's incremented by one, so in the edit form the upper bound doesn't match the value you saved.

Turns out this is because we initially set the numeric range to have inclusive bounds for both the upper and lower values, but on commit Postgres changes the range to a canonical form that has an exclusive upper bound (https://www.postgresql.org/docs/current/static/rangetypes.html#RANGETYPES-DISCRETE). 

I fixed this by changing Work.target_age_string to check whether the bounds are inclusive or exclusive. We had two different implementations of target_age_string on Work and Subject so I combined them.