### PR TITLE
Fixed a case where making the CDN URL for a file hosted on S3 could cause special characters to be incorrectly un-escaped.

### DIFF
--- a/cdn.py
+++ b/cdn.py
@@ -1,5 +1,6 @@
 """Turn local URLs into CDN URLs."""
 import os, sys
+import urllib
 import urlparse
 from nose.tools import set_trace
 
@@ -22,8 +23,11 @@ def cdnify(url, cdns=None):
         # This is a URL like "http://s3.amazonaws.com/bucket/foo".
         # It's equivalent to "http://bucket/foo".
         # i.e. treat the bucket name as the netloc.
-        bucket, path = S3Uploader.bucket_and_filename(url)
-        netloc = bucket
+        #
+        # Since we are using the 'filename' to generate a URL rather
+        # than talk to S3, we don't want it to be unquoted.
+        #
+        netloc, path = S3Uploader.bucket_and_filename(url, unquote=False)
 
     if netloc not in cdns:
         # This domain name is not covered by any of our CDNs.
@@ -32,3 +36,4 @@ def cdnify(url, cdns=None):
     cdn_host = cdns[netloc]
     cdn_scheme, cdn_netloc, i1, i2, i3 = urlparse.urlsplit(cdn_host)
     return urlparse.urlunsplit((cdn_scheme, cdn_netloc, path, query, fragment))
+

--- a/s3.py
+++ b/s3.py
@@ -210,7 +210,7 @@ class S3Uploader(MirrorUploader):
         return root + self.key_join(parts)
 
     @classmethod
-    def bucket_and_filename(cls, url):
+    def bucket_and_filename(cls, url, unquote=True):
         scheme, netloc, path, query, fragment = urlsplit(url)
         if netloc == 's3.amazonaws.com':
             if path.startswith('/'):
@@ -219,7 +219,9 @@ class S3Uploader(MirrorUploader):
         else:
             bucket = netloc
             filename = path[1:]
-        return bucket, urllib.unquote_plus(filename)
+        if unquote:
+            filename = urllib.unquote_plus(filename)
+        return bucket, filename
 
     def final_mirror_url(self, bucket, key):
         """Determine the URL to pass into Representation.set_as_mirrored,

--- a/tests/test_cdn.py
+++ b/tests/test_cdn.py
@@ -40,8 +40,8 @@ class TestCDN(DatabaseTest):
         # Instead of the foo.com URL we accidentally used the full S3
         # address for the bucket that hosts S3. cdnify() handles this
         # with no problem.
-        url = "http://s3.amazonaws.com/foo.com/bar#baz"
-        self.ceq("https://cdn.org/bar#baz", url,
+        url = "http://s3.amazonaws.com/foo.com/bar+bar%21#baz"
+        self.ceq("https://cdn.org/bar+bar%21#baz", url,
                  {"foo.com" : "https://cdn.org/"})
 
     def test_relative_url(self):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -215,6 +215,15 @@ class TestS3Uploader(S3UploaderTest):
         eq_(("book-covers.nypl.org", "directory/filename.jpg"),
             m("http://book-covers.nypl.org/directory/filename.jpg"))
 
+        # By default, escaped characters in the filename are unescaped.
+        eq_(("book-covers.nypl.org", "directory/filename with spaces!.jpg"),
+            m("http://book-covers.nypl.org/directory/filename+with+spaces%21.jpg"))
+
+        # But you can choose to leave them alone.
+        eq_(("book-covers.nypl.org", "directory/filename+with+spaces%21.jpg"),
+            m("http://book-covers.nypl.org/directory/filename+with+spaces%21.jpg", False))
+
+
     def test_mirror_one(self):
         edition, pool = self._edition(with_license_pool=True)
         original_cover_location = "http://example.com/a-cover.png"


### PR DESCRIPTION
This branch resolves https://jira.nypl.org/browse/SIMPLY-1148.