### PR TITLE
Add a fast way of checking whether analytics is enabled for a given library

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -5,14 +5,20 @@ import datetime
 from collections import defaultdict
 from model import ExternalIntegration
 from config import CannotLoadConfiguration
+from sqlalchemy.orm.session import Session
 
 class Analytics(object):
+
+    IS_CONFIGURED = None
+    GLOBAL_ENABLED = None
+    LIBRARY_ENABLED = set()
 
     def __init__(self, _db):
         self.sitewide_providers = []
         self.library_providers = defaultdict(list)
         self.initialization_exceptions = {}
-
+        Analytics.GLOBAL_ENABLED = False
+        Analytics.LIBRARY_ENABLED = set()
         # Find a list of all the ExternalIntegrations set up with a
         # goal of analytics.
         integrations = _db.query(ExternalIntegration).filter(ExternalIntegration.goal==ExternalIntegration.ANALYTICS_GOAL)
@@ -25,10 +31,12 @@ class Analytics(object):
                     if not integration.libraries:
                         provider = provider_class(integration)
                         self.sitewide_providers.append(provider)
+                        Analytics.GLOBAL_ENABLED = True
                     else:
                         for library in integration.libraries:
                             provider = provider_class(integration, library)
                             self.library_providers[library.id].append(provider)
+                            Analytics.LIBRARY_ENABLED.add(library.id)
                 else:
                     self.initialization_exceptions[integration.id] = "Module %s does not have Provider defined." % integration.protocol
             except (ImportError, CannotLoadConfiguration), e:
@@ -42,3 +50,12 @@ class Analytics(object):
             providers.extend(self.library_providers[library.id])
         for provider in providers:
             provider.collect_event(library, license_pool, event_type, time, **kwargs)
+
+    @classmethod
+    def is_configured(cls, library):
+        if cls.GLOBAL_ENABLED is None:
+            Analytics(Session.object_session(library))
+        if cls.GLOBAL_ENABLED:
+            return True
+        else:
+            return library.id in cls.LIBRARY_ENABLED

--- a/analytics.py
+++ b/analytics.py
@@ -9,7 +9,6 @@ from sqlalchemy.orm.session import Session
 
 class Analytics(object):
 
-    IS_CONFIGURED = None
     GLOBAL_ENABLED = None
     LIBRARY_ENABLED = set()
 


### PR DESCRIPTION
This is support work for https://jira.nypl.org/browse/SIMPLY-518 -- it lets us quickly check whether we should show links to the analytics controller for every book in a feed.