### PR TITLE
Remove RBdigital from the list of audio sources excluded by default.

### DIFF
--- a/model/configuration.py
+++ b/model/configuration.py
@@ -633,10 +633,7 @@ class ConfigurationSetting(Base, HasFullTableCache):
     # As of this release of the software, this is our best guess as to
     # which data sources should have their audiobooks excluded from
     # lanes.
-    EXCLUDED_AUDIO_DATA_SOURCES_DEFAULT = [
-        DataSourceConstants.OVERDRIVE,
-        DataSourceConstants.RB_DIGITAL
-    ]
+    EXCLUDED_AUDIO_DATA_SOURCES_DEFAULT = [DataSourceConstants.OVERDRIVE]
 
     @classmethod
     def excluded_audio_data_sources(cls, _db):


### PR DESCRIPTION
This simple branch makes it so if your library has RBdigital audiobooks, they will show up in OPDS feeds once you enable the "Audiobooks" entry point.

Addresses https://jira.nypl.org/browse/SIMPLY-1702