### PR TITLE
Add missing semicolon to migration script.

### DIFF
--- a/migration/20181107-remove-coverage-of-non-books-incorrectly-classified-as-books.sql
+++ b/migration/20181107-remove-coverage-of-non-books-incorrectly-classified-as-books.sql
@@ -27,3 +27,4 @@ delete from workcoveragerecords where operation='choose-edition' and
 	     where e.medium != 'Book'
           )
     )
+;


### PR DESCRIPTION
This broke a real migration I did in preparation for the 2.2.11 release.