### PR TITLE
Track lane size independently for every active entry point

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -72,6 +72,8 @@ class EntryPoint(object):
         cls.ENTRY_POINTS.remove(entrypoint_class)
         del cls.BY_INTERNAL_NAME[entrypoint_class.INTERNAL_NAME]
         del cls.DISPLAY_TITLES[entrypoint_class]
+        if entrypoint_class in cls.DEFAULT_ENABLED:
+            cls.DEFAULT_ENABLED.remove(entrypoint_class)
 
     @classmethod
     def modified_materialized_view_query(cls, qu):

--- a/lane.py
+++ b/lane.py
@@ -2214,15 +2214,13 @@ class Lane(Base, WorkList):
         query = self.works(_db).limit(None)
         query = query.distinct(work_model.works_id)
 
-        # Do the estimate for the lane as a whole.
-        self.size = fast_query_count(query)
-
-        # Now do the estimate for each of the library's active entry points.
-        by_entrypoint = {EverythingEntryPoint.URI: self.size}
-        for entrypoint in self.library.entrypoints:
+        # Do the estimate for every known entry point.
+        by_entrypoint = dict()
+        for entrypoint in EntryPoint.ENTRY_POINTS:
             qu = entrypoint.apply(query)
             by_entrypoint[entrypoint.URI] = fast_query_count(qu)
         self.size_by_entrypoint = by_entrypoint
+        self.size = by_entrypoint[EverythingEntryPoint.URI]
 
     @property
     def genre_ids(self):

--- a/migration/20181015-size-by-entrypoint.sql
+++ b/migration/20181015-size-by-entrypoint.sql
@@ -1,0 +1,1 @@
+alter table lanes add column size_by_entrypoint json;

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -86,6 +86,9 @@ class TestEntryPoint(DatabaseTest):
             EntryPoint.register, Mock2, "Mock!"
         )
 
+        EntryPoint.unregister(Mock)
+        assert Mock not in EntryPoint.DEFAULT_ENABLED
+
 
 class TestEverythingEntryPoint(DatabaseTest):
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -2315,7 +2315,7 @@ class TestLane(DatabaseTest):
         # update_size() sets the Lane's size and size_by_entrypoint to
         # the correct number.
         fiction.size = 100
-        fiction.size_by_entrypoint = {"Nonexistent entrypoint: 200"}
+        fiction.size_by_entrypoint = {"Nonexistent entrypoint": 200}
         fiction.update_size(self._db)
 
         # The total number of books in the lane, regardless of entrypoint,

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -3528,10 +3528,11 @@ class TestWorkListGroups(DatabaseTest):
         lane = self._lane()
         m = lane._size_for_facets
 
-        ebooks, audio, everything = [
+        ebooks, audio, everything, nothing = [
             FeaturedFacets(minimum_featured_quality=0.5, entrypoint=x)
             for x in (
                 EbooksEntryPoint, AudiobooksEntryPoint, EverythingEntryPoint,
+                None
             )
         ]
 
@@ -3548,6 +3549,7 @@ class TestWorkListGroups(DatabaseTest):
             AudiobooksEntryPoint.URI : 2
         }
         eq_(99, m(None))
+        eq_(99, m(nothing))
         eq_(99, m(everything))
         eq_(1, m(ebooks))
         eq_(2, m(audio))

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -558,15 +558,15 @@ class TestLaneSweeperScript(DatabaseTest):
         worklist = script.considered.pop(0)
         eq_(self._default_library, worklist.get_library(self._db))
         eq_(self._default_library.name, worklist.display_name)
-        eq_([good, bad], worklist.children)
+        eq_(set([good, bad]), set(worklist.children))
 
         # After that, every lane was considered for processing, with
         # top-level lanes considered first.
-        eq_([good, bad, good_child], script.considered)
+        eq_(set([good, bad, good_child]), set(script.considered))
 
         # But a lane was processed only if should_process_lane
         # returned True.
-        eq_([good, good_child], script.processed)
+        eq_(set([good, good_child]), set(script.processed))
 
 
 class TestRunCoverageProviderScript(DatabaseTest):


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-1305 by estimating the size of each lane separately for every enabled entry point. The overall lane size is till calculated and can be used (e.g. by the admin interface), but when generating featured feeds we now take the entry point into account.

I took an approach that degrades gracefully if the new `size_by_entrypoint` field is not populated or incompletely populated.

One thing I could do to make it even more graceful is to always calculate the size for every known entrypoint, not just the disabled entrypoints. This will make things work automatically when you enable an entrypoint, without having to first refresh the materialized views. The downside is a performance hit in lane size calculation so long as a given entrypoint is disabled.