### PR TITLE
Only remove null characters from incoming markup if it's actually markup

### DIFF
--- a/model/coverage.py
+++ b/model/coverage.py
@@ -228,10 +228,18 @@ class Timestamp(Base):
         """Use a single method to update all the fields that aren't
         used to identify a Timestamp.
         """
-        self.start = start
-        self.finish = finish
-        self.achievements = achievements
-        self.counter = counter
+
+        if start is not None:
+            self.start = start
+        if finish is not None:
+            self.finish = finish
+        if achievements is not None:
+            self.achievements = achievements
+        if counter is not None:
+            self.counter = counter
+
+        # Unlike the other fields, None is a realistic value for
+        # .exception
         self.exception = exception
 
 

--- a/tests/models/test_coverage.py
+++ b/tests/models/test_coverage.py
@@ -114,6 +114,15 @@ class TestTimestamp(DatabaseTest):
         eq_(counter, stamp.counter)
         eq_(exception, stamp.exception)
 
+        # .exception is the only field update() will set to a value of
+        # None. For all other fields, None means "don't update the existing
+        # value".
+        stamp.update()
+        eq_(start, stamp.start)
+        eq_(finish, stamp.finish)
+        eq_(achievements, stamp.achievements)
+        eq_(counter, stamp.counter)
+        eq_(None, stamp.exception)
 
 class TestBaseCoverageRecord(DatabaseTest):
 

--- a/tests/test_util_xml_parser.py
+++ b/tests/test_util_xml_parser.py
@@ -16,6 +16,33 @@ class MockParser(XMLParser):
 
 class TestXMLParser(object):
 
+    def test_process_all(self):
+        # Verify that process_all can handle either XML markup
+        # or an already-parsed tag object.
+        data = '<atag>This is a tag.</atag>'
+
+        # Try it with markup.
+        parser = MockParser()
+        [tag] = parser.process_all(data, "/*")
+        eq_("atag", tag.tag)
+        eq_("This is a tag.", tag.text)
+
+        # Try it with a tag.
+        [tag2] = parser.process_all(tag, "/*")
+        eq_(tag, tag2)
+
+    def test_process_all_with_xpath(self):
+        # Verify that process_all processes only tags that
+        # match the given XPath expression.
+        data = '<parent><a>First</a><b>Second</b><a>Third</a></parent><a>Fourth</a>'
+
+        parser = MockParser()
+
+        # Only process the <a> tags beneath the <parent> tag.
+        [tag1, tag3] = parser.process_all(data, "/parent/a")
+        eq_("First", tag1.text)
+        eq_("Third", tag3.text)
+
     def test_invalid_characters_are_stripped(self):
         data = '<?xml version="1.0" encoding="utf-8"><tag>I enjoy invalid characters, such as \x00\x01 and \x1F. But I also like \xe2\x80\x9csmart quotes\xe2\x80\x9d.</tag>'
         parser = MockParser()
@@ -27,4 +54,3 @@ class TestXMLParser(object):
         parser = MockParser()
         [tag] = parser.process_all(data, "/tag")
         eq_('I enjoy invalid entities, such as  and ', tag.text)
-

--- a/util/xmlparser.py
+++ b/util/xmlparser.py
@@ -49,21 +49,22 @@ class XMLParser(object):
         return int(v)
 
     def process_all(self, xml, xpath, namespaces=None, handler=None, parser=None):
-        # XMLParser can handle most characters and entities that are
-        # invalid in XML but it will stop processing a document if it
-        # encounters the null character. Remove that character
-        # immediately and XMLParser will handle the rest.
-        xml = xml.replace(b"\x00", "")
         if not parser:
             parser = etree.XMLParser(recover=True)
         if not handler:
             handler = self.process_one
         if isinstance(xml, basestring):
             root = None
-            exception = None
+
+            # XMLParser can handle most characters and entities that are
+            # invalid in XML but it will stop processing a document if it
+            # encounters the null character. Remove that character
+            # immediately and XMLParser will handle the rest.
+            xml = xml.replace(b"\x00", "")
             root = etree.parse(StringIO(xml), parser)
         else:
             root = xml
+
         for i in root.xpath(xpath, namespaces=namespaces):
             data = handler(i, namespaces)
             if data is not None:


### PR DESCRIPTION
This fixes a bug introduced by https://github.com/NYPL-Simplified/server_core/pull/1014.

`XMLParser.process_all` can take either a string containing XML markup or a previously parsed etree tag object. Obviously, the code that removes null characters should only be run if the input is a string.

I didn't find this bug earlier because we have bad test coverage for XMLParser--it was one of the first things I wrote for this project. So I added an extra test to get us closer to full coverage.

This branch also fixes a problem introduced by https://github.com/NYPL-Simplified/server_core/pull/1013. In circulation, we've got a Monitor that sets `Timestamp.counter` to a custom value. But then the generic `Monitor.run` implementation calls `Timestamp.update()` without specifying a value for `counter`. Ideally this would be interpreted as meaning "leave the `counter` alone", but it's interpreted as meaning "set `counter` to `None`." I changed `update()` to interpret missing values as "leave it alone", except for `exception`.

We can assume that if `update()` is called with no exception being specified, it's because there was no exception. A custom `Monitor` won't deal with an exception by setting `Timestamp.exception` -- it will raise the exception and let the generic implementation figure out how to report it.