### PR TITLE
Make it possible to remove equivalencies from consideration if they turn out to be problematic

### DIFF
--- a/migration/20190204-enabled-equivalents.sql
+++ b/migration/20190204-enabled-equivalents.sql
@@ -1,0 +1,6 @@
+alter table equivalents create column enabled default true;
+CREATE INDEX ix_equivalents_enabled ON equivalents USING btree (enabled);
+
+-- Delete the recursive_equivalents function -- it will be recreated in
+-- its new form when the app server starts up.
+DROP FUNCTION IF EXISTS fn_recursive_equivalents(int, int, double precision, int);

--- a/model/files/recursive_equivalents.sql
+++ b/model/files/recursive_equivalents.sql
@@ -20,6 +20,7 @@ $$
                         OR e.output_id = fe.input_id
                         OR e.output_id = fe.output_id
                         )
+			AND e.enabled = true
 			AND ($4 is null or r < $4)
                 )
         SELECT input_id as id

--- a/model/identifier.py
+++ b/model/identifier.py
@@ -31,6 +31,7 @@ import isbnlib
 import logging
 import random
 from sqlalchemy import (
+    Boolean,
     Column,
     Float,
     ForeignKey,
@@ -818,6 +819,12 @@ class Equivalency(Base):
     # assertion that the two Identifiers do *not* identify the
     # same work.
     strength = Column(Float, index=True)
+
+    # Should this equivalency actually be used in calculations? This
+    # is not manipulated directly, but it gives us the ability to use
+    # manual intervention to defuse large chunks of problematic code
+    # without actually deleting the data.
+    enabled = Column(Boolean, default=True, index=True)
 
     def __repr__(self):
         r = u"[%s ->\n %s\n source=%s strength=%.2f votes=%d)]" % (


### PR DESCRIPTION
This branch adds the `equivalents.enabled` field and changes the `fn_recursive_equivalents` function to ignore equivalencies that have it set to false.

There's no code that sets `enabled` to false -- it's intended for use in manual interventions. I've tested it out by changing the metadata wrangler to disable all the equivalencies we took from OCLC Linked Data, and it instantly improved things, hopefully fixing https://jira.nypl.org/browse/SIMPLY-1690.

Identifiers that use to have thousands of equivalencies now only have a few. Here's an example of a book with what is now a relatively large number of equivalencies:

```
   id    |      type      |              identifier              
---------+----------------+--------------------------------------
   10000 | Bibliotheca ID | bygy9r9
   28729 | ISBN           | 9781429993463
 1223378 | OCLC Work ID   | 103607933
 3186702 | ISBN           | 031294957X
 3186574 | ASIN           | B004N635QI
 1223384 | ISBN           | 9780312949570
 3186575 | ASIN           | B001VEYVZE
 4836527 | Overdrive ID   | 5cd97b17-d1bb-4534-8d38-e392c2e8aef2
```

I've verified that all of these refer to the same book, except for B001VEYVZE, which doesn't seem to exist on Amazon anymore.

The problem we were seeing was that slightly incorrect data from OCLC Linked Data (either due to a bug on our side or a mistake on the OCLC side) was ballooning into extremely incorrect data for certain very popular books (e.g. public domain classics), or books that were part of easily-confused series (e.g. Berenstain Bears) The sheer number of equivalent identifiers was also crashing the database in some cases.

We stopped gathering info from OCLC Linked Data a while ago, for performance reasons. Since this branch ensures all the equivalencies derived from that data are no longer considered, this branch ensures there's no path into descriptions, resources, or any other data that we got from OCLC Linked Data. That's a little unfortunate, but in most cases we're able to get this information from Content Cafe or OCLC Classify.

My overall approach to OCLC Linked Data is "wall it off, start over when we need it, do a better job next time", and this basically completes the "wall it off" part.  