### PR TITLE
Make Collection deletion more robust, and implement a ReaperMonitor that deletes Collections flagged for deletion

### DIFF
--- a/model/collection.py
+++ b/model/collection.py
@@ -211,8 +211,10 @@ class Collection(Base, HasFullTableCache):
     def by_protocol(cls, _db, protocol):
         """Query collections that get their licenses through the given protocol.
 
+        Collections marked for deletion are not included.
+
         :param protocol: Protocol to use. If this is None, all
-        Collections will be returned.
+        Collections will be returned except those marked for deletion.
         """
         qu = _db.query(Collection)
         if protocol:
@@ -220,12 +222,18 @@ class Collection(Base, HasFullTableCache):
             ExternalIntegration,
             ExternalIntegration.id==Collection.external_integration_id).filter(
                 ExternalIntegration.goal==ExternalIntegration.LICENSE_GOAL
-            ).filter(ExternalIntegration.protocol==protocol)
+            ).filter(ExternalIntegration.protocol==protocol).filter(
+                Collection.marked_for_deletion==False
+            )
+
         return qu
 
     @classmethod
     def by_datasource(cls, _db, data_source):
-        """Query collections that are associated with the given DataSource."""
+        """Query collections that are associated with the given DataSource.
+
+        Collections marked for deletion are not included.
+        """
         if isinstance(data_source, DataSource):
             data_source = data_source.name
 
@@ -233,7 +241,9 @@ class Collection(Base, HasFullTableCache):
                 cls.external_integration_id==ExternalIntegration.id)\
             .join(ExternalIntegration.settings)\
             .filter(ConfigurationSetting.key==Collection.DATA_SOURCE_NAME_SETTING)\
-            .filter(ConfigurationSetting.value==data_source)
+            .filter(ConfigurationSetting.value==data_source).filter(
+                Collection.marked_for_deletion==False
+            )
         return qu
 
     @hybrid_property

--- a/model/collection.py
+++ b/model/collection.py
@@ -723,10 +723,10 @@ class Collection(Base, HasFullTableCache):
         that can be confined to the background and survive interruption.
         """
         _db = Session.object_session(self)
-        #if not self.marked_for_deletion:
-        #    raise Exception(
-        #        "Cannot delete %s: it is not marked for deletion." % self.name
-        #    )
+        if not self.marked_for_deletion:
+            raise Exception(
+                "Cannot delete %s: it is not marked for deletion." % self.name
+            )
 
         # Delete all the license pools.
         for i, pool in enumerate(self.licensepools):

--- a/model/collection.py
+++ b/model/collection.py
@@ -738,11 +738,19 @@ class Collection(Base, HasFullTableCache):
                 "Cannot delete %s: it is not marked for deletion." % self.name
             )
 
-        # Delete all the license pools.
+        # Delete all the license pools. This should be the only part
+        # of the application where LicensePools are permanently
+        # deleted.
         for i, pool in enumerate(self.licensepools):
             _db.delete(pool)
             if not i % 100:
                 _db.commit()
+            # TODO: If the LicensePool's Work has no other
+            # LicensePools, the Work should be removed from the search
+            # index. We can't do this now because we currently have no
+            # way of removing something from the search index. This
+            # only affects search engine performance -- it won't cause
+            # phantom books to show up in search results.
 
         # Now delete the Collection itself.
         _db.delete(self)

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -68,7 +68,9 @@ class License(Base):
     license_pool_id = Column(Integer, ForeignKey('licensepools.id'), index=True)
 
     # One License can have many Loans.
-    loans = relationship('Loan', backref='license')
+    loans = relationship(
+        'Loan', backref='license', cascade='all, delete-orphan'
+    )
 
     __table_args__ = (
         UniqueConstraint('identifier', 'license_pool_id'),
@@ -122,20 +124,30 @@ class LicensePool(Base):
 
     # If the source provides information about individual licenses, the
     # LicensePool may have many Licenses.
-    licenses = relationship('License', backref='license_pool')
+    licenses = relationship(
+        'License', backref='license_pool', cascade='all, delete-orphan'
+    )
 
     # One LicensePool can have many Loans.
-    loans = relationship('Loan', backref='license_pool')
+    loans = relationship(
+        'Loan', backref='license_pool', cascade='all, delete-orphan'
+    )
 
     # One LicensePool can have many Holds.
-    holds = relationship('Hold', backref='license_pool')
+    holds = relationship(
+        'Hold', backref='license_pool', cascade='all, delete-orphan'
+    )
 
     # One LicensePool can have many CirculationEvents
     circulation_events = relationship(
-        "CirculationEvent", backref="license_pool")
+        "CirculationEvent", backref="license_pool",
+        cascade='all, delete-orphan'
+    )
 
     # One LicensePool can be associated with many Complaints.
-    complaints = relationship('Complaint', backref='license_pool')
+    complaints = relationship(
+        'Complaint', backref='license_pool', cascade='all, delete-orphan'
+    )
 
     # The date this LicensePool was first created in our db
     # (the date we first discovered that ​we had that book in ​our collection).

--- a/monitor.py
+++ b/monitor.py
@@ -794,6 +794,8 @@ class ReaperMonitor(Monitor):
         for i in qu:
             self.log.info("Deleting %r", i)
             self.delete(i)
+            rows_deleted += 1
+        return TimestampData(achievements="Items deleted: %d" % rows_deleted)
 
     def delete(self, row):
         """Delete a row from the database."""

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -96,6 +96,12 @@ class TestCollection(DatabaseTest):
         eq_(set([self.collection, c1, c2]),
             set(Collection.by_protocol(self._db, None).all()))
 
+        # A collection marked for deletion is filtered out.
+        c1.marked_for_deletion = True
+        eq_([self.collection],
+            Collection.by_protocol(self._db, overdrive).all())
+
+
     def test_by_datasource(self):
         """Collections can be found by their associated DataSource"""
         c1 = self._collection(data_source_name=DataSource.GUTENBERG)
@@ -109,6 +115,10 @@ class TestCollection(DatabaseTest):
         overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
         eq_(set([c2]),
             set(Collection.by_datasource(self._db, overdrive).all()))
+
+        # A collection marked for deletion is filtered out.
+        c2.marked_for_deletion = True
+        eq_(0, Collection.by_datasource(self._db, overdrive).count())
 
     def test_parents(self):
         # Collections can return all their parents recursively.
@@ -690,7 +700,7 @@ class TestCollection(DatabaseTest):
         setting1 = integration.set_setting("integration setting", "value2")
         setting2 = ConfigurationSetting.for_library_and_externalintegration(
             self._db, "library+integration setting",
-            self._default_library, integration, 
+            self._default_library, integration,
         )
         setting2.value = "value2"
 
@@ -703,7 +713,7 @@ class TestCollection(DatabaseTest):
         # The LicensePool also has a hold.
         patron2 = self._patron()
         hold, is_new = pool.on_hold_to(patron2)
-        
+
         # And a Complaint.
         complaint, is_new = Complaint.register(
             pool, list(Complaint.VALID_TYPES)[0],

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -718,14 +718,8 @@ class TestCollection(DatabaseTest):
         # Delete the collection.
         collection.delete()
 
-        # The collection and its ExternalIntegration has been deleted.
+        # The collection has been deleted.
         assert collection not in self._db.query(Collection).all()
-
-        assert integration not in self._db.query(ExternalIntegration).all()
-
-        settings = self._db.query(ConfigurationSetting).all()
-        for s in (setting1, setting2):
-            assert s not in settings
 
         # The connection with the default library has been broken.
         eq_([], self._default_library.collections)
@@ -741,6 +735,14 @@ class TestCollection(DatabaseTest):
         # n.b. Annotations are associated with Identifier, not
         # LicensePool, so they can and should survive the deletion of
         # the Collection in which they were originally created.
+
+        # The ExternalIntegration and its settings are still around,
+        # since multiple Collections can be based on the same
+        # ExternalIntegration.
+        assert integration in self._db.query(ExternalIntegration).all()
+        settings = self._db.query(ConfigurationSetting).all()
+        for s in (setting1, setting2):
+            assert s in settings
 
 
 class TestCollectionForMetadataWrangler(DatabaseTest):

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -705,7 +705,8 @@ class TestCollection(DatabaseTest):
         setting2.value = "value2"
 
         # It's got a LicensePool, which has a License, which has a loan.
-        pool = self._licensepool(None)
+        work = self._work(with_license_pool=True)
+        [pool] = work.license_pools
         license = self._license(pool)
         patron = self._patron()
         loan, is_new = license.loan_to(patron)
@@ -754,6 +755,9 @@ class TestCollection(DatabaseTest):
         # n.b. Annotations are associated with Identifier, not
         # LicensePool, so they can and should survive the deletion of
         # the Collection in which they were originally created.
+
+        # The Work is still around -- it just no longer has any LicensePools.
+        eq_([], work.license_pools)
 
         # The ExternalIntegration and its settings are still around,
         # since multiple Collections can be based on the same

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -715,13 +715,22 @@ class TestCollection(DatabaseTest):
             self._db, pool, CirculationEvent.DISTRIBUTOR_TITLE_ADD, 0, 1
         )
 
+        # delete() will not work on a collection that's not marked for
+        # deletion.
+        assert_raises_regexp(
+            Exception,
+            "Cannot delete %s: it is not marked for deletion." % collection.name,
+            collection.delete
+        )
+
         # Delete the collection.
+        collection.marked_for_deletion = True
         collection.delete()
 
-        # The collection has been deleted.
+        # It's gone.
         assert collection not in self._db.query(Collection).all()
 
-        # The connection with the default library has been broken.
+        # The default library now has no collections.
         eq_([], self._default_library.collections)
 
         # The deletion of the Collection's sole LicensePool has

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -948,7 +948,8 @@ class TestReaperMonitor(DatabaseTest):
         eternal = self._credential()
 
         m = CredentialReaper(self._db)
-        m.run_once()
+        result = m.run_once()
+        eq_("Items deleted: 1", result.achievements)
 
         # The expired credential has been reaped; the others
         # are still in the database.
@@ -967,7 +968,8 @@ class TestReaperMonitor(DatabaseTest):
         active.expires = now - datetime.timedelta(
             days=PatronRecordReaper.MAX_AGE - 1
         )
-        m.run_once()
+        result = m.run_once()
+        eq_("Items deleted: 1", result.achievements)
         remaining = self._db.query(Patron).all()
         eq_([active], remaining)
 
@@ -1004,8 +1006,9 @@ class TestCollectionReaper(DatabaseTest):
         c2 = self._collection()
         c2.marked_for_deletion = True
         reaper = CollectionReaper(self._db)
-        reaper.run_once()
+        result = reaper.run_once()
 
         # The Collection marked for deletion has been deleted; the other
         # one is unaffected.
         eq_([c1], self._db.query(Collection).all())
+        eq_("Items deleted: 1", result.achievements)


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-1847. It makes four major changes:

* Add cascading deletes to all one-to-many relationships between LicensePool and some other data model object. These are objects that should be deleted along with the LicensePool. Currently these objects are left dangling when a LicensePool is deleted. (We didn't really notice because `Collection` deletion is the only time we actually remove a LicensePool from the database.)
* Implement `Collection.delete()`, which deletes a `Collection`'s LicensePools in batches before deleting the collection itself. This is by far the most time-consuming part of collection deletion, and this change makes that process robust to interruptions.
* Change `Collection` methods that return all `Collection`s matching certain criteria, so that they exclude `Collection`s marked for deletion. This includes the method used by `CollectionMonitor` to find which collections to act on. This change means that scripts which keep a `Collection` up-to-date with some external data source will ignore any collection that's marked for deletion.
* Implement `CollectionReaper`, which looks for `Collection`s that are marked for deletion and calls `delete` on them. Doing this as a `ReaperMonitor` means we don't have to add a new script.

I also made this minor improvement:

* `ReaperMonitor.run_once` returns a `TimestampData` that explains how many items were reaped. Previously it returned nothing, which meant those monitors didn't keep track of their achiements.