### PR TITLE
Change 'spine' to 'readingOrder'

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -209,7 +209,6 @@ class ExternalSearchIndex(object):
         alias to point to the new index.
         """
         index = new_index or self.works_index
-
         if self.indices.exists(index):
             self.indices.delete(index)
 

--- a/tests/test_util_web_publication_manifest.py
+++ b/tests/test_util_web_publication_manifest.py
@@ -55,15 +55,15 @@ class TestManifest(object):
             dict['links']
         )
 
-    def test_add_spine(self):
+    def test_add_reading_order(self):
         manifest = Manifest()
-        manifest.add_spine("http://foo/", "text/html", "Chapter 1",
+        manifest.add_reading_order("http://foo/", "text/html", "Chapter 1",
                            extra="value")
         dict = manifest.as_dict
         eq_(
             [{'href': 'http://foo/', 'type': 'text/html', 'title': 'Chapter 1',
               'extra': 'value'}],
-            dict['spine']
+            dict['readingOrder']
         )
 
     def test_add_resource(self):

--- a/util/web_publication_manifest.py
+++ b/util/web_publication_manifest.py
@@ -63,7 +63,7 @@ class Manifest(JSONable):
 
     @property
     def component_lists(self):
-        return 'links', 'spine', 'resources'
+        return 'links', 'readingOrder', 'resources'
 
     def _append(self, append_to, **kwargs):
         append_to.append(kwargs)
@@ -71,8 +71,8 @@ class Manifest(JSONable):
     def add_link(self, href, rel, **kwargs):
         self._append(self.links, href=href, rel=rel, **kwargs)
 
-    def add_spine(self, href, type, title, **kwargs):
-        self._append(self.spine, href=href, type=type, title=title, **kwargs)
+    def add_reading_order(self, href, type, title, **kwargs):
+        self._append(self.readingOrder, href=href, type=type, title=title, **kwargs)
 
     def add_resource(self, href, type, **kwargs):
         self._append(self.resources, href=href, type=type, **kwargs)
@@ -111,7 +111,7 @@ class TimelinePart(JSONable):
 
     This has its own class because it can contain child TimelineParts,
     recursively, making it qualitatively more complicated than an
-    entry in 'links' or 'spine'.
+    entry in 'links' or 'readingOrder'.
     """
     def __init__(self, href, title, children=None, **kwargs):
         self.href = href


### PR DESCRIPTION
Partially resolves https://jira.nypl.org/browse/SIMPLY-1105.  For now, the code for "timeline" is still in for potential future use (even though we're not currently using it).  We're not using "sort as" (for author names), so no change was necessary there.