### PR TITLE
Generate a correct search document whether either end of the target age range is inclusive or exclusive.

### DIFF
--- a/migration/20181018-reindex-works-with-target-age.sql
+++ b/migration/20181018-reindex-works-with-target-age.sql
@@ -1,0 +1,3 @@
+-- The target ages of works were being incorrectly indexed.
+-- Reindex all works that have a nontrivial target age.
+delete from workcoveragerecords where operation='update-search-index' and work_id in (select id from works where target_age not in ('[,]', '[18,]'));

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -855,6 +855,7 @@ class TestWork(DatabaseTest):
         eq_(work.quality, search_doc['quality'])
         eq_(work.rating, search_doc['rating'])
         eq_(work.popularity, search_doc['popularity'])
+        eq_(dict(lower=7, upper=8), search_doc['target_age'])
 
         # Each collection in which the Work is found is listed in
         # the 'collections' section.


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-1320 by normalizing a Work's target age to a range that's inclusive on both ends.

The search indexes need to be rebuilt to solve this, so I added a migration script.