### PR TITLE
Add new logger that allows logging to AWS Cloudwatch Logs

### DIFF
--- a/log.py
+++ b/log.py
@@ -259,7 +259,7 @@ class CloudwatchLogs(Logger):
 
     @classmethod
     def get_handler(cls, settings, testing=False):
-        """Turn a Loggly ExternalIntegration into a log handler.
+        """Turn ExternalIntegration into a log handler.
         """
         group = settings.setting(cls.GROUP).value or cls.DEFAULT_APP_NAME
         stream = settings.setting(cls.STREAM).value or cls.DEFAULT_APP_NAME
@@ -419,6 +419,10 @@ class LogConfiguration(object):
 
 
 class MockCloudWatchLogHandler(CloudWatchLogHandler):
+    """
+    Mock handler used during unit testing.
+    """
+
     def __init__(self, log_group=__name__, stream_name=None, use_queues=True, send_interval=60,
                  max_batch_size=1024*1024, max_batch_count=10000):
         self.log_group = log_group

--- a/log.py
+++ b/log.py
@@ -259,16 +259,19 @@ class CloudwatchLogs(Logger):
             "key": GROUP,
             "label": _("Log Group"),
             "default": Logger.DEFAULT_APP_NAME,
+            "required": True,
         },
         {
             "key": STREAM,
             "label": _("Log Stream"),
             "default": Logger.DEFAULT_APP_NAME,
+            "required": True,
         },
         {
             "key": INTERVAL,
             "label": _("Update Interval Seconds"),
             "default": DEFAULT_INTERVAL,
+            "required": True,
         },
         {
             "key": REGION,
@@ -276,6 +279,7 @@ class CloudwatchLogs(Logger):
             "type": "select",
             "options": REGIONS,
             "default": DEFAULT_REGION,
+            "required": True,
         },
         {
             "key": CREATE_GROUP,
@@ -286,6 +290,7 @@ class CloudwatchLogs(Logger):
                 { "key": "FALSE", "label": _("No") },
             ],
             "default": True,
+            "required": True,
         },
     ]
 

--- a/log.py
+++ b/log.py
@@ -427,9 +427,8 @@ class LogConfiguration(object):
             logging.getLogger(logger).setLevel(loop_prevention_log_level)
 
         # If we had an error creating any log handlers report it
-        if errors:
-            for error in errors:
-                logging.getLogger().error(error)
+        for error in errors:
+            logging.getLogger().error(error)
 
         return log_level
 

--- a/log.py
+++ b/log.py
@@ -241,7 +241,6 @@ class CloudwatchLogs(Logger):
     def from_configuration(cls, _db, testing=False):
         settings = None
         cloudwatch = None
-        from model import (ExternalIntegration, ConfigurationSetting)
 
         app_name = cls.DEFAULT_APP_NAME
         if _db and not testing:
@@ -325,12 +324,6 @@ class LogConfiguration(object):
     ]
 
     @classmethod
-    def _defaults(cls, testing=False):
-        log_level = cls.DEFAULT_LOG_LEVEL
-        database_log_level = cls.DEFAULT_DATABASE_LOG_LEVEL
-        return log_level, database_log_level
-
-    @classmethod
     def initialize(cls, _db, testing=False):
         """Make the logging handlers reflect the current logging rules
         as configured in the database.
@@ -395,7 +388,8 @@ class LogConfiguration(object):
         Handler objects that will be associated with the top-level
         logger.
         """
-        (log_level, database_log_level) = cls._defaults(testing)
+        log_level = cls.DEFAULT_LOG_LEVEL
+        database_log_level = cls.DEFAULT_DATABASE_LOG_LEVEL
 
         if _db and not testing:
             log_level = (

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -160,6 +160,7 @@ class ExternalIntegration(Base, HasFullTableCache):
     # Integrations with LOGGING_GOAL
     INTERNAL_LOGGING = u'Internal logging'
     LOGGLY = u"Loggly"
+    CLOUDWATCH = u"AWS Cloudwatch Logs"
 
     # Keys for common configuration settings
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,5 @@ pymarc
 # for author name manipulations
 nameparser>=0.5.1
 fuzzywuzzy
+
+watchtower

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,5 @@ pymarc
 nameparser>=0.5.1
 fuzzywuzzy
 
+# for cloudwatch logs integration
 watchtower

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -159,19 +159,6 @@ class TestLogConfiguration(DatabaseTest):
             cls._defaults(testing=True)
         )
 
-    def test_defaults(self):
-        cls = LogConfiguration
-
-        eq_(
-            (cls.INFO, cls.WARN),
-            cls._defaults(testing=False)
-        )
-
-        eq_(
-            (cls.INFO, cls.WARN),
-            cls._defaults(testing=True)
-        )
-
     def test_set_formatter(self):
         # Create a generic handler.
         handler = logging.StreamHandler()


### PR DESCRIPTION
This commit makes it possible to output the circulation managers logs to AWS CloudWatch and an optional ExternalIntegration.

Some changes here: 
- Move `set_formatter` into the base class since its used by all the subclasses
- Move some of the settings for all loggers out of the `SysLogger` class and into `LogConfiguration`
- Add the `CloudwatchLogs` class
- Add some tests for the `CloudwatchLogs` class

Pinging @leonardr for code review.