### PR TITLE
Record a script's completion as a Timestamp. 

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -1789,7 +1789,7 @@ class CollectionInputScript(Script):
 class OPDSImportScript(CollectionInputScript):
     """Import all books from the OPDS feed associated with a collection."""
 
-    name = "Import all books from the OPDS feed associated with a collection."""
+    name = "Import all books from the OPDS feed associated with a collection."
 
     IMPORTER_CLASS = OPDSImporter
     MONITOR_CLASS = OPDSImportMonitor

--- a/scripts.py
+++ b/scripts.py
@@ -200,9 +200,14 @@ class Script(object):
 class TimestampScript(Script):
     """A script that automatically records a timestamp whenever it runs."""
 
+    def __init__(self, *args, **kwargs):
+        super(TimestampScript, self).__init__(*args, **kwargs)
+        self.timestamp_collection = None
+
     def update_timestamp(self):
         """Update the appropriate Timestamp for this script."""
-        Timestamp.stamp(self._db, self.script_name, collection=None)
+        Timestamp.stamp(self._db, self.script_name,
+                        collection=self.timestamp_collection)
 
 
 class RunMonitorScript(Script):

--- a/scripts.py
+++ b/scripts.py
@@ -1647,7 +1647,7 @@ class WorkConsolidationScript(WorkProcessingScript):
         self._db.commit()
 
 
-class WorkPresentationScript(WorkProcessingScript):
+class WorkPresentationScript(TimestampScript, WorkProcessingScript):
     """Calculate the presentation for Work objects."""
 
     name = "Recalculate the presentation for works that need it."""
@@ -1957,7 +1957,7 @@ class MirrorResourcesScript(CollectionInputScript):
         )
 
 
-class RefreshMaterializedViewsScript(Script):
+class RefreshMaterializedViewsScript(TimestampScript):
     """Refresh all materialized views."""
 
     @classmethod

--- a/scripts.py
+++ b/scripts.py
@@ -1655,7 +1655,7 @@ class WorkConsolidationScript(WorkProcessingScript):
 class WorkPresentationScript(TimestampScript, WorkProcessingScript):
     """Calculate the presentation for Work objects."""
 
-    name = "Recalculate the presentation for works that need it."""
+    name = "Recalculate the presentation for works that need it."
 
     # Do a complete recalculation of the presentation.
     policy = PresentationCalculationPolicy()


### PR DESCRIPTION
Scripts that do nothing but invoke Monitors and CoverageProviders don't get their own timestamps.

This completes https://jira.nypl.org/browse/SIMPLY-1651 and does some of the work for https://jira.nypl.org/browse/SIMPLY-1649. Using the class name as a fallback script name technically completes 1649, but for some scripts the class names are a little vague and I think a more detailed explanation would be better, so I'll tackle that in a separate circulation branch.