### PR TITLE
Featured facets constructor

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -560,14 +560,14 @@ class FeaturedFacets(FacetsWithEntryPoint):
     """
 
     def __init__(self, minimum_featured_quality, uses_customlists=False,
-                 entrypoint=None, **kwargs):
+                 **kwargs):
         """Set up an object that finds featured books in a given
         WorkList.
 
         :param kwargs: Other arguments may be supplied based on user
             input, but the default implementation is to ignore them.
         """
-        super(FeaturedFacets, self).__init__(entrypoint)
+        super(FeaturedFacets, self).__init__(**kwargs)
         self.minimum_featured_quality = minimum_featured_quality
         self.uses_customlists = uses_customlists
 

--- a/lane.py
+++ b/lane.py
@@ -560,14 +560,14 @@ class FeaturedFacets(FacetsWithEntryPoint):
     """
 
     def __init__(self, minimum_featured_quality, uses_customlists=False,
-                 **kwargs):
+                 entrypoint=None, **kwargs):
         """Set up an object that finds featured books in a given
         WorkList.
 
         :param kwargs: Other arguments may be supplied based on user
             input, but the default implementation is to ignore them.
         """
-        super(FeaturedFacets, self).__init__(**kwargs)
+        super(FeaturedFacets, self).__init__(entrypoint=entrypoint, **kwargs)
         self.minimum_featured_quality = minimum_featured_quality
         self.uses_customlists = uses_customlists
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -714,6 +714,16 @@ class TestFacetsApply(DatabaseTest):
 
 class TestFeaturedFacets(DatabaseTest):
 
+    def test_constructor(self):
+        # Verify that constructor arguments are stored.
+        entrypoint = object()
+        facets = FeaturedFacets(1, True, entrypoint, entrypoint_is_default=True)
+        eq_(1, facets.minimum_featured_quality)
+        eq_(True, facets.uses_customlists)
+        eq_(entrypoint, facets.entrypoint)
+        eq_(True, facets.entrypoint_is_default)
+
+
     def test_navigate(self):
         """Test the ability of navigate() to move between slight
         variations of a FeaturedFacets object.


### PR DESCRIPTION
This branch fixes a bug where keyword arguments to the `FeaturedFacets` constructor, such as `entrypoint_is_default`, were not being passed up to the superclass constructor.