### PR TITLE
A SweepMonitor that does no work should not crash.

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -408,6 +408,7 @@ class SweepMonitor(CollectionMonitor):
                 self.service_name, offset, new_offset,
                 (batch_ended_at-batch_started_at).total_seconds()
             )
+            achievements = "Records processed: %d." % total_processed
 
             offset = new_offset
             if offset == 0:
@@ -416,7 +417,6 @@ class SweepMonitor(CollectionMonitor):
 
             # We need to do another batch. If it should raise an exception,
             # we don't want to lose the progress we've already made.
-            achievements = "Records processed: %d." % total_processed
             timestamp.update(
                 counter=new_offset, finish=batch_ended_at,
                 achievements=achievements

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -471,6 +471,14 @@ class TestSweepMonitor(DatabaseTest):
         monitor = MockSweepMonitor(self._db, batch_size=-1)
         eq_(MockSweepMonitor.DEFAULT_BATCH_SIZE, monitor.batch_size)
 
+    def test_run_against_empty_table(self):
+        # If there's nothing in the table to be swept, a SweepMonitor runs
+        # to completion and accomplishes nothing.
+        self.monitor.run()
+        timestamp = self.monitor.timestamp()
+        eq_("Records processed: 0.", timestamp.achievements)
+        eq_(None, timestamp.exception)
+
     def test_run_sweeps_entire_table(self):
         # Three Identifiers -- the batch size is 2.
         i1, i2, i3 = [self._identifier() for i in range(3)]


### PR DESCRIPTION
This small branch fixes https://jira.nypl.org/browse/SIMPLY-1861.