### PR TITLE
Remove TimelinePart, which is no longer used by this code and has been removed from the spec.

### DIFF
--- a/tests/test_util_web_publication_manifest.py
+++ b/tests/test_util_web_publication_manifest.py
@@ -5,7 +5,6 @@ from nose.tools import (
 from util.web_publication_manifest import (
     JSONable,
     Manifest,
-    TimelinePart,
     AudiobookManifest,
 )
 
@@ -118,25 +117,6 @@ class TestUpdateBibliographicMetadata(DatabaseTest):
             assert missing not in manifest.metadata
         eq_([], manifest.links)
 
-class TestTimelinePart(object):
-
-    expect = {
-        'href': 'http://foo/pt1',
-        'title': 'Part 1',
-        'children': [{'extra': 'value', 'href': 'http://foo/ch1',
-                      'title': 'Chapter 1'}]
-    }
-
-    def test_as_dict(self):
-        chapter_1 = TimelinePart("http://foo/ch1", "Chapter 1", extra="value")
-        part_1 = TimelinePart("http://foo/pt1", "Part 1", [chapter_1])
-        eq_(self.expect, part_1.as_dict)
-
-    def test_add_child(self):
-        part_1 = TimelinePart("http://foo/pt1", "Part 1")
-        part_1.add_child("http://foo/ch1", "Chapter 1", extra="value")
-        eq_(self.expect, part_1.as_dict)
-
 
 class TestAudiobookManifest(object):
 
@@ -154,16 +134,4 @@ class TestAudiobookManifest(object):
                 'metadata' : {'@type': manifest.type}
             },
             manifest.as_dict
-        )
-
-    def test_add_timeline(self):
-        manifest = AudiobookManifest()
-        part = manifest.add_timeline("http://foo/pt1", "Part 1", extra="value")
-        # At this point you could add children to `part`.
-        assert isinstance(part, TimelinePart)
-
-        dict = manifest.as_dict
-        eq_(
-            [{'href': 'http://foo/pt1', 'title': 'Part 1', 'extra': 'value'}],
-            dict['timeline']
         )

--- a/util/web_publication_manifest.py
+++ b/util/web_publication_manifest.py
@@ -106,44 +106,9 @@ class Manifest(JSONable):
             self.add_link(edition.cover_thumbnail_url, 'cover')
 
 
-class TimelinePart(JSONable):
-    """A single element in an Audiobook Manifest's 'timeline'.
-
-    This has its own class because it can contain child TimelineParts,
-    recursively, making it qualitatively more complicated than an
-    entry in 'links' or 'readingOrder'.
-    """
-    def __init__(self, href, title, children=None, **kwargs):
-        self.href = href
-        self.title = title
-        self.children = children or []
-        self.extra = kwargs
-
-    def add_child(self, href, title, children=None, **kwargs):
-        self.children.append(TimelinePart(href, title, children, **kwargs))
-
-    @property
-    def as_dict(self):
-        data = dict(href=self.href, title=self.title)
-        if self.children:
-            data['children'] = [x.as_dict for x in self.children]
-        data.update(self.extra)
-        return data
-
-
 class AudiobookManifest(Manifest):
     """A Python object corresponding to a Readium Web Publication
     Manifest.
     """
 
     DEFAULT_TYPE = Manifest.AUDIOBOOK_TYPE
-
-    @property
-    def component_lists(self):
-        return super(AudiobookManifest, self).component_lists + ('timeline',)
-
-    def add_timeline(self, href, title, children=None, **kwargs):
-        """Add an item to the timeline."""
-        part = TimelinePart(href, title, children, **kwargs)
-        self.timeline.append(part)
-        return part


### PR DESCRIPTION
Our Web Publication Manifest code has a class called TimelinePart for creating an audiobook's "timeline". The concept of "timeline" has been removed from the audiobook WPM profile (https://github.com/HadrienGardeur/audiobook-manifest) because it was redundant with the concept of "toc" (https://github.com/readium/webpub-manifest/blob/master/extensions/epub.md#extension-to-the-link-object) in the EPUB profile.

Since the syntax of `timeline` and `toc` are almost identical, I thought about repurposing this class into `TOCPart`, but we don't actually use this code, and we probably won't in the future. The `timeline` used to be where we kept the links to the MP3 files, but we now use `readingOrder` for that. `toc` would only be useful if we actually had to create a table of contents, and we never have that information to begin with.
