### PR TITLE
Boost non-fuzzy searches relative to fuzzy searches

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -312,22 +312,26 @@ class ExternalSearchIndex(object):
 
     def make_query(self, query_string):
 
-        def _boost(query, boost):
+        def _boost(query, boost=1):
             """Boost a preexisting query."""
+            if boost == 1:
+                # No boost.
+                return query
             if 'bool' in query:
                 # It's already a boolean query, just boost it.
                 query['boost'] = boost
             else:
                 # Create a new boolean query with only one clause and
                 # a boost.
-                return {
+                query = {
                     'bool': {
                         'must': query,
                         'boost': boost
                     }
                 }
+            return query
 
-        def make_query_string_query(query_string, fields, boost=15):
+        def make_query_string_query(query_string, fields, boost=1):
             query = {
                 'simple_query_string': {
                     'query': query_string,
@@ -445,7 +449,7 @@ class ExternalSearchIndex(object):
 
         # Query string operators like "AND", "OR", "-", and quotation marks will
         # work in the query string queries, but not the fuzzy query.
-        match_full_query_stemmed = make_query_string_query(query_string, stemmed_query_string_fields)
+        match_full_query_stemmed = make_query_string_query(query_string, stemmed_query_string_fields, boost=15)
         must_match_options = [match_full_query_stemmed]
 
         match_phrase = make_phrase_query(query_string, ['title.minimal', 'author', 'series.minimal'])

--- a/external_search.py
+++ b/external_search.py
@@ -446,10 +446,7 @@ class ExternalSearchIndex(object):
         match_full_query_stemmed = make_query_string_query(query_string, stemmed_query_string_fields, boost=1.5)
         must_match_options = [match_full_query_stemmed]
 
-        # It's great if the query string occurs as a phrase in the title,
-        # author, or series.
         match_phrase = make_phrase_query(query_string, ['title.minimal', 'author', 'series.minimal'])
-        match_phrase = _boost(match_phrase, 3)
         must_match_options.append(match_phrase)
 
         # An exact title or author match outweighs a match that is split

--- a/external_search.py
+++ b/external_search.py
@@ -312,11 +312,18 @@ class ExternalSearchIndex(object):
 
     def make_query(self, query_string):
 
-        def make_query_string_query(query_string, fields):
-            return {
+        def make_query_string_query(query_string, fields, boost=15):
+            query = {
                 'simple_query_string': {
                     'query': query_string,
                     'fields': fields,
+                }
+            }
+            return {
+                'bool': {
+                    'should': query,
+                    'minimum_should_match' : 1,
+                    'boost': boost
                 }
             }
 

--- a/external_search.py
+++ b/external_search.py
@@ -343,7 +343,9 @@ class ExternalSearchIndex(object):
                     'query': query_string,
                     'fields': fields,
                     'type': 'best_fields',
-                    'fuzziness': 'AUTO'
+                    'fuzziness': 'AUTO',
+                    'prefix_length': 1,
+                    'max_expansions': 2,
                 }
             }
 

--- a/external_search.py
+++ b/external_search.py
@@ -449,7 +449,7 @@ class ExternalSearchIndex(object):
 
         # Query string operators like "AND", "OR", "-", and quotation marks will
         # work in the query string queries, but not the fuzzy query.
-        match_full_query_stemmed = make_query_string_query(query_string, stemmed_query_string_fields, boost=15)
+        match_full_query_stemmed = make_query_string_query(query_string, stemmed_query_string_fields, boost=1.5)
         must_match_options = [match_full_query_stemmed]
 
         match_phrase = make_phrase_query(query_string, ['title.minimal', 'author', 'series.minimal'])

--- a/external_search.py
+++ b/external_search.py
@@ -312,6 +312,21 @@ class ExternalSearchIndex(object):
 
     def make_query(self, query_string):
 
+        def _boost(query, boost):
+            """Boost a preexisting query."""
+            if 'bool' in query:
+                # It's already a boolean query, just boost it.
+                query['boost'] = boost
+            else:
+                # Create a new boolean query with only one clause and
+                # a boost.
+                return {
+                    'bool': {
+                        'must': query,
+                        'boost': boost
+                    }
+                }
+
         def make_query_string_query(query_string, fields, boost=15):
             query = {
                 'simple_query_string': {
@@ -319,13 +334,7 @@ class ExternalSearchIndex(object):
                     'fields': fields,
                 }
             }
-            return {
-                'bool': {
-                    'should': query,
-                    'minimum_should_match' : 1,
-                    'boost': boost
-                }
-            }
+            return _boost(query, boost)
 
         def make_phrase_query(query_string, fields, boost=100):
             field_queries = []
@@ -352,7 +361,6 @@ class ExternalSearchIndex(object):
                     'type': 'best_fields',
                     'fuzziness': 'AUTO',
                     'prefix_length': 1,
-                    'max_expansions': 2,
                 }
             }
 

--- a/external_search.py
+++ b/external_search.py
@@ -314,13 +314,7 @@ class ExternalSearchIndex(object):
 
         def _boost(query, boost=1):
             """Boost a preexisting query."""
-            if boost == 1:
-                # No boost.
-                return query
-            if 'bool' in query:
-                # It's already a boolean query, just boost it.
-                query['boost'] = boost
-            else:
+            if boost > 1:
                 # Create a new boolean query with only one clause and
                 # a boost.
                 query = {

--- a/external_search.py
+++ b/external_search.py
@@ -446,7 +446,10 @@ class ExternalSearchIndex(object):
         match_full_query_stemmed = make_query_string_query(query_string, stemmed_query_string_fields, boost=1.5)
         must_match_options = [match_full_query_stemmed]
 
+        # It's great if the query string occurs as a phrase in the title,
+        # author, or series.
         match_phrase = make_phrase_query(query_string, ['title.minimal', 'author', 'series.minimal'])
+        match_phrase = _boost(match_phrase, 3)
         must_match_options.append(match_phrase)
 
         # An exact title or author match outweighs a match that is split

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1039,7 +1039,7 @@ class TestSearchQuery(DatabaseTest):
         # subquery are boosted with respect to the fuzzy subquery,
         # which will come later.
         boosted = stemmed['bool']
-        eq_(15, boosted['boost'])
+        eq_(1.5, boosted['boost'])
         stemmed_query = boosted['must']['simple_query_string']
         eq_("test", stemmed_query['query'])
         assert "title^4" in stemmed_query['fields']

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1034,9 +1034,13 @@ class TestSearchQuery(DatabaseTest):
         # Here are the matching techniques.
         stemmed, minimal, standard_title, standard_author, fuzzy = must
 
-        # The search string is stemmed and matched against a number
-        # of fields such as title and publisher.
-        stemmed_query = stemmed['simple_query_string']
+        # The search string is stemmed and matched against a number of
+        # fields such as title and publisher. Results from this
+        # subquery are boosted with respect to the fuzzy subquery,
+        # which will come later.
+        boosted = stemmed['bool']
+        eq_(15, boosted['boost'])
+        stemmed_query = boosted['must']['simple_query_string']
         eq_("test", stemmed_query['query'])
         assert "title^4" in stemmed_query['fields']
         assert 'publisher' in stemmed_query['fields']
@@ -1100,7 +1104,7 @@ class TestSearchQuery(DatabaseTest):
         must = query['dis_max']['queries']
 
         eq_(6, len(must))
-        full_query = must[0]['simple_query_string']
+        full_query = must[0]['bool']['must']['simple_query_string']
         eq_("test romance", full_query['query'])
         assert "title^4" in full_query['fields']
         assert 'publisher' in full_query['fields']
@@ -1161,7 +1165,7 @@ class TestSearchQuery(DatabaseTest):
         must = query['dis_max']['queries']
 
         eq_(6, len(must))
-        full_query = must[0]['simple_query_string']
+        full_query = must[0]['bool']['must']['simple_query_string']
         eq_("test young adult", full_query['query'])
 
         classification_query = must[5]['bool']['must']
@@ -1179,7 +1183,7 @@ class TestSearchQuery(DatabaseTest):
         must = query['dis_max']['queries']
 
         eq_(6, len(must))
-        full_query = must[0]['simple_query_string']
+        full_query = must[0]['bool']['must']['simple_query_string']
         eq_("test grade 6", full_query['query'])
 
         classification_query = must[5]['bool']['must']
@@ -1202,7 +1206,7 @@ class TestSearchQuery(DatabaseTest):
         must = query['dis_max']['queries']
 
         eq_(6, len(must))
-        full_query = must[0]['simple_query_string']
+        full_query = must[0]['bool']['must']['simple_query_string']
         eq_("test 5-10 years", full_query['query'])
 
         classification_query = must[5]['bool']['must']


### PR DESCRIPTION
This branch partially addresses https://jira.nypl.org/browse/SIMPLY-569 by slightly reducing the importance of fuzzy searches and the situations where a fuzzy search will be employed. The goal is to make some marginal improvements before the push to generating search documents with the Python DSL and the migration to Elasticsearch 6.

`prefix_length=1` exploits the fact that people usually don't misspell the first letter of a word. Fuzzy transforms will no longer affect the first letter of a word in a search query. This means that most typoes will be handled better, but if you transpose the first and second letters you'll get much worse results than before. (In a later version of Elasticsearch I think we can add `transpositions=true` to fix this case.)

The extra boost for the main `simple_query_string` search reflects the fact that most search terms aren't misspelled. This will give search terms that show up in a book's description or subjects a slight boost over similarly-spelled words in a book's title.

I would have liked to make the boost higher, but boosting the `simple_query_string` too much ruins a search for a term like `thomas pychon`, where one word is correctly spelled but that correctly spelled word returns terrible results on its own.

So, as usual, there's a lot more work that can be done -- this just makes a slight improvement without disrupting things too much.