### PR TITLE
Use TimestampData to keep track of the progress of coverage providers, monitors, and scripts

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -264,9 +264,20 @@ class BaseCoverageProvider(object):
     def run_once(self, progress, count_as_covered=None):
         """Try to grant coverage to a number of uncovered items.
 
+        NOTE: If you override this method, it's very important that
+        your implementation eventually do one of the following:
+            * Set progress.finish
+            * Set progress.exception
+            * Raise an exception
+        If you don't do any of these things, run() will assume you still
+        have work to do, and will keep calling run_once() forever.
+
         :param progress: A CoverageProviderTimestampData representing the
            progress made so far, and the number of records that
            need to be ignored for the rest of the run.
+
+        :param count_as_covered: Which values for CoverageRecord.status
+           should count as meaning 'already covered'.
 
         :return: A CoverageProviderTimestampData representing whatever
            additional progress has been made.

--- a/coverage.py
+++ b/coverage.py
@@ -82,13 +82,13 @@ class CoverageFailure(object):
         return record
 
 
-class CoverageProviderTimestampData(TimestampData):
+class CoverageProviderProgress(TimestampData):
 
     """A TimestampData optimized for the special needs of 
     CoverageProviders.
     """
     def __init__(self, *args, **kwargs):
-        super(CoverageProviderTimestampData, self).__init__(*args, **kwargs)
+        super(CoverageProviderProgress, self).__init__(*args, **kwargs)
 
         # The offset is distinct from the counter, in that it's not written
         # to the database -- it's used to track state that's necessary within
@@ -192,7 +192,7 @@ class BaseCoverageProvider(object):
         start = datetime.datetime.utcnow()
         result = self.run_once_and_update_timestamp()
 
-        result = result or CoverageProviderTimestampData()
+        result = result or CoverageProviderProgress()
         self.finalize_timestampdata(result, start=start)
         return result
 
@@ -209,7 +209,7 @@ class BaseCoverageProvider(object):
 
         # We'll use this TimestampData object to track our progress
         # as we grant coverage to items.
-        progress = CoverageProviderTimestampData(start=start_time)
+        progress = CoverageProviderProgress(start=start_time)
 
         for covered_statuses in covered_status_lists:
             # We may have completed our work for the previous value of
@@ -230,7 +230,7 @@ class BaseCoverageProvider(object):
                         progress, count_as_covered=covered_statuses
                     )
                     # run_once can either return a new
-                    # CoverageProviderTimestampData object, or modify
+                    # CoverageProviderProgress object, or modify
                     # in-place the one it was passed.
                     if new_progress is not None:
                         progress = new_progress
@@ -277,14 +277,14 @@ class BaseCoverageProvider(object):
         If you don't do any of these things, run() will assume you still
         have work to do, and will keep calling run_once() forever.
 
-        :param progress: A CoverageProviderTimestampData representing the
+        :param progress: A CoverageProviderProgress representing the
            progress made so far, and the number of records that
            need to be ignored for the rest of the run.
 
         :param count_as_covered: Which values for CoverageRecord.status
            should count as meaning 'already covered'.
 
-        :return: A CoverageProviderTimestampData representing whatever
+        :return: A CoverageProviderProgress representing whatever
            additional progress has been made.
         """
         count_as_covered = count_as_covered or BaseCoverageRecord.DEFAULT_COUNT_AS_COVERED

--- a/coverage.py
+++ b/coverage.py
@@ -1270,18 +1270,19 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
 
 class CollectionCoverageProviderJob(DatabaseJob):
 
-    def __init__(self, collection, provider_class, item_offset,
+    def __init__(self, collection, provider_class, progress,
         **provider_kwargs
     ):
         self.collection = collection
-        self.offset = item_offset
+        self.progress = progress
         self.provider_class = provider_class
         self.provider_kwargs = provider_kwargs
 
     def run(self, _db, **kwargs):
         collection = _db.merge(self.collection)
         provider = self.provider_class(collection, **self.provider_kwargs)
-        provider.run_once(self.offset)
+        provider.run_once(self.progress)
+        provider.finalize_timestampdata(self.progress)
 
 
 class CatalogCoverageProvider(CollectionCoverageProvider):

--- a/coverage.py
+++ b/coverage.py
@@ -226,9 +226,14 @@ class BaseCoverageProvider(object):
             # progress.finish is set.
             while not progress.is_complete:
                 try:
-                    progress = self.run_once(
+                    new_progress = self.run_once(
                         progress, count_as_covered=covered_statuses
                     )
+                    # run_once can either return a new
+                    # CoverageProviderTimestampData object, or modify
+                    # in-place the one it was passed.
+                    if new_progress is not None:
+                        progress = new_progress
                 except Exception, e:
                     logging.error(
                         "CoverageProvider %s raised uncaught exception.",

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -580,6 +580,8 @@ class TimestampData(object):
             if finish is self.NO_VALUE:
                 finish = datetime.datetime.utcnow()
             self.finish = finish
+        if self.start is self.NO_VALUE:
+            self.start = self.finish
         if self.counter is self.NO_VALUE:
             self.counter = counter
         if self.exception is self.NO_VALUE:

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -506,7 +506,7 @@ class FormatData(object):
 
 class TimestampData(object):
 
-    NO_VALUE = object()
+    NO_VALUE = Timestamp.NO_VALUE
 
     def __init__(self, start=NO_VALUE, finish=NO_VALUE, achievements=NO_VALUE,
                  counter=NO_VALUE, exception=NO_VALUE):

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -31,6 +31,7 @@ from model import (
     get_one,
     get_one_or_create,
     CirculationEvent,
+    Collection,
     Contributor,
     CoverageRecord,
     DataSource,
@@ -48,6 +49,7 @@ from model import (
     RightsStatus,
     Representation,
     Resource,
+    Timestamp,
     Work,
 )
 from classifier import NO_VALUE, NO_NUMBER
@@ -501,6 +503,111 @@ class FormatData(object):
         if ((not self.rights_uri) and self.link and self.link.rights_uri):
             self.rights_uri = self.link.rights_uri
 
+
+class TimestampData(object):
+
+    NO_VALUE = object()
+
+    def __init__(self, start=NO_VALUE, finish=NO_VALUE, achievements=NO_VALUE,
+                 counter=NO_VALUE, exception=NO_VALUE):
+        """A constructor intended to be used by a service to customize its
+        eventual Timestamp.
+
+        service, service_type, and collection cannot be set through
+        this constructor, because they are generally not under the
+        control of the code that runs the service. They are set
+        afterwards, in finalize().
+
+        :param start: The time that the service should be considered to
+           have started running.
+        :param finish: The time that the service should be considered
+           to have stopped running.
+        :param achievements: A string describing what was achieved by the
+           service.
+        :param counter: A single integer item of state representing the point
+           at which the service left off.
+        :param exception: A traceback representing an exception that stopped
+           the progress of the service.
+        """
+
+        # These are set by finalize().
+        self.service = self.NO_VALUE
+        self.service_type = self.NO_VALUE
+        self.collection_id = self.NO_VALUE
+
+        self.start = start
+        self.finish = finish
+        self.achievements = achievements
+        self.counter = counter
+        self.exception = exception
+
+    def finalize(self, service, service_type, collection, start=NO_VALUE,
+                 finish=NO_VALUE, achievements=NO_VALUE, counter=NO_VALUE,
+                 exception=NO_VALUE):
+        """Finalize any values that were not set during the constructor.
+
+        This is intended to be run by the code that originally ran the
+        service.
+
+        The given values for `start`, `finish`, `achievements`,
+        `counter`, and `exception` will be used only if the service
+        did not specify its own values for those fields.
+        """
+        self.service = service
+        self.service_type = service_type
+        if collection is None:
+            self.collection_id = None
+        else:
+            self.collection_id = collection.id
+        if self.start is self.NO_VALUE:
+            self.start = start
+        if self.finish is self.NO_VALUE:
+            if finish is self.NO_VALUE:
+                finish = datetime.datetime.utcnow()
+            self.finish = finish
+        if self.counter is self.NO_VALUE:
+            self.counter = counter
+        if self.exception is self.NO_VALUE:
+            self.exception = exception
+
+    def collection(self, _db):
+        return get_one(_db, Collection, id=self.collection_id)
+
+    def apply(self, _db):
+        if any(x is self.NO_VALUE for x in [self.service, self.service_type,
+                                            self.collection_id]):
+            raise ValueError(
+                "Not enough information to write TimestampData to the database."
+            )
+
+        start = self.start
+        finish = self.finish
+        if start is self.NO_VALUE and finish is self.NO_VALUE:
+            start = finish = datetime.datetime.utcnow()
+        elif start is self.NO_VALUE:
+            start = finish
+        elif finish is self.NO_VALUE:
+            finish = start
+        # At this point both start and finish are set to real
+        # timestamps.
+
+        # If any of these fields are still NO_VALUE, it means that the
+        # corresponding database fields should be cleared out -- they
+        # were irrelevant to this service on this particular run.
+        def _v(x):
+            if x is self.NO_VALUE:
+                return None
+            return x
+
+        achievements = _v(self.achievements)
+        counter = _v(self.counter)
+        counter = _v(self.counter)
+        exception = _v(self.exception)
+
+        return Timestamp.stamp(
+            _db, self.service, self.service_type, self.collection(_db),
+            start, finish, achievements, counter, exception
+        )
 
 
 class MetaToModelUtility(object):

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -541,6 +541,21 @@ class TimestampData(object):
         self.counter = counter
         self.exception = exception
 
+    @property
+    def is_failure(self):
+        """Does this TimestampData represent an unrecoverable failure?"""
+        return self.exception not in (None, self.NO_VALUE)
+
+    @property
+    def is_complete(self):
+        """Does this TimestampData represent an operation that has
+        completed?
+
+        An operation is completed if it has failed, or if the time of its
+        completion is known.
+        """
+        return self.is_failure or self.finish not in (None, self.NO_VALUE)
+
     def finalize(self, service, service_type, collection, start=NO_VALUE,
                  finish=NO_VALUE, achievements=NO_VALUE, counter=NO_VALUE,
                  exception=NO_VALUE):

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -100,6 +100,11 @@ class Timestamp(Base):
     COVERAGE_PROVIDER_TYPE = "coverage_provider"
     SCRIPT_TYPE = "script"
 
+    # A stand-in value used to indicate that a field in the timestamps
+    # should be set to None. This is necessary because 'None' generally
+    # means 'use the default value'.
+    NO_VALUE = object()
+
     service_type_enum = Enum(
         MONITOR_TYPE, COVERAGE_PROVIDER_TYPE, SCRIPT_TYPE,
         name="service_type",
@@ -230,8 +235,16 @@ class Timestamp(Base):
         """
 
         if start is not None:
+            if start is self.NO_VALUE:
+                # In most cases, None is not a valid value for
+                # Timestamp.start, but this can be overridden.
+                start = None
             self.start = start
         if finish is not None:
+            if finish is self.NO_VALUE:
+                # In most cases, None is not a valid value for
+                # Timestamp.finish, but this can be overridden.
+                finish = None
             self.finish = finish
         if achievements is not None:
             self.achievements = achievements

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -242,6 +242,13 @@ class Timestamp(Base):
         # .exception
         self.exception = exception
 
+    def to_data(self):
+        """Convert this Timestamp to an unfinalized TimestampData."""
+        from metadata_layer import TimestampData
+        return TimestampData(
+            start=self.start, finish=self.finish,
+            achievements=self.achievements, counter=self.counter
+        )
 
     __table_args__ = (
         UniqueConstraint('service', 'collection_id'),

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -244,7 +244,7 @@ class Timestamp(Base):
 
     def to_data(self):
         """Convert this Timestamp to an unfinalized TimestampData."""
-        from metadata_layer import TimestampData
+        from ..metadata_layer import TimestampData
         return TimestampData(
             start=self.start, finish=self.finish,
             achievements=self.achievements, counter=self.counter

--- a/monitor.py
+++ b/monitor.py
@@ -157,6 +157,9 @@ class Monitor(object):
         # on the subsequent run.
         this_run_start = datetime.datetime.utcnow()
         try:
+            # TODO: run_once needs to take the Timestamp object,
+            # or a TimestampData based on it -- there's no one
+            # way that will work for all Monitors here.
             new_timestamp = self.run_once(last_run_start, this_run_start)
             this_run_finish = datetime.datetime.utcnow()
             if new_timestamp is None:

--- a/monitor.py
+++ b/monitor.py
@@ -345,7 +345,8 @@ class SweepMonitor(CollectionMonitor):
             timestamp.update(counter=new_offset, finish=batch_ended_at)
             self._db.commit()
 
-        # We're done with this run.
+        # We're done with this run. The run() method will do the final
+        # update.
         return TimestampData(counter=offset)
 
     def process_batch(self, offset):

--- a/monitor.py
+++ b/monitor.py
@@ -229,7 +229,7 @@ class TimelineMonitor(Monitor):
     OVERLAP = datetime.timedelta(minutes=5)
 
     def run_once(self, progress):
-        if not progress.finish:
+        if progress.finish in (None, progress.NO_VALUE):
             # This monitor has never run before. Use the default
             # start time for this monitor.
             start = self.initial_start_time

--- a/monitor.py
+++ b/monitor.py
@@ -115,6 +115,9 @@ class Monitor(object):
 
     @property
     def initial_start_time(self):
+        """The time that should be used as the 'start time' the first
+        time this Monitor is run.
+        """
         if self.default_start_time is self.NEVER:
             return None
         if self.default_start_time:

--- a/monitor.py
+++ b/monitor.py
@@ -153,6 +153,8 @@ class Monitor(object):
             new_timestamp = self.run_once(progress)
             this_run_finish = datetime.datetime.utcnow()
             if new_timestamp is None:
+                # Assume this Monitor has no special needs surrounding
+                # its timestamp.
                 new_timestamp = TimestampData()
             if new_timestamp.exception in (None, TimestampData.NO_VALUE):
                 # run_once() completed with no exceptions being raised.

--- a/opds_import.py
+++ b/opds_import.py
@@ -1552,9 +1552,6 @@ class OPDSImportMonitor(CollectionMonitor, HasSelfTests):
     """
     SERVICE_NAME = "OPDS Import Monitor"
 
-    # This Monitor will do its work every time it's invoked.
-    INTERVAL_SECONDS = 0
-
     # The first time this Monitor is invoked we want to get the
     # entire OPDS feed.
     DEFAULT_START_TIME = CollectionMonitor.NEVER

--- a/opds_import.py
+++ b/opds_import.py
@@ -1811,7 +1811,7 @@ class OPDSImportMonitor(CollectionMonitor, HasSelfTests):
                 operation=CoverageRecord.IMPORT_OPERATION
             )
 
-    def run_once(self, start_ignore, cutoff_ignore):
+    def run_once(self, progress_ignore):
         feeds = []
         queue = [self.feed_url]
         seen_links = set([])

--- a/scripts.py
+++ b/scripts.py
@@ -45,7 +45,7 @@ from app_server import ComplaintController
 from config import Configuration, CannotLoadConfiguration
 from coverage import (
     CollectionCoverageProviderJob,
-    CoverageProviderTimestampData,
+    CoverageProviderProgress,
 )
 from lane import Lane
 from metadata_layer import (
@@ -458,7 +458,7 @@ class RunThreadedCollectionCoverageProviderScript(Script):
                 # value as its complets. It woudl be better if all the
                 # jobs could share a single 'progress' object.
                 while offset < query_size:
-                    progress = CoverageProviderTimestampData(
+                    progress = CoverageProviderProgress(
                         start=datetime.datetime.utcnow()
                     )
                     progress.offset = offset

--- a/testing.py
+++ b/testing.py
@@ -207,6 +207,15 @@ class DatabaseTest(object):
         if self.search_mock:
             self.search_mock.stop()
 
+    def time_eq(self, a, b):
+        "Assert that two times are *approximately* the same -- within 2 seconds."
+        if a < b:
+            delta = b-a
+        else:
+            delta = a-b
+        total_seconds = delta.total_seconds()
+        assert (total_seconds < 2), ("Delta was too large: %.2f seconds." % total_seconds)
+
     def shortDescription(self):
         return None # Stop nosetests displaying docstrings instead of class names when verbosity level >= 2.
 

--- a/tests/models/test_coverage.py
+++ b/tests/models/test_coverage.py
@@ -124,6 +124,26 @@ class TestTimestamp(DatabaseTest):
         eq_(counter, stamp.counter)
         eq_(None, stamp.exception)
 
+    def to_data(self):
+        stamp = Timestamp.stamp(
+            self._db, "service", Timestamp.SCRIPT_TYPE,
+            collection=self._default_collection, counter=10, achivements="a"
+        )
+        data = stamp.to_data()
+        assert isinstance(data, TimestampData)
+
+        # The TimestampData is not finalized.
+        eq_(None, data.service)
+        eq_(None, data.service_type)
+        eq_(None, data.collection_id)
+
+        # But all the other information is there.
+        eq_(stamp.start, data.start)
+        eq_(stamp.finish, data.finish)
+        eq_(stamp.achievements, data.achievements)
+        eq_(stamp.counter, data.counter)
+
+
 class TestBaseCoverageRecord(DatabaseTest):
 
     def test_not_covered(self):

--- a/tests/models/test_coverage.py
+++ b/tests/models/test_coverage.py
@@ -97,6 +97,16 @@ class TestTimestamp(DatabaseTest):
         assert stamp3 != stamp
         eq_(self._default_collection, stamp3.collection)
 
+        # Passing in NO_VALUE for start or end will clear an existing
+        # Timestamp.
+        stamp4 = Timestamp.stamp(
+            self._db, service, type,
+            start=Timestamp.NO_VALUE, finish=Timestamp.NO_VALUE
+        )
+        eq_(stamp4, stamp)
+        eq_(None, stamp4.start)
+        eq_(None, stamp4.finish)
+
     def test_update(self):
         # update() can modify the fields of a Timestamp that aren't
         # used to identify it.

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -186,8 +186,9 @@ class TestBaseCoverageProvider(CoverageProviderTest):
             was_run = False
 
             def run_once_and_update_timestamp(self):
-                """Set a variable, don't return anything."""
+                """Set a variable."""
                 self.was_run = True
+                return 0, None
 
         provider = MockProvider(self._db)
         result = provider.run()
@@ -206,7 +207,6 @@ class TestBaseCoverageProvider(CoverageProviderTest):
 
         start = datetime.datetime(2011, 1, 1)
         finish = datetime.datetime(2012, 1, 1)
-        counter = -100
 
         class MockProvider(BaseCoverageProvider):
             """A BaseCoverageProvider that returns a strange TimestampData
@@ -242,9 +242,9 @@ class TestBaseCoverageProvider(CoverageProviderTest):
             SERVICE_NAME = "I do nothing"
             run_once_calls = []
 
-            def run_once(self, progress, count_as_covered=None):
+            def run_once(self, offset, progress, count_as_covered=None):
                 self.run_once_calls.append(count_as_covered)
-                return progress
+                return offset, progress
 
         # We start with no Timestamp.
         service_name = "I do nothing"

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -57,7 +57,7 @@ from ..coverage import (
     CatalogCoverageProvider,
     CollectionCoverageProvider,
     CoverageFailure,
-    CoverageProviderTimestampData,
+    CoverageProviderProgress,
     IdentifierCoverageProvider,
     OPDSEntryWorkCoverageProvider,
     MARCRecordWorkCoverageProvider,
@@ -196,10 +196,10 @@ class TestBaseCoverageProvider(CoverageProviderTest):
         # run_once_and_update_timestamp() was called.
         eq_(True, provider.was_run)
 
-        # run() returned a CoverageProviderTimestampData with basic
+        # run() returned a CoverageProviderProgress with basic
         # timing information, since run_once_and_update_timestamp()
         # didn't provide anything.
-        assert isinstance(result, CoverageProviderTimestampData)
+        assert isinstance(result, CoverageProviderProgress)
         now = datetime.datetime.now()
         assert result.start < result.finish
         for time in (result.start, result.finish):
@@ -213,12 +213,12 @@ class TestBaseCoverageProvider(CoverageProviderTest):
 
         class MockProvider(BaseCoverageProvider):
             """A BaseCoverageProvider that returns a strange
-            CoverageProviderTimestampData representing the work it did.
+            CoverageProviderProgress representing the work it did.
             """
             SERVICE_NAME = "I do nothing"
             was_run = False
 
-            custom_timestamp_data = CoverageProviderTimestampData(
+            custom_timestamp_data = CoverageProviderProgress(
                 start=start, finish=finish, counter=counter
             )
             def run_once_and_update_timestamp(self):
@@ -379,7 +379,7 @@ class TestBaseCoverageProvider(CoverageProviderTest):
         # Now let's run the coverage provider. Every Identifier
         # that's covered will succeed, so the question is which ones
         # get covered.
-        progress = CoverageProviderTimestampData()
+        progress = CoverageProviderProgress()
         eq_(0, progress.offset)
         result = provider.run_once(progress)
 
@@ -387,7 +387,7 @@ class TestBaseCoverageProvider(CoverageProviderTest):
         eq_(progress, result)
 
         # The offset (an extension specific to
-        # CoverageProviderTimestampData, not stored in the database)
+        # CoverageProviderProgress, not stored in the database)
         # has not changed -- if we were to call run_once again we
         # would not need to skip any records.
         eq_(0, progress.offset)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -137,7 +137,7 @@ class TestMonitor(DatabaseTest):
         timestamp = get_timestamp()
         assert timestamp.start > monitor.default_start_time
         assert timestamp.finish > timestamp.start
-        assert (datetime.datetime.utcnow() - timestamp.start).total_seconds() < 2
+        self.time_eq(datetime.datetime.utcnow(), timestamp.start)
 
         # cleanup() was called once.
         eq_([True], monitor.cleanup_records)
@@ -362,7 +362,7 @@ class TestTimelineMonitor(DatabaseTest):
         # catch_up_from() was called once.
         (start, cutoff, progress) = m.catchups.pop()
         eq_(m.initial_start_time, start)
-        assert (cutoff - now).total_seconds() < 2
+        self.time_eq(cutoff, now)
 
         # progress contains a record of the timespan now covered
         # by this Monitor.
@@ -392,7 +392,7 @@ class TestTimelineMonitor(DatabaseTest):
         # The timestamp values have been set to appropriate values for
         # the portion of the timeline covered, overriding our values.
         eq_(None, progress.start)
-        assert (now-progress.finish).total_seconds() < 2
+        self.time_eq(now, progress.finish)
 
         # The non-timestamp values have been left alone.
         eq_(3, progress.counter)
@@ -542,8 +542,8 @@ class TestSweepMonitor(DatabaseTest):
         # timestamp were updated to reflect the work that _was_ done.
         now = datetime.datetime.utcnow()
         assert timestamp.start > original_start
-        assert (now - timestamp.start).total_seconds() < 5
-        assert (now - timestamp.finish).total_seconds() < 5
+        self.time_eq(now, timestamp.start)
+        self.time_eq(now, timestamp.finish)
         assert timestamp.start < timestamp.finish
 
         # I3 was processed, but the batch did not complete, so any
@@ -902,12 +902,11 @@ class TestReaperMonitor(DatabaseTest):
             expect = datetime.datetime.utcnow() - datetime.timedelta(
                 days=value
             )
-            assert (m.cutoff - expect).total_seconds() < 2
+            self.time_eq(m.cutoff, expect)
 
         # But you can pass in a timedelta instead.
         m.MAX_AGE = datetime.timedelta(seconds=99)
-        expect = datetime.datetime.utcnow() - m.MAX_AGE
-        assert (m.cutoff - expect).total_seconds() < 2
+        self.time_eq(m.cutoff, datetime.datetime.utcnow() - m.MAX_AGE)
 
     def test_specific_reapers(self):
         eq_(CachedFeed.timestamp, CachedFeedReaper(self._db).timestamp_field)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -312,6 +312,7 @@ class MockSweepMonitor(SweepMonitor):
         self.processed.append(item)
 
     def cleanup(self):
+        set_trace()
         self.cleanup_called.append(True)
 
 
@@ -391,6 +392,7 @@ class TestSweepMonitor(DatabaseTest):
         class IHateI4(MockSweepMonitor):
             def process_item(self, item):
                 if item is i4:
+                    set_trace()
                     raise Exception("HOW DARE YOU")
                 super(IHateI4, self).process_item(item)
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -143,9 +143,9 @@ class TestMonitor(DatabaseTest):
         now = datetime.datetime.utcnow()
         assert timestamp.start < now
 
-        # Just so we have a value for Timestamp.finish, it's given the
-        # same value as Timestamp.start.
-        eq_(timestamp.finish, timestamp.start)
+        # Timestamp.finish is set to None, on the assumption that the
+        # first run is still in progress.
+        eq_(timestamp.finish, None)
 
     def test_run_once_returning_timestampdata(self):
         # If a Monitor's run_once implementation returns a TimestampData,

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -94,6 +94,23 @@ class TestMonitor(DatabaseTest):
         monitor.collection_id = None
         eq_(None, monitor.collection)
 
+    def test_initial_start_time(self):
+        monitor = MockMonitor(self._db, self._default_collection)
+
+        # Setting the default start time to NEVER explicitly says to use
+        # None as the initial time.
+        monitor.default_start_time = monitor.NEVER
+        eq_(None, monitor.initial_start_time)
+
+        # Setting the value to None means "use the current time".
+        monitor.default_start_time = None
+        self.time_eq(datetime.datetime.utcnow(), monitor.initial_start_time)
+
+        # Any other value is returned as-is.
+        default = object()
+        monitor.default_start_time = default
+        eq_(default, monitor.initial_start_time)
+
     def test_monitor_lifecycle(self):
         monitor = MockMonitor(self._db, self._default_collection)
         monitor.default_start_time = datetime.datetime(2010, 1, 1)

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -2122,7 +2122,7 @@ class TestOPDSImportMonitor(OPDSImporterTest):
         monitor.queue_response([["second next link"], "second page"])
         monitor.queue_response([["next link"], "first page"])
 
-        monitor.run_once(None, None)
+        monitor.run_once(object())
 
         # Feeds are imported in reverse order
         eq_(["last page", "second page", "first page"], monitor.imports)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -383,7 +383,7 @@ class OPDSCollectionMonitor(CollectionMonitor):
         self.test_argument = test_argument
         super(OPDSCollectionMonitor, self).__init__(_db, **kwargs)
 
-    def run_once(self, start, cutoff):
+    def run_once(self, progress):
         self.collection.ran_with_argument = self.test_argument
 
 


### PR DESCRIPTION
This branch introduces a new object to the metadata layer: `TimestampData`. This object corresponds to a row in the `timestamps` table.

`Script`, `Monitor`, and `CoverageProvider` all have an architecture where the superclass calls a "do something" method that the subclass is supposed to define. The `TimestampData` object is now how the subclass communicates back to the superclass about what happened in the "do something" method. The superclass is responsible for filling in any missing information from the `TimestampData` and actually writing it to the database.

In the simplest case, where the "do something" method doesn't have any particular status to report, `Script`, `Monitor`, and `CoverageProvider` will capture the start and finish times, record any exceptions, and write the `TimestampData` to the database.

In more complicated cases, any subclass of `Script`, `Monitor`, or `CoverageProvider` has a significant ability to  customize what goes into its `timestamps` row by having its 'do something' method return a `TimestampData`.

`Monitor` is a little different because if there's an unhandled exception we don't want to modify the `start` or `finish` times. So that class still makes direct use of the `Timestamp` object a lot.

`CoverageProvider` is the complicated one. I subclassed `TimestampData` as `CoverageProviderProgress` so that I could use it to keep track of the variable `offset`. This is different from `TimestampData.counter`, which is written to the database and kept across runs. The `offset` is used _within_ a run to skip over certain database rows that are known to be ignorable _for this run_.

(This may seem like overkill, but my next branch is going to add to `CoverageProviderProgress` the ability to keep track of successes and failures _across batches_, so it's really useful to have a single object that's being passed back and forth between calls to `run_once`.)