### PR TITLE
Ignore Overdrive images that are obviously stand-ins.

### DIFF
--- a/migration/20181108-remove-overdrive-standin-ids.sql
+++ b/migration/20181108-remove-overdrive-standin-ids.sql
@@ -1,0 +1,17 @@
+-- This script takes a belt-and-suspenders approach to removing
+-- placeholder images mistakenly downloaded from Overdrive.
+
+-- Remove the Overdrive bibliographic coverage for affected editions. The
+-- Overdrive bibliographic coverage provider will try to find new images.
+delete from coveragerecords where identifier_id in (select i.id from identifiers i join editions e on e.primary_identifier_id=i.id where (e.cover_full_url like '%00000000-0000-0000-0000%' or e.cover_thumbnail_url like '%00000000-0000-0000-0000%')) and data_source_id in (select ds.id from datasources ds where ds.name='Overdrive');
+
+-- Delete work coverage records for works whose presentation editions ended up with bad cover images. They'll be refreshed and end up with no cover image. Once a better image is located, their presentation will be refreshed again.
+delete from workcoveragerecords where operation='choose-edition' and work_id in (select w.id from works w where presentation_edition_id in (select id from editions where cover_full_url like '%00000000-0000-0000-0000%' or cover_thumbnail_url like '%00000000-0000-0000-0000%'));
+
+-- Remove all hyperlinks that caused an edition to end up with a bad cover or thumbnail.
+delete from hyperlinks where id in (select h.id from hyperlinks h join resources res on h.resource_id=res.id join representations rep on res.representation_id=rep.id join editions e on h.identifier_id=e.primary_identifier_id where (e.cover_full_url like '%00000000-0000-0000-0000%' or e.cover_thumbnail_url like '%00000000-0000-0000-0000%') and h.rel='http://opds-spec.org/image' and res.url like '%00000000-0000-0000-0000%');
+
+-- Change any editions that use bad cover images so that they have no cover image.
+update editions set cover_full_url=null where cover_full_url like '%00000000-0000-0000-0000%';
+update editions set cover_thumbnail_url=null where cover_thumbnail_url like '%00000000-0000-0000-0000%';
+

--- a/overdrive.py
+++ b/overdrive.py
@@ -720,6 +720,11 @@ class OverdriveRepresentationExtractor(object):
         if not link or not 'href' in link:
             return None
         href = OverdriveAPI.make_link_safe(link['href'])
+        if '{00000000-0000-0000-0000' in href:
+            # This is a stand-in cover for preorders. It's better not
+            # to have a cover at all -- we might be able to get one
+            # later, or from another source.
+            return None
         media_type = link.get('type', None)
         return LinkData(rel=rel, href=href, media_type=media_type)
 

--- a/overdrive.py
+++ b/overdrive.py
@@ -719,12 +719,13 @@ class OverdriveRepresentationExtractor(object):
     def image_link_to_linkdata(cls, link, rel):
         if not link or not 'href' in link:
             return None
-        href = OverdriveAPI.make_link_safe(link['href'])
-        if '{00000000-0000-0000-0000' in href:
+        href = link['href']
+        if '00000000-0000-0000-0000' in href:
             # This is a stand-in cover for preorders. It's better not
             # to have a cover at all -- we might be able to get one
             # later, or from another source.
             return None
+        href = OverdriveAPI.make_link_safe(href)
         media_type = link.get('type', None)
         return LinkData(rel=rel, href=href, media_type=media_type)
 


### PR DESCRIPTION
This branch fixes the Overdrive portion of https://jira.nypl.org/browse/SIMPLY-340.

The migration script ensures that tainted editions and works will no longer use the bad images, and that (on the metadata wrangler) the bibliographic coverage provider will try to get them proper cover images the next time it runs.

Once these books have new cover images from the metadata wrangler, the circ managers will pick it up automatically. But even no cover image is better than an inaccurate stand-in.

It looks like about 5000 titles total have been affected.