### PR TITLE
Add new fields to the timestamps table and start using most of them

### DIFF
--- a/config.py
+++ b/config.py
@@ -545,7 +545,8 @@ class Configuration(object):
         if not known_value:
             from model import Timestamp
             known_value = Timestamp.value(
-                _db, cls.SITE_CONFIGURATION_CHANGED, None
+                _db, cls.SITE_CONFIGURATION_CHANGED, service_type=None,
+                collection=None
             )
         if not known_value:
             # The site configuration has never changed.

--- a/coverage.py
+++ b/coverage.py
@@ -189,8 +189,9 @@ class BaseCoverageProvider(object):
         for covered_statuses in covered_status_lists:
             offset = 0
             while offset is not None:
-                # TODO: change run_once to return a number of achievements
-                # (successfully covered records).
+                # TODO: change run_once to return achievement
+                # information (successfully covered records, transient
+                # errors, permanent errors).
                 try:
                     offset = self.run_once(
                         offset, count_as_covered=covered_statuses

--- a/coverage.py
+++ b/coverage.py
@@ -199,14 +199,14 @@ class BaseCoverageProvider(object):
                         "CoverageProvider %s raised uncaught exception.",
                         service_name, exc_info=e
                     )
-                    exception = traceback.exc_info()
+                    exception = traceback.format_exc()
 
         self.update_timestamp(start=start_time, exception=exception)
 
     def update_timestamp(self, **kwargs):
         Timestamp.stamp(
             _db=self._db, service=self.service_name,
-            service_type=Timestamp.COVERAGE_PROVIDER,
+            service_type=Timestamp.COVERAGE_PROVIDER_TYPE,
             collection=self.collection, **kwargs
         )
         self._db.commit()

--- a/coverage.py
+++ b/coverage.py
@@ -193,7 +193,11 @@ class BaseCoverageProvider(object):
         self.update_timestamp()
 
     def update_timestamp(self):
-        Timestamp.stamp(self._db, self.service_name, self.collection)
+        Timestamp.stamp(
+            _db=self._db, service=self.service_name,
+            service_type=Timestamp.COVERAGE_PROVIDER,
+            collection=self.collection
+        )
         self._db.commit()
 
     def run_once(self, offset, count_as_covered=None):

--- a/coverage.py
+++ b/coverage.py
@@ -1,6 +1,7 @@
 from nose.tools import set_trace
 import datetime
 import logging
+import traceback
 
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.functions import func
@@ -197,9 +198,10 @@ class BaseCoverageProvider(object):
                 except Exception, e:
                     logging.error(
                         "CoverageProvider %s raised uncaught exception.",
-                        service_name, exc_info=e
+                        self.service_name, exc_info=e
                     )
                     exception = traceback.format_exc()
+                    break
 
         self.update_timestamp(start=start_time, exception=exception)
 

--- a/migration/20190125-add-timestamp-fields.sql
+++ b/migration/20190125-add-timestamp-fields.sql
@@ -1,0 +1,74 @@
+-- Create a new enumerated type for types of timestamps.
+-- CREATE TYPE service_type AS ENUM (
+--     'monitor',
+--     'coverage_provider',
+--     'script'
+-- );
+
+-- -- Add columns to the timestamp table, including service_type for the
+-- -- enumerated type.
+
+-- ALTER TABLE timestamps ADD COLUMN service_type service_type;
+-- CREATE INDEX ix_timestamps_service_type ON timestamps USING btree (service_type);
+-- ALTER TABLE timestamps ADD COLUMN start TIMESTAMP WITHOUT TIME ZONE;
+-- ALTER TABLE timestamps ADD COLUMN achievements INTEGER;
+-- ALTER TABLE timestamps ADD COLUMN exception CHARACTER VARYING;
+
+-- Set service_type for all known monitors, coverage providers, and
+-- scripts.
+
+-- First let's take care of the easy cases.
+
+-- All 'monitor' and 'sweep' services are monitors.
+update timestamps set service_type='monitor' where (
+       service ilike '%monitor%'
+       or service ilike '%sweep%'
+);
+
+-- All 'coverage' services are coverage providers.
+update timestamps set service_type='coverage_provider' where service ilike '%coverage%';
+
+-- The database migration timestamps are managed by scripts.
+update timestamps set service_type='script' where (
+       service like 'Database Migration%'
+);
+
+-- The metadata wrangler reaper is a coverage provider; all other reapers
+-- are monitors.
+update timestamps set service_type='coverage_provider' where (
+       service='Metadata Wrangler Reaper'
+);
+update timestamps set service_type='monitor' where (
+       service ilike '%reaper%' and service_type is null
+);
+
+-- Now we get into specific cases where it's not clear from the service
+-- name what is what.
+
+-- All RBdigital and search index services are monitors.
+update timestamps set service_type='monitor' where (
+       service ilike 'search index update%' or
+       service ilike 'rbdigital%'
+);
+
+update timestamps set service_type='monitor' where service in (
+       'Metadata Wrangler Collection Updates',
+       'Metadata Wrangler Auxiliary Metadata Delivery',
+       'Work Randomness Updater',
+       'Overdrive Collection Overview'
+);
+
+update timestamps set service_type='coverage_provider' where (
+       service ilike '%metadata wrangler collection registrar%'
+);
+
+update timestamps set service_type='coverage_provider' where service in (
+       'OCLC Classify Identifier Lookup'
+);
+
+-- Finally, apart from the database migration scripts, which are
+-- covered above, every timestamp that uses the counter is a Monitor.
+update timestamps set service_type='monitor' where (
+       counter is not null and service_type is null
+);
+

--- a/migration/20190125-add-timestamp-fields.sql
+++ b/migration/20190125-add-timestamp-fields.sql
@@ -1,18 +1,18 @@
 -- Create a new enumerated type for types of timestamps.
--- CREATE TYPE service_type AS ENUM (
---     'monitor',
---     'coverage_provider',
---     'script'
--- );
+CREATE TYPE service_type AS ENUM (
+    'monitor',
+    'coverage_provider',
+    'script'
+);
 
--- -- Add columns to the timestamp table, including service_type for the
--- -- enumerated type.
+-- Add columns to the timestamp table, including service_type for the
+-- enumerated type.
 
--- ALTER TABLE timestamps ADD COLUMN service_type service_type;
--- CREATE INDEX ix_timestamps_service_type ON timestamps USING btree (service_type);
--- ALTER TABLE timestamps ADD COLUMN start TIMESTAMP WITHOUT TIME ZONE;
--- ALTER TABLE timestamps ADD COLUMN achievements CHARACTER VARYING;
--- ALTER TABLE timestamps ADD COLUMN exception CHARACTER VARYING;
+ALTER TABLE timestamps ADD COLUMN service_type service_type;
+CREATE INDEX ix_timestamps_service_type ON timestamps USING btree (service_type);
+ALTER TABLE timestamps ADD COLUMN start TIMESTAMP WITHOUT TIME ZONE;
+ALTER TABLE timestamps ADD COLUMN achievements CHARACTER VARYING;
+ALTER TABLE timestamps ADD COLUMN exception CHARACTER VARYING;
 
 -- Set service_type for all known monitors, coverage providers, and
 -- scripts.

--- a/migration/20190125-add-timestamp-fields.sql
+++ b/migration/20190125-add-timestamp-fields.sql
@@ -13,6 +13,7 @@ CREATE INDEX ix_timestamps_service_type ON timestamps USING btree (service_type)
 ALTER TABLE timestamps ADD COLUMN start TIMESTAMP WITHOUT TIME ZONE;
 ALTER TABLE timestamps ADD COLUMN achievements CHARACTER VARYING;
 ALTER TABLE timestamps ADD COLUMN exception CHARACTER VARYING;
+ALTER TABLE timestamps RENAME COLUMN timestamp TO finish;
 
 -- Set service_type for all known monitors, coverage providers, and
 -- scripts.

--- a/migration/20190125-add-timestamp-fields.sql
+++ b/migration/20190125-add-timestamp-fields.sql
@@ -11,7 +11,7 @@
 -- ALTER TABLE timestamps ADD COLUMN service_type service_type;
 -- CREATE INDEX ix_timestamps_service_type ON timestamps USING btree (service_type);
 -- ALTER TABLE timestamps ADD COLUMN start TIMESTAMP WITHOUT TIME ZONE;
--- ALTER TABLE timestamps ADD COLUMN achievements INTEGER;
+-- ALTER TABLE timestamps ADD COLUMN achievements CHARACTER VARYING;
 -- ALTER TABLE timestamps ADD COLUMN exception CHARACTER VARYING;
 
 -- Set service_type for all known monitors, coverage providers, and

--- a/migration/20190125-add-timestamp-fields.sql
+++ b/migration/20190125-add-timestamp-fields.sql
@@ -73,3 +73,6 @@ update timestamps set service_type='monitor' where (
        counter is not null and service_type is null
 );
 
+-- Fill in the 'start' values -- they'll be replaced with more accurate values
+-- as the scripts run.
+update timestamps set start=finish where start is null;

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -420,7 +420,7 @@ class SessionManager(object):
         timestamp, is_new = get_one_or_create(
             session, Timestamp, collection=None,
             service=Configuration.SITE_CONFIGURATION_CHANGED,
-            create_method_kwargs=dict(timestamp=datetime.datetime.utcnow())
+            create_method_kwargs=dict(finish=datetime.datetime.utcnow())
         )
         if is_new:
             site_configuration_has_changed(session)

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -207,7 +207,7 @@ class Timestamp(Base):
             service_type=service_type,
             collection=collection,
         )
-        self.update(start, timestamp, achievements, counter, exception)
+        stamp.update(start, timestamp, achievements, counter, exception)
 
         # Committing immediately reduces the risk of contention.
         _db.commit()
@@ -218,11 +218,11 @@ class Timestamp(Base):
         """Use a single method to update all the fields that aren't
         used to identify a Timestamp.
         """
-        stamp.start = start
-        stamp.achievements = achievements
-        stamp.counter = counter
-        stamp.timestamp = timestamp
-        stamp.exception = exception
+        self.start = start
+        self.achievements = achievements
+        self.counter = counter
+        self.timestamp = timestamp
+        self.exception = exception
 
 
     __table_args__ = (

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -99,11 +99,10 @@ class Timestamp(Base):
     MONITOR_TYPE = "monitor"
     COVERAGE_PROVIDER_TYPE = "coverage_provider"
     SCRIPT_TYPE = "script"
-    OTHER_TYPE = "other"
 
     service_type_enum = Enum(
-        MONITOR_TYPE, COVERAGE_PROVIDER_TYPE,,
-        SCRIPT_TYPE, OTHER_TYPE, name='service_type'
+        MONITOR_TYPE, COVERAGE_PROVIDER_TYPE, SCRIPT_TYPE,
+        name="service_type",
     )
 
     # Unique ID
@@ -112,8 +111,10 @@ class Timestamp(Base):
     # Name of the service.
     service = Column(String(255), index=True, nullable=False)
     
-    # Type of the service -- monitor, coverage provider, script or other.
-    service_type = Column(service_type_enum, index=True, default=OTHER_TYPE)
+    # Type of the service -- monitor, coverage provider, or script.
+    # If the service type does not fit into these categories, this field
+    # can be left null.
+    service_type = Column(service_type_enum, index=True, default=None)
 
     # The collection, if any, associated with this service -- some services
     # run separately on a number of collections.

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -206,15 +206,23 @@ class Timestamp(Base):
             service_type=service_type,
             collection=collection,
         )
+        self.update(start, timestamp, achievements, counter, exception)
+
+        # Committing immediately reduces the risk of contention.
+        _db.commit()
+        return stamp
+
+    def update(self, start=None, timestamp=None, achievements=None,
+               counter=None, exception=None):
+        """Use a single method to update all the fields that aren't
+        used to identify a Timestamp.
+        """
         stamp.start = start
         stamp.achievements = achievements
         stamp.counter = counter
         stamp.timestamp = timestamp
         stamp.exception = exception
 
-        # Committing immediately reduces the risk of contention.
-        _db.commit()
-        return stamp
 
     __table_args__ = (
         UniqueConstraint('service', 'collection_id'),

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -128,12 +128,12 @@ class Timestamp(Base):
     # proper.
     timestamp = Column(DateTime)
 
-    # The number of distinct things the service did during its last
-    # runn. Each service may decide for itself what counts as an
+    # A description of the things the service achieved during its last
+    # run. Each service may decide for itself what counts as an
     # 'achievement'; this is just a way to distinguish services that
     # do a lot of things from services that do a few things, or to see
     # services that run to completion but don't actually do anything.
-    achievements = Column(Integer, nullable=True)
+    achievements = Column(Unicode, nullable=True)
 
     # This column allows a service to keep one item of state between
     # runs. For example, a monitor that iterates over a database table

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -154,15 +154,13 @@ class Timestamp(Base):
             start = self.start.strftime(format)
         else:
             start = None
-        if self.counter:
-            timestamp += (' %d' % self.counter)
         if self.collection:
             collection = self.collection.name
         else:
             collection = None
 
-        message = u"<Timestamp %s: collection=%s, start=%s finish=%s>" % (
-            self.service, collection, start, finish
+        message = u"<Timestamp %s: collection=%s, start=%s finish=%s counter=%s>" % (
+            self.service, collection, start, finish, self.counter
         )
         return message.encode("utf8")
 

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -162,10 +162,17 @@ class Timestamp(Base):
         return message.encode("utf8")
 
     @classmethod
-    def value(cls, _db, service, collection):
+    def lookup(cls, _db, service, service_type, collection):
+        return get_one(
+            _db, Timestamp, service=service, service_type=service_type,
+            collection=collection
+        )
+
+    @classmethod
+    def value(cls, _db, service, service_type, collection):
         """Return the current value of the given Timestamp, if it exists.
         """
-        stamp = get_one(_db, Timestamp, service=service, collection=collection)
+        stamp = cls.lookup(_db, service, service_type, collection)
         if not stamp:
             return None
         return stamp.timestamp

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -110,7 +110,7 @@ class Timestamp(Base):
 
     # Name of the service.
     service = Column(String(255), index=True, nullable=False)
-    
+
     # Type of the service -- monitor, coverage provider, or script.
     # If the service type does not fit into these categories, this field
     # can be left null.
@@ -199,7 +199,7 @@ class Timestamp(Base):
             Defaults to now.
         :param date: The time at which this service stopped running.
             Defaults to now.
-        :param achievements: The number of distinct things the service
+        :param achievements: A human-readable description of what the service
             did during its run.
         :param counter: An integer item of state that the service may use
             to track its progress between runs.

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -174,7 +174,30 @@ class Timestamp(Base):
         cls, _db, service, service_type, collection=None, start=None, date=None,
         achievements=None, counter=None, exception=None
     ):
-        """Set a Timestamp, creating it if necessary."""
+        """Set a Timestamp, creating it if necessary.
+
+        This should be called once a service has stopped running,
+        whether or not it was able to complete its task.
+
+        :param _db: A database connection.
+        :param service: The name of the service associated with the Timestamp.
+
+        :param service_type: The type of the service associated with
+            the Timestamp. This must be one of the values in
+            Timestmap.service_type_enum.
+        :param collection: The Collection, if any, on which this service
+            just ran.
+        :param start: The time at which this service started running.
+            Defaults to now.
+        :param date: The time at which this service stopped running.
+            Defaults to now.
+        :param achievements: The number of distinct things the service
+            did during its run.
+        :param counter: An integer item of state that the service may use
+            to track its progress between runs.
+        :param exception: A stack trace for the exception, if any, which
+            stopped the service from running.
+        """
         timestamp = date or datetime.datetime.utcnow()
         start = start or timestamp
         stamp, was_new = get_one_or_create(

--- a/model/listeners.py
+++ b/model/listeners.py
@@ -76,11 +76,11 @@ def _site_configuration_has_changed(_db, timeout=1):
         # Update the timestamp.
         now = datetime.datetime.utcnow()
         earlier = now-datetime.timedelta(seconds=timeout)
-        sql = "UPDATE timestamps SET timestamp=:timestamp WHERE service=:service AND collection_id IS NULL AND timestamp<=:earlier;"
+        sql = "UPDATE timestamps SET finish=:finish WHERE service=:service AND collection_id IS NULL AND finish<=:earlier;"
         _db.execute(
             text(sql),
             dict(service=Configuration.SITE_CONFIGURATION_CHANGED,
-                 timestamp=now, earlier=earlier)
+                 finish=now, earlier=earlier)
         )
 
         # Update the Configuration's record of when the configuration

--- a/monitor.py
+++ b/monitor.py
@@ -305,14 +305,13 @@ class SweepMonitor(CollectionMonitor):
 
         run_started_at = datetime.datetime.utcnow()
         exception = None
-        achievements = 0
+        achievements = None
         while True:
             batch_started_at = time.time()
             old_offset = offset
             try:
-                # TODO: Change process_batch to return number of
-                # achievements as well as offset, and keep track of
-                # the total.
+                # TODO: Change process_batch to return achievement
+                # info as well as offset, and keep track of the total.
                 new_offset = self.process_batch(offset)
             except Exception, e:
                 self.log.error("Error during run: %s", e, exc_info=e)

--- a/monitor.py
+++ b/monitor.py
@@ -166,19 +166,21 @@ class Monitor(object):
                 self.run_once(start, started_running) or started_running
             )
             self.cleanup()
-            duration = datetime.datetime.utcnow() - started_running
-            self.log.info(
-                "Ran %s monitor in %.2f sec.", self.service_name,
-                duration.total_seconds()
-            )
         except Exception, e:
             self.log.error("Error running %s monitor", exc_info=e)
             exception = traceback.exc_info()
 
+        duration = datetime.datetime.utcnow() - started_running
+        self.log.info(
+            "Ran %s monitor in %.2f sec.", self.service_name,
+            duration.total_seconds()
+        )
+
         if self.keep_timestamp:
             # Update the Timestamp values.
             timestamp.update(
-                started_running, new_timestamp_value, exception=exception
+                start=started_running, timestamp=new_timestamp_value,
+                exception=exception
             )
         self._db.commit()
 
@@ -307,13 +309,13 @@ class SweepMonitor(CollectionMonitor):
             old_offset = offset
             try:
                 # TODO: Change process_batch to return number of
-                # achievements, and keep track of the total.
+                # achievements as well as offset, and keep track of
+                # the total.
                 new_offset = self.process_batch(offset)
             except Exception, e:
                 self.log.error("Error during run: %s", e, exc_info=e)
                 exception = traceback.format_exc()
                 break
-
             self._db.commit()
 
             if old_offset != new_offset:

--- a/monitor.py
+++ b/monitor.py
@@ -151,7 +151,6 @@ class Monitor(object):
         # now. Everything that happens after this time can be handled
         # on the subsequent run.
         this_run_start = datetime.datetime.utcnow()
-        update_timestamp_with = dict()
         try:
             this_run_finish = (
                 self.run_once(last_run_start, this_run_start)

--- a/monitor.py
+++ b/monitor.py
@@ -332,7 +332,7 @@ class SweepMonitor(CollectionMonitor):
                 # We completed a sweep. We're done.
                 self.cleanup()
                 break
-       
+
         # We're done with this run, either because we completed
         # a sweep or because an exception was raised.
         run_ended_at = datetime.datetime.utcnow()

--- a/scripts.py
+++ b/scripts.py
@@ -2082,28 +2082,27 @@ class DatabaseMigrationScript(Script):
             self.service = service
             if isinstance(finish, basestring):
                 finish = Script.parse_time(finish)
-            self.start = self.finish = finish
+            self.finish = finish
             if isinstance(counter, basestring):
                 counter = int(counter)
             self.counter = counter
 
         def save(self, _db):
-            self.update(_db, self.start, self.finish, self.counter)
+            self.update(_db, self.finish, self.counter)
 
-        def update(self, _db, start, finish, counter, migration_name=None):
+        def update(self, _db, finish, counter, migration_name=None):
             """Saves a TimestampInfo object to the database.
             """
             # Reset values locally.
-            self.start = start
             self.finish = finish
             self.counter = counter
 
             sql = (
-                "UPDATE timestamps SET start=:start, finish=:finish, counter=:counter"
+                "UPDATE timestamps SET start=:finish, finish=:finish, counter=:counter"
                 " where service=:service"
             )
             values = dict(
-                start=self.start, finish=self.finish, counter=self.counter,
+                finish=self.finish, counter=self.counter,
                 service=self.service,
             )
 
@@ -2492,7 +2491,7 @@ class DatabaseMigrationScript(Script):
         if migration_file.endswith('py') and self.python_timestamp:
             # This is a python migration. Update the python timestamp.
             self.python_timestamp.update(
-                self._db, start=last_run_date, finish=last_run_date,
+                self._db, finish=last_run_date,
                 counter=counter, migration_name=migration_file
             )
 
@@ -2502,7 +2501,7 @@ class DatabaseMigrationScript(Script):
              self.overall_timestamp.counter < counter))
         ):
             self.overall_timestamp.update(
-                self._db, start=last_run_date, finish=last_run_date,
+                self._db, finish=last_run_date,
                 counter=counter, migration_name=migration_file
             )
 

--- a/scripts.py
+++ b/scripts.py
@@ -1666,6 +1666,7 @@ class WorkConsolidationScript(WorkProcessingScript):
 
 class WorkPresentationScript(TimestampScript, WorkProcessingScript):
     """Calculate the presentation for Work objects."""
+
     name = "Recalculate the presentation for works that need it."
 
     # Do a complete recalculation of the presentation.

--- a/scripts.py
+++ b/scripts.py
@@ -2542,10 +2542,12 @@ class DatabaseMigrationInitializationScript(DatabaseMigrationScript):
         # Initialize the required timestamps with the Space Jam release date.
         init_timestamp = self.parse_time('1996-11-15')
         overall_timestamp = existing_timestamp or Timestamp.stamp(
-            self._db, self.SERVICE_NAME, None, date=init_timestamp
+            _db=self._db, service=self.SERVICE_NAME,
+            service_type=Timestamp.SCRIPT_TYPE, date=init_timestamp
         )
         python_timestamp = Timestamp.stamp(
-            self._db, self.PY_TIMESTAMP_SERVICE_NAME, None, date=init_timestamp
+            _db=self._db, service=self.PY_TIMESTAMP_SERVICE_NAME,
+            service_type=Timestamp.SCRIPT_TYPE, date=init_timestamp
         )
 
         if last_run_date:

--- a/scripts.py
+++ b/scripts.py
@@ -2524,7 +2524,7 @@ class DatabaseMigrationInitializationScript(DatabaseMigrationScript):
 
         if last_run_counter and not last_run_date:
             raise ValueError(
-                "Timestamp.counter must be reset alongside Timestamp.timestamp")
+                "Timestamp.counter must be reset alongside Timestamp.finish")
 
         existing_timestamp = get_one(self._db, Timestamp, service=self.name)
         if existing_timestamp and existing_timestamp.timestamp:
@@ -2543,11 +2543,11 @@ class DatabaseMigrationInitializationScript(DatabaseMigrationScript):
         init_timestamp = self.parse_time('1996-11-15')
         overall_timestamp = existing_timestamp or Timestamp.stamp(
             _db=self._db, service=self.SERVICE_NAME,
-            service_type=Timestamp.SCRIPT_TYPE, date=init_timestamp
+            service_type=Timestamp.SCRIPT_TYPE, finish=init_timestamp
         )
         python_timestamp = Timestamp.stamp(
             _db=self._db, service=self.PY_TIMESTAMP_SERVICE_NAME,
-            service_type=Timestamp.SCRIPT_TYPE, date=init_timestamp
+            service_type=Timestamp.SCRIPT_TYPE, finish=init_timestamp
         )
 
         if last_run_date:

--- a/scripts.py
+++ b/scripts.py
@@ -183,8 +183,6 @@ class Script(object):
             stack_trace = traceback.format_exc()
             self.update_timestamp(start_time, stack_trace)
             raise e
-        finally:
-            self.update_timestamp()
 
     def load_configuration(self):
         if not Configuration.cdns_loaded_from_database():

--- a/tests/models/test_coverage.py
+++ b/tests/models/test_coverage.py
@@ -22,32 +22,51 @@ class TestTimestamp(DatabaseTest):
         c2 = self._collection()
 
         # Create a timestamp.
-        timestamp = Timestamp.stamp("service", Timestamp.SCRIPT_TYPE, c1)
+        timestamp = Timestamp.stamp(
+            self._db, "service", Timestamp.SCRIPT_TYPE, c1
+        )
 
         # Look it up.
-        eq_(Timestamp, Timestamp.lookup("service", Timestamp.SCRIPT_TYPE, c1))
+        eq_(
+            timestamp,
+            Timestamp.lookup(self._db, "service", Timestamp.SCRIPT_TYPE, c1)
+        )
 
         # There are a number of ways to _fail_ to look up this timestamp.
-        eq_(None, Timestamp.lookup("other service", Timestamp.SCRIPT_TYPE, c1))
-        eq_(None, Timestamp.lookup("service", Timestamp.MONITOR_TYPE, c1))
-        eq_(None, Timestamp.lookup("service", Timestamp.SCRIPT_TYPE, c2))
+        eq_(
+            None,
+            Timestamp.lookup(
+                self._db, "other service", Timestamp.SCRIPT_TYPE, c1
+            )
+        )
+        eq_(
+            None,
+            Timestamp.lookup(self._db, "service", Timestamp.MONITOR_TYPE, c1)
+        )
+        eq_(
+            None,
+            Timestamp.lookup(self._db, "service", Timestamp.SCRIPT_TYPE, c2)
+        )
 
         # value() works the same way as lookup() but returns the actual
         # timestamp value.
-        eq_(timestamp.value,
-            Timestamp.value("service", Timestamp.SCRIPT_TYPE, c1))
-        eq_(None, Timestamp.value("service", Timestamp.SCRIPT_TYPE, c2))
+        eq_(timestamp.timestamp,
+            Timestamp.value(self._db, "service", Timestamp.SCRIPT_TYPE, c1))
+        eq_(
+            None,
+            Timestamp.value(self._db, "service", Timestamp.SCRIPT_TYPE, c2)
+        )
 
     def test_stamp(self):
         service = "service"
-        type = Timestamp.SCRIPT_TYPE,
+        type = Timestamp.SCRIPT_TYPE
 
         # If no date is specified, the value of the timestamp is the time
         # stamp() was called.
         stamp = Timestamp.stamp(self._db, service, type)
         now = datetime.datetime.utcnow()
-        assert (now - stamp.value).total_seconds() < 2
-        eq_(stamp.start, stamp.value)
+        assert (now - stamp.timestamp).total_seconds() < 2
+        eq_(stamp.start, stamp.timestamp)
         eq_(service, stamp.service)
         eq_(type, stamp.service_type)
         eq_(None, stamp.collection)
@@ -62,8 +81,8 @@ class TestTimestamp(DatabaseTest):
         )
         eq_(stamp, stamp2)
         now = datetime.datetime.utcnow()
-        assert (now - stamp.value).total_seconds() < 2
-        eq_(stamp.start, stamp.value)
+        assert (now - stamp.timestamp).total_seconds() < 2
+        eq_(stamp.start, stamp.timestamp)
         eq_(service, stamp.service)
         eq_(type, stamp.service_type)
         eq_(None, stamp.collection)
@@ -76,7 +95,7 @@ class TestTimestamp(DatabaseTest):
             self._db, service, type, collection=self._default_collection
         )
         assert stamp3 != stamp
-        eq_(self._default_collection, stamp3)
+        eq_(self._default_collection, stamp3.collection)
 
     def test_update(self):
         # update() can modify the fields of a Timestamp that aren't

--- a/tests/models/test_coverage.py
+++ b/tests/models/test_coverage.py
@@ -49,8 +49,8 @@ class TestTimestamp(DatabaseTest):
         )
 
         # value() works the same way as lookup() but returns the actual
-        # timestamp value.
-        eq_(timestamp.timestamp,
+        # timestamp.finish value.
+        eq_(timestamp.finish,
             Timestamp.value(self._db, "service", Timestamp.SCRIPT_TYPE, c1))
         eq_(
             None,
@@ -65,8 +65,8 @@ class TestTimestamp(DatabaseTest):
         # stamp() was called.
         stamp = Timestamp.stamp(self._db, service, type)
         now = datetime.datetime.utcnow()
-        assert (now - stamp.timestamp).total_seconds() < 2
-        eq_(stamp.start, stamp.timestamp)
+        assert (now - stamp.finish).total_seconds() < 2
+        eq_(stamp.start, stamp.finish)
         eq_(service, stamp.service)
         eq_(type, stamp.service_type)
         eq_(None, stamp.collection)
@@ -81,8 +81,8 @@ class TestTimestamp(DatabaseTest):
         )
         eq_(stamp, stamp2)
         now = datetime.datetime.utcnow()
-        assert (now - stamp.timestamp).total_seconds() < 2
-        eq_(stamp.start, stamp.timestamp)
+        assert (now - stamp.finish).total_seconds() < 2
+        eq_(stamp.start, stamp.finish)
         eq_(service, stamp.service)
         eq_(type, stamp.service_type)
         eq_(None, stamp.collection)
@@ -102,14 +102,14 @@ class TestTimestamp(DatabaseTest):
         # used to identify it.
         stamp = Timestamp.stamp(self._db, "service", Timestamp.SCRIPT_TYPE)
         start = datetime.datetime(2010, 1, 2)
-        timestamp = datetime.datetime(2018, 3, 4)
+        finish = datetime.datetime(2018, 3, 4)
         achievements = self._str
         counter = self._id
         exception = self._str
-        stamp.update(start, timestamp, achievements, counter, exception)
+        stamp.update(start, finish, achievements, counter, exception)
 
         eq_(start, stamp.start)
-        eq_(timestamp, stamp.timestamp)
+        eq_(finish, stamp.finish)
         eq_(achievements, stamp.achievements)
         eq_(counter, stamp.counter)
         eq_(exception, stamp.exception)

--- a/tests/models/test_coverage.py
+++ b/tests/models/test_coverage.py
@@ -8,10 +8,93 @@ from .. import DatabaseTest
 from ...model.coverage import (
     BaseCoverageRecord,
     CoverageRecord,
+    Timestamp,
     WorkCoverageRecord,
 )
 from ...model.datasource import DataSource
 from ...model.identifier import Identifier
+
+class TestTimestamp(DatabaseTest):
+
+    def test_lookup(self):
+
+        c1 = self._default_collection
+        c2 = self._collection()
+
+        # Create a timestamp.
+        timestamp = Timestamp.stamp("service", Timestamp.SCRIPT_TYPE, c1)
+
+        # Look it up.
+        eq_(Timestamp, Timestamp.lookup("service", Timestamp.SCRIPT_TYPE, c1))
+
+        # There are a number of ways to _fail_ to look up this timestamp.
+        eq_(None, Timestamp.lookup("other service", Timestamp.SCRIPT_TYPE, c1))
+        eq_(None, Timestamp.lookup("service", Timestamp.MONITOR_TYPE, c1))
+        eq_(None, Timestamp.lookup("service", Timestamp.SCRIPT_TYPE, c2))
+
+        # value() works the same way as lookup() but returns the actual
+        # timestamp value.
+        eq_(timestamp.value,
+            Timestamp.value("service", Timestamp.SCRIPT_TYPE, c1))
+        eq_(None, Timestamp.value("service", Timestamp.SCRIPT_TYPE, c2))
+
+    def test_stamp(self):
+        service = "service"
+        type = Timestamp.SCRIPT_TYPE,
+
+        # If no date is specified, the value of the timestamp is the time
+        # stamp() was called.
+        stamp = Timestamp.stamp(self._db, service, type)
+        now = datetime.datetime.utcnow()
+        assert (now - stamp.value).total_seconds() < 2
+        eq_(stamp.start, stamp.value)
+        eq_(service, stamp.service)
+        eq_(type, stamp.service_type)
+        eq_(None, stamp.collection)
+        eq_(None, stamp.achievements)
+        eq_(None, stamp.counter)
+        eq_(None, stamp.exception)
+
+        # Calling stamp() again will update the Timestamp.
+        stamp2 = Timestamp.stamp(
+            self._db, service, type, achievements="yay",
+            counter=100, exception="boo"
+        )
+        eq_(stamp, stamp2)
+        now = datetime.datetime.utcnow()
+        assert (now - stamp.value).total_seconds() < 2
+        eq_(stamp.start, stamp.value)
+        eq_(service, stamp.service)
+        eq_(type, stamp.service_type)
+        eq_(None, stamp.collection)
+        eq_('yay', stamp.achievements)
+        eq_(100, stamp.counter)
+        eq_('boo', stamp.exception)
+
+        # Passing in a different collection will create a new Timestamp.
+        stamp3 = Timestamp.stamp(
+            self._db, service, type, collection=self._default_collection
+        )
+        assert stamp3 != stamp
+        eq_(self._default_collection, stamp3)
+
+    def test_update(self):
+        # update() can modify the fields of a Timestamp that aren't
+        # used to identify it.
+        stamp = Timestamp.stamp(self._db, "service", Timestamp.SCRIPT_TYPE)
+        start = datetime.datetime(2010, 1, 2)
+        timestamp = datetime.datetime(2018, 3, 4)
+        achievements = self._str
+        counter = self._id
+        exception = self._str
+        stamp.update(start, timestamp, achievements, counter, exception)
+        
+        eq_(start, stamp.start)
+        eq_(timestamp, stamp.timestamp)
+        eq_(achievements, stamp.achievements)
+        eq_(counter, stamp.counter)
+        eq_(exception, stamp.exception)
+        
 
 class TestBaseCoverageRecord(DatabaseTest):
 

--- a/tests/models/test_coverage.py
+++ b/tests/models/test_coverage.py
@@ -88,13 +88,13 @@ class TestTimestamp(DatabaseTest):
         counter = self._id
         exception = self._str
         stamp.update(start, timestamp, achievements, counter, exception)
-        
+
         eq_(start, stamp.start)
         eq_(timestamp, stamp.timestamp)
         eq_(achievements, stamp.achievements)
         eq_(counter, stamp.counter)
         eq_(exception, stamp.exception)
-        
+
 
 class TestBaseCoverageRecord(DatabaseTest):
 

--- a/tests/models/test_listeners.py
+++ b/tests/models/test_listeners.py
@@ -61,9 +61,12 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         # package_setup() for this test run.
         last_update = Configuration.site_configuration_last_update(self._db)
 
-        timestamp_value = Timestamp.value(
-            self._db, Configuration.SITE_CONFIGURATION_CHANGED, None
-        )
+        def ts():
+            return Timestamp.value(
+                self._db, Configuration.SITE_CONFIGURATION_CHANGED, 
+                service_type=None, collection=None
+            )
+        timestamp_value = ts()
         eq_(timestamp_value, last_update)
 
         # Now let's call site_configuration_has_changed().
@@ -71,10 +74,7 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         site_configuration_has_changed(self._db, timeout=0)
 
         # The Timestamp has changed in the database.
-        new_timestamp_value = Timestamp.value(
-            self._db, Configuration.SITE_CONFIGURATION_CHANGED, None
-        )
-        assert new_timestamp_value > timestamp_value
+        assert ts() > timestamp_value
 
         # The locally-stored last update value has been updated.
         new_last_update_time = Configuration.site_configuration_last_update(
@@ -89,7 +89,8 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         # site_configuration_has_changed() -- they will know about the
         # change but we won't be informed.
         timestamp = Timestamp.stamp(
-            self._db, Configuration.SITE_CONFIGURATION_CHANGED, None
+            self._db, Configuration.SITE_CONFIGURATION_CHANGED,
+            service_type=None, collection=None
         )
 
         # Calling Configuration.check_for_site_configuration_update

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -94,9 +94,9 @@ class TestDatabaseInterface(DatabaseTest):
         timestamp = get_one(self._db, Timestamp,
                             collection=None,
                             service=Configuration.SITE_CONFIGURATION_CHANGED)
-        old_timestamp = timestamp.timestamp
+        old_timestamp = timestamp.finish
         SessionManager.initialize_data(self._db)
-        eq_(old_timestamp, timestamp.timestamp)
+        eq_(old_timestamp, timestamp.finish)
 
 class TestMaterializedViews(DatabaseTest):
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -214,15 +214,15 @@ class TestBaseCoverageProvider(CoverageProviderTest):
         provider = MockProvider(self._db)
         provider.run_once_and_update_timestamp()
 
-        # The Timestamp's .start and .timestamp are now set to recent
+        # The Timestamp's .start and .finish are now set to recent
         # values -- the start and end points of run_once().
         timestamp = Timestamp.lookup(
             self._db, service_name, service_type, collection=None
         )
         now = datetime.datetime.utcnow()
-        assert (now - timestamp.timestamp).total_seconds() < 1
         assert (now - timestamp.start).total_seconds() < 1
-        assert timestamp.start < timestamp.timestamp
+        assert (now - timestamp.finish).total_seconds() < 1
+        assert timestamp.start < timestamp.finish
 
         # run_once was called twice: once to exclude items that have
         # any coverage record whatsoever (PREVIOUSLY_ATTEMPTED), and again to
@@ -249,9 +249,9 @@ class TestBaseCoverageProvider(CoverageProviderTest):
             collection=None
         )
         now = datetime.datetime.utcnow()
-        assert (now - timestamp.timestamp).total_seconds() < 1
         assert (now - timestamp.start).total_seconds() < 1
-        assert timestamp.start < timestamp.timestamp
+        assert (now - timestamp.finish).total_seconds() < 1
+        assert timestamp.start < timestamp.finish
 
         assert "Exception: Unhandled exception" in timestamp.exception
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -231,7 +231,7 @@ class TestBaseCoverageProvider(CoverageProviderTest):
         eq_([CoverageRecord.PREVIOUSLY_ATTEMPTED,
              CoverageRecord.DEFAULT_COUNT_AS_COVERED], provider.run_once_calls)
 
-    def test_run_once_and_update_timestamp(self):
+    def test_run_once_and_update_timestamp_catches_exception(self):
         """Test that run_once_and_update_timestamp catches an exception
         and stores a stack trace in the CoverageProvider's Timestamp.
         """
@@ -248,6 +248,11 @@ class TestBaseCoverageProvider(CoverageProviderTest):
             self._db, provider.SERVICE_NAME, Timestamp.COVERAGE_PROVIDER_TYPE,
             collection=None
         )
+        now = datetime.datetime.utcnow()
+        assert (now - timestamp.timestamp).total_seconds() < 1
+        assert (now - timestamp.start).total_seconds() < 1
+        assert timestamp.start < timestamp.timestamp
+
         assert "Exception: Unhandled exception" in timestamp.exception
 
     def test_run_once(self):

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -670,7 +670,10 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
         # The coverage provider's timestamp was not updated, because
         # we're using ensure_coverage on a single record.
         eq_(None,
-            Timestamp.value(self._db, provider.service_name, collection=None)
+            Timestamp.value(
+                self._db, provider.service_name,
+                Timestamp.COVERAGE_PROVIDER_TYPE, collection=None
+            )
         )
 
         # Now let's try a CollectionCoverageProvider that needs to
@@ -739,7 +742,10 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
         # The coverage provider's timestamp was not updated, because
         # we're using ensure_coverage on a single record.
         eq_(None,
-            Timestamp.value(self._db, provider.service_name, collection=None)
+            Timestamp.value(
+                self._db, provider.service_name,
+                service_type=Timestamp.COVERAGE_PROVIDER_TYPE, collection=None
+            )
         )
 
     def test_ensure_coverage_transient_coverage_failure(self):
@@ -752,7 +758,10 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
 
         # Timestamp was not updated.
         eq_(None,
-            Timestamp.value(self._db, provider.service_name, collection=None)
+            Timestamp.value(
+                self._db, provider.service_name,
+                service_type=Timestamp.COVERAGE_PROVIDER_TYPE, collection=None
+            )
         )
 
     def test_ensure_coverage_changes_status(self):
@@ -968,7 +977,10 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
         # We start with no CoverageRecords and no Timestamp.
         eq_([], self._db.query(CoverageRecord).all())
         eq_(None,
-            Timestamp.value(self._db, provider.service_name, collection=None)
+            Timestamp.value(
+                self._db, provider.service_name,
+                service_type=Timestamp.COVERAGE_PROVIDER_TYPE, collection=None
+            )
         )
 
         provider.run()
@@ -981,7 +993,10 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
 
         # But the coverage provider did run, and the timestamp is now set to
         # a recent value.
-        value = Timestamp.value(self._db, provider.service_name, collection=None)
+        value = Timestamp.value(
+            self._db, provider.service_name,
+            service_type=Timestamp.COVERAGE_PROVIDER_TYPE, collection=None
+        )
         assert (datetime.datetime.utcnow() - value).total_seconds() < 1
 
     def test_run_transient_failure(self):
@@ -995,7 +1010,8 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
         eq_([], self._db.query(CoverageRecord).all())
         eq_(None,
             Timestamp.value(
-                self._db, provider.service_name, collection=None
+                self._db, provider.service_name,
+                service_type=Timestamp.COVERAGE_PROVIDER_TYPE, collection=None
             )
         )
 
@@ -1008,7 +1024,8 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
 
         # The timestamp was set.
         timestamp = Timestamp.value(
-            self._db, provider.service_name, collection=None
+            self._db, provider.service_name,
+            service_type=Timestamp.COVERAGE_PROVIDER_TYPE, collection=None
         )
         assert (timestamp-now).total_seconds() < 1
 
@@ -1802,8 +1819,11 @@ class TestWorkCoverageProvider(DatabaseTest):
 
         # We start with no relevant WorkCoverageRecord and no Timestamp.
         eq_([], qu.all())
-        eq_(None, Timestamp.value(
-            self._db, provider.service_name, collection=None)
+        eq_(None,
+            Timestamp.value(
+                self._db, provider.service_name,
+                service_type=Timestamp.COVERAGE_PROVIDER_TYPE, collection=None
+            )
         )
 
         now = datetime.datetime.utcnow()
@@ -1815,7 +1835,10 @@ class TestWorkCoverageProvider(DatabaseTest):
         eq_(provider.operation, record.operation)
 
         # The timestamp is now set.
-        timestamp = Timestamp.value(self._db, provider.service_name, collection=None)
+        timestamp = Timestamp.value(
+            self._db, provider.service_name,
+            service_type=Timestamp.COVERAGE_PROVIDER_TYPE, collection=None
+        )
         assert (timestamp-now).total_seconds() < 1
 
     def test_transient_failure(self):
@@ -1838,7 +1861,10 @@ class TestWorkCoverageProvider(DatabaseTest):
 
         # The timestamp is now set to a recent value.
         service_name = "Never successful (transient, works) (the_operation)"
-        value = Timestamp.value(self._db, service_name, collection=None)
+        value = Timestamp.value(
+            self._db, service_name,
+            service_type=Timestamp.COVERAGE_PROVIDER_TYPE, collection=None
+        )
         assert (datetime.datetime.now()-value).total_seconds() < 2
 
     def test_persistent_failure(self):
@@ -1861,7 +1887,10 @@ class TestWorkCoverageProvider(DatabaseTest):
 
         # The timestamp is now set to a recent value.
         service_name = "Never successful (works) (the_operation)"
-        value = Timestamp.value(self._db, service_name, collection=None)
+        value = Timestamp.value(
+            self._db, service_name,
+            service_type=Timestamp.COVERAGE_PROVIDER_TYPE, collection=None
+        )
         assert (datetime.datetime.now()-value).total_seconds() < 2
 
     def test_items_that_need_coverage(self):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -219,24 +219,32 @@ class TestCollectionMonitor(DatabaseTest):
             PROTOCOL = ExternalIntegration.OPDS_IMPORT
 
         # Here we have three OPDS import Collections...
-        o1 = self._collection()
-        o2 = self._collection()
-        o3 = self._collection()
+        o1 = self._collection("o1")
+        o2 = self._collection("o2")
+        o3 = self._collection("o3")
 
         # ...and a Bibliotheca collection.
         b1 = self._collection(protocol=ExternalIntegration.BIBLIOTHECA)
 
         # o1 just had its Monitor run.
-        Timestamp.stamp(self._db, OPDSCollectionMonitor.SERVICE_NAME, o1)
+        Timestamp.stamp(
+            self._db, OPDSCollectionMonitor.SERVICE_NAME,
+            Timestamp.MONITOR_TYPE, o1
+        )
 
         # o2 and b1 have never had their Monitor run, but o2 has had some other Monitor run.
-        Timestamp.stamp(self._db, "A Different Service", o2)
+        Timestamp.stamp(
+            self._db, "A Different Service", Timestamp.MONITOR_TYPE,
+            o2
+        )
 
         # o3 had its Monitor run an hour ago.
         now = datetime.datetime.utcnow()
         an_hour_ago = now - datetime.timedelta(seconds=3600)
-        Timestamp.stamp(self._db, OPDSCollectionMonitor.SERVICE_NAME,
-                        o3, an_hour_ago)
+        Timestamp.stamp(
+            self._db, OPDSCollectionMonitor.SERVICE_NAME,
+            Timestamp.MONITOR_TYPE, o3, date=an_hour_ago
+        )
 
         monitors = list(OPDSCollectionMonitor.all(self._db))
 
@@ -325,7 +333,9 @@ class TestSweepMonitor(DatabaseTest):
         # The monitor was just run, but it was not able to proceed past
         # i1.
         timestamp = Timestamp.stamp(
-            self._db, self.monitor.service_name, self.monitor.collection
+            self._db, self.monitor.service_name,
+            Timestamp.MONITOR_TYPE,
+            self.monitor.collection
         )
         timestamp.counter = i1.id
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -115,7 +115,11 @@ class TestMonitor(DatabaseTest):
         # the original value, because they were updated to reflect the
         # time that run_once() was called.
         assert timestamp.start > monitor.original_timestamp
-        assert timestamp.timestamp > timestamp.start
+
+        # The timestamp is set to the time the monitor _started_
+        # running, so that the next time it runs it'll catch any
+        # activity that happened _while_ the monitor was running.
+        assert timestamp.timestamp == timestamp.start
 
     def test_initial_timestamp(self):
         class NeverRunMonitor(MockMonitor):

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -1910,7 +1910,7 @@ class TestOPDSImportMonitor(OPDSImporterTest):
 
         # Nothing has been imported yet, so all data is new.
         eq_(True, monitor.feed_contains_new_data(feed))
-        eq_(None, timestamp.timestamp)
+        eq_(None, timestamp.start)
 
         # Now import the editions.
         monitor = MockOPDSImportMonitor(
@@ -1925,7 +1925,7 @@ class TestOPDSImportMonitor(OPDSImporterTest):
 
         # The timestamp has been updated, although unlike most
         # Monitors the timestamp is purely informational.
-        assert timestamp.timestamp != None
+        assert timestamp.finish != None
 
         editions = self._db.query(Edition).all()
         data_source = DataSource.lookup(self._db, DataSource.OA_CONTENT_SERVER)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -163,11 +163,11 @@ class TestTimestampScript(DatabaseTest):
         timestamp = self._ts(script)
 
         # The start and end points of do_run() have become
-        # Timestamp.start and Timestamp.timestamp.
+        # Timestamp.start and Timestamp.finish.
         now = datetime.datetime.utcnow()
         assert (now - timestamp.start).total_seconds() < 5
-        assert (now - timestamp.timestamp).total_seconds() < 5
-        assert timestamp.start < timestamp.timestamp
+        assert (now - timestamp.finish).total_seconds() < 5
+        assert timestamp.start < timestamp.finish
         eq_(None, timestamp.collection)
 
     def test_update_timestamp_with_collection(self):
@@ -187,6 +187,12 @@ class TestTimestampScript(DatabaseTest):
         # A TimestampScript that fails to complete still has its
         # Timestamp set -- the timestamp just records the time that
         # the script stopped running.
+        #
+        # This is different from Monitors, where the timestamp
+        # is only updated when the Monitor runs to completion.
+        # The difference is that Monitors are frequently responsible for
+        # keeping track of everything that happened since a certain
+        # time, and Scripts generally aren't.
         class Broken(TimestampScript):
             def do_run(self):
                 raise Exception("i'm broken")
@@ -196,7 +202,7 @@ class TestTimestampScript(DatabaseTest):
         timestamp = self._ts(script)
 
         now = datetime.datetime.utcnow()
-        assert (now - timestamp.timestamp).total_seconds() < 5
+        assert (now - timestamp.finish).total_seconds() < 5
 
         # A stack trace for the exception has been recorded in the
         # Timestamp object.
@@ -701,7 +707,7 @@ class TestRunThreadedCollectionCoverageProviderScript(DatabaseTest):
             self._db, provider.SERVICE_NAME, Timestamp.COVERAGE_PROVIDER_TYPE,
             collection=collection
         )
-        original_timestamp = timestamp.timestamp
+        original_timestamp = timestamp.finish
         self._db.commit()
 
         pool = DatabasePool(2, script.session_factory)
@@ -807,35 +813,38 @@ class TestTimestampInfo(DatabaseTest):
 
         # But an empty Timestamp has been placed into the database.
         timestamp = self._db.query(Timestamp).filter(Timestamp.service=='test').one()
-        eq_(None, timestamp.timestamp)
+        eq_(None, timestamp.start)
+        eq_(None, timestamp.finish)
         eq_(None, timestamp.counter)
 
         # A repeat search for the empty Timestamp also results in None.
         eq_(None, self.TimestampInfo.find(self._db, 'test'))
 
         # If the Timestamp is stamped, it is returned.
-        timestamp.timestamp = datetime.datetime.utcnow()
+        timestamp.finish = datetime.datetime.utcnow()
         timestamp.counter = 1
         self._db.flush()
 
         result = self.TimestampInfo.find(self._db, 'test')
-        eq_(timestamp.timestamp, result.timestamp)
+        eq_(timestamp.finish, result.finish)
         eq_(1, result.counter)
 
     def test_update(self):
         # Create a Timestamp to be updated.
         past = datetime.datetime.strptime('19980101', '%Y%m%d')
         stamp = Timestamp.stamp(
-            self._db, 'test', Timestamp.SCRIPT_TYPE, None, date=past
+            self._db, 'test', Timestamp.SCRIPT_TYPE, None, start=past,
+            finish=past
         )
         timestamp_info = self.TimestampInfo.find(self._db, 'test')
 
         now = datetime.datetime.utcnow()
-        timestamp_info.update(self._db, now, 2)
+        timestamp_info.update(self._db, now, now, 2)
 
         # When we refresh the Timestamp object, it's been updated.
         self._db.refresh(stamp)
-        eq_(now, stamp.timestamp)
+        eq_(now, stamp.start)
+        eq_(now, stamp.finish)
         eq_(2, stamp.counter)
 
     def save(self):
@@ -849,7 +858,7 @@ class TestTimestampInfo(DatabaseTest):
 
         # The Timestamp exists now.
         timestamp = timestamp_qu.one()
-        eq_(now, timestamp.timestamp)
+        eq_(now, timestamp.finish)
         eq_(47, timestamp.counter)
 
 
@@ -900,7 +909,7 @@ class DatabaseMigrationScriptTest(DatabaseTest):
             # Create unique, innocuous content for a SQL file.
             # This SQL inserts a timestamp into the test database.
             service = "Test Database Migration Script - %s" % unique_string
-            content = (("insert into timestamps(service, timestamp)"
+            content = (("insert into timestamps(service, finish)"
                         " values ('%s', '%s');") % (service, '1970-01-01'))
         elif migration_type=='py':
             # Create unique, innocuous content for a Python file.
@@ -999,15 +1008,18 @@ class TestDatabaseMigrationScript(DatabaseMigrationScriptTest):
         self._create_test_migrations()
 
         stamp = datetime.datetime.strptime('20260810', '%Y%m%d')
-        self.timestamp = Timestamp(service=self.script.name, timestamp=stamp)
+        self.timestamp = Timestamp(
+            service=self.script.name, start=stamp, finish=stamp
+        )
         self.python_timestamp = Timestamp(
-            service=self.script.PY_TIMESTAMP_SERVICE_NAME, timestamp=stamp
+            service=self.script.PY_TIMESTAMP_SERVICE_NAME, start=stamp,
+            finish=stamp
         )
         self._db.add_all([self.timestamp, self.python_timestamp])
         self._db.flush()
 
         self.timestamp_info = self.script.TimestampInfo(
-            self.timestamp.service, self.timestamp.timestamp
+            self.timestamp.service, self.timestamp.start
         )
 
     def test_name(self):
@@ -1049,24 +1061,24 @@ class TestDatabaseMigrationScript(DatabaseMigrationScriptTest):
         ).one()
 
         # Neither Timestamp object has a timestamp.
-        eq_((None, None), (python.timestamp, overall.timestamp))
+        eq_((None, None), (python.finish, overall.finish))
         # So neither timestamp is returned as a property.
         eq_(None, self.script.python_timestamp)
         eq_(None, self.script.overall_timestamp)
 
         # If you give the Timestamps data, suddenly they show up.
-        overall.timestamp = self.script.parse_time('1998-08-25')
-        python.timestamp = self.script.parse_time('1993-06-11')
+        overall.finish = self.script.parse_time('1998-08-25')
+        python.finish = self.script.parse_time('1993-06-11')
         python.counter = 2
         self._db.flush()
 
         overall_timestamp_info = self.script.overall_timestamp
         assert isinstance(overall_timestamp_info, self.script.TimestampInfo)
-        eq_(overall.timestamp, overall_timestamp_info.timestamp)
+        eq_(overall.finish, overall_timestamp_info.finish)
 
         python_timestamp_info = self.script.python_timestamp
         assert isinstance(python_timestamp_info, self.script.TimestampInfo)
-        eq_(python.timestamp, python_timestamp_info.timestamp)
+        eq_(python.finish, python_timestamp_info.finish)
         eq_(2, self.script.python_timestamp.counter)
 
     def test_directories_by_priority(self):
@@ -1218,18 +1230,18 @@ class TestDatabaseMigrationScript(DatabaseMigrationScriptTest):
         """Resets a timestamp according to the date of a migration file"""
 
         migration = '20271202-future-migration-funtime.sql'
-        py_last_run_time = self.python_timestamp.timestamp
+        py_last_run_time = self.python_timestamp.finish
 
         def assert_unchanged_python_timestamp():
-            eq_(py_last_run_time, self.python_timestamp.timestamp)
+            eq_(py_last_run_time, self.python_timestamp.finish)
 
         def assert_timestamp_matches_migration(timestamp, migration, counter=None):
             self._db.refresh(timestamp)
-            timestamp_str = timestamp.timestamp.strftime('%Y%m%d')
+            timestamp_str = timestamp.finish.strftime('%Y%m%d')
             eq_(migration[0:8], timestamp_str)
             eq_(counter, timestamp.counter)
 
-        assert self.timestamp_info.timestamp.strftime('%Y%m%d') != migration[0:8]
+        assert self.timestamp_info.finish.strftime('%Y%m%d') != migration[0:8]
         self.script.update_timestamps(migration)
         assert_timestamp_matches_migration(self.timestamp, migration)
         assert_unchanged_python_timestamp()
@@ -1251,7 +1263,7 @@ class TestDatabaseMigrationScript(DatabaseMigrationScriptTest):
         # the timestamp is not updated.
         migration = '20280801-before-the-existing-timestamp.sql'
         self.script.update_timestamps(migration)
-        eq_(self.timestamp.timestamp.strftime('%Y%m%d'), '20280901')
+        eq_(self.timestamp.finish.strftime('%Y%m%d'), '20280901')
 
         # Python migrations update both timestamps.
         migration = '20281001-new-task.py'
@@ -1261,7 +1273,7 @@ class TestDatabaseMigrationScript(DatabaseMigrationScriptTest):
 
     def test_running_a_migration_updates_the_timestamps(self):
         future_time = datetime.datetime.strptime('20261030', '%Y%m%d')
-        self.timestamp_info.timestamp = future_time
+        self.timestamp_info.finish = future_time
 
         # Create a test migration after that point and grab relevant info
         # about it.
@@ -1283,7 +1295,7 @@ class TestDatabaseMigrationScript(DatabaseMigrationScriptTest):
         self.script.run_migrations(
             [migration_filename], migrations_by_dir, self.timestamp_info
         )
-        eq_(self.timestamp.timestamp.strftime('%Y%m%d'), '20261202')
+        eq_(self.timestamp.finish.strftime('%Y%m%d'), '20261202')
 
         # Even when there are counters.
         self._create_test_migration_file(
@@ -1295,7 +1307,7 @@ class TestDatabaseMigrationScript(DatabaseMigrationScriptTest):
         self.script.run_migrations(
             [migration_filename], migrations_by_dir, self.timestamp_info
         )
-        eq_(self.timestamp.timestamp.strftime('%Y%m%d'), '20261203')
+        eq_(self.timestamp.finish.strftime('%Y%m%d'), '20261203')
         eq_(self.timestamp.counter, 3)
 
     def test_all_migration_files_are_run(self):
@@ -1383,7 +1395,7 @@ class TestDatabaseMigrationInitializationScript(DatabaseMigrationScriptTest):
         self.assert_matches_timestamp(timestamp, last_migration_date)
 
     def assert_matches_timestamp(self, timestamp, migration_date):
-        eq_(timestamp.timestamp.strftime('%Y%m%d'), migration_date)
+        eq_(timestamp.finish.strftime('%Y%m%d'), migration_date)
 
     def test_accurate_timestamps_created(self):
         eq_(
@@ -1429,7 +1441,7 @@ class TestDatabaseMigrationInitializationScript(DatabaseMigrationScriptTest):
 
     def test_error_not_raised_when_timestamp_forced(self):
         past = self.script.parse_time('19951127')
-        Timestamp.stamp(self._db, self.script.name, Timestamp.SCRIPT_TYPE, None, date=past)
+        Timestamp.stamp(self._db, self.script.name, Timestamp.SCRIPT_TYPE, None, finish=past)
         self.script.run(['-f'])
         self.assert_matches_latest_migration(self.script.overall_timestamp)
         self.assert_matches_latest_python_migration(self.script.python_timestamp)
@@ -1438,13 +1450,13 @@ class TestDatabaseMigrationInitializationScript(DatabaseMigrationScriptTest):
         # A timestamp can be passed via the command line.
         self.script.run(['--last-run-date', '20101010'])
         expected_stamp = datetime.datetime.strptime('20101010', '%Y%m%d')
-        eq_(expected_stamp, self.script.overall_timestamp.timestamp)
+        eq_(expected_stamp, self.script.overall_timestamp.finish)
 
         # It will override an existing timestamp if forced.
         self.script.run(['--last-run-date', '20111111', '--force'])
         expected_stamp = datetime.datetime.strptime('20111111', '%Y%m%d')
-        eq_(expected_stamp, self.script.overall_timestamp.timestamp)
-        eq_(expected_stamp, self.script.python_timestamp.timestamp)
+        eq_(expected_stamp, self.script.overall_timestamp.finish)
+        eq_(expected_stamp, self.script.python_timestamp.finish)
 
     def test_accepts_last_run_counter(self):
         # If a counter is passed without a date, an error is raised.
@@ -1453,15 +1465,15 @@ class TestDatabaseMigrationInitializationScript(DatabaseMigrationScriptTest):
         # With a date, the counter can be set.
         self.script.run(['--last-run-date', '20101010', '--last-run-counter', '7'])
         expected_stamp = datetime.datetime.strptime('20101010', '%Y%m%d')
-        eq_(expected_stamp, self.script.overall_timestamp.timestamp)
+        eq_(expected_stamp, self.script.overall_timestamp.finish)
         eq_(7, self.script.overall_timestamp.counter)
 
         # When forced, the counter can be reset on an existing timestamp.
-        previous_timestamp = self.script.overall_timestamp.timestamp
+        previous_timestamp = self.script.overall_timestamp.finish
         self.script.run(['--last-run-date', '20121212', '--last-run-counter', '2', '-f'])
         expected_stamp = datetime.datetime.strptime('20121212', '%Y%m%d')
-        eq_(expected_stamp, self.script.overall_timestamp.timestamp)
-        eq_(expected_stamp, self.script.python_timestamp.timestamp)
+        eq_(expected_stamp, self.script.overall_timestamp.finish)
+        eq_(expected_stamp, self.script.python_timestamp.finish)
         eq_(2, self.script.overall_timestamp.counter)
         eq_(2, self.script.python_timestamp.counter)
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -728,7 +728,8 @@ class TestRunThreadedCollectionCoverageProviderScript(DatabaseTest):
 
         # The timestamp for the provider has been updated.
         new_timestamp = Timestamp.value(
-            self._db, provider.SERVICE_NAME, collection
+            self._db, provider.SERVICE_NAME, Timestamp.COVERAGE_PROVIDER_TYPE,
+            collection
         )
         assert new_timestamp != original_timestamp
         assert new_timestamp > original_timestamp
@@ -1385,14 +1386,20 @@ class TestDatabaseMigrationInitializationScript(DatabaseMigrationScriptTest):
         eq_(timestamp.timestamp.strftime('%Y%m%d'), migration_date)
 
     def test_accurate_timestamps_created(self):
-        eq_(None, Timestamp.value(self._db, self.script.name, collection=None))
+        eq_(
+            None,
+            Timestamp.value(
+                self._db, self.script.name, Timestamp.SCRIPT_TYPE,
+                collection=None
+            )
+        )
         self.script.run()
         self.assert_matches_latest_migration(self.script.overall_timestamp)
         self.assert_matches_latest_python_migration(self.script.python_timestamp)
 
     def test_accurate_python_timestamp_created_python_later(self):
         script = self.create_mock_script(DatabaseMigrationInitializationScript, self._db)
-        eq_(None, Timestamp.value(self._db, script.name, collection=None))
+        eq_(None, Timestamp.value(self._db, script.name, Timestamp.SCRIPT_TYPE, collection=None))
 
         # If the last python migration and the last SQL migration have
         # different timestamps, they're set accordingly.
@@ -1405,7 +1412,7 @@ class TestDatabaseMigrationInitializationScript(DatabaseMigrationScriptTest):
 
     def test_accurate_python_timestamp_created_python_earlier(self):
         script = self.create_mock_script(DatabaseMigrationInitializationScript, self._db)
-        eq_(None, Timestamp.value(self._db, script.name, collection=None))
+        eq_(None, Timestamp.value(self._db, script.name, Timestamp.SCRIPT_TYPE, collection=None))
 
         # If the last python migration and the last SQL migration have
         # different timestamps, they're set accordingly.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -156,8 +156,13 @@ class TestTimestampScript(DatabaseTest):
         script.run()
 
         timestamp = self._ts(script)
+
+        # The start and end points of do_run() have become
+        # Timestamp.start and Timestamp.timestamp.
         now = datetime.datetime.utcnow()
+        assert (now - timestamp.start).total_seconds() < 5
         assert (now - timestamp.timestamp).total_seconds() < 5
+        assert timestamp.start < timestamp.timestamp
         eq_(None, timestamp.collection)
 
     def test_update_timestamp_with_collection(self):
@@ -184,8 +189,13 @@ class TestTimestampScript(DatabaseTest):
         script = Broken(self._db)
         assert_raises_regexp(Exception, "i'm broken", script.run)
         timestamp = self._ts(script)
+
         now = datetime.datetime.utcnow()
         assert (now - timestamp.timestamp).total_seconds() < 5
+
+        # A stack trace for the exception has been recorded in the
+        # Timestamp object.
+        assert "Exception: i'm broken" in timestamp.exception
 
     def test_normal_script_has_no_timestamp(self):
         # Running a normal script does _not_ set a Timestamp.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -143,7 +143,12 @@ class TestScript(DatabaseTest):
 class TestTimestampScript(DatabaseTest):
 
     def _ts(self, script):
-        """Convenience method to look up the Timestamp for a script."""
+        """Convenience method to look up the Timestamp for a script.
+        
+        We don't use Timestamp.stamp() because we want to make sure
+        that Timestamps are being created by the actual code, not test
+        code.
+        """
         return get_one(self._db, Timestamp, service=script.script_name)
 
     def test_update_timestamp(self):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -839,7 +839,7 @@ class TestTimestampInfo(DatabaseTest):
         timestamp_info = self.TimestampInfo.find(self._db, 'test')
 
         now = datetime.datetime.utcnow()
-        timestamp_info.update(self._db, now, now, 2)
+        timestamp_info.update(self._db, now, 2)
 
         # When we refresh the Timestamp object, it's been updated.
         self._db.refresh(stamp)


### PR DESCRIPTION
This branch resolves https://jira.nypl.org/browse/SIMPLY-1650
The columns mentioned here are added to the `timestamps` table: https://jira.nypl.org/browse/SIMPLY-529?focusedCommentId=30722&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-30722

* `service_type`
* `start`
* `exception`
* `achievements`

I changed the signature of `Timestamp.stamp` to allow callers to set the appropriate values. There are four places where this method is called:

* Monitor
* CoverageProvider
* TimestampScript
* Various tests

In each case I changed the `stamp` calls to set the appropriate values, especially `service_type` which is now required when looking up a Timestamp.

I also started setting values for `start` (the start time of the work tracked by the `Timestamp`) and `exception`.  `achievements` is a lot more complicated and can be addressed later.

The migration script is also pretty complicated -- we don't have totally consistent naming conventions for the things that make timestamps, and it's important to set the `service_type` appropriately for everything that's already run, because otherwise it will appear as though the script hasn't been run before. (In most cases that's not a huge deal but it can lead to wasted resources.) I'm pretty sure I got all scripts, monitors, and coverage providers that are currently active in circulation or metadata.