### PR TITLE
Don't make HTTP requests from the Overdrive constructor

### DIFF
--- a/model/credential.py
+++ b/model/credential.py
@@ -54,13 +54,15 @@ class Credential(Base):
 
     @classmethod
     def lookup(self, _db, data_source, type, patron, refresher_method,
-               allow_persistent_token=False):
+               allow_persistent_token=False, allow_empty_token=False):
         from datasource import DataSource
         if isinstance(data_source, basestring):
             data_source = DataSource.lookup(_db, data_source)
         credential, is_new = get_one_or_create(
             _db, Credential, data_source=data_source, type=type, patron=patron)
-        if (is_new or (not credential.expires and not allow_persistent_token)
+        if (is_new
+            or (not credential.expires and not allow_persistent_token)
+            or (not credential.credential and not allow_empty_token)
             or (credential.expires
                 and credential.expires <= datetime.datetime.utcnow())):
             if refresher_method:

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -83,7 +83,7 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         collection = MockOverdriveAPI.mock_collection(self._db)
 
         class NoRequests(OverdriveAPI):
-            MSG = "This is a unit test, you can't call make HTTP requests!"
+            MSG = "This is a unit test, you can't make HTTP requests!"
             def no_requests(self, *args, **kwargs):
                 raise Exception(self.MSG)
             _do_get = no_requests


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-1729. It defers the acquisition of the Overdrive OAuth token or collection token until that data is actually needed. Previously this information was gathered in the constructor. This meant that if an Overdrive collection was misconfigured, the site wouldn't start up, because the constructor would raise an unhandled exception.

This also hurt performance on sites with a large number of Overdrive and Overdrive Advantage collections.
