### PR TITLE
Don't queue a collection token by default.

### DIFF
--- a/overdrive.py
+++ b/overdrive.py
@@ -482,11 +482,6 @@ class MockOverdriveAPI(OverdriveAPI):
         self.requests = []
         self.responses = []
 
-        # Almost all tests will immediately try to access the
-        # collection token, so queue up the response ahead of time.
-        self.queue_response(
-            200, content=self.mock_collection_token("collection token")
-        )
         # Almost all tests will try to request the access token, so
         # set the response that will be returned if an attempt is
         # made.
@@ -494,6 +489,14 @@ class MockOverdriveAPI(OverdriveAPI):
             "bearer token"
         )
         super(MockOverdriveAPI, self).__init__(_db, collection, *args, **kwargs)
+
+    def queue_collection_token(self):
+        # Many tests immediately try to access the
+        # collection token. This is a helper method to make it easy to
+        # queue up the response.
+        self.queue_response(
+            200, content=self.mock_collection_token("collection token")
+        )
 
     def token_post(self, url, payload, headers={}, **kwargs):
         """Mock the request for an OAuth token.


### PR DESCRIPTION
This is a follow-up to https://github.com/NYPL-Simplified/server_core/pull/1034 after discovering a lot of test failures in a circulation branch.

When both core tests and circulation tests are considered, it's much more common for a pre-queued collection token to get in the way than for it to be helpful. There are now only 4 tests that exercise the Overdrive API on such a low level that a request is made for a collection token -- 3 in core and 1 in circulation.

This branch changes the default so that the collection token is not queued up by default. Tests that need it can queue it up using a helper method.

The corresponding circulation PR is https://github.com/NYPL-Simplified/circulation/pull/1191.