### PR TITLE
Make language name lookups work consistently

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -20,7 +20,7 @@ from util import (
     Bigrams,
     english_bigrams,
     LanguageCodes,
-    LookupDict,
+    LookupTable,
     MetadataSimilarity,
     MoneyUtility,
     TitleProcessor,
@@ -369,10 +369,10 @@ class TestMetadataSimilarity(object):
         eq_(1, MetadataSimilarity.author_similarity([], []))
 
 
-class TestLookupDict(object):
+class TestLookupTable(object):
 
     def test_lookup(self):
-        d = LookupDict()
+        d = LookupTable()
         d['key'] = 'value'
         eq_('value', d['key'])
         eq_(None, d['missing'])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -20,6 +20,7 @@ from util import (
     Bigrams,
     english_bigrams,
     LanguageCodes,
+    LookupDict,
     MetadataSimilarity,
     MoneyUtility,
     TitleProcessor,
@@ -366,6 +367,17 @@ class TestMetadataSimilarity(object):
 
     def test_author_similarity(self):
         eq_(1, MetadataSimilarity.author_similarity([], []))
+
+
+class TestLookupDict(object):
+
+    def test_lookup(self):
+        d = LookupDict()
+        d['key'] = 'value'
+        eq_('value', d['key'])
+        eq_(None, d['missing'])
+        eq_(False, 'missing' in d)
+        eq_(None, d['missing'])
 
 
 class TestTitleProcessor(object):

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -65,13 +65,13 @@ def slugify(text, length_limit=None):
         slug = slug[:length_limit]
     return unicode(slug)
 
-class LookupDict(dict):
+class LookupTable(dict):
     """Return None on x[key] when 'key' isn't in the dictionary,
     rather than raising a ValueError.
     """
     def __getitem__(self, k):
         if k in self:
-            return super(LookupDict, self).__getitem__(k)
+            return super(LookupTable, self).__getitem__(k)
         else:
             return None
 
@@ -83,10 +83,10 @@ class LanguageCodes(object):
     http://www.loc.gov/standards/iso639-2/ISO-639-2_utf-8.txt
     """
 
-    two_to_three = LookupDict()
-    three_to_two = LookupDict()
+    two_to_three = LookupTable()
+    three_to_two = LookupTable()
     english_names = defaultdict(list)
-    english_names_to_three = LookupDict()
+    english_names_to_three = LookupTable()
     native_names = defaultdict(list)
 
     RAW_DATA = u"""aar||aa|Afar|afar

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -65,6 +65,17 @@ def slugify(text, length_limit=None):
         slug = slug[:length_limit]
     return unicode(slug)
 
+class LookupDict(dict):
+    """Return None on x[key] when 'key' isn't in the dictionary,
+    rather than raising a ValueError.
+    """
+    def __getitem__(self, k):
+        if k in self:
+            return super(LookupDict, self).__getitem__(k)
+        else:
+            return None
+
+
 class LanguageCodes(object):
     """Convert between ISO-639-2 and ISO-693-1 language codes.
 
@@ -72,10 +83,10 @@ class LanguageCodes(object):
     http://www.loc.gov/standards/iso639-2/ISO-639-2_utf-8.txt
     """
 
-    two_to_three = defaultdict(lambda: None)
-    three_to_two = defaultdict(lambda: None)
+    two_to_three = LookupDict()
+    three_to_two = LookupDict()
     english_names = defaultdict(list)
-    english_names_to_three = defaultdict(lambda: None)
+    english_names_to_three = LookupDict()
     native_names = defaultdict(list)
 
     RAW_DATA = u"""aar||aa|Afar|afar


### PR DESCRIPTION
This branch changes `LanguageCodes` to store its mappings a new class called `LookupTable` instead of  `defaultdict(lambda:None)`. That sort of `defaultdict` changes its contents in a way that can break the `in` operator in a nondeterministic way.

```
from collections import defaultdict
d = defaultdict(lambda:None)
'key' in d # False
d['key'] is None # True
'key' in d # True
```

What we really want here is a dictionary that returns `None` _without modifying the dictionary_ when we look up an item that's not there.

I could have fixed this by changing `LanguageCodes.string_to_alpha_3` to use `cls.three_to_two[s]` instead of `s in cls.three_to_two` but I figured it was safer to make both possible techniques work.