### PR TITLE
Enable axis 360 audiobooks

### DIFF
--- a/config.py
+++ b/config.py
@@ -236,7 +236,7 @@ class Configuration(object):
         },
         { "key": EntryPoint.ENABLED_SETTING,
           "label": _("Enabled entry points"),
-          "description": _("Patrons will see the selected entry points at the top level and in search results. <p>Currently supported audiobook vendors: Bibliotheca"),
+          "description": _("Patrons will see the selected entry points at the top level and in search results. <p>Currently supported audiobook vendors: Bibliotheca, Axis 360"),
           "type": "list",
           "options": [
               { "key": entrypoint.INTERNAL_NAME,

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -635,7 +635,6 @@ class ConfigurationSetting(Base, HasFullTableCache):
     # lanes.
     EXCLUDED_AUDIO_DATA_SOURCES_DEFAULT = [
         DataSourceConstants.OVERDRIVE,
-        DataSourceConstants.AXIS_360,
         DataSourceConstants.RB_DIGITAL
     ]
 


### PR DESCRIPTION
This simple branch removes Axis 360 from the list of vendors whose audiobooks are unsupported. It's possible to do this because of the resolution of https://jira.nypl.org/browse/SIMPLY-1539.