### PR TITLE
If there's a RemoteIntegrationException communicating with the metadata wrangler, don't let that derail the process of determining an author's sort name.

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -24,6 +24,7 @@ import re
 from pymarc import MARCReader
 
 from util import LanguageCodes
+from util.http import RemoteIntegrationException
 from util.personal_names import name_tidy
 from util.median import median
 from classifier import Classifier
@@ -311,9 +312,19 @@ class ContributorData(object):
         # Time to break out the big guns. Ask the metadata wrangler
         # if it can find a sort name for this display name.
         if metadata_client:
-            sort_name = self.display_name_to_sort_name_through_canonicalizer(
-                _db, identifiers, metadata_client
-            )
+            try:
+                sort_name = self.display_name_to_sort_name_through_canonicalizer(
+                    _db, identifiers, metadata_client
+                )
+            except RemoteIntegrationException, e:
+                # There was some kind of problem with the metadata
+                # wrangler. Act as though no metadata wrangler had
+                # been provided.
+                log = logging.getLogger("Abstract metadata layer")
+                log.error(
+                    "Metadata client exception while determining sort name for %s",
+                    self.display_name, exc_info=e
+                )
             if sort_name:
                 self.sort_name = sort_name
                 return True


### PR DESCRIPTION
This fixes https://jira.nypl.org/browse/SIMPLY-1817.

This is much deeper in the code than I expected based on where the problem manifests -- when refreshing the list of NYT best-sellers -- but it makes sense to me that the call to the metadata wrangler would hpapen in `ContributorData`.