### PR TITLE
Replaced HTML tags in summaries with space instead of removing.

### DIFF
--- a/marc.py
+++ b/marc.py
@@ -409,7 +409,7 @@ class Annotator(object):
         else:
             summary = work.summary_text
         if summary:
-            stripped = re.sub('<[^>]+?>', '', summary)
+            stripped = re.sub('<[^>]+?>', ' ', summary)
             record.add_field(
                 Field(
                     tag="520",

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -345,7 +345,7 @@ class TestAnnotator(DatabaseTest):
 
         record = Record()
         Annotator.add_summary(record, work)
-        self._check_field(record, "520", {"a": "Summary"})
+        self._check_field(record, "520", {"a": " Summary "})
 
         # It also works with a materialized work.
         self.add_to_materialized_view([work])
@@ -353,7 +353,7 @@ class TestAnnotator(DatabaseTest):
 
         record = Record()
         Annotator.add_summary(record, mw)
-        self._check_field(record, "520", {"a": "Summary"})
+        self._check_field(record, "520", {"a": " Summary "})
 
     def test_add_simplified_genres(self):
         work = self._work(with_license_pool=True)


### PR DESCRIPTION
This is not great, but it's better than removing the tags entirely since sometimes there would be no space after sentences. Most people probably won't use the summaries anyway.