### PR TITLE
Work presentation coverage providers

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -1358,7 +1358,7 @@ class OPDSEntryWorkCoverageProvider(WorkPresentationProvider):
 
 
 class WorkPresentationEditionCoverageProvider(WorkPresentationProvider):
-    """Make sure all Works have up-to-date presentation edition.
+    """Make sure each Work has an up-to-date presentation edition.
 
     This basically means comparing all the Editions associated with the
     Work and building a composite Edition.

--- a/coverage.py
+++ b/coverage.py
@@ -1338,7 +1338,7 @@ class WorkPresentationProvider(PresentationReadyWorkCoverageProvider):
     needs to have some aspect of its presentation recalculated. These
     providers give back the 'missing' coverage.
     """
-    DEFAULT_BATCH_SIZE = 1000
+    DEFAULT_BATCH_SIZE = 100
 
 
 class OPDSEntryWorkCoverageProvider(WorkPresentationProvider):
@@ -1351,6 +1351,7 @@ class OPDSEntryWorkCoverageProvider(WorkPresentationProvider):
     """
     SERVICE_NAME = "OPDS Entry Work Coverage Provider"
     OPERATION = WorkCoverageRecord.GENERATE_OPDS_OPERATION
+    DEFAULT_BATCH_SIZE = 1000
 
     def process_item(self, work):
         work.calculate_opds_entries()
@@ -1401,7 +1402,8 @@ class WorkPresentationEditionCoverageProvider(WorkPresentationProvider):
         # regenerate the OPDS feeds or update the search index.
         # So we call calculate_presentation in a way where the only actual
         # change made will be
-        return work.calculate_presentation(self.POLICY)
+        work.calculate_presentation(self.POLICY)
+        return work
 
 
 class WorkClassificationCoverageProvider(

--- a/coverage.py
+++ b/coverage.py
@@ -1399,9 +1399,10 @@ class WorkPresentationEditionCoverageProvider(WorkPresentationProvider):
         """Recalculate the presentation for a Work."""
 
         # Calling calculate_presentation_edition won't, on its own,
-        # regenerate the OPDS feeds or update the search index.
-        # So we call calculate_presentation in a way where the only actual
-        # change made will be
+        # regenerate the OPDS feeds or update the search index.  So we
+        # call calculate_presentation with a policy that ensures the
+        # presentation edition will be reevaluated, but nothing
+        # expensive will happen.
         work.calculate_presentation(self.POLICY)
         return work
 

--- a/external_search.py
+++ b/external_search.py
@@ -38,7 +38,7 @@ from model import (
 from monitor import WorkSweepMonitor
 from coverage import (
     CoverageFailure,
-    WorkCoverageProvider,
+    WorkPresentationProvider,
 )
 import os
 import logging
@@ -1468,7 +1468,7 @@ class SearchIndexMonitor(WorkSweepMonitor):
             return 0
 
 
-class SearchIndexCoverageProvider(WorkCoverageProvider):
+class SearchIndexCoverageProvider(WorkPresentationProvider):
     """Make sure all Works have up-to-date representation in the
     search index.
     """

--- a/migration/20181107-remove-coverage-of-non-books-incorrectly-classified-as-books.sql
+++ b/migration/20181107-remove-coverage-of-non-books-incorrectly-classified-as-books.sql
@@ -1,0 +1,29 @@
+-- Delete all choose-edition WorkCoverageRecords for works whose
+-- presentation edition says they are books, but whose data sources say
+-- they are not books.
+--
+-- Later, WorkPresentationEditionCoverageProvider will run and recalculate
+-- the presentation editions properly.
+
+-- We're going to delete some rows from workcoveragerecords.
+delete from workcoveragerecords where operation='choose-edition' and
+  work_id in (
+     -- We're looking for works whose presentation editions say they are books.
+     select w.id
+      from works w
+           join licensepools lp on lp.work_id=w.id
+           join editions e on lp.presentation_edition_id=e.id
+      where
+        e.medium='Book'
+        and lp.id in (
+          -- We're looking for works associated with license pools
+          -- with an associated identifier that says they are _not_ books.
+          select lp.id
+            from licensepools lp
+                 join editions e on (
+                   lp.data_source_id=e.data_source_id
+		   and lp.identifier_id=e.primary_identifier_id
+                 )
+	     where e.medium != 'Book'
+          )
+    )

--- a/model/work.py
+++ b/model/work.py
@@ -861,7 +861,7 @@ class Work(Base):
 
         edition_changed = self.calculate_presentation_edition(policy)
 
-        if policy.choose_cover:
+        if policy.choose_cover or policy.set_edition_metadata:
             cover_changed = self.presentation_edition.calculate_presentation(policy)
             edition_changed = edition_changed or cover_changed
 


### PR DESCRIPTION
This branch adds two new WorkCoverageProviders modeled after OPDSEntryWorkCoverageProvider. These two scripts give us a way to selectively remove coverage of the presentation calculation process, e.g. during a migration script. This gives us a way to fix the fallout from problems like https://jira.nypl.org/browse/SIMPLY-1306 and https://jira.nypl.org/browse/SIMPLY-1364.

Now, if you ever discover that one or more works have the wrong presentation, you don't have to fix the problem immediately -- just remove their coverage and one of these CoverageProviders will fix the problem in the background.

This is the core work of https://jira.nypl.org/browse/SIMPLY-1397.