### PR TITLE
Enforce delivery mechanism-related uniqueness constraints even when one of the fields subject to the constraint is null.

### DIFF
--- a/migration/20190111-unique-delivery-mechanisms.sql
+++ b/migration/20190111-unique-delivery-mechanisms.sql
@@ -1,0 +1,20 @@
+-- The ix_licensepooldeliveries_datasource_identifier_mechanism index
+-- is not necessary - an index is automatically created on the same
+-- fields to enforce a uniqueness constraint.
+drop index if exists ix_licensepooldeliveries_datasource_identifier_mechanism;
+
+-- However, the uniqueness constraint doesn't enforce uniqueness when one
+-- of the fields is null, and one of these fields -- resource_id -- is
+-- _usually_ null. So we need a unique partial index to properly enforce
+-- the constraint.
+CREATE UNIQUE INDEX ix_licensepooldeliveries_unique_when_no_resource ON public.licensepooldeliveries USING btree (data_source_id, identifier_id, delivery_mechanism_id) WHERE (resource_id IS NULL);
+
+
+-- deliverymechanisms doesn't have a uniqueness constraint, just a unique index.
+-- Let's change it to a uniqueness constraint (which comes with an implicit
+-- index) and then add a conditional unique index.
+drop index if exists ix_deliverymechanisms_drm_scheme_content_type;
+
+ALTER TABLE deliverymechanisms ADD CONSTRAINT deliverymechanisms_content_type_drm_scheme UNIQUE (content_type, drm_scheme);
+
+CREATE UNIQUE INDEX ix_deliverymechanisms_unique_when_no_drm ON public.deliverymechanisms USING btree (content_type) WHERE (drm_scheme IS NULL);


### PR DESCRIPTION
This addresses https://jira.nypl.org/browse/SIMPLY-1621 for `licensepooldeliverymechanisms` and `deliverymechanisms`. It prohibits the creation of duplicate `LicensePoolDeliveryMechanism` and `DeliveryMechanism` objects even in a case where one of the fields is null--a situation where a Postgresql uniqueness constraint is not enforced.

Note that this branch removes some unique indexes. I [learned](https://www.postgresql.org/docs/9.4/indexes-unique.html) while working on this that:

"PostgreSQL automatically creates a unique index when a unique constraint or primary key is defined for a table. The index covers the columns that make up the primary key or unique constraint (a multicolumn index, if appropriate), and is the mechanism that enforces the constraint."

That implies that our explicit indexes are redundant--a unique constraint _is_ an index and it will be used in queries. I checked this by running SQL like `explain select * from licensepooldeliveries where identifier_id=10 and data_source_id=4;` and it did show it would be doing an index scan against the unique constraint.

I tested the migration script by migrating my local test database and running the tests against it.