### PR TITLE
If an attempt to parse an XML document results in an XMLSyntaxError, remove known bad characters and try again.

### DIFF
--- a/tests/test_util_xml_parser.py
+++ b/tests/test_util_xml_parser.py
@@ -1,0 +1,36 @@
+# encoding: utf-8
+from nose.tools import (
+    assert_raises,
+    eq_,
+    set_trace,
+)
+
+from ..util.xmlparser import XMLParser
+from lxml.etree import XMLSyntaxError
+
+class MockParser(XMLParser):
+    """A mock XMLParser that just returns every tag it hears about."""
+
+    def process_one(self, tag, namespaces):
+        return tag
+
+
+class TestXMLParser(object):
+
+    def test_invalid_characters_are_stripped(self):
+        data = u"<tag>I enjoy invalid characters, such as \x00 and \x1F</tag>"
+        parser = MockParser()
+        [tag] = parser.process_all(data, "/tag")
+        eq_('I enjoy invalid characters, such as  and ', tag.text)
+
+    def test_exception_when_scrub_fails(self):
+        # Reraise the lxml exception if invalid characters somehow
+        # make it through the scrubbing process.
+        class Mock(MockParser):
+            def scrub_xml(cls, xml):
+                # Don't scrub at all.
+                return xml
+
+        data = u"<tag>I enjoy invalid characters, such as \x00 and \x1F</tag>"
+        parser = Mock()
+        assert_raises(XMLSyntaxError, list, parser.process_all(data, "/tag"))

--- a/util/xmlparser.py
+++ b/util/xmlparser.py
@@ -1,3 +1,5 @@
+import re
+import sys
 from nose.tools import set_trace
 from lxml import etree
 from StringIO import StringIO
@@ -7,6 +9,28 @@ class XMLParser(object):
     """Helper functions to process XML data."""
 
     NAMESPACES = {}
+
+    # Some Unicode characters are illegal within an XML document
+    # _illegal_xml_chars_RE will match them so we can remove them.
+    #
+    # Source:
+    # https://stackoverflow.com/questions/1707890/fast-way-to-filter-illegal-xml-unicode-chars-in-python
+    _illegal_unichrs = [(0x00, 0x08), (0x0B, 0x0C), (0x0E, 0x1F),
+                       (0x7F, 0x84), (0x86, 0x9F),
+                       (0xFDD0, 0xFDDF), (0xFFFE, 0xFFFF)]
+    if sys.maxunicode >= 0x10000:  # not narrow build
+        _illegal_unichrs.extend([(0x1FFFE, 0x1FFFF), (0x2FFFE, 0x2FFFF),
+                                 (0x3FFFE, 0x3FFFF), (0x4FFFE, 0x4FFFF),
+                                 (0x5FFFE, 0x5FFFF), (0x6FFFE, 0x6FFFF),
+                                 (0x7FFFE, 0x7FFFF), (0x8FFFE, 0x8FFFF),
+                                 (0x9FFFE, 0x9FFFF), (0xAFFFE, 0xAFFFF),
+                                 (0xBFFFE, 0xBFFFF), (0xCFFFE, 0xCFFFF),
+                                 (0xDFFFE, 0xDFFFF), (0xEFFFE, 0xEFFFF),
+                                 (0xFFFFE, 0xFFFFF), (0x10FFFE, 0x10FFFF)])
+
+    _illegal_ranges = ["%s-%s" % (unichr(low), unichr(high))
+                       for (low, high) in _illegal_unichrs]
+    _illegal_xml_chars_RE = re.compile(u'[%s]' % u''.join(_illegal_ranges))
 
     @classmethod
     def _xpath(cls, tag, expression, namespaces=None):
@@ -46,18 +70,44 @@ class XMLParser(object):
             return v
         return int(v)
 
+    def scrub_xml(self, xml):
+        """Remove invalid characters from XML.
+
+        We remove the characters rather than replacing them with
+        REPLACEMENT_CHARACTER, because they shouldn't have been in the
+        XML file in the first place.
+        """
+        return self._illegal_xml_chars_RE.sub("", xml)
+
     def process_all(self, xml, xpath, namespaces=None, handler=None, parser=None):
         if not parser:
             parser = etree.XMLParser()
         if not handler:
             handler = self.process_one
         if isinstance(xml, basestring):
-            root = etree.parse(StringIO(xml), parser)
+            root = None
+            exception = None
+            for transform in (None, self.scrub_xml):
+                if transform is None:
+                    transformed = xml
+                else:
+                    transformed = transform(xml)
+                try:
+                    root = etree.parse(StringIO(transformed), parser)
+                    break
+                except etree.XMLSyntaxError, e:
+                    exception = e
+                    continue
+            if root is None:
+                # Re-raise the last exception raised. This should
+                # never happen unless there is a problem with
+                # scrub_xml.
+                raise exception
         else:
             root = xml
         for i in root.xpath(xpath, namespaces=namespaces):
             data = handler(i, namespaces)
-            if data:
+            if data is not None:
                 yield data
 
     def process_one(self, tag, namespaces):


### PR DESCRIPTION
This addresses the general case of https://jira.nypl.org/browse/SIMPLY-1174. If an XML document contains characters not valid in XML, they will be removed.

Since very few XML documents contain such characters, we only scrub XML documents if they have a problem, rather than doing it preemptively.