### PR TITLE
Don't use the available now facet if it's not one of the library's enabled facets.

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -315,7 +315,8 @@ class Facets(FacetsWithEntryPoint):
         )
         order = order or library.default_facet(self.ORDER_FACET_GROUP_NAME)
 
-        if (availability == self.AVAILABLE_ALL and (library and not library.allow_holds)):
+        if (availability == self.AVAILABLE_ALL and (library and not library.allow_holds)
+            and (self.AVAILABLE_NOW in library.enabled_facets(self.AVAILABILITY_FACET_GROUP_NAME))):
             # Under normal circumstances we would show all works, but
             # library configuration says to hide books that aren't
             # available.


### PR DESCRIPTION
This fixes a bug I ran into with Open Bookshelf. I had only enabled the 'all' facet for availability since that facet group isn't applicable to Open Bookshelf - everything is always available. Then I disabled holds in the configuration to give the right info to the registry, and it started added the disabled 'now' facet to some of the links and those links no longer worked.