### PR TITLE
Before scrubbing invalid characters from an XML string, convert it to Unicode

### DIFF
--- a/tests/test_util_xml_parser.py
+++ b/tests/test_util_xml_parser.py
@@ -18,10 +18,10 @@ class MockParser(XMLParser):
 class TestXMLParser(object):
 
     def test_invalid_characters_are_stripped(self):
-        data = u"<tag>I enjoy invalid characters, such as \x00 and \x1F</tag>"
+        data = "<tag>I enjoy invalid characters, such as \x00 and \x1F. But I also like \xe2\x80\x9csmart quotes\xe2\x80\x9d.</tag>"
         parser = MockParser()
         [tag] = parser.process_all(data, "/tag")
-        eq_('I enjoy invalid characters, such as  and ', tag.text)
+        eq_(u'I enjoy invalid characters, such as  and . But I also like “smart quotes”.', tag.text)
 
     def test_invalid_entities_are_stripped(self):
         data = u"<tag>I enjoy invalid entities, such as &#xfdd0; and &#x1F;</tag>"

--- a/util/xmlparser.py
+++ b/util/xmlparser.py
@@ -85,6 +85,10 @@ class XMLParser(object):
         REPLACEMENT_CHARACTER, because they shouldn't have been in the
         XML file in the first place.
         """
+        # Convert the XML to Unicode so we can remove invalid Unicode
+        # characters from the data without worrying about how they're
+        # encoded.
+        xml = xml.decode("utf8")
         scrubbed = self._illegal_xml_chars_RE.sub("", xml)
         return self._illegal_xml_entities_RE.sub("", scrubbed)
 


### PR DESCRIPTION
This addresses https://jira.nypl.org/browse/SIMPLY-1664. The regular expression is correct but I was running it on a bytestring.