### PR TITLE
When allowing the configuration of entry points, mention the currently supported audiobook vendors.

### DIFF
--- a/config.py
+++ b/config.py
@@ -225,7 +225,7 @@ class Configuration(object):
         },
         { "key": EntryPoint.ENABLED_SETTING,
           "label": _("Enabled entry points"),
-          "description": _("Patrons will see the selected entry points at the top level and in search results."),
+          "description": _("Patrons will see the selected entry points at the top level and in search results. <p>Currently supported audiobook vendors: Bibliotheca"),
           "type": "list",
           "options": [
               { "key": entrypoint.INTERNAL_NAME,


### PR DESCRIPTION
The simplest solution I could come up with for https://jira.nypl.org/browse/SIMPLY-1274.

Adding Axis or Overdrive support will require server changes, which will give us a chance to change this copy.

Theoretically we could start supporting RBdigital audiobooks with no further server changes, which would make this text inaccurate, but there's certainly going to be server releases between now and then, and even in the worst case we can just explain the situation to a small number of people.