### PR TITLE
Better default facets

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -275,21 +275,7 @@ class Facets(FacetsWithEntryPoint):
     """
     @classmethod
     def default(cls, library):
-        default_collection = library.default_facet(
-            Facets.COLLECTION_FACET_GROUP_NAME
-        )
-        default_availability = library.default_facet(
-            Facets.AVAILABILITY_FACET_GROUP_NAME
-        )
-        default_order = library.default_facet(
-            Facets.ORDER_FACET_GROUP_NAME
-        )
-        return cls(
-            library,
-            collection=default_collection,
-            availability=default_availability,
-            order=default_order,
-        )
+        return cls(library, collection=None, availability=None, order=None)
 
     @classmethod
     def from_request(cls, library, config, get_argument, get_header, worklist,

--- a/lane.py
+++ b/lane.py
@@ -275,11 +275,20 @@ class Facets(FacetsWithEntryPoint):
     """
     @classmethod
     def default(cls, library):
+        default_collection = library.default_facet(
+            Facets.COLLECTION_FACET_GROUP_NAME
+        )
+        default_availability = library.default_facet(
+            Facets.AVAILABILITY_FACET_GROUP_NAME
+        )
+        default_order = library.default_facet(
+            Facets.ORDER_FACET_GROUP_NAME
+        )
         return cls(
             library,
-            collection=cls.COLLECTION_MAIN,
-            availability=cls.AVAILABLE_ALL,
-            order=cls.ORDER_AUTHOR
+            collection=default_collection,
+            availability=default_availability,
+            order=default_order,
         )
 
     @classmethod

--- a/lane.py
+++ b/lane.py
@@ -30,6 +30,7 @@ from sqlalchemy import (
     Integer,
     Table,
     Unicode,
+    text,
 )
 from sqlalchemy.ext.associationproxy import (
     association_proxy,
@@ -1801,7 +1802,7 @@ class WorkList(object):
         )
 
         lane_query = lane_query.order_by(
-            "quality_tier desc", work_model.random.desc()
+            text("quality_tier desc"), work_model.random.desc()
         )
 
         # Allow some overage to reduce the risk that we'll have to

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -334,8 +334,8 @@ class TestFacets(DatabaseTest):
             def __init__(self, library, **kwargs):
                 self.library = library
                 self.kwargs = kwargs
-        facets = Mock.default(library)
-        eq_(library, facets.library)
+        facets = Mock.default(self._default_library)
+        eq_(self._default_library, facets.library)
         eq_(dict(collection=None, availability=None, order=None),
             facets.kwargs)
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -327,6 +327,18 @@ class TestFacets(DatabaseTest):
         expect = [['order', 'title', True], ['order', 'work_id', False]]
         eq_(expect, sorted([list(x[:2]) + [x[-1]] for x in all_groups]))
 
+    def test_default(self):
+        # Calling Facets.default() is like calling the constructor with
+        # no arguments except the library.
+        class Mock(Facets):
+            def __init__(self, library, **kwargs):
+                self.library = library
+                self.kwargs = kwargs
+        facets = Mock.default(library)
+        eq_(library, facets.library)
+        eq_(dict(collection=None, availability=None, order=None),
+            facets.kwargs)
+
     def test_default_availability(self):
 
         # Normally, the availability will be the library's default availability

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -3099,7 +3099,7 @@ class TestWorkListGroups(DatabaseTest):
         random.seed(42)
 
     def test_groups(self):
-        """A comprehensive test of WorkList.groups()"""
+        # A comprehensive test of WorkList.groups()
         def _w(**kwargs):
             """Helper method to create a work with license pool."""
             return self._work(with_license_pool=True, **kwargs)

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1105,9 +1105,8 @@ class TestOPDS(DatabaseTest):
 
 
     def test_groups_feed(self):
-        """Test the ability to create a grouped feed of recommended works for
-        a given lane.
-        """
+        # Test the ability to create a grouped feed of recommended works for
+        # a given lane.
         epic_fantasy = self._lane(
             "Epic Fantasy", parent=self.fantasy, genres=["Epic Fantasy"]
         )
@@ -2160,10 +2159,9 @@ class TestEntrypointLinkInsertion(DatabaseTest):
         AcquisitionFeed.add_entrypoint_links = self.old_add_entrypoint_links
 
     def test_groups(self):
-        """When AcquisitionFeed.groups() generates a grouped
-        feed, it will link to different entry points into the feed,
-        assuming the WorkList has different entry points.
-        """
+        # When AcquisitionFeed.groups() generates a grouped
+        # feed, it will link to different entry points into the feed,
+        # assuming the WorkList has different entry points.
         def run(wl=None, facets=None):
             """Call groups() and see what add_entrypoint_links
             was called with.


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-1662. Default facets are created by calling the constructor with empty arguments (which fills in library-specific defaults), not by guessing at 'default' values that may be disabled for a given library.