### PR TITLE
Update elasticsearch requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ addons:
       - postgresql-contrib-9.3
 
 env:
-#  - ES_VERSION="6.3.2" ES_DOWNLOAD="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz" SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_core_test"
-  - ES_VERSION="1.7.0" ES_DOWNLOAD="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz" SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_core_test"
+  global:
+    - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_core_test"
+  matrix:
+  - ES_VERSION="6.3.2" ES_DOWNLOAD="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz" SIMPLIFIED_ELASTICSEARCH_VERSION=6
+  - ES_VERSION="1.7.0" ES_DOWNLOAD="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz" SIMPLIFIED_ELASTICSEARCH_VERSION=1
 
 services:
   - postgresql
@@ -22,6 +25,7 @@ python:
 cache: pip
 
 before_install:
+  - pip install --upgrade pip
   - pip install "setuptools>=18.5"
   - sleep 10
 

--- a/elasticsearch-requirements-1.txt
+++ b/elasticsearch-requirements-1.txt
@@ -1,0 +1,2 @@
+elasticsearch==2.1.0
+elasticsearch-dsl<2.0.0

--- a/elasticsearch-requirements-6.txt
+++ b/elasticsearch-requirements-6.txt
@@ -1,0 +1,2 @@
+elasticsearch>6.0.0,<7.0.0
+elasticsearch-dsl>6.0.0,<7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,8 @@ flask
 isbnlib
 textblob
 rdflib
-#elasticsearch>6.0.0,<7.0.0
-#elasticsearch-dsl>6.0.0,<7.0.0
-elasticsearch==2.1.0
-elasticsearch-dsl<2.0.0
+
+-r elasticsearch-requirements-${SIMPLIFIED_ELASTICSEARCH_VERSION}.txt
 
 python-dateutil
 uwsgi


### PR DESCRIPTION
## Related Tickets / PRs

https://jira.nypl.org/browse/SIMPLY-1518
Based on comments in: https://github.com/NYPL-Simplified/circulation/pull/1180

## What does this PR do?

Update `requirements.txt` so that you can install either the libraries for Elastic Search 1 or Elastic Search 6 depending on the `SIMPLIFIED_ELASTICSEARCH_VERSION` environment variable. 

This PR also modifies travis-ci to run the test with both the ES1 and ES6 libraries.

## Changes

When installing requirements you will need to have the `SIMPLIFIED_ELASTICSEARCH_VERSION` environment variable set.