### PR TITLE
Remove illegal XML characters even if they're encoded as character entities.

### DIFF
--- a/tests/test_util_xml_parser.py
+++ b/tests/test_util_xml_parser.py
@@ -23,6 +23,12 @@ class TestXMLParser(object):
         [tag] = parser.process_all(data, "/tag")
         eq_('I enjoy invalid characters, such as  and ', tag.text)
 
+    def test_invalid_entities_are_stripped(self):
+        data = u"<tag>I enjoy invalid entities, such as &#xfdd0; and &#x1F;</tag>"
+        parser = MockParser()
+        [tag] = parser.process_all(data, "/tag")
+        eq_('I enjoy invalid entities, such as  and ', tag.text)
+
     def test_exception_when_scrub_fails(self):
         # Reraise the lxml exception if invalid characters somehow
         # make it through the scrubbing process.


### PR DESCRIPTION
My previous branch on this topic didn't go far enough. In the actual case found in https://jira.nypl.org/browse/SIMPLY-1174, the bad characters weren't embedded in the XML document directly; they were encoded as character entities. This branch adds a second regular expression to find and remove invalid character entities.