### PR TITLE
Fail gracefully when Elasticsearch server is inaccessible or not working as expected

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -1,6 +1,7 @@
 from nose.tools import set_trace
 from elasticsearch import Elasticsearch
 from elasticsearch.helpers import bulk as elasticsearch_bulk
+from elasticsearch.exceptions import ElasticsearchException
 from flask_babel import lazy_gettext as _
 from config import (
     Configuration,
@@ -142,7 +143,13 @@ class ExternalSearchIndex(object):
         # Document upload runs against the works_index.
         # Search queries run against works_alias.
         if works_index and integration:
-            self.set_works_index_and_alias(_db)
+            try:
+                self.set_works_index_and_alias(_db)
+            except ElasticsearchException, e:
+                raise CannotLoadConfiguration(
+                    "Exception communicating with Elasticsearch server: %s" %
+                    repr(e)
+                )
 
         def bulk(docs, **kwargs):
             return elasticsearch_bulk(self.__client, docs, **kwargs)

--- a/lane.py
+++ b/lane.py
@@ -1322,7 +1322,7 @@ class WorkList(object):
             )
 
         # Get the search results from Elasticsearch.
-        results = None
+        results = []
 
         if not media:
             media = self.media
@@ -1372,13 +1372,13 @@ class WorkList(object):
 
             try:
                 docs = search_client.query_works(**kwargs)
-            except elasticsearch.exceptions.ConnectionError, e:
+            except elasticsearch.exceptions.ElasticsearchException, e:
                 logging.error(
-                    "Could not connect to ElasticSearch. Returning empty list of search results."
+                    "Problem communicating with ElasticSearch. Returning empty list of search results.",
+                    exc_info=e
                 )
             b = time.time()
             logging.debug("Elasticsearch query completed in %.2fsec", b-a)
-            results = []
             if docs:
                 doc_ids = [
                     int(x['_id']) for x in docs['hits']['hits']


### PR DESCRIPTION
This branch changes the behavior of the ExternalSearch class so that if there's a problem connecting to or communicating with the ElasticSearch server on startup, `CannotLoadConfiguration` is raised rather than one `ElasticSearchException` or another. The circulation manger is prepared to catch `CannotLoadConfiguration` here if there's a problem, but it shouldn't need to know about the particular search service in use.

The motivating case for this code is https://jira.nypl.org/browse/SIMPLY-1128. Without this code, it's possible to get your configuration into a state where you can't get into the admin interface.

Also, if there's a problem communicating with the server during a search, `Lane.search` now always returns an empty list; previously it could sometimes return `None`, which would cause other code to raise an uncaught exception.

This second change should hopefully resolve some mysterious ISEs seen in production.