### PR TITLE
Added a MARCExporter setting for a web client URL for those who use a web client with no registry.

### DIFF
--- a/marc.py
+++ b/marc.py
@@ -469,6 +469,7 @@ class MARCExporter(object):
     # http://www.loc.gov/marc/organizations/org-search.php
     MARC_ORGANIZATION_CODE = "marc_organization_code"
 
+    WEB_CLIENT_URL = u'marc_web_client_url'
     INCLUDE_SUMMARY = u'include_summary'
     INCLUDE_SIMPLIFIED_GENRES = u'include_simplified_genres'
     STORAGE_PROTOCOL = u'storage_protocol'
@@ -483,6 +484,11 @@ class MARCExporter(object):
         { "key": MARC_ORGANIZATION_CODE,
           "label": _("The MARC organization code for this library (003 field)."),
           "description": _("MARC organization codes are assigned by the Library of Congress."),
+        },
+        {
+          "key": WEB_CLIENT_URL,
+          "label": _("The base URL for the web catalog for this library, for the 856 field."),
+          "description": _("If using a library registry that provides a web catalog, this can be left blank."),
         },
         { "key": INCLUDE_SUMMARY,
           "label": _("Include summaries in MARC records (520 field)"),


### PR DESCRIPTION
https://github.com/NYPL-Simplified/circulation-patron-web/pull/57 makes it possible to set up a web client with no library registry, so it's necessary to be able to configure the web client URL to use in MARC files without going through the registration process.

So I added a library setting to the MARC exporter for it. If we need to use the web client URL somewhere other than MARC files, this wouldn't be very good. Another option would be adding a new integration with the "discovery" goal that doesn't use a registration protocol, but lets you configure a web client URL. That would make the MARC-related code simpler but would be more complicated overall. Let me know if you think that would be better.