### PR TITLE
Excluded audio sources

### DIFF
--- a/config.py
+++ b/config.py
@@ -199,6 +199,7 @@ class Configuration(object):
         },
         {
             "key": EXCLUDED_AUDIO_DATA_SOURCES,
+            "label": _("Excluded audiobook sources"),
             "description": _("Audiobooks from these data sources will be hidden from the collection, even if they would otherwise show up as available."),
             "default": None,
         },
@@ -274,7 +275,7 @@ class Configuration(object):
         """Load configuration information from the filesystem, and
         (optionally) from the database.
         """
-        cls.instance = cls.load_from_file(_db)
+        cls.instance = cls.load_from_file()
         if _db:
             # Only do the database portion of the work if
             # a database connection was provided.

--- a/config.py
+++ b/config.py
@@ -167,6 +167,8 @@ class Configuration(object):
         { "key": ERROR, "label": _("Error") },
     ]
 
+    EXCLUDED_AUDIO_DATA_SOURCES = 'excluded_audio_data_sources'
+
     SITEWIDE_SETTINGS = [
         {
             "key": NONGROUPED_MAX_AGE_POLICY,
@@ -194,6 +196,11 @@ class Configuration(object):
             "type": "select", "options": LOG_LEVEL_UI,
             "description": _("Database logs are extremely verbose, so unless you're diagnosing a database-related problem, it's a good idea to set a higher log level for database messages."),
             "default": WARN,
+        },
+        {
+            "key": EXCLUDED_AUDIO_DATA_SOURCES,
+            "description": _("Audiobooks from these data sources will be hidden from the collection, even if they would otherwise show up as available."),
+            "default": None,
         },
     ]
 

--- a/model.py
+++ b/model.py
@@ -11202,6 +11202,15 @@ class ConfigurationSetting(Base, HasFullTableCache):
             return json.loads(self.value)
         return None
 
+    # As of this release of the software, this is our best guess as to
+    # which data sources should have their audiobooks excluded from
+    # lanes.
+    EXCLUDED_AUDIO_DATA_SOURCES_DEFAULT = [
+        DataSource.OVERDRIVE,
+        DataSource.AXIS_360,
+        DataSource.RB_DIGITAL
+    ]
+
     @classmethod
     def excluded_audio_data_sources(cls, _db):
         """List the data sources whose audiobooks should not be published in
@@ -11211,12 +11220,6 @@ class ConfigurationSetting(Base, HasFullTableCache):
         Most methods like this go into Configuration, but this one needs
         to reference data model objects for its default value.
         """
-        AUDIO_EXCLUSIONS_DEFAULT = [
-            DataSource.OVERDRIVE,
-            DataSource.AXIS_360,
-            DataSource.RB_DIGITAL
-        ]
-
         value = cls.sitewide(
             _db, Configuration.EXCLUDED_AUDIO_DATA_SOURCES
         ).json_value

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,6 +4,7 @@ import base64
 import datetime
 import feedparser
 import os
+import json
 import sys
 import site
 import random
@@ -8954,6 +8955,69 @@ class TestCollection(DatabaseTest):
         pool.work = new_work
         eq_(0, len(list1.entries))
         eq_(1, len(list2.entries))
+
+    def test_restrict_to_ready_deliverable_works(self):
+        """A partial test of restrict_to_ready_deliverable_works.
+
+        This only covers the bit that excludes audiobooks from certain
+        data sources. The other parts are tested indirectly in lane.py,
+        but could use a more explicit test here.
+        """
+
+        # Create two audiobooks and one ebook.
+        overdrive_audiobook = self._work(
+            data_source_name=DataSource.OVERDRIVE, with_license_pool=True,
+            title="Overdrive Audiobook"
+        )
+        overdrive_audiobook.presentation_edition.medium = Edition.AUDIO_MEDIUM
+        overdrive_ebook = self._work(
+            data_source_name=DataSource.OVERDRIVE, with_license_pool=True,
+            title="Overdrive Ebook",
+        )
+        rbdigital_audiobook = self._work(
+            data_source_name=DataSource.RB_DIGITAL, with_license_pool=True,
+            title="RBDigital Audiobook"
+        )
+        rbdigital_audiobook.presentation_edition.medium = Edition.AUDIO_MEDIUM
+
+        # Add them to the materialized view.
+        self.add_to_materialized_view(
+            [overdrive_audiobook, overdrive_ebook, rbdigital_audiobook]
+        )
+
+        def expect(qu, works):
+            """Modify the query `qu` by calling
+            restrict_to_ready_deliverable_works(), then validate that
+            the query returns the works expected by `works`.
+            """
+            from model import MaterializedWorkWithGenre as work_model
+            restricted_query = Collection.restrict_to_ready_deliverable_works(
+                qu, work_model
+            )
+            expect_ids = [x.id for x in works]
+            actual_ids = [x.works_id for x in restricted_query]
+            eq_(set(expect_ids), set(actual_ids))
+
+        # Here's the setting which controls which data sources should
+        # have their audiobooks excluded.
+        setting = ConfigurationSetting.sitewide(
+            self._db, Configuration.EXCLUDED_AUDIO_DATA_SOURCES
+        )
+
+        # When its value is set to the empty list, every work shows
+        # up.
+        setting.value = json.dumps([])
+        expect(qu, [overdrive_ebook, overdrive_audiobook, rbdigital_audiobook])
+
+        # Putting a data source in the list excludes its audiobooks, but
+        # not its ebooks.
+        setting.value = json.dumps([DataSource.OVERDRIVE])
+        expect(qu, [overdrive_ebook, rbdigital_audiobook])
+
+        setting.value = json.dumps(
+            [DataSource.OVERDRIVE, DataSource.RB_DIGITAL]
+        )
+        expect(qu, [overdrive_ebook])
 
 
 class TestCollectionForMetadataWrangler(DatabaseTest):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8959,11 +8959,11 @@ class TestCollection(DatabaseTest):
     def test_restrict_to_ready_deliverable_works(self):
         """A partial test of restrict_to_ready_deliverable_works.
 
-        This only covers the bit that excludes audiobooks from certain
-        data sources. The other parts are tested indirectly in lane.py,
-        but could use a more explicit test here.
+        This only covers the bit that excludes audiobooks that come
+        from certain data sources. The other parts are tested
+        indirectly in lane.py, but could use a more explicit test
+        here.
         """
-
         # Create two audiobooks and one ebook.
         overdrive_audiobook = self._work(
             data_source_name=DataSource.OVERDRIVE, with_license_pool=True,
@@ -8987,7 +8987,7 @@ class TestCollection(DatabaseTest):
 
         def expect(qu, works):
             """Modify the query `qu` by calling
-            restrict_to_ready_deliverable_works(), then validate that
+            restrict_to_ready_deliverable_works(), then verify that
             the query returns the works expected by `works`.
             """
             from model import MaterializedWorkWithGenre as work_model

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -9005,12 +9005,12 @@ class TestCollection(DatabaseTest):
             [overdrive_audiobook, overdrive_ebook, rbdigital_audiobook]
         )
 
+        from model import MaterializedWorkWithGenre as work_model
         def expect(qu, works):
             """Modify the query `qu` by calling
             restrict_to_ready_deliverable_works(), then verify that
             the query returns the works expected by `works`.
             """
-            from model import MaterializedWorkWithGenre as work_model
             restricted_query = Collection.restrict_to_ready_deliverable_works(
                 qu, work_model
             )
@@ -9023,6 +9023,8 @@ class TestCollection(DatabaseTest):
         setting = ConfigurationSetting.sitewide(
             self._db, Configuration.EXCLUDED_AUDIO_DATA_SOURCES
         )
+
+        qu = self._db.query(work_model).join(work_model.license_pool)
 
         # When its value is set to the empty list, every work shows
         # up.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8209,6 +8209,26 @@ class TestConfigurationSetting(DatabaseTest):
         jsondata.value = "tra la la"
         assert_raises(ValueError, lambda: jsondata.json_value)
 
+    def test_excluded_audio_data_sources(self):
+        # Get a handle on the underlying ConfigurationSetting
+        setting = ConfigurationSetting.sitewide(
+            self._db, Configuration.EXCLUDED_AUDIO_DATA_SOURCES
+        )
+
+        m = ConfigurationSetting.excluded_audio_data_sources
+
+        # When no explicit value is set for the ConfigurationSetting,
+        # the return value of the method is AUDIO_EXCLUSIONS -- whatever
+        # the default is for the current version of the circulation manager.
+        eq_(None, setting.value)
+        eq_(ConfigurationSetting.EXCLUDED_AUDIO_DATA_SOURCES_DEFAULT,
+            m(self._db))
+
+        # When an explicit value for the ConfigurationSetting, is set, that
+        # value is interpreted as JSON and returned.
+        setting.value = "[]"
+        eq_([], m(self._db))
+
     def test_explain(self):
         """Test that ConfigurationSetting.explain gives information
         about all site-wide configuration settings.


### PR DESCRIPTION
This branch resolves https://jira.nypl.org/browse/SIMPLY-1144 by setting up a default list of data sources whose audiobooks should not show up in lanes. The default list will change as SimplyE and the circulation manager add support for more audiobook vendors, but it's stored as a site-wide configuration setting so you can explicitly set it to whatever you want.

The currently excluded data sources are these:

* Overdrive - No SimplyE support, no circ manager support
* Axis 360 - SimplyE support, no circ manager support
* RBdigital - No SimplyE support, circ manager support

The exclusion happens in `Collection.restrict_to_ready_deliverable_works`, which is the lowest-level opportunity we have to say "no, don't include that". So every piece of code that grabs books from the materialized view should respect it -- it's on the same level as "we don't own any licenses for this book".