### PR TITLE
Make it easy to find LicensePools with no delivery mechanisms

### DIFF
--- a/model/collection.py
+++ b/model/collection.py
@@ -482,8 +482,16 @@ class Collection(Base, HasFullTableCache):
 
         return collection, is_new
 
-    def pools_with_missing_delivery_mechanisms(self):
-        """Find all LicensePools that have no delivery mechanisms whatsoever."""
+    @property
+    def pools_with_no_delivery_mechanisms(self):
+        """Find all LicensePools in this Collection that have no delivery
+        mechanisms whatsoever.
+
+        :return: A query object.
+        """
+        _db = Session.object_session(self)
+        qu = LicensePool.with_no_delivery_mechanisms(_db)
+        return qu.filter(LicensePool.collection==self)
 
     def explain(self, include_secrets=False):
         """Create a series of human-readable strings to explain a collection's

--- a/model/collection.py
+++ b/model/collection.py
@@ -482,6 +482,9 @@ class Collection(Base, HasFullTableCache):
 
         return collection, is_new
 
+    def pools_with_missing_delivery_mechanisms(self):
+        """Find all LicensePools that have no delivery mechanisms whatsoever."""
+
     def explain(self, include_secrets=False):
         """Create a series of human-readable strings to explain a collection's
         settings.

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -204,8 +204,14 @@ class LicensePool(Base):
 
     @classmethod
     def with_no_delivery_mechanisms(cls, _db):
-        """Find LicensePools that have no delivery mechanisms."""
-        
+        """Find LicensePools that have no delivery mechanisms.
+
+        :return: A query object.
+        """
+        return _db.query(LicensePool).outerjoin(
+            LicensePool.delivery_mechanisms).filter(
+                LicensePoolDeliveryMechanism.id==None
+            )
 
     @property
     def deliverable(self):

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -202,6 +202,11 @@ class LicensePool(Base):
         return _db.query(LicensePool).outerjoin(Work).filter(
             Work.id==None).all()
 
+    @classmethod
+    def with_no_delivery_mechanisms(cls, _db):
+        """Find LicensePools that have no delivery mechanisms."""
+        
+
     @property
     def deliverable(self):
         """This LicensePool can actually be delivered to patrons.
@@ -1302,6 +1307,8 @@ class DeliveryMechanism(Base, HasFullTableCache):
         (MediaTypes.EPUB_MEDIA_TYPE, NO_DRM),
         (MediaTypes.EPUB_MEDIA_TYPE, ADOBE_DRM),
         (MediaTypes.EPUB_MEDIA_TYPE, BEARER_TOKEN),
+        (None, FINDAWAY_DRM),
+        (MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE, None),
     ])
 
     license_pool_delivery_mechanisms = relationship(

--- a/selftest.py
+++ b/selftest.py
@@ -56,7 +56,11 @@ class SelfTestResult(object):
             value['start'] = f(self.start)
         if self.end:
             value['end'] = f(self.end)
-        if isinstance(self.result, basestring):
+
+        # String results will be displayed in a fixed-width font.
+        # Lists of strings will be hidden behind an expandable toggle.
+        # Other return values have no defined method of display.
+        if isinstance(self.result, basestring) or isinstance(self.result, list):
             value['result'] = self.result
         else:
             value['result'] = None

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -279,6 +279,29 @@ class TestCollection(DatabaseTest):
         ).value = 954
         eq_(954, self.collection.default_reservation_period)
 
+    def test_pools_with_no_delivery_mechanisms(self):
+        # Collection.pools_with_no_delivery_mechanisms returns a query
+        # that finds all LicensePools in the Collection which are
+        # missing delivery mechanisms.
+        collection1 = self._default_collection
+        collection2 = self._collection()
+        pool1 = self._licensepool(None, collection=collection1)
+        pool2 = self._licensepool(None, collection=collection2)
+
+        # At first, the query matches nothing, because
+        # all LicensePools have delivery mechanisms.
+        qu = collection1.pools_with_no_delivery_mechanisms
+        eq_([], qu.all())
+
+        # Let's delete all the delivery mechanisms.
+        for pool in (pool1, pool2):
+            [self._db.delete(x) for x in pool.delivery_mechanisms]
+
+        # Now the query matches LicensePools if they are in the
+        # appropriate collection.
+        eq_([pool1], qu.all())
+        eq_([pool2], collection2.pools_with_no_delivery_mechanisms.all())
+
     def test_explain(self):
         """Test that Collection.explain gives all relevant information
         about a Collection.

--- a/tests/models/test_licensing.py
+++ b/tests/models/test_licensing.py
@@ -215,6 +215,20 @@ class TestLicensePool(DatabaseTest):
             collection=None
         )
 
+    def test_with_no_delivery_mechanisms(self):
+        # LicensePool.with_no_delivery_mechanisms returns a
+        # query that finds all LicensePools which are missing
+        # delivery mechanisms.
+        qu = LicensePool.with_no_delivery_mechanisms(self._db)
+        pool = self._licensepool(None)
+
+        # The LicensePool was created with a delivery mechanism.
+        eq_([], qu.all())
+
+        # Let's delete it.
+        [self._db.delete(x) for x in pool.delivery_mechanisms]
+        eq_([pool], qu.all())
+
     def test_no_license_pool_for_non_primary_identifier(self):
         """Overdrive offers licenses, but to get an Overdrive license pool for
         a book you must identify the book by Overdrive's primary

--- a/tests/test_selftest.py
+++ b/tests/test_selftest.py
@@ -47,6 +47,20 @@ class TestSelfTestResult(object):
         eq_(True, d['success'])
         eq_(None, d['exception'])
 
+        # A test result can be either a string (which will be displayed
+        # in a fixed-width font) or a list of strings (which will be hidden
+        # behind an expandable toggle).
+        list_result = ["list", "of", "strings"]
+        result.result = list_result
+        d = result.to_dict
+        eq_(list_result, d['result'])
+
+        # Other .result values don't make it into the dictionary because
+        # it's not defined how to display them.
+        result.result = {"a": "dictionary"}
+        d = result.to_dict
+        eq_(None, d['result'])
+
     def test_repr_failure(self):
         """Show the string representation of a failed test result."""
 


### PR DESCRIPTION
This is a core branch in support of https://jira.nypl.org/browse/SIMPLY-1711. I'll be using `Collection.pools_with_no_delivery_mechanisms` in an Axis 360 self-test.