### PR TITLE
RBdigital collections are working again.

### DIFF
--- a/model/configuration.py
+++ b/model/configuration.py
@@ -634,7 +634,7 @@ class ConfigurationSetting(Base, HasFullTableCache):
     # which data sources should have their audiobooks excluded from
     # lanes.
     EXCLUDED_AUDIO_DATA_SOURCES_DEFAULT = [
-        DataSourceConstants.OVERDRIVE, DataSourceConstants.RB_DIGITAL
+        DataSourceConstants.OVERDRIVE
     ]
 
     @classmethod


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-1702 (again) following the validation of the fix to https://jira.nypl.org/browse/SIMPLY-1723.

https://jira.nypl.org/browse/SIMPLY-1742 has also cropped up, and I thought about this as a reason to disable Axis 360 audiobooks, but the books work fine -- you just can't return them. I'd rather let people listen to their audiobooks and deal with the confusion until B&T fixes their side of it.