### PR TITLE
The only invalid XML character we need to handle is the null character. XMLParser can handle all the others.

### DIFF
--- a/tests/test_util_xml_parser.py
+++ b/tests/test_util_xml_parser.py
@@ -14,29 +14,17 @@ class MockParser(XMLParser):
     def process_one(self, tag, namespaces):
         return tag
 
-
 class TestXMLParser(object):
 
     def test_invalid_characters_are_stripped(self):
-        data = "<tag>I enjoy invalid characters, such as \x00 and \x1F. But I also like \xe2\x80\x9csmart quotes\xe2\x80\x9d.</tag>"
+        data = "<tag>I enjoy invalid characters, such as \x00\x01 and \x1F. But I also like \xe2\x80\x9csmart quotes\xe2\x80\x9d.</tag>"
         parser = MockParser()
         [tag] = parser.process_all(data, "/tag")
         eq_(u'I enjoy invalid characters, such as  and . But I also like “smart quotes”.', tag.text)
 
     def test_invalid_entities_are_stripped(self):
-        data = u"<tag>I enjoy invalid entities, such as &#xfdd0; and &#x1F;</tag>"
+        data = u"<tag>I enjoy invalid entities, such as &#x00;&#x01; and &#x1F;</tag>"
         parser = MockParser()
         [tag] = parser.process_all(data, "/tag")
         eq_('I enjoy invalid entities, such as  and ', tag.text)
 
-    def test_exception_when_scrub_fails(self):
-        # Reraise the lxml exception if invalid characters somehow
-        # make it through the scrubbing process.
-        class Mock(MockParser):
-            def scrub_xml(cls, xml):
-                # Don't scrub at all.
-                return xml
-
-        data = u"<tag>I enjoy invalid characters, such as \x00 and \x1F</tag>"
-        parser = Mock()
-        assert_raises(XMLSyntaxError, list, parser.process_all(data, "/tag"))

--- a/tests/test_util_xml_parser.py
+++ b/tests/test_util_xml_parser.py
@@ -17,13 +17,13 @@ class MockParser(XMLParser):
 class TestXMLParser(object):
 
     def test_invalid_characters_are_stripped(self):
-        data = "<tag>I enjoy invalid characters, such as \x00\x01 and \x1F. But I also like \xe2\x80\x9csmart quotes\xe2\x80\x9d.</tag>"
+        data = '<?xml version="1.0" encoding="utf-8"><tag>I enjoy invalid characters, such as \x00\x01 and \x1F. But I also like \xe2\x80\x9csmart quotes\xe2\x80\x9d.</tag>'
         parser = MockParser()
         [tag] = parser.process_all(data, "/tag")
         eq_(u'I enjoy invalid characters, such as  and . But I also like “smart quotes”.', tag.text)
 
     def test_invalid_entities_are_stripped(self):
-        data = u"<tag>I enjoy invalid entities, such as &#x00;&#x01; and &#x1F;</tag>"
+        data = '<?xml version="1.0" encoding="utf-8"><tag>I enjoy invalid entities, such as &#x00;&#x01; and &#x1F;</tag>'
         parser = MockParser()
         [tag] = parser.process_all(data, "/tag")
         eq_('I enjoy invalid entities, such as  and ', tag.text)

--- a/util/http.py
+++ b/util/http.py
@@ -234,8 +234,8 @@ class HTTP(object):
 
         try:
             if verbose:
-                logging.info("Sending %s request to %s: kwargs %r",
-                             http_method, url, kwargs)
+                logging.info("Sending request to %s: args %r kwargs %r",
+                             url, args, kwargs)
             if len(args) == 1:
                 # requests.request takes two positional arguments,
                 # an HTTP method and a URL. In most cases, the URL

--- a/util/xmlparser.py
+++ b/util/xmlparser.py
@@ -10,36 +10,6 @@ class XMLParser(object):
 
     NAMESPACES = {}
 
-    # Some Unicode characters are illegal within an XML document
-    # _illegal_xml_chars_RE will match them so we can remove them.
-    #
-    # Source:
-    # https://stackoverflow.com/questions/1707890/fast-way-to-filter-illegal-xml-unicode-chars-in-python
-    _illegal_unichrs = [(0x00, 0x08), (0x0B, 0x0C), (0x0E, 0x1F),
-                       (0x7F, 0x84), (0x86, 0x9F),
-                       (0xFDD0, 0xFDDF), (0xFFFE, 0xFFFF)]
-    if sys.maxunicode >= 0x10000:  # not narrow build
-        _illegal_unichrs.extend([(0x1FFFE, 0x1FFFF), (0x2FFFE, 0x2FFFF),
-                                 (0x3FFFE, 0x3FFFF), (0x4FFFE, 0x4FFFF),
-                                 (0x5FFFE, 0x5FFFF), (0x6FFFE, 0x6FFFF),
-                                 (0x7FFFE, 0x7FFFF), (0x8FFFE, 0x8FFFF),
-                                 (0x9FFFE, 0x9FFFF), (0xAFFFE, 0xAFFFF),
-                                 (0xBFFFE, 0xBFFFF), (0xCFFFE, 0xCFFFF),
-                                 (0xDFFFE, 0xDFFFF), (0xEFFFE, 0xEFFFF),
-                                 (0xFFFFE, 0xFFFFF), (0x10FFFE, 0x10FFFF)])
-
-    _illegal_entities = []
-    _illegal_ranges = []
-    for (low, high) in _illegal_unichrs:
-        _illegal_ranges.append("%s-%s" % (unichr(low), unichr(high)))
-        for illegal in range(low, high+1):
-            _illegal_entities.append("%02x" % illegal)
-
-    _illegal_xml_chars_RE = re.compile(u'[%s]' % u''.join(_illegal_ranges))
-    _illegal_xml_entities_RE = re.compile(
-        "&#x(%s);" % "|".join(_illegal_entities), re.I
-    )
-
     @classmethod
     def _xpath(cls, tag, expression, namespaces=None):
         if not namespaces:
@@ -78,44 +48,20 @@ class XMLParser(object):
             return v
         return int(v)
 
-    def scrub_xml(self, xml):
-        """Remove invalid characters from XML.
-
-        We remove the characters rather than replacing them with
-        REPLACEMENT_CHARACTER, because they shouldn't have been in the
-        XML file in the first place.
-        """
-        # Convert the XML to Unicode so we can remove invalid Unicode
-        # characters from the data without worrying about how they're
-        # encoded.
-        xml = xml.decode("utf8")
-        scrubbed = self._illegal_xml_chars_RE.sub("", xml)
-        return self._illegal_xml_entities_RE.sub("", scrubbed)
-
     def process_all(self, xml, xpath, namespaces=None, handler=None, parser=None):
+        # XMLParser can handle most characters and entities that are
+        # invalid in XML but it will stop processing a document if it
+        # encounters the null character. Remove that character
+        # immediately and XMLParser will handle the rest.
+        xml = xml.replace("\x00", "")
         if not parser:
-            parser = etree.XMLParser()
+            parser = etree.XMLParser(recover=True)
         if not handler:
             handler = self.process_one
         if isinstance(xml, basestring):
             root = None
             exception = None
-            for transform in (None, self.scrub_xml):
-                if transform is None:
-                    transformed = xml
-                else:
-                    transformed = transform(xml)
-                try:
-                    root = etree.parse(StringIO(transformed), parser)
-                    break
-                except etree.XMLSyntaxError, e:
-                    exception = e
-                    continue
-            if root is None:
-                # Re-raise the last exception raised. This should
-                # never happen unless there is a problem with
-                # scrub_xml.
-                raise exception
+            root = etree.parse(StringIO(xml), parser)
         else:
             root = xml
         for i in root.xpath(xpath, namespaces=namespaces):

--- a/util/xmlparser.py
+++ b/util/xmlparser.py
@@ -53,7 +53,7 @@ class XMLParser(object):
         # invalid in XML but it will stop processing a document if it
         # encounters the null character. Remove that character
         # immediately and XMLParser will handle the rest.
-        xml = xml.replace("\x00", "")
+        xml = xml.replace(b"\x00", "")
         if not parser:
             parser = etree.XMLParser(recover=True)
         if not handler:


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-1684. It takes a much simpler approach than we were using previously to parsing XML documents that contain XML characters -- take care of the null character ourselves and let `lxml.XMLParser` handle everything else.