### PR TITLE
Make it possible to run a search with no query string

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -1065,6 +1065,10 @@ class Query(SearchBase):
         """
         query_string = self.query_string
 
+        if query_string is None:
+            # There is no query string.
+            return Q("match_all")
+
         # The search query will create a dis_max query, which tests a
         # number of hypotheses about what the query string might
         # 'really' mean. For each book, the highest-rated hypothesis

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -945,13 +945,10 @@ class TestSearchOrder(EndToEndExternalSearchTest):
             facets = Facets(
                 self._default_library, None, None, order=sort_field, order_ascending=True
             )
-            # TODO: It should not be necessary to pass in a query string at all. In a real
-            # scenario we will use sorting to generate paginated feeds, which have a filter
-            # defined by their lane but no query string.
-            expect(order, "moby", Filter(facets=facets, **filter_kwargs))
+            expect(order, None, Filter(facets=facets, **filter_kwargs))
 
             facets.order_ascending = False
-            expect(list(reversed(order)), "moby", Filter(facets=facets, **filter_kwargs))
+            expect(list(reversed(order)), None, Filter(facets=facets, **filter_kwargs))
 
         # We can sort by title.
         assert_order(Facets.ORDER_TITLE, [self.moby_dick, self.moby_duck])
@@ -1336,6 +1333,13 @@ class TestQuery(DatabaseTest):
                 self._combine_hypotheses_called_with = hypotheses
                 return hypotheses
 
+        # Before we get started, try an easy case. If there is no query
+        # string we get a match_all query that returns everything.
+        query = Mock(None)
+        result = query.query()
+        eq_(dict(match_all=dict()), result.to_dict())
+
+        # Now try a real query string.
         q = "query string"
         query = Mock(q)
         result = query.query()


### PR DESCRIPTION
Fixes https://jira.nypl.org/browse/SIMPLY-1900