### PR TITLE
No absolute imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ addons:
       - postgresql-contrib-9.3
 
 env:
-  - ES_VERSION="1.7.0" ES_DOWNLOAD="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz"
-  - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_core_test"
+  - ES_VERSION="1.7.0" ES_DOWNLOAD="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz" SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_core_test"
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ before_install:
 install:
   - pip install -r requirements.txt
   - python -m textblob.download_corpora
-  - cp config.json.sample config.json
   - wget ${ES_DOWNLOAD}
   - export ES_PATH=elasticsearch-${ES_VERSION}
   - tar -xzf ${ES_PATH}.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
 
 env:
   - ES_VERSION="1.7.0" ES_DOWNLOAD="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz"
+  - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_core_test"
 
 services:
   - postgresql
@@ -28,7 +29,6 @@ install:
   - pip install -r requirements.txt
   - python -m textblob.download_corpora
   - cp config.json.sample config.json
-  - export SIMPLIFIED_CONFIGURATION_FILE="${TRAVIS_BUILD_DIR}/config.json"
   - wget ${ES_DOWNLOAD}
   - export ES_PATH=elasticsearch-${ES_VERSION}
   - tar -xzf ${ES_PATH}.tar.gz

--- a/analytics.py
+++ b/analytics.py
@@ -25,11 +25,18 @@ class Analytics(object):
         # Turn each integration into an analytics provider.
         for integration in integrations:
             try:
-                # Import the module relative to the package this
-                # module is in.
-                provider_module = importlib.import_module(
-                    ".." + integration.protocol, package=__name__
-                )
+                try:
+                    # Import the module name as-is, relying on sys.path
+                    # to find it.
+                    provider_module = importlib.import_module(
+                        integration.protocol
+                    )
+                except ImportException, e:
+                    # Import the module relative to the package this
+                    # module is in.
+                    provider_module = importlib.import_module(
+                        '..' + integration.protocol, package=__name__
+                    )
                 provider_class = getattr(provider_module, "Provider", None)
                 if provider_class:
                     if not integration.libraries:

--- a/analytics.py
+++ b/analytics.py
@@ -4,7 +4,7 @@ import contextlib
 import datetime
 from collections import defaultdict
 from model import ExternalIntegration
-from core.config import CannotLoadConfiguration
+from config import CannotLoadConfiguration
 from sqlalchemy.orm.session import Session
 
 class Analytics(object):

--- a/analytics.py
+++ b/analytics.py
@@ -31,7 +31,7 @@ class Analytics(object):
                     provider_module = importlib.import_module(
                         integration.protocol
                     )
-                except ImportException, e:
+                except ImportError, e:
                     # Import the module relative to the package this
                     # module is in.
                     provider_module = importlib.import_module(

--- a/analytics.py
+++ b/analytics.py
@@ -2,6 +2,7 @@ from nose.tools import set_trace
 import importlib
 import contextlib
 import datetime
+import os
 from collections import defaultdict
 from model import ExternalIntegration
 from config import CannotLoadConfiguration
@@ -24,7 +25,11 @@ class Analytics(object):
         # Turn each integration into an analytics provider.
         for integration in integrations:
             try:
-                provider_module = importlib.import_module(integration.protocol)
+                # Import the module relative to the package this
+                # module is in.
+                provider_module = importlib.import_module(
+                    ".." + integration.protocol, package=__name__
+                )
                 provider_class = getattr(provider_module, "Provider", None)
                 if provider_class:
                     if not integration.libraries:

--- a/app_server.py
+++ b/app_server.py
@@ -62,14 +62,14 @@ def load_lending_policy(policy):
                         audience)
     return policy
 
-def feed_response(feed, acquisition=True, cache_for=AcquisitionFeed.DEFAULT_FEED_CACHE_TIME):
+def feed_response(feed, acquisition=True, cache_for=AcquisitionFeed.FEED_CACHE_TIME):
     if acquisition:
         content_type = OPDSFeed.ACQUISITION_FEED_TYPE
     else:
         content_type = OPDSFeed.NAVIGATION_FEED_TYPE
     return _make_response(feed, content_type, cache_for)
 
-def entry_response(entry, cache_for=AcquisitionFeed.DEFAULT_FEED_CACHE_TIME):
+def entry_response(entry, cache_for=AcquisitionFeed.FEED_CACHE_TIME):
     content_type = OPDSFeed.ENTRY_TYPE
     return _make_response(entry, content_type, cache_for)
 

--- a/app_server.py
+++ b/app_server.py
@@ -35,7 +35,7 @@ from model import (
 )
 from cdn import cdnify
 from classifier import Classifier
-from core.config import Configuration
+from config import Configuration
 from lane import (
     Facets,
     Pagination,

--- a/app_server.py
+++ b/app_server.py
@@ -49,9 +49,9 @@ def cdn_url_for(*args, **kwargs):
 
 def load_lending_policy(policy):
     if not policy:
-        logging.info("No lending policy.")
         return {}
     if isinstance(policy, basestring):
+        logging.info("Lending policy: %s" % policy)
         policy = json.loads(policy)
     for external_type, p in policy.items():
         if Patron.AUDIENCE_RESTRICTION_POLICY in p:

--- a/app_server.py
+++ b/app_server.py
@@ -62,14 +62,14 @@ def load_lending_policy(policy):
                         audience)
     return policy
 
-def feed_response(feed, acquisition=True, cache_for=AcquisitionFeed.FEED_CACHE_TIME):
+def feed_response(feed, acquisition=True, cache_for=AcquisitionFeed.DEFAULT_FEED_CACHE_TIME):
     if acquisition:
         content_type = OPDSFeed.ACQUISITION_FEED_TYPE
     else:
         content_type = OPDSFeed.NAVIGATION_FEED_TYPE
     return _make_response(feed, content_type, cache_for)
 
-def entry_response(entry, cache_for=AcquisitionFeed.FEED_CACHE_TIME):
+def entry_response(entry, cache_for=AcquisitionFeed.DEFAULT_FEED_CACHE_TIME):
     content_type = OPDSFeed.ENTRY_TYPE
     return _make_response(entry, content_type, cache_for)
 

--- a/cdn.py
+++ b/cdn.py
@@ -4,7 +4,7 @@ import urllib
 import urlparse
 from nose.tools import set_trace
 
-from core.config import Configuration, CannotLoadConfiguration
+from config import Configuration, CannotLoadConfiguration
 from s3 import S3Uploader
 
 def cdnify(url, cdns=None):

--- a/config.py
+++ b/config.py
@@ -539,7 +539,7 @@ class Configuration(object):
 
     @classmethod
     def load_from_file(cls, _db=None):
-        """Load additional site configuration from a config file.
+        """Load additional site configuration from config file.
 
         This is being phased out in favor of taking all configuration from a
         database.

--- a/config.py
+++ b/config.py
@@ -271,6 +271,7 @@ class Configuration(object):
                 # Load the Configuration object.
                 url = cls.database_url()
                 engine = create_engine(url)
+                logging.error("IN CONFIGURATION, connecting to database %s", url)
                 connection = engine.connect()
                 _db = Session(connection)
                 cls._instance = cls.load_from_file(_db)

--- a/external_list.py
+++ b/external_list.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm.session import Session
 
 from opds_import import SimplifiedOPDSLookup
 import logging
-from core.config import Configuration
+from config import Configuration
 from metadata_layer import (
     CSVMetadataImporter,
     ReplacementPolicy,

--- a/external_search.py
+++ b/external_search.py
@@ -3,7 +3,7 @@ from elasticsearch import Elasticsearch
 from elasticsearch.helpers import bulk as elasticsearch_bulk
 from elasticsearch.exceptions import ElasticsearchException
 from flask_babel import lazy_gettext as _
-from core.config import (
+from config import (
     Configuration,
     CannotLoadConfiguration,
 )

--- a/lane.py
+++ b/lane.py
@@ -1491,8 +1491,6 @@ class WorkList(object):
         items. There may be more or less; this controls the size of
         the window and the LIMIT on the query.
         """
-        work_model = MaterializedWorkWithGenre
-
         lane_query = self.works(_db, facets=facets)
 
         # Make sure this query finds a number of works proportinal

--- a/lane.py
+++ b/lane.py
@@ -57,6 +57,7 @@ from model import (
     tuple_to_numericrange,
     Base,
     CachedFeed,
+    Collection,
     CustomList,
     CustomListEntry,
     DataSource,
@@ -67,6 +68,7 @@ from model import (
     Library,
     LicensePool,
     LicensePoolDeliveryMechanism,
+    MaterializedWorkWithGenre as work_model,
     Session,
     Work,
     WorkGenre,
@@ -437,7 +439,6 @@ class Facets(FacetsWithEntryPoint):
         """Turn the name of an order facet into a materialized-view field
         for use in an ORDER BY clause.
         """
-        from model import MaterializedWorkWithGenre as work_model
         order_facet_to_database_field = {
             cls.ORDER_ADDED_TO_COLLECTION: work_model.availability_time,
             cls.ORDER_WORK_ID : work_model.works_id,
@@ -455,7 +456,6 @@ class Facets(FacetsWithEntryPoint):
         ordered appropriately.
         """
         qu = super(Facets, self).apply(_db, qu)
-        from model import MaterializedWorkWithGenre as work_model
         if self.availability == self.AVAILABLE_NOW:
             availability_clause = or_(
                 LicensePool.open_access==True,
@@ -500,7 +500,6 @@ class Facets(FacetsWithEntryPoint):
         """Given these Facets, create a complete ORDER BY clause for queries
         against WorkModelWithGenre.
         """
-        from model import MaterializedWorkWithGenre as work_model
         work_id = work_model.works_id
         default_sort_order = [
             work_model.sort_author, work_model.sort_title, work_id
@@ -570,7 +569,6 @@ class FeaturedFacets(FacetsWithEntryPoint):
         apply() on a query to get a featured subset of that query,
         this will work.
         """
-        from model import MaterializedWorkWithGenre as work_model
         qu = super(FeaturedFacets, self).apply(_db, qu)
         quality = self.quality_tier_field()
         qu = qu.order_by(
@@ -600,9 +598,9 @@ class FeaturedFacets(FacetsWithEntryPoint):
         """
         if hasattr(self, '_quality_tier_field'):
             return self._quality_tier_field
-        from model import MaterializedWorkWithGenre as mwg
         featurable_quality = self.minimum_featured_quality
 
+        mwg = work_model
         # Being of featureable quality is great.
         featurable_quality = case(
             [(mwg.quality >= featurable_quality, 5)],
@@ -1038,10 +1036,7 @@ class WorkList(object):
         :return: A Query, or None if the WorkList is deemed to be a
            bad idea in the first place.
         """
-        from model import (
-            MaterializedWorkWithGenre,
-        )
-        mw = MaterializedWorkWithGenre
+        mw = work_model
         # apply_filters() will apply the genre
         # restrictions.
 
@@ -1100,7 +1095,7 @@ class WorkList(object):
 
         # Get a list of MaterializedWorkWithGenre objects as though we
         # had called works().
-        from model import MaterializedWorkWithGenre as mw
+        mw = work_model
         qu = _db.query(mw).join(
             LicensePool, mw.license_pool_id==LicensePool.id
         ).filter(
@@ -1133,7 +1128,6 @@ class WorkList(object):
         subclass-specific filters defined by
         bibliographic_filter_clause().
         """
-        from model import MaterializedWorkWithGenre as work_model
         # In general, we only show books that are ready to be delivered
         # to patrons.
         qu = self.only_show_ready_deliverable_works(_db, qu)
@@ -1177,7 +1171,6 @@ class WorkList(object):
         # WorkLists. (So are genre and collection restrictions, bt those
         # were applied back in works().)
 
-        from model import MaterializedWorkWithGenre as work_model
         clauses = self.audience_filter_clauses(_db, qu)
         if self.languages:
             clauses.append(work_model.language.in_(self.languages))
@@ -1207,7 +1200,6 @@ class WorkList(object):
         """
         if not self.audiences:
             return []
-        from model import MaterializedWorkWithGenre as work_model
         clauses = [work_model.audience.in_(self.audiences)]
         if (Classifier.AUDIENCE_CHILDREN in self.audiences
             or Classifier.AUDIENCE_YOUNG_ADULT in self.audiences):
@@ -1233,9 +1225,8 @@ class WorkList(object):
         Note that this assumes the query has an active join against
         LicensePool.
         """
-        from model import MaterializedWorkWithGenre as mwg, Collection
         return Collection.restrict_to_ready_deliverable_works(
-            query, mwg, show_suppressed=show_suppressed,
+            query, work_model, show_suppressed=show_suppressed,
             collection_ids=self.collection_ids
         )
 
@@ -1286,7 +1277,6 @@ class WorkList(object):
         """Avoid eager loading of objects that are contained in the
         materialized view.
         """
-        from model import MaterializedWorkWithGenre as work_model
         return qu.options(
             lazyload(work_model.license_pool, LicensePool.data_source),
             lazyload(work_model.license_pool, LicensePool.identifier),
@@ -1300,7 +1290,6 @@ class WorkList(object):
         we can stop from even being sent over from the
         database.
         """
-        from model import MaterializedWorkWithGenre as work_model
         if Configuration.DEFAULT_OPDS_FORMAT == "simple_opds_entry":
             return query.options(defer(work_model.verbose_opds_entry))
         else:
@@ -1502,7 +1491,6 @@ class WorkList(object):
         items. There may be more or less; this controls the size of
         the window and the LIMIT on the query.
         """
-        from model import MaterializedWorkWithGenre
         work_model = MaterializedWorkWithGenre
 
         lane_query = self.works(_db, facets=facets)
@@ -1526,7 +1514,6 @@ class WorkList(object):
         """Restrict the given SQLAlchemy query so that it matches
         approximately `target_size` items.
         """
-        from model import MaterializedWorkWithGenre as work_model
         if query is None:
             return query
         window_start, window_end = self.featured_window(target_size)
@@ -1910,8 +1897,7 @@ class Lane(Base, WorkList):
     def update_size(self, _db):
         """Update the stored estimate of the number of Works in this Lane."""
         query = self.works(_db).limit(None)
-        from model import MaterializedWorkWithGenre as mw
-        query = query.distinct(mw.works_id)
+        query = query.distinct(work_model.works_id)
         self.size = fast_query_count(query)
 
     @property
@@ -2159,7 +2145,6 @@ class Lane(Base, WorkList):
         `statement` is a SQLAlchemy statement suitable for passing
         into filter() or case().
         """
-        from model import MaterializedWorkWithGenre as work_model
         qu, superclass_clause = super(
             Lane, self
         ).bibliographic_filter_clause(
@@ -2205,7 +2190,6 @@ class Lane(Base, WorkList):
         """Create a clause that filters out all books not classified as
         suitable for this Lane's age range.
         """
-        from model import MaterializedWorkWithGenre as work_model
         if self.target_age == None:
             return []
 

--- a/lane.py
+++ b/lane.py
@@ -10,7 +10,7 @@ from psycopg2.extras import NumericRange
 from sqlalchemy.sql import select
 from sqlalchemy.sql.expression import Select
 
-from core.config import Configuration
+from config import Configuration
 from flask_babel import lazy_gettext as _
 
 import classifier

--- a/log.py
+++ b/log.py
@@ -9,8 +9,6 @@ from config import Configuration
 from StringIO import StringIO
 from loggly.handlers import HTTPSHandler as LogglyHandler
 
-if not Configuration.instance:
-    Configuration.load()
 
 class JSONFormatter(logging.Formatter):
     hostname = socket.gethostname()

--- a/log.py
+++ b/log.py
@@ -5,7 +5,7 @@ import json
 import os
 import socket
 from flask_babel import lazy_gettext as _
-from core.config import Configuration
+from config import Configuration
 from StringIO import StringIO
 from loggly.handlers import HTTPSHandler as LogglyHandler
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -516,7 +516,6 @@ class MetaToModelUtility(object):
 
         The model_object can be either a pool or an edition.
         """
-
         if link_obj.rel not in Hyperlink.MIRRORED:
             # we only host locally open-source epubs and cover images
             if link.href:

--- a/mirror.py
+++ b/mirror.py
@@ -1,6 +1,6 @@
 from nose.tools import set_trace
 import datetime
-from core.config import CannotLoadConfiguration
+from config import CannotLoadConfiguration
 
 class MirrorUploader(object):
 

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -321,7 +321,7 @@ class SessionManager(object):
         return engine, engine.connect()
 
     @classmethod
-    def initialize_schema(cls, engine, create_materialized_view=True):
+    def initialize_schema(cls, engine):
         """Initialize the database schema."""
         # Use SQLAlchemy to create all the tables.
         to_create = [

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -386,8 +386,8 @@ class SessionManager(object):
     def initialize_data(cls, session, set_site_configuration=True):
         # Make sure the Configuration object is initialized. This
         # will make site_configuration_has_changed work correctly.
-        if Configuration._instance is None:
-            Configuration.load_from_database(session)
+        if Configuration.instance is None:
+            Configuration.load(session)
 
         # Create initial content.
         from datasource import DataSource

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -387,22 +387,10 @@ class SessionManager(object):
 
     @classmethod
     def initialize_data(cls, session, set_site_configuration=True):
-        # Make sure the Configuration object is initialized. This
-        # will make site_configuration_has_changed work correctly.
-        if Configuration.instance is None:
-            Configuration.load(session)
-
         # Create initial content.
         from datasource import DataSource
         from classification import Genre
         from licensing import DeliveryMechanism
-
-        # Reset the full-table caches, in case initialize_data was
-        # called once before and then the database schema was reset.
-        # (This would only happen during a test.)
-        for cached in (DataSource, Genre, DeliveryMechanism):
-            cached.reset_cache()
-
         list(DataSource.well_known_sources(session))
 
         # Load all existing Genre objects.

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -282,7 +282,7 @@ class SessionManager(object):
         """Initialize the database.
 
         This includes the schema, the materialized views, the custom
-        functions, and the content.
+        functions, and the initial content.
         """
         if url in cls.engine_for_url:
             engine = cls.engine_for_url[url]
@@ -389,7 +389,7 @@ class SessionManager(object):
         if Configuration._instance is None:
             Configuration.load_from_database(session)
 
-        # Create initial data sources.
+        # Create initial content.
         from datasource import DataSource
         from classification import Genre
         from licensing import DeliveryMechanism

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -274,7 +274,7 @@ class SessionManager(object):
         return sessionmaker(bind=bind_obj)
 
     @classmethod
-    def initialize(cls, url, create_materialized_work_class=True):
+    def initialize(cls, url):
         if url in cls.engine_for_url:
             engine = cls.engine_for_url[url]
             return engine, engine.connect()
@@ -360,9 +360,7 @@ class SessionManager(object):
         engine = connection = 0
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=sa_exc.SAWarning)
-            engine, connection = cls.initialize(
-                url, create_materialized_work_class=initialize_data
-            )
+            engine, connection = cls.initialize(url)
         session = Session(connection)
         if initialize_data:
             session = cls.initialize_data(session)

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -40,7 +40,7 @@ from constants import (
     LinkRelations,
     MediaTypes,
 )
-from core import classifier
+import classifier
 
 def flush(db):
     """Flush the database connection unless it's known to already be flushing."""
@@ -366,8 +366,8 @@ class SessionManager(object):
                     foreign_keys=LicensePool.id, lazy='joined', uselist=False)
 
             globals()['MaterializedWorkWithGenre'] = MaterializedWorkWithGenre
-            import core.model
-            core.model.MaterializedWorkWithGenre = MaterializedWorkWithGenre
+            import model
+            model.MaterializedWorkWithGenre = MaterializedWorkWithGenre
 
         cls.engine_for_url[url] = engine
         return engine, engine.connect()
@@ -379,7 +379,7 @@ class SessionManager(object):
             _db.commit()
         # Immediately update the number of works associated with each
         # lane.
-        from core.lane import Lane
+        from lane import Lane
         for lane in _db.query(Lane):
             lane.update_size(_db)
 
@@ -454,7 +454,7 @@ def production_session():
     # incorrectly, but 1) this method isn't normally called during
     # unit tests, and 2) package_setup() will call initialize() again
     # with the right arguments.
-    from core.log import LogConfiguration
+    from log import LogConfiguration
     LogConfiguration.initialize(_db)
     return _db
 

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -44,7 +44,7 @@ from constants import (
     LinkRelations,
     MediaTypes,
 )
-import classifier
+from .. import classifier
 
 def flush(db):
     """Flush the database connection unless it's known to already be flushing."""
@@ -370,7 +370,7 @@ class SessionManager(object):
             _db.commit()
         # Immediately update the number of works associated with each
         # lane.
-        from lane import Lane
+        from ..lane import Lane
         for lane in _db.query(Lane):
             lane.update_size(_db)
 

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -345,7 +345,6 @@ class SessionManager(object):
         session = Session(connection)
         cls.initialize_data(session)
 
-
         if connection:
             connection.close()
 
@@ -378,7 +377,8 @@ class SessionManager(object):
     def initialize_data(cls, session, set_site_configuration=True):
         # Make sure the Configuration object is initialized. This
         # will make site_configuration_has_changed work correctly.
-        Configuration.load_from_database(session)
+        if Configuration._instance is None:
+            Configuration.load_from_database(session)
 
         # Create initial data sources.
         from datasource import DataSource

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -280,11 +280,9 @@ class SessionManager(object):
             return engine, engine.connect()
 
         engine = cls.engine(url)
-        Base.metadata.create_all(engine)
 
         base_path = os.path.split(__file__)[0]
         resource_path = os.path.join(base_path, "files")
-
         connection = None
         for view_name, filename in cls.MATERIALIZED_VIEWS.items():
             if engine.has_table(view_name):
@@ -308,6 +306,8 @@ class SessionManager(object):
             result = connection.execute(
                 "REFRESH MATERIALIZED VIEW %s;" % view_name
             )
+
+        Base.metadata.create_all(engine)
 
         if not connection:
             connection = engine.connect()

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -392,8 +392,8 @@ class SessionManager(object):
         from licensing import DeliveryMechanism
 
         # Reset the full-table caches, in case initialize_data was
-        # called previously, e.g. during a test, before the database
-        # schema was reset.
+        # called once before and then the database schema was reset.
+        # (This would only happen during a test.)
         for cached in (DataSource, Genre, DeliveryMechanism):
             cached.reset_cache()
 

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -419,7 +419,7 @@ def production_session():
     # incorrectly, but 1) this method isn't normally called during
     # unit tests, and 2) package_setup() will call initialize() again
     # with the right arguments.
-    from core.log import LogConfiguration
+    from log import LogConfiguration
     LogConfiguration.initialize(_db)
     return _db
 

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -345,7 +345,7 @@ class SessionManager(object):
                 continue
             if not connection:
                 connection = engine.connect()
-            resource_file = os.path.join(self.resource_directory(), filename)
+            resource_file = os.path.join(cls.resource_directory(), filename)
             if not os.path.exists(resource_file):
                 raise IOError("Could not load materialized view from %s: file does not exist." % resource_file)
             logging.info(

--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -74,8 +74,8 @@ class CachedFeed(Base):
     @classmethod
     def fetch(cls, _db, lane, type, facets, pagination, annotator,
               force_refresh=False, max_age=None):
-        from opds import AcquisitionFeed
-        from lane import Lane, WorkList
+        from ..opds import AcquisitionFeed
+        from ..lane import Lane, WorkList
         if max_age is None:
             if type == cls.GROUPS_TYPE:
                 max_age = AcquisitionFeed.grouped_max_age(_db)

--- a/model/classification.py
+++ b/model/classification.py
@@ -13,8 +13,8 @@ from . import (
 from constants import DataSourceConstants
 from hasfulltablecache import HasFullTableCache
 
-import classifier
-from classifier import (
+from .. import classifier
+from ..classifier import (
     Classifier,
     COMICS_AND_GRAPHIC_NOVELS,
     Erotica,

--- a/model/classification.py
+++ b/model/classification.py
@@ -13,8 +13,8 @@ from . import (
 from constants import DataSourceConstants
 from hasfulltablecache import HasFullTableCache
 
-from core import classifier
-from core.classifier import (
+import classifier
+from classifier import (
     Classifier,
     COMICS_AND_GRAPHIC_NOVELS,
     Erotica,

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -7,11 +7,11 @@ from . import (
     get_one,
     get_one_or_create,
 )
-from core.config import CannotLoadConfiguration
+from config import CannotLoadConfiguration
 from constants import DataSourceConstants
 from hasfulltablecache import HasFullTableCache
 from library import Library
-from core.mirror import MirrorUploader
+from mirror import MirrorUploader
 
 import json
 import logging

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -7,11 +7,11 @@ from . import (
     get_one,
     get_one_or_create,
 )
-from config import CannotLoadConfiguration
+from ..config import CannotLoadConfiguration
 from constants import DataSourceConstants
 from hasfulltablecache import HasFullTableCache
 from library import Library
-from mirror import MirrorUploader
+from ..mirror import MirrorUploader
 
 import json
 import logging

--- a/model/contributor.py
+++ b/model/contributor.py
@@ -28,7 +28,7 @@ from sqlalchemy.orm import (
     synonym,
 )
 from sqlalchemy.orm.session import Session
-from core.util.personal_names import display_name_to_sort_name
+from util.personal_names import display_name_to_sort_name
 
 class Contributor(Base):
 

--- a/model/contributor.py
+++ b/model/contributor.py
@@ -28,7 +28,7 @@ from sqlalchemy.orm import (
     synonym,
 )
 from sqlalchemy.orm.session import Session
-from util.personal_names import display_name_to_sort_name
+from ..util.personal_names import display_name_to_sort_name
 
 class Contributor(Base):
 

--- a/model/customlist.py
+++ b/model/customlist.py
@@ -245,7 +245,7 @@ class CustomListEntry(Base):
 
         new_work = None
         if not metadata:
-            from metadata_layer import Metadata
+            from ..metadata_layer import Metadata
             metadata = Metadata.from_edition(edition)
 
         # Try to guess based on metadata, if we can get a high-quality

--- a/model/edition.py
+++ b/model/edition.py
@@ -37,11 +37,11 @@ from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
-from core.util import (
+from util import (
     LanguageCodes,
     TitleProcessor
 )
-from core.util.permanent_work_id import WorkIDCalculator
+from util.permanent_work_id import WorkIDCalculator
 
 class Edition(Base, EditionConstants):
 

--- a/model/edition.py
+++ b/model/edition.py
@@ -4,6 +4,7 @@ from nose.tools import set_trace
 
 from . import (
     Base,
+    get_one,
     get_one_or_create,
     PresentationCalculationPolicy,
 )

--- a/model/edition.py
+++ b/model/edition.py
@@ -37,11 +37,11 @@ from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
-from util import (
+from ..util import (
     LanguageCodes,
     TitleProcessor
 )
-from util.permanent_work_id import WorkIDCalculator
+from ..util.permanent_work_id import WorkIDCalculator
 
 class Edition(Base, EditionConstants):
 

--- a/model/edition.py
+++ b/model/edition.py
@@ -109,16 +109,19 @@ class Edition(Base, EditionConstants):
     # A Project Gutenberg text was likely `published` long before being `issued`.
     published = Column(Date)
 
+    MEDIUM_ENUM = Enum(EditionConstants.BOOK_MEDIUM,
+                       EditionConstants.PERIODICAL_MEDIUM,
+                       EditionConstants.AUDIO_MEDIUM,
+                       EditionConstants.MUSIC_MEDIUM,
+                       EditionConstants.VIDEO_MEDIUM,
+                       EditionConstants.IMAGE_MEDIUM,
+                       EditionConstants.COURSEWARE_MEDIUM,
+                       name="medium"
+    )
+
+
     medium = Column(
-        Enum(EditionConstants.BOOK_MEDIUM,
-            EditionConstants.PERIODICAL_MEDIUM,
-            EditionConstants.AUDIO_MEDIUM,
-            EditionConstants.MUSIC_MEDIUM,
-            EditionConstants.VIDEO_MEDIUM,
-            EditionConstants.IMAGE_MEDIUM,
-            EditionConstants.COURSEWARE_MEDIUM,
-             name="medium"),
-        default=EditionConstants.BOOK_MEDIUM, index=True
+        MEDIUM_ENUM, default=EditionConstants.BOOK_MEDIUM, index=True
     )
 
     cover_id = Column(

--- a/model/identifier.py
+++ b/model/identifier.py
@@ -49,7 +49,7 @@ from sqlalchemy.sql.expression import (
     or_,
 )
 import urllib
-from core.util.summary import SummaryEvaluator
+from util.summary import SummaryEvaluator
 
 class Identifier(Base, IdentifierConstants):
     """A way of uniquely referring to a particular edition.

--- a/model/identifier.py
+++ b/model/identifier.py
@@ -49,7 +49,7 @@ from sqlalchemy.sql.expression import (
     or_,
 )
 import urllib
-from util.summary import SummaryEvaluator
+from ..util.summary import SummaryEvaluator
 
 class Identifier(Base, IdentifierConstants):
     """A way of uniquely referring to a particular edition.
@@ -764,7 +764,7 @@ class Identifier(Base, IdentifierConstants):
             most_recent_update = max(timestamps)
 
         quality = Measurement.overall_quality(self.measurements)
-        from opds import AcquisitionFeed
+        from ..opds import AcquisitionFeed
         return AcquisitionFeed.minimal_opds_entry(
             identifier=self, cover=cover_image, description=description,
             quality=quality, most_recent_update=most_recent_update

--- a/model/library.py
+++ b/model/library.py
@@ -6,10 +6,10 @@ from . import (
     Base,
     get_one,
 )
-from config import Configuration
+from ..config import Configuration
 from edition import Edition
-from entrypoint import EntryPoint
-from facets import FacetConstants
+from ..entrypoint import EntryPoint
+from ..facets import FacetConstants
 from hasfulltablecache import HasFullTableCache
 from licensing import LicensePool
 from work import Work

--- a/model/library.py
+++ b/model/library.py
@@ -6,10 +6,10 @@ from . import (
     Base,
     get_one,
 )
-from core.config import Configuration
+from config import Configuration
 from edition import Edition
-from core.entrypoint import EntryPoint
-from core.facets import FacetConstants
+from entrypoint import EntryPoint
+from facets import FacetConstants
 from hasfulltablecache import HasFullTableCache
 from licensing import LicensePool
 from work import Work

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -357,7 +357,7 @@ class LicensePool(Base):
 
         # Note: We can do a cleaner solution, if we refactor to not use metadata's
         # methods to update editions.  For now, we're choosing to go with the below approach.
-        from metadata_layer import (
+        from ..metadata_layer import (
             Metadata,
             IdentifierData,
             ReplacementPolicy,

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -357,7 +357,7 @@ class LicensePool(Base):
 
         # Note: We can do a cleaner solution, if we refactor to not use metadata's
         # methods to update editions.  For now, we're choosing to go with the below approach.
-        from metadata_layer import (
+        from core.metadata_layer import (
             Metadata,
             IdentifierData,
             ReplacementPolicy,

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -357,7 +357,7 @@ class LicensePool(Base):
 
         # Note: We can do a cleaner solution, if we refactor to not use metadata's
         # methods to update editions.  For now, we're choosing to go with the below approach.
-        from core.metadata_layer import (
+        from metadata_layer import (
             Metadata,
             IdentifierData,
             ReplacementPolicy,

--- a/model/listeners.py
+++ b/model/listeners.py
@@ -17,7 +17,7 @@ from admin import (
 from datasource import DataSource
 from classification import Genre
 from collection import Collection
-from core.config import Configuration
+from config import Configuration
 from configuration import (
     ConfigurationSetting,
     ExternalIntegration,

--- a/model/listeners.py
+++ b/model/listeners.py
@@ -17,7 +17,7 @@ from admin import (
 from datasource import DataSource
 from classification import Genre
 from collection import Collection
-from config import Configuration
+from ..config import Configuration
 from configuration import (
     ConfigurationSetting,
     ExternalIntegration,

--- a/model/patron.py
+++ b/model/patron.py
@@ -24,7 +24,7 @@ from sqlalchemy import (
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
-from core.user_profile import ProfileStorage
+from user_profile import ProfileStorage
 import uuid
 
 class LoanAndHoldMixin(object):

--- a/model/patron.py
+++ b/model/patron.py
@@ -24,7 +24,7 @@ from sqlalchemy import (
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
-from user_profile import ProfileStorage
+from ..user_profile import ProfileStorage
 import uuid
 
 class LoanAndHoldMixin(object):

--- a/model/resource.py
+++ b/model/resource.py
@@ -7,7 +7,7 @@ from . import (
     get_one,
     get_one_or_create,
 )
-from core.config import Configuration
+from config import Configuration
 from constants import (
     DataSourceConstants,
     IdentifierConstants,
@@ -19,7 +19,7 @@ from licensing import (
     LicensePool,
     LicensePoolDeliveryMechanism,
 )
-from core.util.http import HTTP
+from util.http import HTTP
 
 from cStringIO import StringIO
 import datetime

--- a/model/resource.py
+++ b/model/resource.py
@@ -7,7 +7,7 @@ from . import (
     get_one,
     get_one_or_create,
 )
-from config import Configuration
+from ..config import Configuration
 from constants import (
     DataSourceConstants,
     IdentifierConstants,
@@ -19,7 +19,7 @@ from licensing import (
     LicensePool,
     LicensePoolDeliveryMechanism,
 )
-from util.http import HTTP
+from ..util.http import HTTP
 
 from cStringIO import StringIO
 import datetime

--- a/model/work.py
+++ b/model/work.py
@@ -1552,35 +1552,50 @@ class BaseMaterializedWork(object):
     """A mixin class for materialized views that incorporate Work and Edition."""
     pass
 
+
 class MaterializedWorkWithGenre(Base, BaseMaterializedWork):
     p = dict(primary_key=True)
-    # TODO: I think we need to specify every single field here,
-    # because we can't vacuum it up from an existing database schema.
+    # Every field in the materialized view is specified here, in the
+    # same order as the SQL file which creates the view.
     __table__ = Table(
         'mv_works_for_lanes',
         Base.metadata,
         Column('works_id', Integer, **p),
-        Column('workgenres_id', Integer, **p),
-        Column('list_id', Integer, ForeignKey('customlists.id'), **p),
-        Column('list_edition_id', Integer, ForeignKey('editions.id'), **p),
-        Column('genre_id', Integer, ForeignKey('genres.id')),
         Column('editions_id', Integer, ForeignKey('editions.id')),
-        Column('license_pool_id', Integer, ForeignKey('licensepools.id')),
-        Column('simple_opds_entry', Unicode, default=None),
-        Column('collection_id', Integer, ForeignKey('collections.id')),
-        Column('sort_title', Unicode, default=None),
-        Column('sort_author', Unicode, default=None),
-        Column('series_position', Integer),
+        Column('data_source_id', Integer, ForeignKey('datasources.id')),
+        Column('identifier_id', Integer, ForeignKey('identifiers.id')),
+        Column('sort_title', Unicode),
+        Column('permanent_work_id', Unicode),
+        Column('sort_author', Unicode),
         Column('medium', Edition.MEDIUM_ENUM),
         Column('language', Unicode),
-
-        Column('random', Numeric(4,3)),
-        Column('quality', Numeric(4,3)),
+        Column('cover_full_url', Unicode),
+        Column('cover_thumbnail_url', Unicode),
+        Column('series', Unicode),
+        Column('series_position', Integer),
+        Column('name', Unicode), # datasources.name
+        Column('type', Unicode), # identifiers.type
+        Column('identifier', Unicode),
+        Column('workgenres_id', Integer, **p),
+        Column('genre_id', Integer, ForeignKey('genres.id')),
+        Column('affinity', Unicode),
         Column('audience', Unicode),
         Column('target_age', INT4RANGE),
         Column('fiction', Boolean),
-        Column('availability_time', DateTime),
+        Column('quality', Numeric(4,3)),
+        Column('rating', Float),
+        Column('popularity', Float),
+        Column('random', Numeric(4,3)),
         Column('last_update_time', DateTime),
+        Column('simple_opds_entry', Unicode),
+        Column('verbose_opds_entry', Unicode),
+        Column('license_pool_id', Integer, ForeignKey('licensepools.id')),
+        Column('open_access_download_url', Unicode),
+        Column('availability_time', DateTime),
+        Column('collection_id', Integer, ForeignKey('collections.id')),
+        Column('list_id', Integer, ForeignKey('customlists.id'), **p),
+        Column('list_edition_id', Integer, ForeignKey('editions.id'), **p),
+        Column('first_appearance', DateTime),
     )
     license_pool = relationship(
         'LicensePool',

--- a/model/work.py
+++ b/model/work.py
@@ -19,7 +19,7 @@ from contributor import (
     Contribution,
     Contributor,
 )
-from core.classifier import (
+from classifier import (
     Classifier,
     WorkClassifier,
 )
@@ -31,7 +31,7 @@ from datasource import DataSource
 from edition import Edition
 from identifier import Identifier
 from measurement import Measurement
-from core.util import LanguageCodes
+from util import LanguageCodes
 
 from collections import Counter
 import datetime
@@ -1036,7 +1036,7 @@ class Work(Base):
         return u"\n".join(l)
 
     def calculate_opds_entries(self, verbose=True):
-        from core.opds import (
+        from opds import (
             AcquisitionFeed,
             Annotator,
             VerboseAnnotator,

--- a/model/work.py
+++ b/model/work.py
@@ -1554,6 +1554,8 @@ class BaseMaterializedWork(object):
 
 class MaterializedWorkWithGenre(Base, BaseMaterializedWork):
     p = dict(primary_key=True)
+    # TODO: I think we need to specify every single field here,
+    # because we can't vacuum it up from an existing database schema.
     __table__ = Table(
         'mv_works_for_lanes',
         Base.metadata,
@@ -1566,7 +1568,19 @@ class MaterializedWorkWithGenre(Base, BaseMaterializedWork):
         Column('license_pool_id', Integer, ForeignKey('licensepools.id')),
         Column('simple_opds_entry', Unicode, default=None),
         Column('collection_id', Integer, ForeignKey('collections.id')),
-        Column('fiction', Boolean)
+        Column('sort_title', Unicode, default=None),
+        Column('sort_author', Unicode, default=None),
+        Column('series_position', Integer),
+        Column('medium', Edition.MEDIUM_ENUM),
+        Column('language', Unicode),
+
+        Column('random', Numeric(4,3)),
+        Column('quality', Numeric(4,3)),
+        Column('audience', Unicode),
+        Column('target_age', INT4RANGE),
+        Column('fiction', Boolean),
+        Column('availability_time', DateTime),
+        Column('last_update_time', DateTime),
     )
     license_pool = relationship(
         'LicensePool',

--- a/model/work.py
+++ b/model/work.py
@@ -19,7 +19,7 @@ from contributor import (
     Contribution,
     Contributor,
 )
-from classifier import (
+from ..classifier import (
     Classifier,
     WorkClassifier,
 )
@@ -31,7 +31,7 @@ from datasource import DataSource
 from edition import Edition
 from identifier import Identifier
 from measurement import Measurement
-from util import LanguageCodes
+from ..util import LanguageCodes
 
 from collections import Counter
 import datetime
@@ -1037,7 +1037,7 @@ class Work(Base):
         return u"\n".join(l)
 
     def calculate_opds_entries(self, verbose=True):
-        from opds import (
+        from ..opds import (
             AcquisitionFeed,
             Annotator,
             VerboseAnnotator,

--- a/monitor.py
+++ b/monitor.py
@@ -11,7 +11,7 @@ from sqlalchemy.sql.expression import (
 )
 
 import log # This sets the appropriate log format and level.
-from core.config import Configuration
+from config import Configuration
 from coverage import CoverageFailure
 from model import (
     get_one,

--- a/opds.py
+++ b/opds.py
@@ -28,7 +28,7 @@ import requests
 from lxml import builder, etree
 
 from cdn import cdnify
-from core.config import Configuration
+from config import Configuration
 from classifier import Classifier
 from entrypoint import EntryPoint
 from facets import FacetConstants

--- a/opds.py
+++ b/opds.py
@@ -553,7 +553,7 @@ class AcquisitionFeed(OPDSFeed):
 
     FACET_REL = "http://opds-spec.org/facet"
     NO_CACHE = object()
-    DEFAULT_FEED_CACHE_TIME = 600
+    FEED_CACHE_TIME = int(Configuration.get('default_feed_cache_time', 600))
 
     @classmethod
     def groups(cls, _db, title, url, lane, annotator,

--- a/opds.py
+++ b/opds.py
@@ -552,8 +552,8 @@ class VerboseAnnotator(Annotator):
 class AcquisitionFeed(OPDSFeed):
 
     FACET_REL = "http://opds-spec.org/facet"
-    FEED_CACHE_TIME = int(Configuration.get('default_feed_cache_time', 600))
     NO_CACHE = object()
+    DEFAULT_FEED_CACHE_TIME = 600
 
     @classmethod
     def groups(cls, _db, title, url, lane, annotator,

--- a/opds_import.py
+++ b/opds_import.py
@@ -21,7 +21,7 @@ from lxml import builder, etree
 from monitor import CollectionMonitor
 from util import LanguageCodes
 from util.xmlparser import XMLParser
-from core.config import (
+from config import (
     CannotLoadConfiguration,
     Configuration,
     IntegrationException,

--- a/opds_import.py
+++ b/opds_import.py
@@ -36,8 +36,8 @@ from metadata_layer import (
     SubjectData,
     ReplacementPolicy,
 )
+
 from model import (
-    get_one,
     Collection,
     CoverageRecord,
     DataSource,
@@ -49,9 +49,11 @@ from model import (
     LicensePool,
     Measurement,
     Representation,
-    Subject,
     RightsStatus,
+    Subject,
+    get_one,
 )
+
 from coverage import CoverageFailure
 from util.http import (
     BadResponseException,

--- a/overdrive.py
+++ b/overdrive.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm.exc import (
 )
 from sqlalchemy.orm.session import Session
 
-from core.config import (
+from config import (
     temp_config,
     CannotLoadConfiguration,
     Configuration,

--- a/s3.py
+++ b/s3.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm.session import Session
 from urlparse import urlsplit
 from mirror import MirrorUploader
 
-from core.config import CannotLoadConfiguration
+from config import CannotLoadConfiguration
 from model import ExternalIntegration
 from requests.exceptions import (
     ConnectionError,

--- a/scripts.py
+++ b/scripts.py
@@ -173,7 +173,7 @@ class Script(object):
             raise e
 
     def load_configuration(self):
-        if not Configuration.loaded_from_database():
+        if not Configuration.cdns_loaded_from_database():
             Configuration.load(self._db)
 
 

--- a/scripts.py
+++ b/scripts.py
@@ -41,7 +41,7 @@ from sqlalchemy.orm import Session
 
 from app_server import ComplaintController
 # from axis import Axis360BibliographicCoverageProvider
-from core.config import Configuration, CannotLoadConfiguration
+from config import Configuration, CannotLoadConfiguration
 from coverage import CollectionCoverageProviderJob
 from lane import Lane
 from metadata_layer import (

--- a/testing.py
+++ b/testing.py
@@ -69,6 +69,7 @@ def package_setup():
     """Make sure the database schema is initialized and initial
     data is in place.
     """
+    os.environ['TESTING'] = 'true'
 
     # Ensure that the log configuration starts in a known state.
     LogConfiguration.initialize(None, testing=True)
@@ -92,6 +93,12 @@ def package_setup():
     _db.commit()
     connection.close()
     engine.dispose()
+
+
+def package_teardown():
+    if 'TESTING' in os.environ:
+        del os.environ['TESTING']
+
 
 class DatabaseTest(object):
 
@@ -119,7 +126,6 @@ class DatabaseTest(object):
         )
         Configuration.instance[Configuration.INTEGRATIONS][ExternalIntegration.CDN] = {}
 
-        os.environ['TESTING'] = 'true'
 
     @classmethod
     def teardown_class(cls):
@@ -135,8 +141,6 @@ class DatabaseTest(object):
             logging.warn("Cowardly refusing to remove 'temporary' directory %s" % cls.tmp_data_dir)
 
         Configuration.instance[Configuration.DATA_DIRECTORY] = cls.old_data_dir
-        if 'TESTING' in os.environ:
-            del os.environ['TESTING']
 
     def setup(self, mock_search=True):
         # Create a new connection to the database.

--- a/testing.py
+++ b/testing.py
@@ -76,7 +76,7 @@ def package_setup():
 
     engine, connection = DatabaseTest.get_database_connection()
 
-    # First, recreate the schema.
+    # First, drop any existing schema.
     #
     # Base.metadata.drop_all(connection) doesn't work here, so we
     # approximate by dropping everything except the materialized
@@ -85,7 +85,8 @@ def package_setup():
         if not table.name.startswith('mv_'):
             engine.execute(table.delete())
 
-    Base.metadata.create_all(connection)
+    # Recreate the schema.
+    SessionManager.initialize_schema(engine)
 
     # Initialize basic database data needed by the application.
     _db = Session(connection)

--- a/testing.py
+++ b/testing.py
@@ -10,7 +10,7 @@ import tempfile
 import uuid
 from nose.tools import set_trace
 from sqlalchemy.orm.session import Session
-from core.config import Configuration
+from config import Configuration
 
 from lane import (
     Lane,

--- a/testing.py
+++ b/testing.py
@@ -24,33 +24,35 @@ from model import (
     get_one_or_create,
 )
 
-from model.background import CoverageRecord
-from model.classification import Classification
-from model.classification import Genre
-from model.classification import Subject
-from model.collection import Collection
-from model.complaint import Complaint
-from model.configuration import ConfigurationSetting
-from model.configuration import ExternalIntegration
-from model.contributor import Contributor
-from model.credential import Credential
-from model.credential import DelegatedPatronIdentifier
-from model.customlist import CustomList
-from model.datasource import DataSource
-from model.edition import Edition
-from model.identifier import Identifier
-from model.integrationclient import IntegrationClient
-from model.library import Library
-from model.licensing import DeliveryMechanism
-from model.licensing import LicensePool
-from model.licensing import LicensePoolDeliveryMechanism
-from model.licensing import RightsStatus
-from model.patron import Patron
-from model.resource import Hyperlink
-from model.resource import Representation
-from model.resource import Resource
-from model.work import Work
-from model.work import WorkCoverageRecord
+from model import (
+    CoverageRecord,
+    Classification,
+    Collection,
+    Complaint,
+    ConfigurationSetting,
+    Contributor,
+    Credential,
+    CustomList,
+    DataSource,
+    DelegatedPatronIdentifier,
+    DeliveryMechanism,
+    Edition,
+    ExternalIntegration,
+    Genre,
+    Hyperlink,
+    Identifier,
+    IntegrationClient,
+    Library,
+    LicensePool,
+    LicensePoolDeliveryMechanism,
+    Patron,
+    Representation,
+    Resource,
+    RightsStatus,
+    Subject,
+    Work,
+    WorkCoverageRecord,
+)
 
 from classifier import Classifier
 from coverage import (

--- a/testing.py
+++ b/testing.py
@@ -69,6 +69,7 @@ def package_setup():
     """Make sure the database schema is initialized and initial
     data is in place.
     """
+    # This will make sure we always connect to the test database.
     os.environ['TESTING'] = 'true'
 
     # Ensure that the log configuration starts in a known state.
@@ -100,7 +101,6 @@ def package_teardown():
     if 'TESTING' in os.environ:
         del os.environ['TESTING']
 
-
 class DatabaseTest(object):
 
     engine = None
@@ -108,7 +108,7 @@ class DatabaseTest(object):
 
     @classmethod
     def get_database_connection(cls):
-        url = Configuration.database_url(test=True)
+        url = Configuration.database_url()
         engine, connection = SessionManager.initialize(url)
 
         return engine, connection

--- a/testing.py
+++ b/testing.py
@@ -19,37 +19,39 @@ from lane import (
 from model.constants import MediaTypes
 from model import (
     Base,
-    Classification,
-    IntegrationClient,
-    Collection,
-    Complaint,
-    ConfigurationSetting,
-    Contributor,
-    CoverageRecord,
-    Credential,
-    CustomList,
-    DataSource,
-    DeliveryMechanism,
-    DelegatedPatronIdentifier,
-    Edition,
-    ExternalIntegration,
-    Genre,
-    Hyperlink,
-    Identifier,
-    Library,
-    LicensePool,
-    LicensePoolDeliveryMechanism,
-    Patron,
     PresentationCalculationPolicy,
-    Representation,
-    Resource,
-    RightsStatus,
     SessionManager,
-    Subject,
-    Work,
-    WorkCoverageRecord,
     get_one_or_create,
 )
+
+from model.background import CoverageRecord
+from model.classification import Classification
+from model.classification import Genre
+from model.classification import Subject
+from model.collection import Collection
+from model.complaint import Complaint
+from model.configuration import ConfigurationSetting
+from model.configuration import ExternalIntegration
+from model.contributor import Contributor
+from model.credential import Credential
+from model.credential import DelegatedPatronIdentifier
+from model.customlist import CustomList
+from model.datasource import DataSource
+from model.edition import Edition
+from model.identifier import Identifier
+from model.integrationclient import IntegrationClient
+from model.library import Library
+from model.licensing import DeliveryMechanism
+from model.licensing import LicensePool
+from model.licensing import LicensePoolDeliveryMechanism
+from model.licensing import RightsStatus
+from model.patron import Patron
+from model.resource import Hyperlink
+from model.resource import Representation
+from model.resource import Resource
+from model.work import Work
+from model.work import WorkCoverageRecord
+
 from classifier import Classifier
 from coverage import (
     BibliographicCoverageProvider,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,7 +17,13 @@ from testing import (
     DatabaseTest,
     DummyMetadataClient,
     DummyHTTPClient,
-    package_setup
+    package_setup,
+    package_teardown,
 )
 
-package_setup()
+def setup_package():
+    package_setup()
+
+def teardown_package():
+    package_teardown()
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,18 +2,17 @@ import sys
 import os
 from nose.tools import set_trace
 
-# Add the parent directory to the path so that import statements will work
-# the same in tests as in code.
-this_dir = os.path.abspath(os.path.dirname(__file__))
-parent = os.path.split(this_dir)[0]
-sys.path.insert(0, parent)
+# NOTE: Don't be tempted to change sys.path to simplify imports.
+# Those imports will mean something different in circulation and
+# metadata, which will stop the applications that use core from
+# working.
 
 # Having problems with the database not being initialized? This module is
 # being imported twice through two different paths. Uncomment this
 # set_trace() and see where the second one is happening.
 #
 # set_trace()
-from testing import (
+from ..testing import (
     DatabaseTest,
     DummyMetadataClient,
     DummyHTTPClient,

--- a/tests/classifiers/test_age.py
+++ b/tests/classifiers/test_age.py
@@ -2,13 +2,13 @@ from nose.tools import (
     eq_,
     set_trace,
 )
-from classifier import (
+from ...classifier import (
     Classifier,
     AgeOrGradeClassifier,
     LCSHClassifier as LCSH,
 )
 
-from classifier.age import (
+from ...classifier.age import (
     GradeLevelClassifier,
     InterestLevelClassifier,
     AgeClassifier,

--- a/tests/classifiers/test_bic.py
+++ b/tests/classifiers/test_bic.py
@@ -1,7 +1,7 @@
 from nose.tools import eq_, set_trace
-import classifier
-from classifier import *
-from classifier.bic import BICClassifier as BIC
+from ... import classifier
+from ...classifier import *
+from ...classifier.bic import BICClassifier as BIC
 
 class TestBIC(object):
 

--- a/tests/classifiers/test_bisac.py
+++ b/tests/classifiers/test_bisac.py
@@ -4,11 +4,11 @@ from nose.tools import (
     eq_,
     set_trace
 )
-from classifier import (
+from ...classifier import (
     BISACClassifier,
     Classifier,
 )
-from classifier.bisac import (
+from ...classifier.bisac import (
     MatchingRule,
     RE,
     anything,

--- a/tests/classifiers/test_classifier.py
+++ b/tests/classifiers/test_classifier.py
@@ -4,15 +4,15 @@ from nose.tools import eq_, set_trace
 from .. import DatabaseTest
 from collections import Counter
 from psycopg2.extras import NumericRange
-from model import (
+from ...model import (
     Genre,
     DataSource,
     Subject,
     Classification,
 )
 
-import classifier
-from classifier import (
+from ... import classifier
+from ...classifier import (
         Classifier,
         Lowercased,
         WorkClassifier,
@@ -22,18 +22,18 @@ from classifier import (
         GenreData,
     )
 
-from classifier.age import (
+from ...classifier.age import (
     AgeClassifier,
     GradeLevelClassifier,
     InterestLevelClassifier,
 )
-from classifier.ddc import DeweyDecimalClassifier as DDC
-from classifier.keyword import (
+from ...classifier.ddc import DeweyDecimalClassifier as DDC
+from ...classifier.keyword import (
     LCSHClassifier as LCSH,
     FASTClassifier as FAST,
 )
-from classifier.lcc import LCCClassifier as LCC
-from classifier.simplified import SimplifiedGenreClassifier
+from ...classifier.lcc import LCCClassifier as LCC
+from ...classifier.simplified import SimplifiedGenreClassifier
 
 genres = dict()
 GenreData.populate(globals(), genres, fiction_genres, nonfiction_genres)

--- a/tests/classifiers/test_ddc.py
+++ b/tests/classifiers/test_ddc.py
@@ -1,7 +1,7 @@
 from nose.tools import eq_, set_trace
-from classifier.ddc import DeweyDecimalClassifier as DDC
-from classifier import *
-import classifier
+from ...classifier.ddc import DeweyDecimalClassifier as DDC
+from ...classifier import *
+from ... import classifier
 
 class TestDewey(object):
 

--- a/tests/classifiers/test_keyword.py
+++ b/tests/classifiers/test_keyword.py
@@ -1,7 +1,7 @@
 from nose.tools import eq_, set_trace
-import classifier
-from classifier import *
-from classifier.keyword import (
+from ... import classifier
+from ...classifier import *
+from ...classifier.keyword import (
     KeywordBasedClassifier as Keyword,
     LCSHClassifier as LCSH,
     FASTClassifier as FAST,

--- a/tests/classifiers/test_lcc.py
+++ b/tests/classifiers/test_lcc.py
@@ -1,7 +1,7 @@
 from nose.tools import eq_, set_trace
-import classifier
-from classifier import *
-from classifier.lcc import LCCClassifier as LCC
+from ... import classifier
+from ...classifier import *
+from ...classifier.lcc import LCCClassifier as LCC
 
 class TestLCC(object):
 

--- a/tests/classifiers/test_overdrive.py
+++ b/tests/classifiers/test_overdrive.py
@@ -3,8 +3,8 @@ from nose.tools import (
     eq_,
     set_trace,
 )
-from classifier import *
-from classifier.overdrive import OverdriveClassifier as Overdrive
+from ...classifier import *
+from ...classifier.overdrive import OverdriveClassifier as Overdrive
 
 class TestOverdriveClassifier(object):
 

--- a/tests/classifiers/test_rbdigital.py
+++ b/tests/classifiers/test_rbdigital.py
@@ -2,7 +2,7 @@ from nose.tools import (
     eq_,
     set_trace,
 )
-from classifier import (
+from ...classifier import (
     RBDigitalAudienceClassifier,
     RBDigitalSubjectClassifier,
     Classifier,

--- a/tests/classifiers/test_simplified.py
+++ b/tests/classifiers/test_simplified.py
@@ -1,6 +1,6 @@
 from nose.tools import eq_, set_trace
-import classifier
-from classifier import *
+from ... import classifier
+from ...classifier import *
 
 class TestSimplifiedGenreClassifier(object):
 

--- a/tests/models/test_admin.py
+++ b/tests/models/test_admin.py
@@ -5,8 +5,8 @@ from nose.tools import (
     set_trace,
 )
 from .. import DatabaseTest
-from model import create
-from model.admin import (
+from ...model import create
+from ...model.admin import (
     Admin,
     AdminRole,
 )

--- a/tests/models/test_background.py
+++ b/tests/models/test_background.py
@@ -5,13 +5,13 @@ from nose.tools import (
 )
 import datetime
 from .. import DatabaseTest
-from model.background import (
+from ...model.background import (
     BaseCoverageRecord,
     CoverageRecord,
     WorkCoverageRecord,
 )
-from model.datasource import DataSource
-from model.identifier import Identifier
+from ...model.datasource import DataSource
+from ...model.identifier import Identifier
 
 class TestBaseCoverageRecord(DatabaseTest):
 

--- a/tests/models/test_cachedfeed.py
+++ b/tests/models/test_cachedfeed.py
@@ -5,13 +5,13 @@ from nose.tools import (
 )
 import datetime
 from .. import DatabaseTest
-from classifier import Classifier
-from lane import (
+from ...classifier import Classifier
+from ...lane import (
     Facets,
     Pagination,
     WorkList,
 )
-from model.cachedfeed import CachedFeed
+from ...model.cachedfeed import CachedFeed
 
 class TestCachedFeed(DatabaseTest):
 

--- a/tests/models/test_circulationevent.py
+++ b/tests/models/test_circulationevent.py
@@ -5,11 +5,11 @@ from nose.tools import (
 )
 import datetime
 from .. import DatabaseTest
-from model import get_one_or_create
-from model.circulationevent import CirculationEvent
-from model.datasource import DataSource
-from model.identifier import Identifier
-from model.licensing import LicensePool
+from ...model import get_one_or_create
+from ...model.circulationevent import CirculationEvent
+from ...model.datasource import DataSource
+from ...model.identifier import Identifier
+from ...model.licensing import LicensePool
 
 class TestCirculationEvent(DatabaseTest):
 

--- a/tests/models/test_classification.py
+++ b/tests/models/test_classification.py
@@ -8,13 +8,13 @@ from nose.tools import (
 from psycopg2.extras import NumericRange
 from sqlalchemy.exc import IntegrityError
 from .. import DatabaseTest
-from classifier import Classifier
-from model import (
+from ...classifier import Classifier
+from ...model import (
     create,
     get_one,
     get_one_or_create,
 )
-from model.classification import (
+from ...model.classification import (
     Subject,
     Genre,
 )

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -8,21 +8,21 @@ from nose.tools import (
 import base64
 import datetime
 from .. import DatabaseTest
-from model import (
+from ...model import (
     create,
     get_one_or_create,
 )
-from model.background import (
+from ...model.background import (
     CoverageRecord,
     WorkCoverageRecord,
 )
-from model.collection import Collection
-from model.configuration import ExternalIntegration
-from model.customlist import CustomList
-from model.datasource import DataSource
-from model.edition import Edition
-from model.hasfulltablecache import HasFullTableCache
-from model.identifier import Identifier
+from ...model.collection import Collection
+from ...model.configuration import ExternalIntegration
+from ...model.customlist import CustomList
+from ...model.datasource import DataSource
+from ...model.edition import Edition
+from ...model.hasfulltablecache import HasFullTableCache
+from ...model.identifier import Identifier
 
 class TestCollection(DatabaseTest):
 

--- a/tests/models/test_complaint.py
+++ b/tests/models/test_complaint.py
@@ -6,7 +6,7 @@ from nose.tools import (
 )
 import datetime
 from .. import DatabaseTest
-from model.complaint import Complaint
+from ...model.complaint import Complaint
 
 class TestComplaint(DatabaseTest):
 

--- a/tests/models/test_configuration.py
+++ b/tests/models/test_configuration.py
@@ -7,14 +7,14 @@ from nose.tools import (
 )
 from sqlalchemy.exc import IntegrityError
 from .. import DatabaseTest
-from config import CannotLoadConfiguration
-from model import create
-from model.collection import Collection
-from model.configuration import (
+from ...config import CannotLoadConfiguration
+from ...model import create
+from ...model.collection import Collection
+from ...model.configuration import (
     ConfigurationSetting,
     ExternalIntegration,
 )
-from model.datasource import DataSource
+from ...model.datasource import DataSource
 
 class TestConfigurationSetting(DatabaseTest):
 

--- a/tests/models/test_configuration.py
+++ b/tests/models/test_configuration.py
@@ -7,7 +7,7 @@ from nose.tools import (
 )
 from sqlalchemy.exc import IntegrityError
 from .. import DatabaseTest
-from core.config import CannotLoadConfiguration
+from config import CannotLoadConfiguration
 from model import create
 from model.collection import Collection
 from model.configuration import (

--- a/tests/models/test_contributor.py
+++ b/tests/models/test_contributor.py
@@ -4,11 +4,11 @@ from nose.tools import (
     set_trace,
 )
 from .. import DatabaseTest
-from model import get_one_or_create
-from model.contributor import Contributor
-from model.datasource import DataSource
-from model.edition import Edition
-from model.identifier import Identifier
+from ...model import get_one_or_create
+from ...model.contributor import Contributor
+from ...model.datasource import DataSource
+from ...model.edition import Edition
+from ...model.identifier import Identifier
 
 class TestContributor(DatabaseTest):
 

--- a/tests/models/test_credential.py
+++ b/tests/models/test_credential.py
@@ -5,12 +5,12 @@ from nose.tools import (
 )
 import datetime
 from .. import DatabaseTest
-from model.credential import (
+from ...model.credential import (
     Credential,
     DelegatedPatronIdentifier,
     DRMDeviceIdentifier,
 )
-from model.datasource import DataSource
+from ...model.datasource import DataSource
 
 class TestCredentials(DatabaseTest):
 

--- a/tests/models/test_customlist.py
+++ b/tests/models/test_customlist.py
@@ -6,13 +6,13 @@ from nose.tools import (
 )
 import datetime
 from .. import DatabaseTest
-from model import get_one_or_create
-from model.background import WorkCoverageRecord
-from model.customlist import (
+from ...model import get_one_or_create
+from ...model.background import WorkCoverageRecord
+from ...model.customlist import (
     CustomList,
     CustomListEntry,
 )
-from model.datasource import DataSource
+from ...model.datasource import DataSource
 
 class TestCustomList(DatabaseTest):
 

--- a/tests/models/test_datasource.py
+++ b/tests/models/test_datasource.py
@@ -6,9 +6,9 @@ from nose.tools import (
 )
 from sqlalchemy.orm.exc import NoResultFound
 from .. import DatabaseTest
-from model.datasource import DataSource
-from model.hasfulltablecache import HasFullTableCache
-from model.identifier import Identifier
+from ...model.datasource import DataSource
+from ...model.hasfulltablecache import HasFullTableCache
+from ...model.identifier import Identifier
 
 class TestDataSource(DatabaseTest):
 

--- a/tests/models/test_edition.py
+++ b/tests/models/test_edition.py
@@ -6,13 +6,13 @@ from nose.tools import (
 )
 import datetime
 from .. import DatabaseTest
-from model import get_one_or_create
-from model.background import CoverageRecord
-from model.contributor import Contributor
-from model.datasource import DataSource
-from model.edition import Edition
-from model.identifier import Identifier
-from model.resource import (
+from ...model import get_one_or_create
+from ...model.background import CoverageRecord
+from ...model.contributor import Contributor
+from ...model.datasource import DataSource
+from ...model.edition import Edition
+from ...model.identifier import Identifier
+from ...model.resource import (
     Hyperlink,
     Representation,
 )

--- a/tests/models/test_hasfulltablecache.py
+++ b/tests/models/test_hasfulltablecache.py
@@ -4,7 +4,7 @@ from nose.tools import (
     set_trace,
 )
 from .. import DatabaseTest
-from model.hasfulltablecache import HasFullTableCache
+from ...model.hasfulltablecache import HasFullTableCache
 
 class MockHasTableCache(HasFullTableCache):
 

--- a/tests/models/test_identifier.py
+++ b/tests/models/test_identifier.py
@@ -9,10 +9,10 @@ import datetime
 import feedparser
 from lxml import etree
 from .. import DatabaseTest
-from model.datasource import DataSource
-from model.edition import Edition
-from model.identifier import Identifier
-from model.resource import (
+from ...model.datasource import DataSource
+from ...model.edition import Edition
+from ...model.identifier import Identifier
+from ...model.resource import (
     Hyperlink,
     Representation,
 )

--- a/tests/models/test_integrationclient.py
+++ b/tests/models/test_integrationclient.py
@@ -6,7 +6,7 @@ from nose.tools import (
 )
 import datetime
 from .. import DatabaseTest
-from model.integrationclient import IntegrationClient
+from ...model.integrationclient import IntegrationClient
 
 class TestIntegrationClient(DatabaseTest):
 

--- a/tests/models/test_library.py
+++ b/tests/models/test_library.py
@@ -6,9 +6,9 @@ from nose.tools import (
     set_trace,
 )
 from .. import DatabaseTest
-from model.configuration import ConfigurationSetting
-from model.hasfulltablecache import HasFullTableCache
-from model.library import Library
+from ...model.configuration import ConfigurationSetting
+from ...model.hasfulltablecache import HasFullTableCache
+from ...model.library import Library
 
 class TestLibrary(DatabaseTest):
 

--- a/tests/models/test_licensing.py
+++ b/tests/models/test_licensing.py
@@ -7,24 +7,24 @@ from nose.tools import (
     set_trace,
 )
 import datetime
-from mock_analytics_provider import MockAnalyticsProvider
+from ...mock_analytics_provider import MockAnalyticsProvider
 from sqlalchemy.exc import IntegrityError
 from .. import DatabaseTest
-from model import create
-from model.circulationevent import CirculationEvent
-from model.collection import CollectionMissing
-from model.complaint import Complaint
-from model.contributor import Contributor
-from model.datasource import DataSource
-from model.edition import Edition
-from model.identifier import Identifier
-from model.licensing import (
+from ...model import create
+from ...model.circulationevent import CirculationEvent
+from ...model.collection import CollectionMissing
+from ...model.complaint import Complaint
+from ...model.contributor import Contributor
+from ...model.datasource import DataSource
+from ...model.edition import Edition
+from ...model.identifier import Identifier
+from ...model.licensing import (
     DeliveryMechanism,
     LicensePool,
     LicensePoolDeliveryMechanism,
     RightsStatus,
 )
-from model.resource import (
+from ...model.resource import (
     Hyperlink,
     Representation,
 )

--- a/tests/models/test_listeners.py
+++ b/tests/models/test_listeners.py
@@ -6,7 +6,7 @@ from nose.tools import (
 import datetime
 
 from .. import DatabaseTest
-from core.config import Configuration
+from config import Configuration
 import lane
 import model
 from model import (

--- a/tests/models/test_listeners.py
+++ b/tests/models/test_listeners.py
@@ -6,10 +6,10 @@ from nose.tools import (
 import datetime
 
 from .. import DatabaseTest
-from config import Configuration
-import lane
-import model
-from model import (
+from ...config import Configuration
+from ... import lane
+from ... import model
+from ...model import (
     CachedFeed,
     ConfigurationSetting,
     create,

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm.exc import MultipleResultsFound
 
 from .. import DatabaseTest
 import classifier
-from core.config import Configuration
+from config import Configuration
 import model
 from model import (
     DataSource,

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -10,10 +10,9 @@ from sqlalchemy import not_
 from sqlalchemy.orm.exc import MultipleResultsFound
 
 from .. import DatabaseTest
-import classifier
-from config import Configuration
-import model
-from model import (
+from ... import classifier
+from ...config import Configuration
+from ...model import (
     DataSource,
     Edition,
     Genre,
@@ -33,7 +32,7 @@ class TestSessionManager(DatabaseTest):
         fiction = self._lane(display_name="Fiction", fiction=True)
         nonfiction = self._lane(display_name="Nonfiction", fiction=False)
 
-        from model import MaterializedWorkWithGenre as mwg
+        from ...model import MaterializedWorkWithGenre as mwg
 
         # There are no items in the materialized views.
         eq_([], self._db.query(mwg).all())
@@ -118,7 +117,7 @@ class TestMaterializedViews(DatabaseTest):
         # Make sure the Work shows up in the materialized view.
         SessionManager.refresh_materialized_views(self._db)
 
-        from model import MaterializedWorkWithGenre as mwgc
+        from ...model import MaterializedWorkWithGenre as mwgc
         [mwg] = self._db.query(mwgc).all()
 
         eq_(pool1.id, mwg.license_pool_id)
@@ -173,7 +172,7 @@ class TestMaterializedViews(DatabaseTest):
 
         SessionManager.refresh_materialized_views(self._db)
 
-        from model import MaterializedWorkWithGenre as mwgc
+        from ...model import MaterializedWorkWithGenre as mwgc
         [mwg] = self._db.query(mwgc).all()
 
         # We would expect the data source to be Gutenberg, since
@@ -215,7 +214,7 @@ class TestMaterializedViews(DatabaseTest):
         # The materialized view can handle this revelation
         # and stores the two list entries in different rows.
         SessionManager.refresh_materialized_views(self._db)
-        from model import MaterializedWorkWithGenre as mw
+        from ...model import MaterializedWorkWithGenre as mw
         [o1, o2] = self._db.query(mw).order_by(mw.list_edition_id)
 
         # Both MaterializedWorkWithGenre objects are on the same

--- a/tests/models/test_patron.py
+++ b/tests/models/test_patron.py
@@ -7,11 +7,11 @@ from nose.tools import (
 )
 import datetime
 from .. import DatabaseTest
-from model import create
-from model.datasource import DataSource
-from model.library import Library
-from model.licensing import PolicyException
-from model.patron import (
+from ...model import create
+from ...model.datasource import DataSource
+from ...model.library import Library
+from ...model.licensing import PolicyException
+from ...model.patron import (
     Annotation,
     Hold,
     PatronProfileStorage,

--- a/tests/models/test_resource.py
+++ b/tests/models/test_resource.py
@@ -9,17 +9,17 @@ from .. import (
     DatabaseTest,
     DummyHTTPClient,
 )
-from model import create
-from model.datasource import DataSource
-from model.edition import Edition
-from model.identifier import Identifier
-from model.licensing import RightsStatus
-from model.resource import (
+from ...model import create
+from ...model.datasource import DataSource
+from ...model.edition import Edition
+from ...model.identifier import Identifier
+from ...model.licensing import RightsStatus
+from ...model.resource import (
     Hyperlink,
     Representation,
     Resource,
 )
-from testing import MockRequestsResponse
+from ...testing import MockRequestsResponse
 
 class TestHyperlink(DatabaseTest):
 

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -5,34 +5,34 @@ from nose.tools import (
     set_trace,
 )
 import datetime
-from external_search import DummyExternalSearchIndex
+from ...external_search import DummyExternalSearchIndex
 import os
 from psycopg2.extras import NumericRange
 import random
 from .. import DatabaseTest
-from classifier import (
+from ...classifier import (
     Classifier,
     Fantasy,
     Romance,
     Science_Fiction,
 )
-from model import get_one_or_create
-from model.background import WorkCoverageRecord
-from model.classification import (
+from ...model import get_one_or_create
+from ...model.background import WorkCoverageRecord
+from ...model.classification import (
     Genre,
     Subject,
 )
-from model.complaint import Complaint
-from model.contributor import Contributor
-from model.datasource import DataSource
-from model.edition import Edition
-from model.identifier import Identifier
-from model.licensing import LicensePool
-from model.resource import (
+from ...model.complaint import Complaint
+from ...model.contributor import Contributor
+from ...model.datasource import DataSource
+from ...model.edition import Edition
+from ...model.identifier import Identifier
+from ...model.licensing import LicensePool
+from ...model.resource import (
     Hyperlink,
     Representation,
 )
-from model.work import (
+from ...model.work import (
     Work,
     WorkGenre,
 )
@@ -136,7 +136,7 @@ class TestWork(DatabaseTest):
         # It's possible to filter a field other than Identifier.id.
         # Here, we filter based on the value of
         # mv_works_for_lanes.identifier_id.
-        from model import MaterializedWorkWithGenre as mw
+        from ...model import MaterializedWorkWithGenre as mw
         qu = self._db.query(mw)
         m = lambda: Work.from_identifiers(
             self._db, [lp.identifier], base_query=qu,

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -2,15 +2,15 @@ from nose.tools import (
     eq_,
     set_trace,
 )
-from config import (
+from ..config import (
     Configuration,
     temp_config,
 )
-from analytics import Analytics
-from mock_analytics_provider import MockAnalyticsProvider
-from local_analytics_provider import LocalAnalyticsProvider
+from ..analytics import Analytics
+from ..mock_analytics_provider import MockAnalyticsProvider
+from ..local_analytics_provider import LocalAnalyticsProvider
 from . import DatabaseTest
-from model import (
+from ..model import (
     CirculationEvent,
     ExternalIntegration,
     Library,

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -2,7 +2,7 @@ from nose.tools import (
     eq_,
     set_trace,
 )
-from core.config import (
+from config import (
     Configuration,
     temp_config,
 )

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -77,7 +77,7 @@ class TestHeartbeatController(object):
 
         # Create a mock configuration object to test with.
         class MockConfiguration(Configuration):
-            _instance = dict()
+            instance = dict()
 
         with app.test_request_context('/'):
             response = controller.heartbeat(conf_class=MockConfiguration)

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -37,7 +37,7 @@ from app_server import (
     load_pagination_from_request,
 )
 
-from core.config import Configuration
+from config import Configuration
 
 from entrypoint import (
     AudiobooksEntryPoint,

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -18,17 +18,17 @@ from . import (
     DatabaseTest,
 )
 
-from opds import TestAnnotator
+from ..opds import TestAnnotator
 
-from model import Identifier
+from ..model import Identifier
 
-from lane import (
+from ..lane import (
     Facets,
     Pagination,
     WorkList,
 )
 
-from app_server import (
+from ..app_server import (
     HeartbeatController,
     URNLookupController,
     ErrorHandler,
@@ -37,20 +37,20 @@ from app_server import (
     load_pagination_from_request,
 )
 
-from config import Configuration
+from ..config import Configuration
 
-from entrypoint import (
+from ..entrypoint import (
     AudiobooksEntryPoint,
     EbooksEntryPoint,
     EntryPoint,
 )
 
-from problem_details import (
+from ..problem_details import (
     INVALID_INPUT,
     INVALID_URN,
 )
 
-from util.opds_writer import (
+from ..util.opds_writer import (
     OPDSFeed,
     OPDSMessage,
 )

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -77,7 +77,7 @@ class TestHeartbeatController(object):
 
         # Create a mock configuration object to test with.
         class MockConfiguration(Configuration):
-            instance = dict()
+            _instance = dict()
 
         with app.test_request_context('/'):
             response = controller.heartbeat(conf_class=MockConfiguration)

--- a/tests/test_appeal.py
+++ b/tests/test_appeal.py
@@ -13,7 +13,7 @@ from . import (
     DatabaseTest,
 )
 
-from model import (
+from ..model import (
     Work,
 )
 

--- a/tests/test_authentication_for_opds.py
+++ b/tests/test_authentication_for_opds.py
@@ -4,7 +4,7 @@ from nose.tools import (
     assert_raises_regexp,
     set_trace,
 )
-from util.authentication_for_opds import (
+from ..util.authentication_for_opds import (
     AuthenticationForOPDSDocument as Doc,
     OPDSAuthenticationFlow as Flow,
 )

--- a/tests/test_cachedfeed.py
+++ b/tests/test_cachedfeed.py
@@ -5,25 +5,25 @@ from nose.tools import (
     set_trace,
 )
 
-from config import (
+from ..config import (
     Configuration,
     temp_config,
 )
 
-from model import (
+from ..model import (
     get_one_or_create,
     CachedFeed,
     WillNotGenerateExpensiveFeed,
 )
 
-from lane import (
+from ..lane import (
     Lane,
     Pagination,
     Facets,
     WorkList,
 )
 
-from opds import AcquisitionFeed
+from ..opds import AcquisitionFeed
 
 from . import (
     DatabaseTest

--- a/tests/test_cachedfeed.py
+++ b/tests/test_cachedfeed.py
@@ -5,7 +5,7 @@ from nose.tools import (
     set_trace,
 )
 
-from core.config import (
+from config import (
     Configuration,
     temp_config,
 )

--- a/tests/test_cdn.py
+++ b/tests/test_cdn.py
@@ -5,9 +5,9 @@ from nose.tools import (
 )
 from . import DatabaseTest
 
-from config import Configuration, temp_config
-from model import ExternalIntegration
-from cdn import cdnify
+from ..config import Configuration, temp_config
+from ..model import ExternalIntegration
+from ..cdn import cdnify
 
 
 class TestCDN(DatabaseTest):

--- a/tests/test_cdn.py
+++ b/tests/test_cdn.py
@@ -5,7 +5,7 @@ from nose.tools import (
 )
 from . import DatabaseTest
 
-from core.config import Configuration, temp_config
+from config import Configuration, temp_config
 from model import ExternalIntegration
 from cdn import cdnify
 

--- a/tests/test_cdn.py
+++ b/tests/test_cdn.py
@@ -19,11 +19,12 @@ class TestCDN(DatabaseTest):
         cdns = cdns or {}
         with temp_config() as config:
             config[Configuration.INTEGRATIONS][ExternalIntegration.CDN] = cdns
+            config[Configuration.CDNS_LOADED_FROM_DATABASE] = True
             eq_(expect, cdnify(url))
 
     def test_no_cdns(self):
         url = "http://foo/"
-        self.unchanged(url, Configuration.UNINITIALIZED_CDNS)
+        self.unchanged(url, {})
 
     def test_non_matching_cdn(self):
         url = "http://foo.com/bar"

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -7,7 +7,7 @@ from nose.tools import (
 from copy import deepcopy
 import datetime
 
-from metadata_layer import (
+from ..metadata_layer import (
     CirculationData,
     ContributorData,
     FormatData,
@@ -18,7 +18,7 @@ from metadata_layer import (
     SubjectData,
 )
 
-from model import (
+from ..model import (
     Collection,
     DataSource,
     DeliveryMechanism,
@@ -34,7 +34,7 @@ from . import (
     DummyHTTPClient,
 )
 
-from s3 import MockS3Uploader
+from ..s3 import MockS3Uploader
 
 
 class TestCirculationData(DatabaseTest):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,7 +29,7 @@ class TestConfiguration(DatabaseTest):
             f.write(content)
 
     def test_app_version(self):
-        self.Conf.instance = dict()
+        self.Conf._instance = dict()
 
         # Without a .version file, the key is set to a null object.
         result = self.Conf.app_version()
@@ -41,7 +41,7 @@ class TestConfiguration(DatabaseTest):
         )
 
         # An empty .version file yields the same results.
-        self.Conf.instance = dict()
+        self.Conf._instance = dict()
         self.create_version_file(' \n')
         result = self.Conf.app_version()
         eq_(self.Conf.NO_APP_VERSION_FOUND, result)
@@ -51,7 +51,7 @@ class TestConfiguration(DatabaseTest):
         )
 
         # A .version file with content loads the content.
-        self.Conf.instance = dict()
+        self.Conf._instance = dict()
         self.create_version_file('ba.na.na')
         result = self.Conf.app_version()
         eq_('ba.na.na', result)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,14 @@
 import os
 from nose.tools import eq_, set_trace
+from sqlalchemy.orm.session import Session
 
 from testing import DatabaseTest
 
 from config import Configuration as BaseConfiguration
-from model import ConfigurationSetting
+from model import (
+    ConfigurationSetting,
+    ExternalIntegration,
+)
 
 
 # Create a configuration object that the tests can run against without
@@ -29,7 +33,7 @@ class TestConfiguration(DatabaseTest):
             f.write(content)
 
     def test_app_version(self):
-        self.Conf._instance = dict()
+        self.Conf.instance = dict()
 
         # Without a .version file, the key is set to a null object.
         result = self.Conf.app_version()
@@ -41,7 +45,7 @@ class TestConfiguration(DatabaseTest):
         )
 
         # An empty .version file yields the same results.
-        self.Conf._instance = dict()
+        self.Conf.instance = dict()
         self.create_version_file(' \n')
         result = self.Conf.app_version()
         eq_(self.Conf.NO_APP_VERSION_FOUND, result)
@@ -51,8 +55,50 @@ class TestConfiguration(DatabaseTest):
         )
 
         # A .version file with content loads the content.
-        self.Conf._instance = dict()
+        self.Conf.instance = dict()
         self.create_version_file('ba.na.na')
         result = self.Conf.app_version()
         eq_('ba.na.na', result)
         eq_('ba.na.na', self.Conf.get(self.Conf.APP_VERSION))
+
+    def test_load_cdns(self):
+        """Test our ability to load CDN configuration from the database.
+        """
+        self._external_integration(
+            protocol=ExternalIntegration.CDN,
+            goal=ExternalIntegration.CDN_GOAL,
+            settings = { self.Conf.CDN_MIRRORED_DOMAIN_KEY : "site.com",
+                         ExternalIntegration.URL : "http://cdn/" }
+        )
+
+        self.Conf.load_cdns(self._db)
+
+        integrations = self.Conf.instance[self.Conf.INTEGRATIONS]
+        eq_({'site.com' : 'http://cdn/'}, integrations[ExternalIntegration.CDN])
+        eq_(True, self.Conf.instance[self.Conf.CDNS_LOADED_FROM_DATABASE])
+
+    def test_cdns_loaded_dynamically(self):
+        # When you call cdns() on a Configuration object that was
+        # never initialized, it creates a new database connection and
+        # loads CDN configuration from the database. This lets
+        # us avoid having to have a database connection handy to pass into
+        # cdns().
+        #
+        # We can't do an end-to-end test, because any changes we
+        # commit won't show up in the new connection (this test is
+        # running inside a transaction that will be rolled back).
+        #
+        # But we can verify that load_cdns is called with a new
+        # database connection.
+        class Mock(MockConfiguration):
+            @classmethod
+            def load_cdns(cls, _db, config_instance=None):
+                cls.called_with = (_db, config_instance)
+
+        cdns = Mock.cdns()
+        eq_({}, cdns)
+
+        new_db, none = Mock.called_with
+        assert new_db != self._db
+        assert isinstance(new_db, Session)
+        eq_(None, none)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,10 +2,10 @@ import os
 from nose.tools import eq_, set_trace
 from sqlalchemy.orm.session import Session
 
-from testing import DatabaseTest
+from ..testing import DatabaseTest
 
-from config import Configuration as BaseConfiguration
-from model import (
+from ..config import Configuration as BaseConfiguration
+from ..model import (
     ConfigurationSetting,
     ExternalIntegration,
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ from nose.tools import eq_, set_trace
 
 from testing import DatabaseTest
 
-from core.config import Configuration as BaseConfiguration
+from config import Configuration as BaseConfiguration
 from model import ConfigurationSetting
 
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -8,7 +8,7 @@ from nose.tools import (
 from . import (
     DatabaseTest
 )
-from testing import (
+from ..testing import (
     AlwaysSuccessfulBibliographicCoverageProvider,
     AlwaysSuccessfulCollectionCoverageProvider,
     AlwaysSuccessfulCoverageProvider,
@@ -21,7 +21,7 @@ from testing import (
     TransientFailureCoverageProvider,
     TransientFailureWorkCoverageProvider,
 )
-from model import (
+from ..model import (
     Collection,
     CollectionMissing,
     Contributor,
@@ -40,7 +40,7 @@ from model import (
     Work,
     WorkCoverageRecord,
 )
-from metadata_layer import (
+from ..metadata_layer import (
     Metadata,
     CirculationData,
     FormatData,
@@ -50,8 +50,8 @@ from metadata_layer import (
     ReplacementPolicy,
     SubjectData,
 )
-from s3 import MockS3Uploader
-from coverage import (
+from ..s3 import MockS3Uploader
+from ..coverage import (
     BaseCoverageProvider,
     BibliographicCoverageProvider,
     CatalogCoverageProvider,

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,14 +1,14 @@
-from testing import DatabaseTest
+from ..testing import DatabaseTest
 import json
 from nose.tools import (
     assert_raises_regexp,
     eq_,
     set_trace,
 )
-from model import (
+from ..model import (
     Edition,
 )
-from entrypoint import (
+from ..entrypoint import (
     EntryPoint,
     EbooksEntryPoint,
     EverythingEntryPoint,
@@ -106,7 +106,7 @@ class TestMediumEntryPoint(DatabaseTest):
         class Videos(MediumEntryPoint):
             INTERNAL_NAME = Edition.VIDEO_MEDIUM
 
-        from model import MaterializedWorkWithGenre
+        from ..model import MaterializedWorkWithGenre
         qu = self._db.query(MaterializedWorkWithGenre)
 
         # The default entry points filter out the video.

--- a/tests/test_equivalency.py
+++ b/tests/test_equivalency.py
@@ -4,7 +4,7 @@ from nose.tools import (
     set_trace,
 )
 
-from model import (
+from ..model import (
     CirculationEvent,
     DataSource,
     get_one_or_create,

--- a/tests/test_external_list.py
+++ b/tests/test_external_list.py
@@ -12,13 +12,13 @@ from . import (
     DummyMetadataClient,
 )
 
-from model import (
+from ..model import (
     DataSource,
     Edition,
     Identifier,
     Subject,
 )
-from external_list import (
+from ..external_list import (
     CustomListFromCSV,
     MembershipManager,
     ClassificationBasedMembershipManager,

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -14,7 +14,7 @@ from . import (
 
 from elasticsearch.exceptions import ElasticsearchException
 
-from core.config import CannotLoadConfiguration
+from config import CannotLoadConfiguration
 from lane import Lane
 from model import (
     Edition,

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -14,21 +14,21 @@ from . import (
 
 from elasticsearch.exceptions import ElasticsearchException
 
-from config import CannotLoadConfiguration
-from lane import Lane
-from model import (
+from ..config import CannotLoadConfiguration
+from ..lane import Lane
+from ..model import (
     Edition,
     ExternalIntegration,
     WorkCoverageRecord,
 )
-from external_search import (
+from ..external_search import (
     ExternalSearchIndex,
     ExternalSearchIndexVersions,
     DummyExternalSearchIndex,
     SearchIndexCoverageProvider,
     SearchIndexMonitor,
 )
-from classifier import Classifier
+from ..classifier import Classifier
 
 
 class ExternalSearchTest(DatabaseTest):

--- a/tests/test_facets.py
+++ b/tests/test_facets.py
@@ -5,7 +5,7 @@ from nose.tools import (
 
 from . import DatabaseTest
 
-from facets import (
+from ..facets import (
     FacetConstants as Facets,
     FacetConfig,
 )

--- a/tests/test_local_analytics_provider.py
+++ b/tests/test_local_analytics_provider.py
@@ -2,9 +2,9 @@ from nose.tools import (
     assert_raises_regexp,
     eq_,
 )
-from local_analytics_provider import LocalAnalyticsProvider
 from . import DatabaseTest
-from model import (
+from ..local_analytics_provider import LocalAnalyticsProvider
+from ..model import (
     CirculationEvent,
     ExternalIntegration,
     create,

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -9,7 +9,7 @@ from nose.tools import (
 )
 
 from . import DatabaseTest
-from log import (
+from ..log import (
     UTF8Formatter,
     JSONFormatter,
     LogglyHandler,
@@ -18,11 +18,11 @@ from log import (
     Loggly,
     Logger
 )
-from model import (
+from ..model import (
     ExternalIntegration,
     ConfigurationSetting
 )
-from config import Configuration
+from ..config import Configuration
 
 class TestJSONFormatter(object):
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -22,7 +22,7 @@ from model import (
     ExternalIntegration,
     ConfigurationSetting
 )
-from core.config import Configuration
+from config import Configuration
 
 class TestJSONFormatter(object):
 

--- a/tests/test_measurement.py
+++ b/tests/test_measurement.py
@@ -6,7 +6,7 @@ from nose.tools import (
     set_trace,
 )
 
-from model import (
+from ..model import (
     DataSource,
     Measurement,
     get_one_or_create

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -8,8 +8,8 @@ import pkgutil
 import csv
 from copy import deepcopy
 
-from classifier import Classifier
-from metadata_layer import (
+from ..classifier import Classifier
+from ..metadata_layer import (
     CSVFormatError,
     CSVMetadataImporter,
     CirculationData,
@@ -26,7 +26,7 @@ from metadata_layer import (
 )
 
 import os
-from model import (
+from ..model import (
     Contributor,
     CoverageRecord,
     DataSource,
@@ -46,8 +46,8 @@ from . import (
     DummyMetadataClient,
 )
 
-from s3 import MockS3Uploader
-from classifier import NO_VALUE, NO_NUMBER
+from ..s3 import MockS3Uploader
+from ..classifier import NO_VALUE, NO_NUMBER
 
 class TestIdentifierData(object):
 

--- a/tests/test_mirror_uploader.py
+++ b/tests/test_mirror_uploader.py
@@ -4,9 +4,9 @@ from nose.tools import (
     assert_raises_regexp,
 )
 from . import DatabaseTest
-from config import CannotLoadConfiguration
-from mirror import MirrorUploader
-from model import ExternalIntegration
+from ..config import CannotLoadConfiguration
+from ..mirror import MirrorUploader
+from ..model import ExternalIntegration
 
 class DummySuccessUploader(MirrorUploader):
 

--- a/tests/test_mirror_uploader.py
+++ b/tests/test_mirror_uploader.py
@@ -4,7 +4,7 @@ from nose.tools import (
     assert_raises_regexp,
 )
 from . import DatabaseTest
-from core.config import CannotLoadConfiguration
+from config import CannotLoadConfiguration
 from mirror import MirrorUploader
 from model import ExternalIntegration
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -8,27 +8,27 @@ import datetime
 
 from . import DatabaseTest
 
-from testing import (
+from ..testing import (
     AlwaysSuccessfulCoverageProvider,
     NeverSuccessfulCoverageProvider,
     BrokenCoverageProvider,
 )
 
-from model import (
+from ..model import (
     CachedFeed,
+    Subject,
     Collection,
     CollectionMissing,
     Credential,
     DataSource,
     ExternalIntegration,
     Identifier,
-    Subject,
     Timestamp,
     Work,
     WorkCoverageRecord,
 )
 
-from monitor import (
+from ..monitor import (
     CachedFeedReaper,
     CollectionMonitor,
     CoverageProvidersFailed,

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -14,7 +14,7 @@ from . import (
 )
 
 from psycopg2.extras import NumericRange
-from core.config import (
+from config import (
     Configuration,
     temp_config,
 )

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -14,19 +14,18 @@ from . import (
 )
 
 from psycopg2.extras import NumericRange
-from config import (
+from ..config import (
     Configuration,
     temp_config,
 )
-from entrypoint import (
+from ..entrypoint import (
     AudiobooksEntryPoint,
     EbooksEntryPoint,
     EntryPoint,
     EverythingEntryPoint,
 )
-from facets import FacetConstants
-import model
-from model import (
+from ..facets import FacetConstants
+from ..model import (
     CachedFeed,
     ConfigurationSetting,
     Contributor,
@@ -34,6 +33,7 @@ from model import (
     DeliveryMechanism,
     ExternalIntegration,
     Genre,
+    MaterializedWorkWithGenre,
     Measurement,
     Representation,
     SessionManager,
@@ -41,10 +41,9 @@ from model import (
     Work,
     get_one,
 )
+from ..facets import FacetConstants
 
-from facets import FacetConstants
-
-from lane import (
+from ..lane import (
     Facets,
     FeaturedFacets,
     Lane,
@@ -53,7 +52,7 @@ from lane import (
     WorkList,
 )
 
-from opds import (
+from ..opds import (
     AcquisitionFeed,
     Annotator,
     LookupAcquisitionFeed,
@@ -65,14 +64,14 @@ from opds import (
     TestUnfulfillableAnnotator
 )
 
-from util.opds_writer import (
+from ..util.opds_writer import (
     AtomFeed,
     OPDSFeed,
     OPDSMessage,
 )
-from opds_import import OPDSXMLParser
+from ..opds_import import OPDSXMLParser
 
-from classifier import (
+from ..classifier import (
     Classifier,
     Contemporary_Romance,
     Epic_Fantasy,
@@ -82,7 +81,7 @@ from classifier import (
     Mystery,
 )
 
-from external_search import DummyExternalSearchIndex
+from ..external_search import DummyExternalSearchIndex
 import xml.etree.ElementTree as ET
 from flask_babel import lazy_gettext as _
 
@@ -543,7 +542,6 @@ class TestOPDS(DatabaseTest):
         # Verify that the same group_uri is created whether a Work or
         # a MaterializedWorkWithGenre is passed in.
         self.add_to_materialized_view([work])
-        from model import MaterializedWorkWithGenre
         [mw] = self._db.query(MaterializedWorkWithGenre).all()
 
         mw_uri, mw_title = annotator.group_uri(mw, lp, lp.identifier)
@@ -943,6 +941,7 @@ class TestOPDS(DatabaseTest):
                 'thumbnail.com' : 'http://foo/',
                 'full.com' : 'http://bar/'
             }
+            config[Configuration.CDNS_LOADED_FROM_DATABASE] = True
             work.calculate_opds_entries(verbose=False)
 
         feed = feedparser.parse(work.simple_opds_entry)

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -19,11 +19,11 @@ from . import (
     DatabaseTest,
 )
 
-from config import (
+from ..config import (
     CannotLoadConfiguration,
     IntegrationException,
 )
-from opds_import import (
+from ..opds_import import (
     AccessNotAuthenticated,
     MetadataWranglerOPDSLookup,
     OPDSImporter,
@@ -31,17 +31,17 @@ from opds_import import (
     OPDSXMLParser,
     SimplifiedOPDSLookup,
 )
-from util.opds_writer import (
+from ..util.opds_writer import (
     AtomFeed,
     OPDSFeed,
     OPDSMessage,
 )
-from metadata_layer import (
+from ..metadata_layer import (
     LinkData,
     CirculationData,
     Metadata,
 )
-from model import (
+from ..model import (
     Collection,
     Contributor,
     CoverageRecord,
@@ -57,14 +57,14 @@ from model import (
     Subject,
     Work,
 )
-from coverage import CoverageFailure
+from ..coverage import CoverageFailure
 
-from s3 import (
+from ..s3 import (
     S3Uploader,
     MockS3Uploader,
 )
-from testing import DummyHTTPClient
-from util.http import BadResponseException
+from ..testing import DummyHTTPClient
+from ..util.http import BadResponseException
 
 
 class DoomedOPDSImporter(OPDSImporter):
@@ -787,7 +787,7 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_('7', seven.subject.identifier)
         eq_(100, seven.weight)
         eq_(Subject.AGE_RANGE, seven.subject.type)
-        from classifier import Classifier
+        from ..classifier import Classifier
         classifier = Classifier.classifiers.get(seven.subject.type, None)
         classifier.classify(seven.subject)
 

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -19,7 +19,7 @@ from . import (
     DatabaseTest,
 )
 
-from core.config import (
+from config import (
     CannotLoadConfiguration,
     IntegrationException,
 )

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -3,10 +3,10 @@ from nose.tools import (
     eq_,
 )
 
-from model import Genre
-from classifier import Classifier
-from opensearch import OpenSearchDocument
-from lane import Lane
+from ..model import Genre
+from ..classifier import Classifier
+from ..opensearch import OpenSearchDocument
+from ..lane import Lane
 from . import DatabaseTest
 
 class TestOpenSearchDocument(DatabaseTest):

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -20,7 +20,7 @@ from coverage import (
     CoverageFailure,
 )
 
-from core.config import CannotLoadConfiguration
+from config import CannotLoadConfiguration
 
 from model import (
     Collection,

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -8,7 +8,7 @@ import os
 import json
 import pkgutil
 
-from overdrive import (
+from ..overdrive import (
     OverdriveAPI,
     MockOverdriveAPI,
     OverdriveAdvantageAccount,
@@ -16,13 +16,13 @@ from overdrive import (
     OverdriveBibliographicCoverageProvider,
 )
 
-from coverage import (
+from ..coverage import (
     CoverageFailure,
 )
 
-from config import CannotLoadConfiguration
+from ..config import CannotLoadConfiguration
 
-from model import (
+from ..model import (
     Collection,
     Contributor,
     DeliveryMechanism,
@@ -34,11 +34,11 @@ from model import (
     Measurement,
     Hyperlink,
 )
-from scripts import RunCollectionCoverageProviderScript
+from ..scripts import RunCollectionCoverageProviderScript
 
-from testing import MockRequestsResponse
+from ..testing import MockRequestsResponse
 
-from util.http import (
+from ..util.http import (
     BadResponseException,
     HTTP,
 )

--- a/tests/test_personal_names.py
+++ b/tests/test_personal_names.py
@@ -15,7 +15,7 @@ from nose.tools import (
     set_trace,
 )
 
-from model import (
+from ..model import (
     Contributor,
     DataSource,
     Work,
@@ -31,10 +31,10 @@ from . import (
     DummyHTTPClient,
 )
 
-from util.personal_names import (
+from ..util.personal_names import (
     display_name_to_sort_name,
 )
-from mock_analytics_provider import MockAnalyticsProvider
+from ..mock_analytics_provider import MockAnalyticsProvider
 
 
 

--- a/tests/test_problem_detail.py
+++ b/tests/test_problem_detail.py
@@ -7,7 +7,7 @@ from nose.tools import (
     set_trace,
 )
 
-from util.problem_detail import (
+from ..util.problem_detail import (
     ProblemDetail,
 )
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -16,18 +16,18 @@ from nose.tools import (
 from . import (
     DatabaseTest
 )
-from model import (
+from ..model import (
     DataSource,
     ExternalIntegration,
     Hyperlink,
     Representation,
 )
-from s3 import (
+from ..s3 import (
     S3Uploader,
     MockS3Client,
 )
-from mirror import MirrorUploader
-from config import CannotLoadConfiguration
+from ..mirror import MirrorUploader
+from ..config import CannotLoadConfiguration
 
 class S3UploaderTest(DatabaseTest):
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -27,7 +27,7 @@ from s3 import (
     MockS3Client,
 )
 from mirror import MirrorUploader
-from core.config import CannotLoadConfiguration
+from config import CannotLoadConfiguration
 
 class S3UploaderTest(DatabaseTest):
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -18,7 +18,7 @@ from . import (
 )
 from classifier import Classifier
 
-from core.config import (
+from config import (
     Configuration,
     temp_config,
 )

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -16,15 +16,15 @@ from nose.tools import (
 from . import (
     DatabaseTest,
 )
-from classifier import Classifier
+from ..classifier import Classifier
 
-from config import (
+from ..config import (
     Configuration,
     temp_config,
 )
-from external_search import DummyExternalSearchIndex
-from mirror import MirrorUploader
-from model import (
+from ..external_search import DummyExternalSearchIndex
+from ..mirror import MirrorUploader
+from ..model import (
     create,
     dump_query,
     get_one,
@@ -42,14 +42,15 @@ from model import (
     Identifier,
     Library,
     LicensePool,
+    MaterializedWorkWithGenre as work_model,
     RightsStatus,
     Timestamp,
     Work,
 )
-from lane import Lane
-from metadata_layer import LinkData
+from ..lane import Lane
+from ..metadata_layer import LinkData
 
-from scripts import (
+from ..scripts import (
     AddClassificationScript,
     CheckContributorNamesInDB,
     CollectionInputScript,
@@ -87,21 +88,21 @@ from scripts import (
     WorkClassificationScript,
     WorkProcessingScript,
 )
-from testing import(
+from ..testing import(
     AlwaysSuccessfulBibliographicCoverageProvider,
     BrokenBibliographicCoverageProvider,
     AlwaysSuccessfulCollectionCoverageProvider,
     AlwaysSuccessfulWorkCoverageProvider,
 )
-from monitor import (
+from ..monitor import (
     Monitor,
     CollectionMonitor,
     ReaperMonitor,
 )
-from util.opds_writer import (
+from ..util.opds_writer import (
     OPDSFeed,
 )
-from util.worker_pools import (
+from ..util.worker_pools import (
     DatabasePool,
 )
 
@@ -2193,7 +2194,6 @@ Here's your problem: your works aren't open access and have no licenses owned.
         work.presentation_ready = False
 
         # It's not in the materialized view.
-        from model import MaterializedWorkWithGenre as work_model
         mw_query = self._db.query(work_model)
         eq_(0, mw_query.count())
 
@@ -2263,7 +2263,6 @@ I would now expect you to be able to find 1 works.
         work.presentation_ready = False
 
         # It's not in the materialized view.
-        from model import MaterializedWorkWithGenre as work_model
         mw_query = self._db.query(work_model)
         eq_(0, mw_query.count())
 

--- a/tests/test_selftest.py
+++ b/tests/test_selftest.py
@@ -13,12 +13,12 @@ import datetime
 
 from . import DatabaseTest
 
-from selftest import (
+from ..selftest import (
     SelfTestResult,
     HasSelfTests,
 )
 
-from util.http import IntegrationException
+from ..util.http import IntegrationException
 
 class TestSelfTestResult(object):
 

--- a/tests/test_summary_evaluator.py
+++ b/tests/test_summary_evaluator.py
@@ -2,7 +2,7 @@
 
 from textblob import TextBlob
 from textblob.exceptions import MissingCorpusError
-from util.summary import SummaryEvaluator
+from ..util.summary import SummaryEvaluator
 from nose.tools import eq_, set_trace
 
 class TestSummaryEvaluator(object):

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -3,7 +3,7 @@ from nose.tools import (
     set_trace
 )
 import json
-from user_profile import (
+from ..user_profile import (
     ProfileController,
     MockProfileStorage,
 )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -9,14 +9,14 @@ from nose.tools import (
     set_trace,
 )
 
-from model import (
+from ..model import (
     Identifier,
     Edition
 )
 
 from . import DatabaseTest
 
-from util import (
+from ..util import (
     Bigrams,
     english_bigrams,
     LanguageCodes,
@@ -27,7 +27,7 @@ from util import (
     fast_query_count,
     slugify
 )
-from util.median import median
+from ..util.median import median
 
 class TestLanguageCodes(object):
 

--- a/tests/test_util_http.py
+++ b/tests/test_util_http.py
@@ -1,6 +1,6 @@
 import requests
 import json
-from util.http import (
+from ..util.http import (
     HTTP,
     BadResponseException,
     RemoteIntegrationException,
@@ -13,9 +13,9 @@ from nose.tools import (
     eq_,
     set_trace
 )
-from testing import MockRequestsResponse
-from util.problem_detail import ProblemDetail
-from problem_details import INVALID_INPUT
+from ..testing import MockRequestsResponse
+from ..util.problem_detail import ProblemDetail
+from ..problem_details import INVALID_INPUT
 
 class TestHTTP(object):
 

--- a/tests/test_util_opds_writer.py
+++ b/tests/test_util_opds_writer.py
@@ -4,7 +4,7 @@ from nose.tools import (
     set_trace
 )
 from lxml import etree
-from util.opds_writer import (
+from ..util.opds_writer import (
     AtomFeed,
     OPDSMessage
 )

--- a/tests/test_util_web_publication_manifest.py
+++ b/tests/test_util_web_publication_manifest.py
@@ -2,7 +2,7 @@ from nose.tools import (
     eq_,
     set_trace,
 )
-from util.web_publication_manifest import (
+from ..util.web_publication_manifest import (
     JSONable,
     Manifest,
     AudiobookManifest,

--- a/tests/test_util_worker_pools.py
+++ b/tests/test_util_worker_pools.py
@@ -6,11 +6,11 @@ from nose.tools import (
     set_trace,
 )
 
-from model import (
+from ..model import (
     Identifier,
     SessionManager,
 )
-from util.worker_pools import (
+from ..util.worker_pools import (
     DatabaseJob,
     DatabasePool,
     DatabaseWorker,


### PR DESCRIPTION
This branch makes https://github.com/NYPL-Simplified/server_core/pull/948 work as a standalone core branch and as a component of an app server like circulation or metadata.

These are the main changes I made:

* The equivalent of https://github.com/NYPL-Simplified/server_core/pull/954
* All imports from 'core.x' are changed to imports from 'x'
* The test setup no longer modifies sys.path. This has made core tests easier to write for a long time, but it caused [the double import trap](https://python-notes.curiousefficiency.org/en/latest/python_concepts/import_traps.html#the-double-import-trap). The double import trap wasn't a big problem most of the time, but 948 puts all of the data model objects in their own files and then imports them from `model`. The resulting objects are known as `model.Foo` within core but `core.model.Foo` within circulation or metadata.
So basically, imports from 'x' are changed to imports from '..x' in tests.
* MaterializedWorkWithGenre is now defined with the rest of the other data model objects, rather than being defined by slurping the schema out of the database as soon as the database connection is initiated. This means we have to explicitly define every field in the materialized view in Python code as well as in SQL.