### PR TITLE
Fixed some migration problems seen in a real migration.

### DIFF
--- a/migration/20190111-unique-delivery-mechanisms.sql
+++ b/migration/20190111-unique-delivery-mechanisms.sql
@@ -7,7 +7,7 @@ drop index if exists ix_licensepooldeliveries_datasource_identifier_mechanism;
 -- of the fields is null, and one of these fields -- resource_id -- is
 -- _usually_ null. So we need a unique partial index to properly enforce
 -- the constraint.
-CREATE UNIQUE INDEX ix_licensepooldeliveries_unique_when_no_resource ON public.licensepooldeliveries USING btree (data_source_id, identifier_id, delivery_mechanism_id) WHERE (resource_id IS NULL);
+CREATE UNIQUE INDEX if not exists ix_licensepooldeliveries_unique_when_no_resource ON public.licensepooldeliveries USING btree (data_source_id, identifier_id, delivery_mechanism_id) WHERE (resource_id IS NULL);
 
 
 -- deliverymechanisms doesn't have a uniqueness constraint, just a unique index.
@@ -17,4 +17,4 @@ drop index if exists ix_deliverymechanisms_drm_scheme_content_type;
 
 ALTER TABLE deliverymechanisms ADD CONSTRAINT deliverymechanisms_content_type_drm_scheme UNIQUE (content_type, drm_scheme);
 
-CREATE UNIQUE INDEX ix_deliverymechanisms_unique_when_no_drm ON public.deliverymechanisms USING btree (content_type) WHERE (drm_scheme IS NULL);
+CREATE UNIQUE INDEX if not exists ix_deliverymechanisms_unique_when_no_drm ON public.deliverymechanisms USING btree (content_type) WHERE (drm_scheme IS NULL);

--- a/scripts.py
+++ b/scripts.py
@@ -2081,6 +2081,7 @@ class DatabaseMigrationScript(Script):
                             "Yes, everything should be fine -- I was able to find a timestamp in the new schema."
                         )
                     exception = None
+                    _db.commit()
                     break
                 except ProgrammingError, e:
                     # The database connection is now tainted; we must


### PR DESCRIPTION
The main problem here is a failure to commit the database session after modifying the `timestamps` table. The first 3.1.0 migration script runs, but since the database session isn't committed, when we go to run the next migration step the `timestamps` table hasn't actually changed.