### PR TITLE
Improved memory usage when generating large MARC files.

### DIFF
--- a/marc.py
+++ b/marc.py
@@ -612,14 +612,12 @@ class MARCExporter(object):
         # and Representation, but don't actually mirror it.
         if not mirror:
             storage_protocol = self.integration.setting(self.STORAGE_PROTOCOL).value
-            if storage_protocol == ExternalIntegration.S3:
-                mirror_integration = ExternalIntegration.lookup(
-                    self._db, storage_protocol, ExternalIntegration.STORAGE_GOAL)
-                if mirror_integration:
-                    mirror = mirror or S3Uploader(mirror_integration)
+            mirror = MirrorUploader.sitewide(self._db)
+            if mirror.NAME != storage_protocol:
+                raise Exception("Sitewide mirror integration does not match configured storage protocol")
 
         if not mirror:
-            raise Exception("No mirror integration for configured protocol %s" % storage_protocol)
+            raise Exception("No mirror integration is configured")
 
         # End time is before we start the query, because if any records are changed
         # during the processing we may not catch them, and they should be handled

--- a/marc.py
+++ b/marc.py
@@ -30,6 +30,7 @@ from model import (
     Work,
 )
 from classifier import Classifier
+from mirror import MirrorUploader
 from s3 import S3Uploader
 from lane import Lane
 from util import LanguageCodes


### PR DESCRIPTION
This branch uses multipart S3 uploads and batched queries to reduce the memory usage when creating MARC files for large collections.

I chose the batch sizes by testing with a large local collection, and the maximum memory use I got from this was around 3GB, which is still a lot but it was well over 10GB before. @jonathangreen does that seem good enough?