### PR TITLE
Identifier->Work lookup no longer calls calculate_presentation if there's already a presentation-ready work

### DIFF
--- a/model/licensing.py
+++ b/model/licensing.py
@@ -802,7 +802,6 @@ class LicensePool(Base):
         else:
             self.set_presentation_edition()
             presentation_edition = self.presentation_edition
-
         if presentation_edition:
             if self not in presentation_edition.is_presentation_for:
                 raise ValueError(
@@ -935,16 +934,11 @@ class LicensePool(Base):
             work.license_pools.append(self)
             licensepools_changed = True
 
-        # Recalculate the display information for the Work, since the
+        # Recalculate the display information for the Work. Either the
         # associated LicensePools have changed, which may have caused
-        # the Work's presentation Edition to change.
-        #
-        # TODO: In theory we can speed things up by only calling
-        # calculate_presentation if licensepools_changed is
-        # True. However, some bits of other code call calculate_work()
-        # under the assumption that it always calls
-        # calculate_presentation(), so we'd need to evaluate those
-        # call points first.
+        # the Work's presentation Edition to change, or
+        # the caller has reason to believe that the presentation Edition
+        # is changing for some other reason.
         work.calculate_presentation(exclude_search=exclude_search)
 
         # Ensure that all LicensePools with this Identifier share

--- a/model/work.py
+++ b/model/work.py
@@ -966,6 +966,11 @@ class Work(Base):
                 representation = repr(self)
             logging.info("Presentation %s for work: %s", changed, representation)
 
+        # We want works to be presentation-ready as soon as possible,
+        # unless they are missing crucial information like language or
+        # title.
+        self.set_presentation_ready_based_on_content()
+
     @property
     def detailed_representation(self):
         """A description of this work more detailed than repr()"""

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -155,6 +155,7 @@ class TestWork(DatabaseTest):
         # - there can be only one edition that thinks it's the presentation edition for this work.
         # - time stamps are stamped.
         # - higher-standard sources (library staff) can replace, but not delete, authors.
+        # - works are made presentation-ready as soon as possible
 
         gutenberg_source = DataSource.GUTENBERG
         gitenberg_source = DataSource.PROJECT_GITENBERG
@@ -317,6 +318,23 @@ class TestWork(DatabaseTest):
         # The author of the Work is still the author of edition2 and was not clobbered.
         eq_("Alice Adder, Bob Bitshifter", work.author)
         eq_("Adder, Alice ; Bitshifter, Bob", work.sort_author)
+
+    def test_calculate_presentation_sets_presentation_ready_based_on_content(self):
+
+        # This work is incorrectly presentation-ready; its presentation
+        # edition has no language.
+        work = self._work(with_license_pool=True)
+        edition = work.presentation_edition
+        edition.language = None
+
+        eq_(True, work.presentation_ready)
+        work.calculate_presentation()
+        eq_(False, work.presentation_ready)
+
+        # Give it a language, and it becomes presentation-ready again.
+        edition.language = "eng"
+        work.calculate_presentation()
+        eq_(True, work.presentation_ready)
 
     def test_set_presentation_ready(self):
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1502,6 +1502,24 @@ class TestCollectionCoverageProvider(CoverageProviderTest):
         assert isinstance(work, Work)
         eq_(None, work.title)
 
+        # If a work exists but is not presentation-ready,
+        # CollectionCoverageProvider.work() will call calculate_work()
+        # in an attempt to fix it.
+        edition.title = u'Finally a title'
+        work2 = provider.work(pool.identifier, pool)
+        eq_(work2, work)
+        eq_(u'Finally a title', work.title)
+        eq_(True, work.presentation_ready)
+
+        # Once the work is presentation_ready, calling
+        # CollectionCoverageProvider.work() will no longer call
+        # calculate_work() -- it will just return the work.
+        def explode():
+            raise Exception("don't call me!")
+        pool.calculate_work = explode
+        work2 = provider.work(pool.identifier, pool)
+        eq_(work2, work)
+
     def test_set_metadata_and_circulationdata(self):
         """Verify that a CollectionCoverageProvider can set both
         metadata (on an Edition) and circulation data (on a LicensePool).


### PR DESCRIPTION
This changes the two main places in core where we go from an Identifier to a Work, possibly creating a new Work in the process.

These two places are the OPDSImporter.update_work_for_edition (called immediately after metadata comes in from an OPDS import) and CollectionCoverageProvider.work() (called by CollectionCoverageProvider.set_metadata())

In both cases, I remove the call to LicensePool.calculate_presentation() except when a new work needs to be created, or a work exists but it's not presentation-ready. In all other cases, we skip the potentially expensive call and expect that a background process will eventually update the Work's presentation information with whatever new metadata just came in. We expect this will happen because when a presentation-ready Work already exists, the adjacent call to Metadata.apply() put that Work in the 'registered' state for a full or partial metadata update.

This should dramatically speed up the process of importing new metadata from the metadata wrangler (OPDSImporter) as well as from all other data sources (each of which, I think, creates Works using a BibliographicCoverageProvider, which is a CollectionCoverageProvider).
