### PR TITLE
Mark work for presentation calculation when metadata changes

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -1364,8 +1364,8 @@ class WorkPresentationEditionCoverageProvider(WorkPresentationProvider):
     This basically means comparing all the Editions associated with the
     Work and building a composite Edition.
 
-    Expensive operations -- calculating work quality, summary, and presentation
-    -- are reserved for WorkClassificationCoverageProvider
+    Expensive operations -- calculating work quality, summary, and genre
+    classification -- are reserved for WorkClassificationCoverageProvider
     """
     SERVICE_NAME = 'Calculated presentation coverage provider'
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1732,7 +1732,7 @@ class Metadata(MetaToModelUtility):
             # Any LicensePool will do here, since all LicensePools for
             # a given Identifier have the same Work.
             pool = get_one(
-                self._db, LicensePool, identifier=edition.primary_identifier,
+                _db, LicensePool, identifier=edition.primary_identifier,
                 on_multiple='interchangeable'
             )
             if pool.work:

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -41,6 +41,7 @@ from model import (
     Identifier,
     LicensePool,
     LicensePoolDeliveryMechanism,
+    LinkRelations,
     Subject,
     Hyperlink,
     PresentationCalculationPolicy,
@@ -1405,6 +1406,10 @@ class Metadata(MetaToModelUtility):
                     success = True
         return success
 
+    REL_REQUIRES_NEW_PRESENTATION_EDITION = [
+        LinkRelations.IMAGE, LinkRelations.THUMBNAIL_IMAGE
+    ]
+    REL_REQUIRES_FULL_RECALCULATION = [LinkRelations.DESCRIPTION]
 
     # TODO: We need to change all calls to apply() to use a ReplacementPolicy
     # instead of passing in individual `replace` arguments. Once that's done,
@@ -1598,7 +1603,10 @@ class Metadata(MetaToModelUtility):
                     original_resource=original_resource,
                     transformation_settings=link.transformation_settings,
                 )
-                work_requires_new_presentation_edition = True
+                if link.rel in self.REL_REQUIRES_NEW_PRESENTATION_EDITION:
+                    work_requires_new_presentation_edition = True
+                elif link.rel in self.REL_REQUIRES_FULL_RECALCULATION:
+                    work_requires_full_recalculation = True
 
             link_objects[link] = link_obj
             if link.thumbnail:

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1735,7 +1735,8 @@ class Metadata(MetaToModelUtility):
                 _db, LicensePool, identifier=edition.primary_identifier,
                 on_multiple='interchangeable'
             )
-            if pool.work:
+            if pool and pool.work:
+                work = pool.work
                 if work_requires_full_recalculation:
                     work.needs_full_presentation_recalculation()
                 else:

--- a/model/work.py
+++ b/model/work.py
@@ -1099,7 +1099,7 @@ class Work(Base):
         """
         return self._reset_coverage(WorkCoverageRecord.CLASSIFY_OPERATION)
 
-    def needs_presentation_edition_recalculation(self):
+    def needs_new_presentation_edition(self):
         """Mark this work as needing to have its presentation edition
         regenerated. This is significantly less work than
         calling needs_full_presentation_recalculation, but it will

--- a/model/work.py
+++ b/model/work.py
@@ -1086,15 +1086,25 @@ class Work(Base):
         """
         self.external_index_needs_updating()
 
-    def needs_presentation_recalculation(self):
-        """Mark this work as needing to have its presentation
-        recalculated. This shifts the time spent recalculating
-        presentation to a script dedicated to this purpose, rather
-        than a script that interacts with APIs. It's also more
-        efficient, since a work might be flagged multiple times before
-        we actually get around to recalculating the presentation.
+    def needs_full_presentation_recalculation(self):
+        """Mark this work as needing to have its presentation completely
+        recalculated.
+
+        This shifts the time spent recalculating presentation to a
+        script dedicated to this purpose, rather than a script that
+        interacts with APIs. It's also more efficient, since a work
+        might be flagged multiple times before we actually get around
+        to recalculating the presentation.
         """
         return self._reset_coverage(WorkCoverageRecord.CLASSIFY_OPERATION)
+
+    def needs_presentation_edition_recalculation(self):
+        """Mark this work as needing to have its presentation edition
+        regenerated. This is significantly less work than
+        calling needs_full_presentation_recalculation, but it will
+        not update a Work's quality score, summary, or genre classification.
+        """
+        return self._reset_coverage(WorkCoverageRecord.CHOOSE_EDITION_OPERATION)
 
     def set_presentation_ready(
         self, as_of=None, search_index_client=None, exclude_search=False

--- a/model/work.py
+++ b/model/work.py
@@ -1068,6 +1068,7 @@ class Work(Base):
         record, is_new = WorkCoverageRecord.add_for(
             self, operation=operation, status=CoverageRecord.REGISTERED
         )
+        return record
 
     def external_index_needs_updating(self):
         """Mark this work as needing to have its search document reindexed.

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -1064,7 +1064,7 @@ class TestWork(DatabaseTest):
         for method, operation in (
             (work.needs_full_presentation_recalculation,
              WCR.CLASSIFY_OPERATION),
-            (work.needs_presentation_edition_recalculation,
+            (work.needs_new_presentation_edition,
              WCR.CHOOSE_EDITION_OPERATION),
             (work.external_index_needs_updating,
              WCR.UPDATE_SEARCH_INDEX_OPERATION)


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-1485.

Whenever metadata.apply() is called, we keep track of whether the metadata changes might change the presentation edition of any associated Work (for simple stuff like title and contributor changes) or whether it might require the Work's presentation to be completely and expensively recalculated (for changes to subjects, measurements, or the summary).

At the end of the method, we check whether such a `Work` actually exists. If it does, we call a new `Work` helper method to put the appropriate `WorkCoverageRecord` in the REGISTERED state.

Some pieces of code call metadata.apply() and then immediately call Work.calculate_presentation(), or a method that calls Work.calculate_presentation such as LicensePool.calculate_work(). This isn't wrong, but it's now potentially inefficient. We need to evaluate these places to see whether we offload the work of calculating presentations to the background scripts.