### PR TITLE
Fixed error when annotating a lane that inherits custom lists from its parent.

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -1037,7 +1037,7 @@ class WorkList(object):
 
     def get_customlists(self, _db):
         """Get customlists associated with the Worklist."""
-        if hasattr(self, "_customlist_ids"):
+        if hasattr(self, "_customlist_ids") and self._customlist_ids is not None:
             return _db.query(CustomList).filter(CustomList.id.in_(self._customlist_ids)).all()
         return []
 


### PR DESCRIPTION
I was getting an error loading a feed for a lane which doesn't have its own custom lists, but inherits parent restrictions and has a parent with a custom list.

It looks like this method is only used to pick a name for a crawlable list feed when adding a link to it. It calls `uses_customlists` which checks the parent, and then `get_customlists` which does not. In this case, the annotator probably shouldn't try to add that link at all, but I still think this change is useful in case there are other times this method is called on a lane without any custom lists.

Here's the error I was getting:
{"host": "MacBook-Pro.local", "name": "root", "level": "ERROR", "timestamp": "2018-10-30T02:11:54.568359", "app": "simplified", "traceback": "Traceback (most recent call last):\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/flask/app.py\", line 1612, in full_dispatch_request\n    rv = self.dispatch_request()\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/flask/app.py\", line 1598, in dispatch_request\n    return self.view_functions[rule.endpoint](**req.view_args)\n  File \"/Users/aslagle/dev/circulation/api/routes.py\", line 150, in decorated\n    return f(*args, **kwargs)\n  File \"/Users/aslagle/dev/circulation/api/routes.py\", line 114, in wrapped_function\n    resp = make_response(f(*args, **kwargs))\n  File \"/Users/aslagle/dev/circulation/core/app_server.py\", line 147, in decorated\n    v = f(*args, **kwargs)\n  File \"/Users/aslagle/dev/circulation/api/routes.py\", line 227, in feed\n    return app.manager.opds_feeds.feed(lane_identifier)\n  File \"/Users/aslagle/dev/circulation/api/controller.py\", line 695, in feed\n    pagination=pagination,\n  File \"/Users/aslagle/dev/circulation/core/opds.py\", line 747, in page\n    annotator.annotate_feed(feed, lane)\n  File \"/Users/aslagle/dev/circulation/api/opds.py\", line 787, in annotate_feed\n    customlist = lane.get_customlists(_db)\n  File \"/Users/aslagle/dev/circulation/core/lane.py\", line 1041, in get_customlists\n    return _db.query(CustomList).filter(CustomList.id.in_(self._customlist_ids)).all()\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/sqlalchemy/sql/operators.py\", line 513, in in_\n    return self.operate(in_op, other)\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/sqlalchemy/orm/attributes.py\", line 180, in operate\n    return op(self.comparator, *other, **kwargs)\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/sqlalchemy/sql/operators.py\", line 1147, in in_op\n    return a.in_(b)\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/sqlalchemy/sql/operators.py\", line 513, in in_\n    return self.operate(in_op, other)\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/sqlalchemy/orm/properties.py\", line 270, in operate\n    return op(self.__clause_element__(), *other, **kwargs)\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/sqlalchemy/sql/operators.py\", line 1147, in in_op\n    return a.in_(b)\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/sqlalchemy/sql/operators.py\", line 513, in in_\n    return self.operate(in_op, other)\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/sqlalchemy/sql/elements.py\", line 692, in operate\n    return op(self.comparator, *other, **kwargs)\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/sqlalchemy/sql/operators.py\", line 1147, in in_op\n    return a.in_(b)\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/sqlalchemy/sql/operators.py\", line 513, in in_\n    return self.operate(in_op, other)\n  File \"<string>\", line 1, in <lambda>\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/sqlalchemy/sql/type_api.py\", line 63, in operate\n    return o[0](self.expr, op, *(other + o[1:]), **kwargs)\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/sqlalchemy/sql/default_comparator.py\", line 161, in _in_impl\n    for o in seq_or_selectable:\nTypeError: 'NoneType' object is not iterable", "message": "Exception in web app: 'NoneType' object is not iterable", "filename": "app_server.py"}