### PR TITLE
Move custom list filtering code from Lane to WorkList

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -785,9 +785,9 @@ class WorkList(object):
 
     def initialize(self, library, display_name=None, genres=None,
                    audiences=None, languages=None, media=None,
-                   children=None, priority=None, entrypoints=None,
                    customlist_ids=None, list_datasource_id=None,
-                   list_seen_in_previous_days=None
+                   list_seen_in_previous_days=None,
+                   children=None, priority=None, entrypoints=None,
     ):
         """Initialize with basic data.
 

--- a/lane.py
+++ b/lane.py
@@ -785,7 +785,10 @@ class WorkList(object):
 
     def initialize(self, library, display_name=None, genres=None,
                    audiences=None, languages=None, media=None,
-                   children=None, priority=None, entrypoints=None):
+                   children=None, priority=None, entrypoints=None,
+                   customlist_ids=None, list_datasource_id=None,
+                   list_seen_in_previous_days=None
+    ):
         """Initialize with basic data.
 
         This is not a constructor, to avoid conflicts with `Lane`, an
@@ -819,6 +822,9 @@ class WorkList(object):
 
         :param entrypoints: A list of EntryPoint classes representing
         different ways of slicing up this WorkList.
+
+        :param customlist_ids: Only Works included on one of these CustomLists
+        will be included in lists.
         """
         self.library_id = None
         self.collection_ids = []
@@ -836,6 +842,10 @@ class WorkList(object):
         self.languages = languages
         self.media = media
 
+        self.customlist_ids = customlist_ids
+        self.list_datasource_id = list_datasource_id
+        self.list_seen_in_previous_days = list_seen_in_previous_days
+
         # By default, a WorkList doesn't have a fiction status or target age.
         # Set them to None so they can be ignored in search on a WorkList, but
         # used when calling search on a Lane.
@@ -849,6 +859,15 @@ class WorkList(object):
             self.entrypoints = list(entrypoints)
         else:
             self.entrypoints = []
+
+    @property
+    def uses_customlists(self):
+        """Does the works() implementation for this WorkList look for works on
+        CustomLists?
+        """
+        if self.customlist_ids or self.list_datasource_id:
+            return True
+        return False
 
     def get_library(self, _db):
         """Find the Library object associated with this WorkList."""
@@ -884,13 +903,6 @@ class WorkList(object):
         with Lane.
         """
         return []
-
-    @property
-    def customlist_ids(self):
-        """WorkLists per se are not associated with custom lists, although
-        Lanes might be.
-        """
-        return None
 
     @property
     def full_identifier(self):
@@ -1164,7 +1176,7 @@ class WorkList(object):
 
         return qu
 
-    def bibliographic_filter_clause(self, _db, qu, featured=False):
+    def bibliographic_filter_clause(self, _db, qu, featured=False, outer_join=False):
         """Create a SQLAlchemy filter that excludes books whose bibliographic
         metadata doesn't match what we're looking for.
 
@@ -1195,6 +1207,13 @@ class WorkList(object):
                 qu.genre_id_filtered = True
                 field = work_model.genre_id
             clauses.append(field.in_(self.genre_ids))
+
+        if self.customlist_ids:
+            qu, customlist_clauses = self.customlist_filter_clauses(
+                qu, featured, outer_join
+            )
+            clauses.extend(customlist_clauses)
+
         if not clauses:
             clause = None
         else:
@@ -1222,6 +1241,95 @@ class WorkList(object):
             gutenberg = DataSource.lookup(_db, DataSource.GUTENBERG)
             clauses.append(LicensePool.data_source_id != gutenberg.id)
         return clauses
+
+    def customlist_filter_clauses(
+            self, qu, must_be_featured=False, outer_join=False
+    ):
+        """Create a filter clause that only books that are on one of the
+        CustomLists allowed by Lane configuration.
+
+        :param must_be_featured: It's not enough for the book to be on
+        an appropriate list; it must be _featured_ on an appropriate list.
+
+        :return: A 3-tuple (query, clauses).
+
+        `query` is the same query as `qu`, possibly extended with
+        additional table joins.
+
+        `clauses` is a list of SQLAlchemy statements for use in a
+        filter() or case() statement.
+        """
+        from model import MaterializedWorkWithGenre as work_model
+        if not self.uses_customlists:
+            # This lane does not require that books be on any particular
+            # CustomList.
+            return qu, []
+
+        already_filtered_customlist_on_materialized_view = getattr(
+            qu, 'customlist_id_filtered', False
+        )
+
+        # We will be joining against CustomListEntry at least once, to
+        # run filters on fields like `featured` not found in the
+        # materialized view. For a lane derived from the intersection
+        # of two or more custom lists, we may be joining
+        # CustomListEntry multiple times. To avoid confusion, we make
+        # a new alias for the table every time except the first time.
+        if already_filtered_customlist_on_materialized_view:
+            a_entry = aliased(CustomListEntry)
+        else:
+            a_entry = CustomListEntry
+
+        clause = a_entry.work_id==work_model.works_id
+        if not already_filtered_customlist_on_materialized_view:
+            # Since this is the first join, we're treating
+            # work_model.list_id as a stand-in for CustomListEntry.list_id,
+            # which means we should force them to be the same when joining
+            # the view to the table.
+            #
+            # For subsequent joins, this won't apply -- we want to
+            # match a _different_ list's entry for the same work.
+            clause = and_(clause, a_entry.list_id==work_model.list_id)
+        if outer_join:
+            qu = qu.outerjoin(a_entry, clause)
+        else:
+            qu = qu.join(a_entry, clause)
+
+        # Actually build the restriction clauses.
+        clauses = []
+        customlist_ids = None
+        if self.list_datasource_id:
+            # Use a subquery to obtain the CustomList IDs of all
+            # CustomLists from this DataSource. This is significantly
+            # simpler than adding a join against CustomList.
+            customlist_ids = Select(
+                [CustomList.id],
+                CustomList.data_source_id==self.list_datasource_id
+            )
+        else:
+            customlist_ids = self.customlist_ids
+        if customlist_ids is not None:
+            clauses.append(a_entry.list_id.in_(customlist_ids))
+            if not already_filtered_customlist_on_materialized_view:
+                clauses.append(work_model.list_id.in_(customlist_ids))
+                # Now that we've put a restriction on the materialized
+                # view's list_id, we need to signal that no future
+                # call to this method should put a restriction on the
+                # same field.
+                #
+                # Future calls will apply their restrictions
+                # solely by restricting CustomListEntry.list_id,
+                # as above.
+                qu.customlist_id_filtered = True
+        if must_be_featured:
+            clauses.append(a_entry.featured==True)
+        if self.list_seen_in_previous_days:
+            cutoff = datetime.datetime.utcnow() - datetime.timedelta(
+                self.list_seen_in_previous_days
+            )
+            clauses.append(a_entry.most_recent_appearance >=cutoff)
+
+        return qu, clauses
 
     def only_show_ready_deliverable_works(
             self, _db, query, show_suppressed=False
@@ -1760,6 +1868,10 @@ class Lane(Base, WorkList):
         return self.library
 
     @property
+    def list_datasource_id(self):
+        return self._list_datasource_id
+
+    @property
     def collection_ids(self):
         return [x.id for x in self.library.collections]
 
@@ -2163,7 +2275,7 @@ class Lane(Base, WorkList):
         qu, superclass_clause = super(
             Lane, self
         ).bibliographic_filter_clause(
-            _db, qu, featured
+            _db, qu, featured, outer_join
         )
         clauses = []
         if superclass_clause is not None:
@@ -2190,10 +2302,6 @@ class Lane(Base, WorkList):
             clauses.append(work_model.medium.in_(self.media))
 
         clauses.extend(self.age_range_filter_clauses())
-        qu, customlist_clauses = self.customlist_filter_clauses(
-            qu, featured, outer_join
-        )
-        clauses.extend(customlist_clauses)
 
         if clauses:
             clause = and_(*clauses)
@@ -2226,95 +2334,6 @@ class Lane(Base, WorkList):
                 audience_has_no_target_age
             )
         ]
-
-    def customlist_filter_clauses(
-            self, qu, must_be_featured=False, outer_join=False
-    ):
-        """Create a filter clause that only books that are on one of the
-        CustomLists allowed by Lane configuration.
-
-        :param must_be_featured: It's not enough for the book to be on
-        an appropriate list; it must be _featured_ on an appropriate list.
-
-        :return: A 3-tuple (query, clauses).
-
-        `query` is the same query as `qu`, possibly extended with
-        additional table joins.
-
-        `clauses` is a list of SQLAlchemy statements for use in a
-        filter() or case() statement.
-        """
-        from model import MaterializedWorkWithGenre as work_model
-        if not self.customlists and not self.list_datasource:
-            # This lane does not require that books be on any particular
-            # CustomList.
-            return qu, []
-
-        already_filtered_customlist_on_materialized_view = getattr(
-            qu, 'customlist_id_filtered', False
-        )
-
-        # We will be joining against CustomListEntry at least once, to
-        # run filters on fields like `featured` not found in the
-        # materialized view. For a lane derived from the intersection
-        # of two or more custom lists, we may be joining
-        # CustomListEntry multiple times. To avoid confusion, we make
-        # a new alias for the table every time except the first time.
-        if already_filtered_customlist_on_materialized_view:
-            a_entry = aliased(CustomListEntry)
-        else:
-            a_entry = CustomListEntry
-
-        clause = a_entry.work_id==work_model.works_id
-        if not already_filtered_customlist_on_materialized_view:
-            # Since this is the first join, we're treating
-            # work_model.list_id as a stand-in for CustomListEntry.list_id,
-            # which means we should force them to be the same when joining
-            # the view to the table.
-            #
-            # For subsequent joins, this won't apply -- we want to
-            # match a _different_ list's entry for the same work.
-            clause = and_(clause, a_entry.list_id==work_model.list_id)
-        if outer_join:
-            qu = qu.outerjoin(a_entry, clause)
-        else:
-            qu = qu.join(a_entry, clause)
-
-        # Actually build the restriction clauses.
-        clauses = []
-        customlist_ids = None
-        if self.list_datasource:
-            # Use a subquery to obtain the CustomList IDs of all
-            # CustomLists from this DataSource. This is significantly
-            # simpler than adding a join against CustomList.
-            customlist_ids = Select(
-                [CustomList.id],
-                CustomList.data_source_id==self.list_datasource.id
-            )
-        else:
-            customlist_ids = self.customlist_ids
-        if customlist_ids is not None:
-            clauses.append(a_entry.list_id.in_(customlist_ids))
-            if not already_filtered_customlist_on_materialized_view:
-                clauses.append(work_model.list_id.in_(customlist_ids))
-                # Now that we've put a restriction on the materialized
-                # view's list_id, we need to signal that no future
-                # call to this method should put a restriction on the
-                # same field.
-                #
-                # Future calls will apply their restrictions
-                # solely by restricting CustomListEntry.list_id,
-                # as above.
-                qu.customlist_id_filtered = True
-        if must_be_featured:
-            clauses.append(a_entry.featured==True)
-        if self.list_seen_in_previous_days:
-            cutoff = datetime.datetime.utcnow() - datetime.timedelta(
-                self.list_seen_in_previous_days
-            )
-            clauses.append(a_entry.most_recent_appearance >=cutoff)
-
-        return qu, clauses
 
     def explain(self):
         """Create a series of human-readable strings to explain a lane's settings."""

--- a/lane.py
+++ b/lane.py
@@ -813,6 +813,16 @@ class WorkList(object):
         :param media: Only Works in one of these media will be included
         in lists.
 
+        :param customlist_ids: Only Works included on one of these CustomLists
+        will be included in lists.
+
+        :param list_datasource_id: Only Works included on a CustomList
+        associated with this DataSource will be included in lists.
+
+        :param list_seen_in_previous_days: Only Works that were added
+        to a matching CustomList within this number of days will be
+        included in lists.
+
         :param children: This WorkList has children, which are also
         WorkLists.
 
@@ -823,8 +833,6 @@ class WorkList(object):
         :param entrypoints: A list of EntryPoint classes representing
         different ways of slicing up this WorkList.
 
-        :param customlist_ids: Only Works included on one of these CustomLists
-        will be included in lists.
         """
         self.library_id = None
         self.collection_ids = []
@@ -2297,9 +2305,6 @@ class Lane(Base, WorkList):
 
         if self.fiction is not None:
             clauses.append(work_model.fiction==self.fiction)
-
-        if self.media:
-            clauses.append(work_model.medium.in_(self.media))
 
         clauses.extend(self.age_range_filter_clauses())
 

--- a/lane.py
+++ b/lane.py
@@ -2039,13 +2039,20 @@ class Lane(Base, WorkList):
         """
         if value:
             self.customlists = []
-            value = value.id
-        self._list_datasource_id = value
+            if hasattr(self, '_customlist_ids'):
+                # The next time someone asks for .customlist_ids,
+                # the list will be refreshed.
+                del self._customlist_ids
+
+        # TODO: It's not clear to me why it's necessary to set these two
+        # values separately.
+        self._list_datasource = value
+        self._list_datasource_id = value.id
 
     @property
     def list_datasource_id(self):
-        if self.list_datasource:
-            return self.list_datasource.id
+        if self._list_datasource_id:
+            return self._list_datasource_id
         return None
 
     @property

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1135,6 +1135,20 @@ class TestWorkList(DatabaseTest):
         wl_child.priority = 0
         eq_([wl_child, lane_child], wl.visible_children)
 
+    def test_uses_customlists(self):
+        """A WorkList is said to use CustomLists if either .customlist_ids
+        or .list_datasource_id is set.
+        """
+        wl = WorkList()
+        wl.initialize(self._default_library)
+        eq_(False, wl.uses_customlists)
+
+        wl.customlist_ids = object()
+        eq_(True, wl.uses_customlists)
+
+        wl.customlist_ids = None
+        wl.list_datasource_id = object()
+        eq_(True, wl.uses_customlists)
 
     def test_groups(self):
         w1 = MockWork(1)
@@ -1442,14 +1456,25 @@ class TestWorkList(DatabaseTest):
             bibliographic_filter_clause() calls various hook methods.
             """
 
-            def __init__(self, languages=None, genre_ids=None, media=None):
+            def __init__(self, languages=None, genre_ids=None, media=None,
+                         customlist_ids=None, list_datasource_id=None,
+                         list_seen_in_previous_days=None):
                 self.languages = languages
                 self.genre_ids = genre_ids
                 self.media = media
+                self.customlist_ids=customlist_ids
+                self.list_datasource_id=list_datasource_id
+                self.list_seen_in_previous_days = list_seen_in_previous_days
 
             def audience_filter_clauses(self, _db, qu):
-                called['apply_audience_filter'] = True
+                called['apply_audience_filter'] = (_db, qu)
                 return []
+
+            def customlist_filter_clauses(self, *args, **kwargs):
+                called['customlist_filter_clauses'] = (args, kwargs)
+                return super(MockWorkList, self).customlist_filter_clauses(
+                    *args, **kwargs
+                )
 
         wl = MockWorkList()
         from model import MaterializedWorkWithGenre as wg
@@ -1465,9 +1490,15 @@ class TestWorkList(DatabaseTest):
         eq_(original_qu, final_qu)
         eq_(None, bibliographic_filter)
 
-        # But at least the hook methods were called with the correct
+        # But at least the apply_audience_filter was called with the correct
         # arguments.
-        eq_(True, called['apply_audience_filter'])
+        _db, qu = called['apply_audience_filter']
+        eq_(self._db, _db)
+        eq_(original_qu, qu)
+
+        # customlist_filter_clauses was not called because the WorkList
+        # doesn't do anything relating to custom lists.
+        assert 'customlist_filter_clauses' not in called
 
         # If languages, media, and genre IDs are specified, then they are
         # incorporated into the query.
@@ -1482,14 +1513,16 @@ class TestWorkList(DatabaseTest):
         # Create a WorkList that will find the MaterializedWorkWithGenre
         # for the English SF book.
         def worklist_has_books(
-                expect_books, **worklist_constructor_args
+                expect_books, featured=False, outer_join=False,
+                **worklist_constructor_args
         ):
             """Apply bibliographic filters to a query and verify
             that it finds only the given books.
             """
             worklist = MockWorkList(**worklist_constructor_args)
             qu, clause = worklist.bibliographic_filter_clause(
-                self._db, original_qu, False
+                self._db, original_qu, featured=featured,
+                outer_join=outer_join
             )
             qu = qu.filter(clause)
             expect_titles = sorted([x.sort_title for x in expect_books])
@@ -1509,6 +1542,29 @@ class TestWorkList(DatabaseTest):
             [],
             languages=["eng"], genre_ids=[sf.id], media=[Edition.AUDIO_MEDIUM]
         )
+
+        # If the WorkList has custom list IDs, then works will only show up if
+        # they're on one of the matching CustomLists.
+
+        sf_list, ignore = self._customlist(num_entries=0)
+        sf_list.add_entry(english_sf)
+        empty_list, ignore = self._customlist(num_entries=0)
+        self.add_to_materialized_view(english_sf)
+
+        worklist_has_books([], featured="featured value",
+                           outer_join="outer_join value",
+                           customlist_ids=[empty_list.id])
+        # There were no results, but customlist_filter_clauses was
+        # called, with the arguments we passed in for `featured`
+        # and `outer_join` (plus an intermediary query that we can't
+        # really test).
+        args, kwargs= called['customlist_filter_clauses']
+        untestable, featured, outer_join = args
+        eq_(outer_join, "outer_join value")
+        eq_(featured, "featured value")
+
+        worklist_has_books([english_sf], customlist_ids=[sf_list.id])
+
 
     def test_audience_filter_clauses(self):
 
@@ -1576,6 +1632,151 @@ class TestWorkList(DatabaseTest):
         eq_(set([gutenberg_adult.id, gutenberg_children.id,
                  non_gutenberg_children.id]),
             set(for_audiences()))
+
+    def test_customlist_filter_clauses(self):
+        """Standalone test of customlist_filter_clauses
+
+        Some of this code is also tested by test_apply_custom_filters.
+        """
+
+        # If a lane has nothing to do with CustomLists,
+        # apply_customlist_filter does nothing.
+        no_lists = self._lane()
+        qu = self._db.query(Work)
+        new_qu, clauses = no_lists.customlist_filter_clauses(qu)
+        eq_(qu, new_qu)
+        eq_([], clauses)
+
+        # Now set up a Work and a CustomList that contains the work.
+        work = self._work(with_license_pool=True)
+        gutenberg = DataSource.lookup(self._db, DataSource.GUTENBERG)
+        eq_(gutenberg, work.license_pools[0].data_source)
+        gutenberg_list, ignore = self._customlist(num_entries=0)
+        gutenberg_list.data_source = gutenberg
+        gutenberg_list_entry, ignore = gutenberg_list.add_entry(work)
+
+        # This WorkList gets every work on a specific list.
+        works_on_list = WorkList()
+        works_on_list.initialize(
+            self._default_library, customlist_ids=[gutenberg_list.id]
+        )
+
+        # This lane gets every work on every list associated with Project
+        # Gutenberg.
+        works_on_gutenberg_lists = WorkList()
+        works_on_gutenberg_lists.initialize(
+            self._default_library, list_datasource_id=gutenberg.id
+        )
+        self.add_to_materialized_view([work])
+
+        from model import MaterializedWorkWithGenre as work_model
+        def _run(qu, clauses):
+            # Run a query with certain clauses and pick out the
+            # work IDs returned.
+            modified = qu.filter(and_(*clauses))
+            return [x.works_id for x in modified]
+
+        def results(wl=works_on_gutenberg_lists, must_be_featured=False):
+            qu = self._db.query(work_model)
+            new_qu, clauses = wl.customlist_filter_clauses(
+                qu, must_be_featured=must_be_featured
+            )
+
+            if must_be_featured or wl.list_seen_in_previous_days:
+                # The query comes out different than it goes in -- there's a
+                # new join against CustomListEntry.
+                assert new_qu != qu
+            return _run(new_qu, clauses)
+
+        # Both lanes contain the work.
+        eq_([work.id], results(works_on_list))
+        eq_([work.id], results(works_on_gutenberg_lists))
+
+        # If there's another list with the same work on it, the
+        # work only shows up once.
+        gutenberg_list_2, ignore = self._customlist(num_entries=0)
+        gutenberg_list_2_entry, ignore = gutenberg_list_2.add_entry(work)
+        works_on_list.customlist_ids.append(gutenberg_list.id)
+        eq_([work.id], results(works_on_list))
+
+        # This WorkList gets every work on a list associated with Overdrive.
+        # There are no such lists, so the lane is empty.
+        overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
+        works_on_overdrive_lists = WorkList()
+        works_on_overdrive_lists.initialize(
+            self._default_library, list_datasource_id=overdrive.id
+        )
+        eq_([], results(works_on_overdrive_lists))
+
+        # It's possible to restrict a WorkList so that only works that
+        # are _featured_ on a list show up. The work isn't featured,
+        # so it doesn't show up.
+        eq_([], results(must_be_featured=True))
+
+        # Now it's featured, and it shows up.
+        gutenberg_list_entry.featured = True
+        eq_([work.id], results(must_be_featured=True))
+
+        # It's possible to restrict a WorkList to works that were seen on
+        # a certain list recently.
+        now = datetime.datetime.utcnow()
+        two_days_ago = now - datetime.timedelta(days=2)
+        gutenberg_list_entry.most_recent_appearance = two_days_ago
+
+        # The lane will only show works that were seen within the last
+        # day. There are no such works.
+        works_on_gutenberg_lists.list_seen_in_previous_days = 1
+        eq_([], results())
+
+        # Now it's been loosened to three days, and the work shows up.
+        works_on_gutenberg_lists.list_seen_in_previous_days = 3
+        eq_([work.id], results())
+
+        # Now let's test what happens when we chain calls to this
+        # method.
+        gutenberg_list_2_wl = WorkList()
+        gutenberg_list_2_wl.initialize(
+            self._default_library, customlist_ids = [gutenberg_list_2.id]
+        )
+
+        # These two lines don't do anything, because these are
+        # WorkLists, not Lanes, but they show the scenario in which
+        # this would actually happen. When determining which works
+        # belong in the child lane, Lane.customlist_filter_clauses()
+        # will be called on the parent lane and then on the child. In
+        # this case, only want books that are on _both_ works_on_list
+        # and gutenberg_list_2.
+        gutenberg_list_2_wl.parent = works_on_list
+        gutenberg_list_2_wl.inherit_parent_restrictions = True
+
+        qu = self._db.query(work_model)
+        list_1_qu, list_1_clauses = works_on_list.customlist_filter_clauses(qu)
+
+        # The query has been modified to indicate that we are filtering
+        # on the materialized view's customlist_id field.
+        eq_(True, list_1_qu.customlist_id_filtered)
+        eq_([work.id], [x.works_id for x in list_1_qu])
+
+        # Now call customlist_filter_clauses again so that the query
+        # must only match books on _both_ lists. This simulates
+        # what happens when the second lane is a child of the first,
+        # and inherits its restrictions.
+        both_lists_qu, list_2_clauses = gutenberg_list_2_wl.customlist_filter_clauses(
+            list_1_qu,
+        )
+        both_lists_clauses = list_1_clauses + list_2_clauses
+
+        # The combined query matches the work that shows up on
+        # both lists.
+        eq_([work.id], _run(both_lists_qu, both_lists_clauses))
+
+        # If we remove `work` from either list, the combined query
+        # matches nothing. This works even though the materialized
+        # view has not been refreshed.
+        for l in [gutenberg_list, gutenberg_list_2]:
+            l.remove_entry(work)
+            eq_([], _run(both_lists_qu, both_lists_clauses))
+            l.add_entry(work)
 
     def test_random_sample(self):
         # This lets me test which items are chosen in a random sample,
@@ -2432,142 +2633,6 @@ class TestLane(DatabaseTest):
         # shows up despite having no target age at all.
         older_ya.target_age = (16,18)
         eq_([adult.id], filtered(older_ya))
-
-    def test_customlist_filter_clauses(self):
-        """Standalone test of apply_customlist_filter.
-
-        Some of this code is also tested by test_apply_custom_filters.
-        """
-
-        # If a lane has nothing to do with CustomLists,
-        # apply_customlist_filter does nothing.
-        no_lists = self._lane()
-        qu = self._db.query(Work)
-        new_qu, clauses = no_lists.customlist_filter_clauses(qu)
-        eq_(qu, new_qu)
-        eq_([], clauses)
-
-        # Now set up a Work and a CustomList that contains the work.
-        work = self._work(with_license_pool=True)
-        gutenberg = DataSource.lookup(self._db, DataSource.GUTENBERG)
-        eq_(gutenberg, work.license_pools[0].data_source)
-        gutenberg_list, ignore = self._customlist(num_entries=0)
-        gutenberg_list.data_source = gutenberg
-        gutenberg_list_entry, ignore = gutenberg_list.add_entry(work)
-
-        # This lane gets every work on a specific list.
-        gutenberg_list_lane = self._lane()
-        gutenberg_list_lane.customlists.append(gutenberg_list)
-
-        # This lane gets every work on every list associated with Project
-        # Gutenberg.
-        gutenberg_lists_lane = self._lane()
-        gutenberg_lists_lane.list_datasource = gutenberg
-        self.add_to_materialized_view([work])
-
-        from model import MaterializedWorkWithGenre as work_model
-        def _run(qu, clauses):
-            # Run a query with certain clauses and pick out the
-            # work IDs returned.
-            modified = qu.filter(and_(*clauses))
-            return [x.works_id for x in modified]
-
-        def results(lane=gutenberg_lists_lane, must_be_featured=False):
-            qu = self._db.query(work_model)
-            new_qu, clauses = lane.customlist_filter_clauses(
-                qu, must_be_featured=must_be_featured
-            )
-
-            if must_be_featured or lane.list_seen_in_previous_days:
-                # The query comes out different than it goes in -- there's a
-                # new join against CustomListEntry.
-                assert new_qu != qu
-            return _run(new_qu, clauses)
-
-        # Both lanes contain the work.
-        eq_([work.id], results(gutenberg_list_lane))
-        eq_([work.id], results(gutenberg_lists_lane))
-
-        # If there's another list with the same work on it, the
-        # work only shows up once.
-        gutenberg_list_2, ignore = self._customlist(num_entries=0)
-        gutenberg_list_2_entry, ignore = gutenberg_list_2.add_entry(work)
-        gutenberg_list_lane.customlists.append(gutenberg_list)
-        eq_([work.id], results(gutenberg_list_lane))
-
-        # This lane gets every work on a list associated with Overdrive.
-        # There are no such lists, so the lane is empty.
-        overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
-        overdrive_lists_lane = self._lane()
-        overdrive_lists_lane.list_datasource = overdrive
-        eq_([], results(overdrive_lists_lane))
-
-        # It's possible to restrict a lane so that only works that are
-        # _featured_ on a list show up. The work isn't featured, so it
-        # doesn't show up.
-        eq_([], results(must_be_featured=True))
-
-        # Now it's featured, and it shows up.
-        gutenberg_list_entry.featured = True
-        eq_([work.id], results(must_be_featured=True))
-
-        # It's possible to restrict a lane to works that were seen on
-        # a certain list in a given timeframe.
-        now = datetime.datetime.utcnow()
-        two_days_ago = now - datetime.timedelta(days=2)
-        gutenberg_list_entry.most_recent_appearance = two_days_ago
-
-        # The lane will only show works that were seen within the last
-        # day. There are no such works.
-        gutenberg_lists_lane.list_seen_in_previous_days = 1
-        eq_([], results())
-
-        # Now it's been loosened to three days, and the work shows up.
-        gutenberg_lists_lane.list_seen_in_previous_days = 3
-        eq_([work.id], results())
-
-        # Now let's test what happens when we chain calls to this
-        # method.
-        gutenberg_list_2_lane = self._lane()
-        gutenberg_list_2_lane.customlists.append(gutenberg_list_2)
-
-        # These two lines aren't necessary for the test but they
-        # illustrate how this would happen in a real scenario -- When
-        # determining which works belong in the child lane,
-        # customlist_filter_clauses() will be called on the parent
-        # lane and then on the child. We only want books that are
-        # on _both_ gutenberg_list and gutenberg_list_2.
-        gutenberg_list_2_lane.parent = gutenberg_list_lane
-        gutenberg_list_2_lane.inherit_parent_restrictions = True
-
-        qu = self._db.query(work_model)
-        list_1_qu, list_1_clauses = gutenberg_list_lane.customlist_filter_clauses(qu)
-
-        # The query has been modified to indicate that we are filtering
-        # on the materialized view's customlist_id field.
-        eq_(True, list_1_qu.customlist_id_filtered)
-        eq_([work.id], [x.works_id for x in list_1_qu])
-
-        # Now call customlist_filter_clauses again so that the query
-        # must only match books on _both_ lists. This simulates
-        # what happens when the second lane is a child of the first,
-        # and inherits its restrictions.
-        both_lists_qu, list_2_clauses = gutenberg_list_2_lane.customlist_filter_clauses(
-            list_1_qu,
-        )
-        both_lists_clauses = list_1_clauses + list_2_clauses
-
-        # The combined query matches the work that shows up on
-        # both lists.
-        eq_([work.id], _run(both_lists_qu, both_lists_clauses))
-
-        # If we remove `work` from either list, the combined query
-        # matches nothing. This works even though the materialized
-        # view has not been refreshed.
-        for l in [gutenberg_list, gutenberg_list_2]:
-            l.remove_entry(work)
-            eq_([], _run(both_lists_qu, both_lists_clauses))
-            l.add_entry(work)
 
     def test_explain(self):
         parent = self._lane(display_name="Parent")

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1026,13 +1026,13 @@ class TestWorkList(DatabaseTest):
 
         gutenberg = DataSource.lookup(self._db, DataSource.GUTENBERG)
 
-        customlist1 = self._customlist(
+        customlist1, ignore = self._customlist(
             data_source_name=gutenberg.name, num_entries=0
         )
-        customlist2 = self._customlist(
+        customlist2, ignore = self._customlist(
             data_source_name=gutenberg.name, num_entries=0
         )
-        customlist3 = self._customlist(
+        customlist3, ignore = self._customlist(
             data_source_name=DataSource.OVERDRIVE, num_entries=0
         )
 
@@ -1996,12 +1996,29 @@ class TestLane(DatabaseTest):
         lane = self._lane()
         eq_(self._default_library, lane.get_library(self._db))
 
-    def test_list_datasource_id(self):
+    def test_list_datasource(self):
+        """Test setting and retrieving the DataSource object and
+        the underlying ID.
+        """
         lane = self._lane()
+
+        # This lane is based on a specific CustomList.
+        customlist1, ignore = self._customlist(num_entries=0)
+        customlist2, ignore = self._customlist(num_entries=0)
+        lane.customlists.append(customlist1)
+        eq_(None, lane.list_datasource)
         eq_(None, lane.list_datasource_id)
-        gutenberg = DataSource.lookup(self._db, DataSource.GUTENBERG)
-        lane.list_datasource = gutenberg
-        eq_(gutenberg.id, lane.list_datasource_id)
+        eq_([customlist1.id], lane.customlist_ids)
+
+        # Now change it so it's based on all CustomLists from a given
+        # DataSource.
+        source = customlist1.data_source
+        lane.list_datasource = source
+        eq_(source, lane.list_datasource)
+        eq_(source.id, lane.list_datasource_id)
+
+        # The lane is now based on two CustomLists instead of one.
+        eq_(set([customlist1.id, customlist2.id]), set(lane.customlist_ids))
 
     def test_set_audiences(self):
         """Setting Lane.audiences to a single value will


### PR DESCRIPTION
This branch gives WorkList the capability to find only works that are on specific `CustomLists`. Previously this functionality was only available to `Lane`. The underlying code is the same, except that `WorkList.customlist_ids` are specified up-front in `initialize`, and `Lane.customlist_ids` are kept in the database.

To get this to work I had to not only move `customlist_ids` over to WorkList, but also `list_datasource_id` and `list_seen_in_previous_days`. That's kind of overkill, but it's not a problem, since theoretically a WorkList might want to use those features.

I believe there's no reason why other things used in `Lane.bibliographic_filter_clause` like `fiction` and `license_datasource` couldn't also be moved to `WorkList` -- we just haven't needed those features in a `WorkList` yet.