### PR TITLE
Minor MARC fix

### DIFF
--- a/marc.py
+++ b/marc.py
@@ -184,15 +184,17 @@ class Annotator(object):
         if non_filing_characters > 9:
             non_filing_characters = 0
 
+        subfields = ["a", unicode(edition.title or "")]
+        if edition.subtitle:
+            subfields += ["b", unicode(edition.subtitle)]
+        if edition.author:
+            subfields += ["c", unicode(edition.author)]
         record.add_field(
             Field(
                 tag="245",
                 indicators=["0", non_filing_characters],
-                subfields=[
-                    "a", unicode(edition.title or ""),
-                    "b", unicode(edition.subtitle or ""),
-                    "c", unicode(edition.author or ""),
-                ]))
+                subfields=subfields,
+            ))
 
     @classmethod
     def add_contributors(cls, record, edition):

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -159,6 +159,20 @@ class TestAnnotator(DatabaseTest):
                 "c": edition.author,
             }, ["0", "4"])
 
+        # If there's no subtitle or no author, those subfields are left out.
+        edition.subtitle = None
+        edition.author = None
+
+        record = Record()
+        Annotator.add_title(record, edition)
+        [field] = record.get_fields("245")
+        self._check_field(
+            record, "245", {
+                "a": edition.title,
+            }, ["0", "4"])
+        eq_([], field.get_subfields("b"))
+        eq_([], field.get_subfields("c"))
+
     def test_add_contributors(self):
         author = "a"
         author2 = "b"


### PR DESCRIPTION
This fixes a problem found by Lizzy Baus - when I tried to put an empty string in the subfield for subtitle, it was still ending up as "None" in the final file.

I'm not sure exactly why, but I removed the subfields for subtitle and author when those don't exist, since that's better than having the subfields present but empty anyway.