### PR TITLE
A work with no medium can have no permanent work ID.

### DIFF
--- a/model/constants.py
+++ b/model/constants.py
@@ -124,6 +124,19 @@ class EditionConstants(object):
     for k, v in medium_to_additional_type.items():
         additional_type_to_medium[v] = k
 
+
+    # Map the medium constants to the strings used when generating
+    # permanent work IDs.
+    medium_for_permanent_work_id = {
+        BOOK_MEDIUM : "book",
+        AUDIO_MEDIUM : "book",
+        MUSIC_MEDIUM : "music",
+        PERIODICAL_MEDIUM : "book",
+        VIDEO_MEDIUM: "movie",
+        IMAGE_MEDIUM: "image",
+        COURSEWARE_MEDIUM: "courseware"
+    }
+
 class IdentifierConstants(object):
     # Common types of identifiers.
     OVERDRIVE_ID = u"Overdrive ID"

--- a/model/edition.py
+++ b/model/edition.py
@@ -541,27 +541,13 @@ class Edition(Base, EditionConstants):
 
     def calculate_permanent_work_id(self, debug=False):
         title = self.title_for_permanent_work_id
-        if not title:
-            # If a book has no title, it has no permanent work ID.
+        medium = self.medium_for_permanent_work_id.get(self.medium, None)
+        if not title or not medium:
+            # If a book has no title or medium, it has no permanent work ID.
             self.permanent_work_id = None
             return
 
         author = self.author_for_permanent_work_id
-
-        if self.medium == Edition.BOOK_MEDIUM:
-            medium = "book"
-        elif self.medium == Edition.AUDIO_MEDIUM:
-            medium = "book"
-        elif self.medium == Edition.MUSIC_MEDIUM:
-            medium = "music"
-        elif self.medium == Edition.PERIODICAL_MEDIUM:
-            medium = "book"
-        elif self.medium == Edition.VIDEO_MEDIUM:
-            medium = "movie"
-        elif self.medium == Edition.IMAGE_MEDIUM:
-            medium = "image"
-        elif self.medium == Edition.COURSEWARE_MEDIUM:
-            medium = "courseware"
 
         w = WorkIDCalculator
         norm_title = w.normalize_title(title)

--- a/tests/models/test_edition.py
+++ b/tests/models/test_edition.py
@@ -460,16 +460,23 @@ class TestEdition(DatabaseTest):
             [x.data_source for x in records]
         )
 
-    def test_no_permanent_work_id_for_edition_with_no_title(self):
-        """An edition with no title is not assigned a permanent work ID."""
+    def test_no_permanent_work_id_for_edition_without_title_or_medium(self):
+        # An edition with no title or medium is not assigned a permanent work
+        # ID.
         edition = self._edition()
-        edition.title = ''
         eq_(None, edition.permanent_work_id)
+
+        edition.title = ''
         edition.calculate_permanent_work_id()
         eq_(None, edition.permanent_work_id)
+
         edition.title = u'something'
         edition.calculate_permanent_work_id()
         assert_not_equal(None, edition.permanent_work_id)
+
+        edition.medium = None
+        edition.calculate_permanent_work_id()
+        eq_(None, edition.permanent_work_id)
 
     def test_choose_cover_can_choose_full_image_and_thumbnail_separately(self):
         edition = self._edition()


### PR DESCRIPTION
The fix to https://jira.nypl.org/browse/SIMPLY-1306 means the metadata wrangler no longer makes assumptions about a book's medium. But if a book has no medium we can't generate a permanent work ID for it. Currently `Edition.calculate_permanent_work_id` crashes if it's asked to operate on an Edition with no `.medium`. This branch fixes that by treating a work with no medium the same as a work with no title.

It's possible this will have negative side effects when these OPDS entries are imported into a circ manager, but I think the circ manager will either assume the Edition is an ebook (old code) or will decline to create a PWID for the imported Edition (new code). As long as the presentation edition has `.medium` set, which should always be the case outside the metadata wrangler, the presentation edition will have a PWID.