### PR TITLE
Reduce the timeout period when checking with the database whether site configuration has changed.

### DIFF
--- a/config.py
+++ b/config.py
@@ -477,7 +477,7 @@ class Configuration(object):
                 _db, cls.SITE_CONFIGURATION_TIMEOUT
             ).value
         if timeout is None:
-            timeout = 600
+            timeout = 60
 
         last_check = cls.instance.get(
             cls.LAST_CHECKED_FOR_SITE_CONFIGURATION_UPDATE
@@ -510,7 +510,6 @@ class Configuration(object):
         # Whether that record changed or not, the time at which we
         # _checked_ is going to be set to the current time.
         cls.instance[cls.LAST_CHECKED_FOR_SITE_CONFIGURATION_UPDATE] = now
-
         return last_update
 
     @classmethod


### PR DESCRIPTION
This branch comes out of research that verified that https://jira.nypl.org/browse/SIMPLY-530 has been fixed. Since it's been fixed, we can reduce the time we wait before checking with the database whether or not the site configuration changed recently -- it will no longer think the configuration changed every time we check.

Reducing this time will improve the experience for site admins because they won't have to wait as long for their changes to show up on the circ manager.