### PR TITLE
Fix two flaws in hold time estimates.

### DIFF
--- a/model.py
+++ b/model.py
@@ -894,8 +894,7 @@ class Hold(Base, LoanAndHoldMixin):
         # Start with the default loan period to clear out everyone who
         # currently has the book checked out.
         duration = default_loan_period
-
-        if queue_position < total_licenses:
+        if queue_position <= total_licenses:
             # After that period, the book will be available to this patron.
             # Do nothing.
             pass
@@ -924,14 +923,16 @@ class Hold(Base, LoanAndHoldMixin):
             # not obviously wrong, so use it.
             return self.end
 
-        if default_reservation_period is None:
-            # This hold has no definite end date.
+        if default_loan_period is None or default_reservation_period is None:
+            # This hold has no definite end date, because there's no known
+            # upper bound on how long someone in front of you can keep the
+            # book.
             return None
 
         start = datetime.datetime.utcnow()
         licenses_available = self.license_pool.licenses_owned
         position = self.position
-        if not position:
+        if position is None:
             # We don't know where in line we are. Assume we're at the
             # end.
             position = self.license_pool.patrons_in_hold_queue

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5140,38 +5140,38 @@ class TestHold(DatabaseTest):
 
         # I'm 20th in line for 4 books.
         #
-        # After 6 days, four copies are released and I am 16th in line.
-        # After 13 days, those copies are released and I am 12th in line.
-        # After 20 days, those copies are released and I am 8th in line.
-        # After 27 days, those copies are released and I am 4th in line.
-        # After 34 days, those copies are released and get my notification.
+        # After 7 days, four copies are released and I am 16th in line.
+        # After 14 days, those copies are released and I am 12th in line.
+        # After 21 days, those copies are released and I am 8th in line.
+        # After 28 days, those copies are released and I am 4th in line.
+        # After 35 days, those copies are released and get my notification.
         a = Hold._calculate_until(
             start, 20, 4, default_loan, default_reservation)
-        eq_(a, start + datetime.timedelta(days=(7*5)-1))
+        eq_(a, start + datetime.timedelta(days=(7*5)))
 
         # If I am 21st in line, I need to wait six weeks.
         b = Hold._calculate_until(
             start, 21, 4, default_loan, default_reservation)
-        eq_(b, start + datetime.timedelta(days=(7*6)-1))
+        eq_(b, start + datetime.timedelta(days=(7*6)))
 
-        # If I am 3rd in line, I only need to wait six days--that's when
+        # If I am 3rd in line, I only need to wait seven days--that's when
         # I'll get the notification message.
         b = Hold._calculate_until(
             start, 3, 4, default_loan, default_reservation)
-        eq_(b, start + datetime.timedelta(days=6))
+        eq_(b, start + datetime.timedelta(days=7))
 
         # A new person gets the book every week. Someone has the book now
         # and there are 3 people ahead of me in the queue. I will get
-        # the book in 6 days + 3 weeks
+        # the book in 7 days + 3 weeks
         c = Hold._calculate_until(
             start, 3, 1, default_loan, default_reservation)
-        eq_(c, start + datetime.timedelta(days=(7*4)-1))
+        eq_(c, start + datetime.timedelta(days=(7*4)))
 
-        # I'm first in line for 1 book. After 6 days, one copy is
+        # I'm first in line for 1 book. After 7 days, one copy is
         # released and I'll get my notification.
         a = Hold._calculate_until(
             start, 1, 1, default_loan, default_reservation)
-        eq_(a, start + datetime.timedelta(days=7-1))
+        eq_(a, start + datetime.timedelta(days=7))
 
         # The book is reserved to me. I need to hurry up and check it out.
         d = Hold._calculate_until(


### PR DESCRIPTION
This branch closes http://jira.nypl.org/browse/SIMPLY-1104. There are numerous problems with estimated wait times, but this branch closes three problems that are simply due to bad math.

* If there is no known default loan time, we can't make any estimate and we have to give up. This wouldn't have happened on any real site.
* If you are at the very front of the queue, such that the book is reserved to you, your estimated wait time is given as though you were at the end of the queue. I don't think this is shown to SimplyE users, since the book is available right now and you can borrow it, but if it were visible it would be very confusing.
* A `<` instead of a `<=` greatly increased the estimated wait time in the case where your position in line was an exact multiple of the number of available copies. This was especially noticeable when there was one copy of the book.

As part of this work I added test coverage for `Hold.until`, which was previously not covered (though the helper method it calls is covered pretty well).