### PR TITLE
Reap records one at a time so that the SQLAlchemy cascades will run.

### DIFF
--- a/model/patron.py
+++ b/model/patron.py
@@ -136,6 +136,11 @@ class Patron(Base):
 
     AUDIENCE_RESTRICTION_POLICY = 'audiences'
 
+    def __repr__(self):
+        return '<Patron authentication_identifier=%s last_external_sync=%s>' % (
+            self.authorization_identifier, self.last_external_sync
+        )
+
     def identifier_to_remote_service(self, remote_data_source, generator=None):
         """Find or randomly create an identifier to use when identifying
         this patron to a remote service.

--- a/model/patron.py
+++ b/model/patron.py
@@ -137,8 +137,19 @@ class Patron(Base):
     AUDIENCE_RESTRICTION_POLICY = 'audiences'
 
     def __repr__(self):
-        return '<Patron authentication_identifier=%s last_external_sync=%s>' % (
-            self.authorization_identifier, self.last_external_sync
+        def date(d):
+            """Format an object that might be a datetime as a date.
+
+            This keeps a patron representation short.
+            """
+            if d is None:
+                return None
+            if isinstance(d, datetime.datetime):
+                return d.date()
+            return d
+        return '<Patron authentication_identifier=%s expires=%s sync=%s>' % (
+            self.authorization_identifier, date(self.authorization_expires),
+            date(self.last_external_sync)
         )
 
     def identifier_to_remote_service(self, remote_data_source, generator=None):

--- a/monitor.py
+++ b/monitor.py
@@ -680,8 +680,12 @@ class ReaperMonitor(Monitor):
         return self.timestamp_field < self.cutoff
 
     def run_once(self, *args, **kwargs):
-        rows_deleted = self.query().delete(synchronize_session=False)
-        self.log.info("Deleted %d row(s)", rows_deleted)
+        rows_deleted = 0
+        qu = self.query()
+        self.log.info("Deleting %d row(s)", qu.count())
+        for i in qu:
+            self.log.info("Deleting %r", i)
+            self._db.delete(i)
 
     def query(self):
         return self._db.query(self.MODEL_CLASS).filter(self.where_clause)
@@ -703,9 +707,9 @@ class CredentialReaper(ReaperMonitor):
     MAX_AGE = 1
 ReaperMonitor.REGISTRY.append(CredentialReaper)
 
-class PatronReaper(ReaperMonitor):
+class PatronRecordReaper(ReaperMonitor):
     """Remove patron records that expired more than 60 days ago"""
     MODEL_CLASS = Patron
     TIMESTAMP_FIELD = 'authorization_expires'
     MAX_AGE = 60
-ReaperMonitor.REGISTRY.append(PatronReaper)
+ReaperMonitor.REGISTRY.append(PatronRecordReaper)

--- a/tests/models/test_patron.py
+++ b/tests/models/test_patron.py
@@ -377,6 +377,17 @@ class TestLoans(DatabaseTest):
 
 class TestPatron(DatabaseTest):
 
+    def test_repr(self):
+
+        patron = self._patron(external_identifier="a patron")
+
+        patron.authorization_expires=datetime.datetime(2018, 1, 2, 3, 4, 5)
+        patron.last_external_sync=None
+        eq_(
+            "<Patron authentication_identifier=None expires=2018-01-02 sync=None>",
+            repr(patron)
+        )
+
     def test_identifier_to_remote_service(self):
 
         # Here's a patron.


### PR DESCRIPTION
This branch fixes a problem discovered while testing https://jira.nypl.org/browse/SIMPLY-1256. Deleting all the reaped records at once only works if there are no records in other tables that need to be deleted in a cascade. We do cascades at the SQLAlchemy level, not the database level, which means we need to call delete() on each individual item.

This isn't so bad because it gives us a chance to report each decision individually. I added a `__repr__` implementation to Patron so that we can log the patron records that get reaped in this way, in case there's any confusion or problems resulting from this work.

I also renamed `PatronReaper` to `PatronRecordReaper` because the class name sounded creepy.