### PR TITLE
If the only pool for a book is suppressed, it should not be superceded.

### DIFF
--- a/model.py
+++ b/model.py
@@ -7038,6 +7038,11 @@ class LicensePool(Base):
         if self.suppressed:
             return False
 
+        # If the previous champion is suppressed but we have a license pool
+        # that's not, it's definitely better.
+        if champion.suppressed:
+            return True
+
         challenger_resource = self.best_open_access_link
         if not challenger_resource:
             # This LicensePool is supposedly open-access but we don't

--- a/model.py
+++ b/model.py
@@ -7024,11 +7024,6 @@ class LicensePool(Base):
         if not self.identifier:
             return False
 
-        # A suppressed license pool should never be used, even if there is
-        # no alternative.
-        if self.suppressed:
-            return False
-
         # A non-open-access license pool is not eligible for consideration.
         if not self.open_access:
             return False
@@ -7037,6 +7032,11 @@ class LicensePool(Base):
         # better than nothing.
         if not champion:
             return True
+
+        # A suppressed license pool should never be used unless there is
+        # no alternative.
+        if self.suppressed:
+            return False
 
         challenger_resource = self.best_open_access_link
         if not challenger_resource:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3065,6 +3065,16 @@ class TestWork(DatabaseTest):
         eq_(gitenberg1.superceded, True)
         eq_(gitenberg2.superceded, False)
 
+        # A suppressed pool won't be superceded if it's the only pool for a work.
+        only_pool = self._licensepool(
+            None, open_access=True, with_open_access_download=True
+        )
+        work, ignore = only_pool.calculate_work()
+        only_pool.suppressed = True
+        work.mark_licensepools_as_superceded()
+        eq_(False, only_pool.superceded)
+        
+
     def test_work_remains_viable_on_pools_suppressed(self):
         """ If a work has all of its pools suppressed, the work's author, title, 
         and subtitle still have the last best-known info in them.


### PR DESCRIPTION
This lets us display suppressed books in the admin interface without needing to show books that have a non-suppressed pool as well.