### PR TITLE
Properly quote the URI in a content type parameter value

### DIFF
--- a/model/licensing.py
+++ b/model/licensing.py
@@ -1293,7 +1293,7 @@ class DeliveryMechanism(Base, HasFullTableCache):
     OVERDRIVE_DRM = u"Overdrive DRM"
     BEARER_TOKEN = u"application/vnd.librarysimplified.bearer-token+json"
 
-    STREAMING_PROFILE = ";profile=http://librarysimplified.org/terms/profiles/streaming-media"
+    STREAMING_PROFILE = ';profile="http://librarysimplified.org/terms/profiles/streaming-media"'
     MEDIA_TYPES_FOR_STREAMING = {
         STREAMING_TEXT_CONTENT_TYPE: MediaTypes.TEXT_HTML_MEDIA_TYPE
     }


### PR DESCRIPTION
This fixes https://jira.nypl.org/browse/SIMPLY-1802.

The unquoted XML screws up the current Android parser  -- I believe this is either https://jira.nypl.org/browse/SIMPLY-1801 or https://jira.nypl.org/browse/SIMPLY-1788. We didn't notice this earlier because on the circulation manager, the streaming text delivery mechanisms are always later in the `<entry>` tag than a mechanism we've already decided we support.

No migration is needed because this the value stored in the database is `Streaming Text` and we translate to `text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"` when generating OPDS.

I've verified that lxml correctly escapes these quotes and we end up with XML like this:

```
<opds:indirectAcquisition type="text/html;profile=&quot;http://librarysimplified.org/terms/profiles/streaming-media&quot;"/>
```

We need to be careful when QAing this because there's a slight change this will break the SimplyE parser; if we do, getting this fix in will be a lot more complicated. It's unlikely this will happen, though, since we correctly escape the profile for the annotation endpoints, creating XML like this:

```
    <link href="http://localhost:6500/lib/annotations/Overdrive%20ID/0d85564b-a4b3-43d5-875d-1df3ca06ae65/" type="application/ld+json; profile=&quot;http://www.w3.org/ns/anno.jsonld&quot;" rel="http://www.w3.org/ns/oa#annotationService"/>
```

And we know SimplyE uses that endpoint on both platforms.

