### PR TITLE
Fix inconsistencies and remove duplicate code between the timestamp metadata layer and model

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -506,6 +506,8 @@ class FormatData(object):
 
 class TimestampData(object):
 
+    CLEAR_VALUE = Timestamp.CLEAR_VALUE
+
     def __init__(self, start=None, finish=None, achievements=None,
                  counter=None, exception=None):
         """A constructor intended to be used by a service to customize its
@@ -542,7 +544,7 @@ class TimestampData(object):
     @property
     def is_failure(self):
         """Does this TimestampData represent an unrecoverable failure?"""
-        return self.exception not in (None, Timestamp.CLEAR_VALUE)
+        return self.exception not in (None, self.CLEAR_VALUE)
 
     @property
     def is_complete(self):
@@ -552,9 +554,7 @@ class TimestampData(object):
         An operation is completed if it has failed, or if the time of its
         completion is known.
         """
-        return self.is_failure or self.finish not in (
-            None, Timestamp.CLEAR_VALUE
-        )
+        return self.is_failure or self.finish not in (None, self.CLEAR_VALUE)
 
     def finalize(self, service, service_type, collection, start=None,
                  finish=None, achievements=None, counter=None,

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -597,18 +597,10 @@ class TimestampData(object):
                 "Not enough information to write TimestampData to the database."
             )
 
-        start = self.start
-        finish = self.finish
-        if start is None and finish is None:
-            start = finish = datetime.datetime.utcnow()
-        elif start is None:
-            start = finish
-        elif finish is None:
-            finish = start
-
         return Timestamp.stamp(
             _db, self.service, self.service_type, self.collection(_db),
-            start, finish, achievements, counter, exception
+            self.start, self.finish, self.achievements, self.counter,
+            self.exception
         )
 
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -506,10 +506,10 @@ class FormatData(object):
 
 class TimestampData(object):
 
-    NO_VALUE = Timestamp.NO_VALUE
+    CLEAR_VALUE = Timestamp.CLEAR_VALUE
 
-    def __init__(self, start=NO_VALUE, finish=NO_VALUE, achievements=NO_VALUE,
-                 counter=NO_VALUE, exception=NO_VALUE):
+    def __init__(self, start=None, finish=None, achievements=None,
+                 counter=None, exception=None):
         """A constructor intended to be used by a service to customize its
         eventual Timestamp.
 
@@ -531,9 +531,9 @@ class TimestampData(object):
         """
 
         # These are set by finalize().
-        self.service = self.NO_VALUE
-        self.service_type = self.NO_VALUE
-        self.collection_id = self.NO_VALUE
+        self.service = None
+        self.service_type = None
+        self.collection_id = None
 
         self.start = start
         self.finish = finish
@@ -544,7 +544,7 @@ class TimestampData(object):
     @property
     def is_failure(self):
         """Does this TimestampData represent an unrecoverable failure?"""
-        return self.exception not in (None, self.NO_VALUE)
+        return self.exception not in (None, self.CLEAR_VALUE)
 
     @property
     def is_complete(self):
@@ -554,11 +554,11 @@ class TimestampData(object):
         An operation is completed if it has failed, or if the time of its
         completion is known.
         """
-        return self.is_failure or self.finish not in (None, self.NO_VALUE)
+        return self.is_failure or self.finish not in (None, self.CLEAR_VALUE)
 
-    def finalize(self, service, service_type, collection, start=NO_VALUE,
-                 finish=NO_VALUE, achievements=NO_VALUE, counter=NO_VALUE,
-                 exception=NO_VALUE):
+    def finalize(self, service, service_type, collection, start=None,
+                 finish=None, achievements=None, counter=None,
+                 exception=None):
         """Finalize any values that were not set during the constructor.
 
         This is intended to be run by the code that originally ran the
@@ -574,45 +574,43 @@ class TimestampData(object):
             self.collection_id = None
         else:
             self.collection_id = collection.id
-        if self.start is self.NO_VALUE:
+        if self.start is None:
             self.start = start
-        if self.finish is self.NO_VALUE:
-            if finish is self.NO_VALUE:
+        if self.finish is None:
+            if finish is None:
                 finish = datetime.datetime.utcnow()
             self.finish = finish
-        if self.start is self.NO_VALUE:
+        if self.start is None:
             self.start = self.finish
-        if self.counter is self.NO_VALUE:
+        if self.counter is None:
             self.counter = counter
-        if self.exception is self.NO_VALUE:
+        if self.exception is None:
             self.exception = exception
 
     def collection(self, _db):
         return get_one(_db, Collection, id=self.collection_id)
 
     def apply(self, _db):
-        if any(x is self.NO_VALUE for x in [self.service, self.service_type,
-                                            self.collection_id]):
+        if any(x is None for x in [self.service, self.service_type,
+                                   self.collection_id]):
             raise ValueError(
                 "Not enough information to write TimestampData to the database."
             )
 
         start = self.start
         finish = self.finish
-        if start is self.NO_VALUE and finish is self.NO_VALUE:
+        if start is None and finish is None:
             start = finish = datetime.datetime.utcnow()
-        elif start is self.NO_VALUE:
+        elif start is None:
             start = finish
-        elif finish is self.NO_VALUE:
+        elif finish is None:
             finish = start
-        # At this point both start and finish are set to real
-        # timestamps.
 
-        # If any of these fields are still NO_VALUE, it means that the
+        # If any of these fields are CLEAR_VALUE, it means that the
         # corresponding database fields should be cleared out -- they
         # were irrelevant to this service on this particular run.
         def _v(x):
-            if x is self.NO_VALUE:
+            if x is self.CLEAR_VALUE:
                 return None
             return x
 
@@ -620,6 +618,8 @@ class TimestampData(object):
         counter = _v(self.counter)
         counter = _v(self.counter)
         exception = _v(self.exception)
+        start = _v(start)
+        finish = _v(finish)
 
         return Timestamp.stamp(
             _db, self.service, self.service_type, self.collection(_db),

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -506,8 +506,6 @@ class FormatData(object):
 
 class TimestampData(object):
 
-    CLEAR_VALUE = Timestamp.CLEAR_VALUE
-
     def __init__(self, start=None, finish=None, achievements=None,
                  counter=None, exception=None):
         """A constructor intended to be used by a service to customize its
@@ -544,7 +542,7 @@ class TimestampData(object):
     @property
     def is_failure(self):
         """Does this TimestampData represent an unrecoverable failure?"""
-        return self.exception not in (None, self.CLEAR_VALUE)
+        return self.exception not in (None, Timestamp.CLEAR_VALUE)
 
     @property
     def is_complete(self):
@@ -554,7 +552,9 @@ class TimestampData(object):
         An operation is completed if it has failed, or if the time of its
         completion is known.
         """
-        return self.is_failure or self.finish not in (None, self.CLEAR_VALUE)
+        return self.is_failure or self.finish not in (
+            None, Timestamp.CLEAR_VALUE
+        )
 
     def finalize(self, service, service_type, collection, start=None,
                  finish=None, achievements=None, counter=None,
@@ -591,8 +591,7 @@ class TimestampData(object):
         return get_one(_db, Collection, id=self.collection_id)
 
     def apply(self, _db):
-        if any(x is None for x in [self.service, self.service_type,
-                                   self.collection_id]):
+        if any(x is None for x in [self.service, self.service_type]):
             raise ValueError(
                 "Not enough information to write TimestampData to the database."
             )

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -606,21 +606,6 @@ class TimestampData(object):
         elif finish is None:
             finish = start
 
-        # If any of these fields are CLEAR_VALUE, it means that the
-        # corresponding database fields should be cleared out -- they
-        # were irrelevant to this service on this particular run.
-        def _v(x):
-            if x is self.CLEAR_VALUE:
-                return None
-            return x
-
-        achievements = _v(self.achievements)
-        counter = _v(self.counter)
-        counter = _v(self.counter)
-        exception = _v(self.exception)
-        start = _v(start)
-        finish = _v(finish)
-
         return Timestamp.stamp(
             _db, self.service, self.service_type, self.collection(_db),
             start, finish, achievements, counter, exception

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -255,8 +255,10 @@ class Timestamp(Base):
                 counter = None
             self.counter = counter
 
-        # Unlike the other fields, None is a realistic value for
-        # .exception
+        # Unlike the other fields, None is the default value for
+        # .exception, so passing in None to mean "use the default" and
+        # None to mean "no exception" mean the same thing. But we'll
+        # support CLEAR_VALUE anyway.
         if exception is self.CLEAR_VALUE:
             exception = None
         self.exception = exception

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -247,12 +247,18 @@ class Timestamp(Base):
                 finish = None
             self.finish = finish
         if achievements is not None:
+            if achievements is self.CLEAR_VALUE:
+                achievements = None
             self.achievements = achievements
         if counter is not None:
+            if counter is self.CLEAR_VALUE:
+                counter = None
             self.counter = counter
 
         # Unlike the other fields, None is a realistic value for
         # .exception
+        if exception is self.CLEAR_VALUE:
+            exception = None
         self.exception = exception
 
     def to_data(self):

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -101,9 +101,9 @@ class Timestamp(Base):
     SCRIPT_TYPE = "script"
 
     # A stand-in value used to indicate that a field in the timestamps
-    # should be set to None. This is necessary because 'None' generally
-    # means 'use the default value'.
-    NO_VALUE = object()
+    # table should be explicitly set to None. Passing in None for most
+    # fields will use default values.
+    CLEAR_VALUE = object()
 
     service_type_enum = Enum(
         MONITOR_TYPE, COVERAGE_PROVIDER_TYPE, SCRIPT_TYPE,
@@ -235,13 +235,13 @@ class Timestamp(Base):
         """
 
         if start is not None:
-            if start is self.NO_VALUE:
+            if start is self.CLEAR_VALUE:
                 # In most cases, None is not a valid value for
                 # Timestamp.start, but this can be overridden.
                 start = None
             self.start = start
         if finish is not None:
-            if finish is self.NO_VALUE:
+            if finish is self.CLEAR_VALUE:
                 # In most cases, None is not a valid value for
                 # Timestamp.finish, but this can be overridden.
                 finish = None

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -214,8 +214,12 @@ class Timestamp(Base):
         :param exception: A stack trace for the exception, if any, which
             stopped the service from running.
         """
-        finish = finish or datetime.datetime.utcnow()
-        start = start or finish
+        if start is None and finish is None:
+            start = finish = datetime.datetime.utcnow()
+        elif start is None:
+            start = finish
+        elif finish is None:
+            finish = start
         stamp, was_new = get_one_or_create(
             _db, Timestamp,
             service=service,

--- a/monitor.py
+++ b/monitor.py
@@ -197,7 +197,7 @@ class Monitor(object):
                 self.service_name, exc_info=e
             )
             exception = traceback.format_exc()
-        if exception not in ignorable:
+        if exception is not None:
             # We will update Timestamp.exception but not go through
             # the whole TimestampData.apply() process, which might
             # erase the information the Monitor needs to recover from

--- a/monitor.py
+++ b/monitor.py
@@ -160,6 +160,8 @@ class Monitor(object):
 
         this_run_start = datetime.datetime.utcnow()
         exception = None
+
+        ignorable = (None, TimestampData.CLEAR_VALUE)
         try:
             new_timestamp = self.run_once(progress)
             this_run_finish = datetime.datetime.utcnow()
@@ -167,7 +169,6 @@ class Monitor(object):
                 # Assume this Monitor has no special needs surrounding
                 # its timestamp.
                 new_timestamp = TimestampData()
-            ignorable = (None, TimestampData.CLEAR_VALUE)
             if new_timestamp.achievements not in ignorable:
                 # This eliminates the need to create similar-looking
                 # strings for TimestampData.achievements and for the log.

--- a/monitor.py
+++ b/monitor.py
@@ -167,11 +167,12 @@ class Monitor(object):
                 # Assume this Monitor has no special needs surrounding
                 # its timestamp.
                 new_timestamp = TimestampData()
-            if new_timestamp.achievements not in (None, TimestampData.NO_VALUE):
+            ignorable = (None, TimestampData.CLEAR_VALUE)
+            if new_timestamp.achievements not in ignorable:
                 # This eliminates the need to create similar-looking
                 # strings for TimestampData.achievements and for the log.
                 self.log.info(new_timestamp.achievements)
-            if new_timestamp.exception in (None, TimestampData.NO_VALUE):
+            if new_timestamp.exception in ignorable:
                 # run_once() completed with no exceptions being raised.
                 # We can run the cleanup code and finalize the timestamp.
                 self.cleanup()
@@ -195,7 +196,7 @@ class Monitor(object):
                 self.service_name, exc_info=e
             )
             exception = traceback.format_exc()
-        if exception is not None:
+        if exception not in ignorable:
             # We will update Timestamp.exception but not go through
             # the whole TimestampData.apply() process, which might
             # erase the information the Monitor needs to recover from
@@ -244,7 +245,7 @@ class TimelineMonitor(Monitor):
     OVERLAP = datetime.timedelta(minutes=5)
 
     def run_once(self, progress):
-        if progress.finish in (None, progress.NO_VALUE):
+        if progress.finish is None:
             # This monitor has never run before. Use the default
             # start time for this monitor.
             start = self.initial_start_time

--- a/tests/models/test_coverage.py
+++ b/tests/models/test_coverage.py
@@ -97,11 +97,11 @@ class TestTimestamp(DatabaseTest):
         assert stamp3 != stamp
         eq_(self._default_collection, stamp3.collection)
 
-        # Passing in NO_VALUE for start or end will clear an existing
+        # Passing in CLEAR_VALUE for start or end will clear an existing
         # Timestamp.
         stamp4 = Timestamp.stamp(
             self._db, service, type,
-            start=Timestamp.NO_VALUE, finish=Timestamp.NO_VALUE
+            start=Timestamp.CLEAR_VALUE, finish=Timestamp.CLEAR_VALUE
         )
         eq_(stamp4, stamp)
         eq_(None, stamp4.start)

--- a/tests/models/test_coverage.py
+++ b/tests/models/test_coverage.py
@@ -97,15 +97,17 @@ class TestTimestamp(DatabaseTest):
         assert stamp3 != stamp
         eq_(self._default_collection, stamp3.collection)
 
-        # Passing in CLEAR_VALUE for start or end will clear an existing
-        # Timestamp.
+        # Passing in CLEAR_VALUE for start, end, or exception will
+        # clear an existing Timestamp.
         stamp4 = Timestamp.stamp(
             self._db, service, type,
-            start=Timestamp.CLEAR_VALUE, finish=Timestamp.CLEAR_VALUE
+            start=Timestamp.CLEAR_VALUE, finish=Timestamp.CLEAR_VALUE,
+            exception=Timestamp.CLEAR_VALUE
         )
         eq_(stamp4, stamp)
         eq_(None, stamp4.start)
         eq_(None, stamp4.finish)
+        eq_(None, stamp4.exception)
 
     def test_update(self):
         # update() can modify the fields of a Timestamp that aren't

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1481,6 +1481,23 @@ class TestTimestampData(DatabaseTest):
         eq_("yay", timestamp.achievements)
         eq_("oops", timestamp.exception)
 
+        # We can also use apply() to clear out the values for all
+        # fields other than the ones that uniquely identify the
+        # Timestamp.
+        clear = TimestampData.CLEAR_VALUE
+        d.start = clear
+        d.finish = clear
+        d.counter = clear
+        d.achievements = clear
+        d.exception = clear
+        d.apply(self._db)
+
+        eq_(None, timestamp.start)
+        eq_(None, timestamp.finish)
+        eq_(None, timestamp.counter)
+        eq_(None, timestamp.achievements)
+        eq_(None, timestamp.exception)
+
 
 class TestAssociateWithIdentifiersBasedOnPermanentWorkID(DatabaseTest):
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1337,12 +1337,12 @@ class TestTimestampData(DatabaseTest):
 
     def test_constructor(self):
 
-        # By default, all fields are set to NO_VALUE
+        # By default, all fields are set to None
         d = TimestampData()
         for i in (d.service, d.service_type, d.collection_id,
                   d.start, d.finish, d.achievements, d.counter,
                   d.exception):
-            eq_(i, d.NO_VALUE)
+            eq_(i, None)
 
         # Some, but not all, of the fields can be set to real values.
         d = TimestampData(start="a", finish="b", achievements="c",
@@ -1355,7 +1355,7 @@ class TestTimestampData(DatabaseTest):
 
     def test_is_failure(self):
         # A TimestampData represents failure if its exception is set to
-        # any value other than None or NO_VALUE.
+        # any value other than None or CLEAR_VALUE.
         d = TimestampData()
         eq_(False, d.is_failure)
 
@@ -1365,10 +1365,13 @@ class TestTimestampData(DatabaseTest):
         d.exception = None
         eq_(False, d.is_failure)
 
+        d.exception = d.CLEAR_VALUE
+        eq_(False, d.is_failure)
+
     def test_is_complete(self):
         # A TimestampData is complete if it represents a failure
         # (see above) or if its .finish is set to any value other
-        # than None or NO_VALUE
+        # than None or CLEAR_VALUE
 
         d = TimestampData()
         eq_(False, d.is_complete)
@@ -1379,6 +1382,9 @@ class TestTimestampData(DatabaseTest):
         d.finish = None
         eq_(False, d.is_complete)
 
+        d.finish = d.CLEAR_VALUE
+        eq_(False, d.is_complete)
+
         d.exception = "oops"
         eq_(True, d.is_complete)
 
@@ -1387,7 +1393,7 @@ class TestTimestampData(DatabaseTest):
         # timestamp values to sensible defaults and leaves everything
         # else alone.
 
-        # This TimestampData starts out with everything set to NO_VALUE.
+        # This TimestampData starts out with everything set to None.
         d = TimestampData()
         d.finalize("service", "service_type", self._default_collection)
 
@@ -1400,9 +1406,9 @@ class TestTimestampData(DatabaseTest):
         eq_(d.start, d.finish)
         assert (datetime.datetime.now() - d.start).total_seconds() < 2
 
-        # Other fields are still at NO_VALUE.
+        # Other fields are still at None.
         for i in d.achievements, d.counter, d.exception:
-            eq_(i, d.NO_VALUE)
+            eq_(i, None)
 
     def test_finalize_full(self):
         # You can call finalize() with a complete set of arguments.
@@ -1418,7 +1424,7 @@ class TestTimestampData(DatabaseTest):
         eq_("exception", d.exception)
 
         # If the TimestampData fields are already set to values other
-        # than NO_VALUE, the required fields will be overwritten but
+        # than CLEAR_VALUE, the required fields will be overwritten but
         # the optional fields will be left alone.
         new_collection = self._collection()
         d.finalize(
@@ -1453,7 +1459,7 @@ class TestTimestampData(DatabaseTest):
         )
 
         # Set the basic timestamp information. Optional fields will stay
-        # at NO_VALUE.
+        # at None.
         collection = self._default_collection
         d.finalize("service", Timestamp.SCRIPT_TYPE, collection)
         d.apply(self._db)

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -2142,8 +2142,8 @@ class TestOPDSImportMonitor(OPDSImporterTest):
         
         # The TimestampData returned by run_once does not include any
         # timing information; that's provided by run().
-        eq_(TimestampData.NO_VALUE, progress.start)
-        eq_(TimestampData.NO_VALUE, progress.finish)
+        eq_(None, progress.start)
+        eq_(None, progress.finish)
 
     def test_update_headers(self):
         """Test the _update_headers helper method."""


### PR DESCRIPTION
The `Timestamp.NO_VALUE` object is being used in inconsistent ways. In `Timestamp` this value means "set the value of this field to None, even if that violates the normal expectations of the Timestamp data model". In `TimestampData` this value means "I don't care what the value of this field is".

This branch renames NO_VALUE to CLEAR_VALUE so that there's no ambiguity in the name. Within `TimestampData` we go back to the standard technique of using `None` to stand in for "I don't care what the value of this field is". It turns out use of `CLEAR_VALUE` is pretty uncommon, so using the standard technique is less confusing than creating a second special constant for "don't care".

This change revealed that there's code in `TimestampData.apply` that duplicates code in `Timestamp.stamp` in an inconsistent way. Since `apply` calls `stamp`, this inconsistency actually made it impossible to use `apply` to force `Timestamp.finish` to be None -- it would be set to `None` in `apply` and then `stamp` would set it to the current time.

This was revealed by my investigations into https://jira.nypl.org/browse/SIMPLY-1796.