### PR TITLE
Implement facets as Elasticsearch filters

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -1507,7 +1507,6 @@ class Filter(SearchBase):
                  subcollection_filter=None, order=None, order_ascending=False,
                  minimum_featured_quality=0.65
     ):
-
         if isinstance(collections, Library):
             # Find all works in this Library's collections.
             collections = collections.collections
@@ -1517,6 +1516,9 @@ class Filter(SearchBase):
             # 'minumum featured quality' has no meaning. This feature
             # should not be used outside a library context, but just
             # in case, we'll set it to 0 to include everything.
+            #
+            # The Facets object may have a better answer. If so, it
+            # will provide it when we call modify_search_filter().
             minimum_featured_quality = 0
         self.minimum_featured_quality = minimum_featured_quality
 

--- a/external_search.py
+++ b/external_search.py
@@ -1505,10 +1505,10 @@ class Filter(SearchBase):
                  genre_restriction_sets=None, customlist_restriction_sets=None,
                  facets=None,
     ):
+
         if isinstance(collections, Library):
             # Find all works in this Library's collections.
             collections = collections.collections
-
         self.collection_ids = self._filter_ids(collections)
 
         self.media = media
@@ -1542,8 +1542,8 @@ class Filter(SearchBase):
         else:
             self.customlist_restriction_sets = []
 
-        # These values may be set by the Facets constructor; this just
-        # establishes default values for them.
+        # Establish default values for additional restrictions that may be
+        # imposed by the Facets object.
         self.minimum_featured_quality = 0
         self.availability = None
         self.subcollection = None

--- a/external_search.py
+++ b/external_search.py
@@ -1504,8 +1504,7 @@ class Filter(SearchBase):
                  fiction=None, audiences=None, target_age=None,
                  genre_restriction_sets=None, customlist_restriction_sets=None,
                  facets=None, availability_filter=None,
-                 subcollection_filter=None, order=None, order_ascending=False,
-                 minimum_featured_quality=0.65
+                 subcollection_filter=None, order=None, order_ascending=False
     ):
         if isinstance(collections, Library):
             # Find all works in this Library's collections.

--- a/external_search.py
+++ b/external_search.py
@@ -1503,8 +1503,7 @@ class Filter(SearchBase):
     def __init__(self, collections=None, media=None, languages=None,
                  fiction=None, audiences=None, target_age=None,
                  genre_restriction_sets=None, customlist_restriction_sets=None,
-                 facets=None, availability_filter=None,
-                 subcollection_filter=None, order=None, order_ascending=False
+                 facets=None,
     ):
         if isinstance(collections, Library):
             # Find all works in this Library's collections.
@@ -1543,14 +1542,13 @@ class Filter(SearchBase):
         else:
             self.customlist_restriction_sets = []
 
-        # These are generally set by the Facets object, but for some
-        # of them it's also possible to pass values into the
-        # constructor.
+        # These values may be set by the Facets constructor; this just
+        # establishes default values for them.
         self.minimum_featured_quality = 0
-        self.availability = availability_filter
-        self.subcollection = subcollection_filter
-        self.order = order
-        self.order_ascending = order_ascending
+        self.availability = None
+        self.subcollection = None
+        self.order = None
+        self.order_ascending = False
 
         # Give the Facets object a chance to modify any or all of this
         # information.

--- a/external_search.py
+++ b/external_search.py
@@ -1509,17 +1509,6 @@ class Filter(SearchBase):
         if isinstance(collections, Library):
             # Find all works in this Library's collections.
             collections = collections.collections
-            minimum_featured_quality = collections.minimum_featured_quality
-        else:
-            # Outside of the context of a library, the idea of a
-            # 'minumum featured quality' has no meaning. This feature
-            # should not be used outside a library context, but just
-            # in case, we'll set it to 0 to include everything.
-            #
-            # The Facets object may have a better answer. If so, it
-            # will provide it when we call modify_search_filter().
-            minimum_featured_quality = 0
-        self.minimum_featured_quality = minimum_featured_quality
 
         self.collection_ids = self._filter_ids(collections)
 
@@ -1554,8 +1543,10 @@ class Filter(SearchBase):
         else:
             self.customlist_restriction_sets = []
 
-        # These are generally set by the Facets object, but it's also
-        # possible to pass values into the constructor.
+        # These are generally set by the Facets object, but for some
+        # of them it's also possible to pass values into the
+        # constructor.
+        self.minimum_featured_quality = 0
         self.availability = availability_filter
         self.subcollection = subcollection_filter
         self.order = order

--- a/lane.py
+++ b/lane.py
@@ -576,10 +576,16 @@ class Facets(FacetsWithEntryPoint):
 
     def modify_search_filter(self, filter):
         """Modify the given external_search.Filter object
-        so that it reflects this SearchFacets object.
+        so that it reflects the settings of this Facets object.
+
+        This is the Elasticsearch equivalent of apply(). However, the
+        Elasticsearch implementation of (e.g.) the meaning of the
+        different availabilty statuses is kept in Filter.build().
         """
         super(Facets, self).modify_search_filter(filter)
 
+        filter.availability = self.availability
+        filter.subcollection = self.collection
         if self.order:
             order = self.SORT_ORDER_TO_ELASTICSEARCH_FIELD_NAME.get(self.order)
             if order:

--- a/lane.py
+++ b/lane.py
@@ -584,6 +584,9 @@ class Facets(FacetsWithEntryPoint):
         """
         super(Facets, self).modify_search_filter(filter)
 
+        if self.library:
+            filter.minimum_featured_quality = self.library.minimum_featured_quality
+
         filter.availability = self.availability
         filter.subcollection = self.collection
         if self.order:

--- a/lane.py
+++ b/lane.py
@@ -597,6 +597,7 @@ class Facets(FacetsWithEntryPoint):
             else:
                 logging.error("Unrecognized sort order: %s", self.order)
 
+
 class FeaturedFacets(FacetsWithEntryPoint):
 
     """A simple faceting object that configures a query so that the 'most

--- a/model/work.py
+++ b/model/work.py
@@ -1421,6 +1421,10 @@ class Work(Base):
         # Whenever LicensePool.open_access is changed, or
         # licenses_available moves to zero or away from zero, the
         # LicensePool signals that its Work needs reindexing.
+        #
+        # The work quality field is stored in the main document, but
+        # it's also stored here, so that we can apply a nested filter
+        # that combines quality with other fields found only in the subdocument.
         licensepools = select(
             [
                 LicensePool.id.label('licensepool_id'),

--- a/model/work.py
+++ b/model/work.py
@@ -1380,6 +1380,10 @@ class Work(Base):
             works_alias.name + '.' + works_alias.c.work_id.name
         )
 
+        work_quality_column = literal_column(
+            works_alias.name + '.' + works_alias.c.quality.name
+        )
+
         def query_to_json(query):
             """Convert the results of a query to a JSON object."""
             return select(
@@ -1424,7 +1428,7 @@ class Work(Base):
                 LicensePool.open_access.label('open_access'),
                 (LicensePool.licenses_available > 0).label('available'),
                 (LicensePool.licenses_owned > 0).label('owned'),
-                Work.quality.label('quality'),
+                work_quality_column,
                 func.to_char(
                     LicensePool.availability_time,
                     cls.ELASTICSEARCH_TIME_FORMAT

--- a/model/work.py
+++ b/model/work.py
@@ -1422,7 +1422,9 @@ class Work(Base):
                 LicensePool.id.label('licensepool_id'),
                 LicensePool.collection_id.label('collection_id'),
                 LicensePool.open_access.label('open_access'),
-                LicensePool.licenses_available.label('available') > 0,
+                (LicensePool.licenses_available > 0).label('available'),
+                (LicensePool.licenses_owned > 0).label('owned'),
+                Work.quality.label('quality'),
                 func.to_char(
                     LicensePool.availability_time,
                     cls.ELASTICSEARCH_TIME_FORMAT

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -794,6 +794,8 @@ class TestWork(DatabaseTest):
         self._default_library.collections.append(collection2)
         pool2 = self._licensepool(edition=edition, collection=collection2)
         pool2.work_id = work.id
+        pool2.licenses_available = 0
+        pool2.licenses_owned = 10
         work.license_pools.append(pool2)
 
         # Create a third Collection that's just hanging around, not
@@ -911,6 +913,15 @@ class TestWork(DatabaseTest):
             [match] = [x for x in licensepools if x['licensepool_id'] == pool.id]
             eq_(pool.open_access, match['open_access'])
             eq_(pool.collection_id, match['collection_id'])
+
+            eq_(pool.licenses_available > 0, match['available'])
+            eq_(pool.licenses_owned > 0, match['owned'])
+
+            # The work quality is stored in the main document, but
+            # it's also stored in the license pool subdocument so that
+            # we can apply a nested filter that includes quality +
+            # information from the subdocument.
+            eq_(work.quality, match['quality'])
 
             assert_time_match(
                 pool.availability_time, match['availability_time']

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -918,7 +918,7 @@ class TestFacetFilters(EndToEndExternalSearchTest):
         # Sleep to give the index time to catch up.
         time.sleep(1)
 
-        def expect(collection, availability, works):
+        def expect(availability, collection, works):
             facets = Facets(
                 self._default_library, availability, collection,
                 order=Facets.ORDER_TITLE
@@ -932,8 +932,8 @@ class TestFacetFilters(EndToEndExternalSearchTest):
                [self.becoming, self.horse, self.moby, self.duck])
 
         # Show only works that can be borrowed right now.
-        set_trace()
-        expect(Facets.COLLECTION_FULL, Facets.AVAILABLE_NOW)
+        expect(Facets.COLLECTION_FULL, Facets.AVAILABLE_NOW,
+               [self.horse, self.moby, self.duck])
 
         # Show only open-access works.
         expect(Facets.COLLECTION_FULL, Facets.AVAILABLE_OPEN_ACCESS, 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -2315,6 +2315,7 @@ class TestFilter(DatabaseTest):
         # No sort order.
         f = Filter()
         eq_(None, f.sort_order)
+        eq_(False, f.order_ascending)
 
         # A simple field, either ascending or descending.
         f.order='field'

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -932,6 +932,7 @@ class TestFacetFilters(EndToEndExternalSearchTest):
                [self.becoming, self.horse, self.moby, self.duck])
 
         # Show only works that can be borrowed right now.
+        set_trace()
         expect(Facets.COLLECTION_FULL, Facets.AVAILABLE_NOW)
 
         # Show only open-access works.

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -411,7 +411,9 @@ class TestExternalSearchWithWorks(EndToEndExternalSearchTest):
 
         if self.search:
 
-            self.moby_dick = _work(title="Moby Dick", authors="Herman Melville", fiction=True)
+            self.moby_dick = _work(
+                title="Moby Dick", authors="Herman Melville", fiction=True,
+            )
             self.moby_dick.presentation_edition.subtitle = "Or, the Whale"
             self.moby_dick.presentation_edition.series = "Classics"
             self.moby_dick.summary_text = "Ishmael"
@@ -557,6 +559,12 @@ class TestExternalSearchWithWorks(EndToEndExternalSearchTest):
             sherlock_2, is_new = self.sherlock_pool_2.calculate_work()
             eq_(self.sherlock, sherlock_2)
             eq_(2, len(self.sherlock.license_pools))
+
+            # This book looks good for some search results, but we own
+            # no copies of it, so it will never show up.
+            self.no_copies = _work(title="Moby Dick 2")
+            self.no_copies.license_pools[0].licenses_owned = 0
+
 
     def test_query_works(self):
         # An end-to-end test of the search functionality.
@@ -943,7 +951,8 @@ class TestSearchOrder(EndToEndExternalSearchTest):
             """
             expect = self._expect_results
             facets = Facets(
-                self._default_library, None, None, order=sort_field, order_ascending=True
+                self._default_library, Facets.COLLECTION_FULL,
+                Facets.AVAILABLE_ALL, order=sort_field, order_ascending=True
             )
             expect(order, None, Filter(facets=facets, **filter_kwargs))
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -884,21 +884,23 @@ class TestFacetFilters(EndToEndExternalSearchTest):
             self.horse = _work(
                 title="Diseases of the Horse", with_open_access_download=True
             )
-            self.horse = 0.2
+            self.horse.quality = 0.2
 
             # A high-quality open-access work.
             self.moby = _work(
-                title="Moby-Dick", with_open_access_download=True
+                title="Moby Dick", with_open_access_download=True
             )
             self.moby.quality = 0.8
 
             # A currently available commercially-licensed work.
             self.duck = _work(title='Moby Duck')
             self.duck.license_pools[0].licenses_available = 1
-
+            self.duck.quality = 0.5
+            
             # A currently unavailable commercially-licensed work.
             self.becoming = _work(title='Becoming')
             self.becoming.license_pools[0].licenses_available = 0
+            self.becoming.quality = 0.9
 
     def test_facet_filtering(self):
 
@@ -925,8 +927,24 @@ class TestFacetFilters(EndToEndExternalSearchTest):
                 works, None, Filter(facets=facets), order=False
             )
 
+        # Get all the books in alphabetical order by title.
         expect(Facets.COLLECTION_FULL, Facets.AVAILABLE_ALL, 
-               [self.horse, self.moby, self.duck, self.becoming])
+               [self.becoming, self.horse, self.moby, self.duck])
+
+        # Show only works that can be borrowed right now.
+        expect(Facets.COLLECTION_FULL, Facets.AVAILABLE_NOW)
+
+        # Show only open-access works.
+        expect(Facets.COLLECTION_FULL, Facets.AVAILABLE_OPEN_ACCESS, 
+               [self.horse, self.moby])
+
+        # Show only featured-quality works.
+        expect(Facets.COLLECTION_FEATURED, Facets.AVAILABLE_ALL, 
+               [self.becoming, self.moby])
+
+        # Eliminate low-quality open-access works.
+        expect(Facets.COLLECTION_MAIN, Facets.AVAILABLE_ALL, 
+               [self.becoming, self.moby, self.duck])
 
 
 class TestSearchOrder(EndToEndExternalSearchTest):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1315,6 +1315,7 @@ class TestQuery(DatabaseTest):
         # A nested filter is always applied, to filter out
         # LicensePools that were once part of a collection but
         # currently have no owned licenses.
+        open_access = dict(term={'licensepools.open_access': True})
         def assert_ownership_filter(built):
             # Extract the call that created the ownership filter
             # and verify its structure.
@@ -1332,7 +1333,6 @@ class TestQuery(DatabaseTest):
             # access or the collection must currently own licenses for
             # it.
             owned = dict(term={'licensepools.owned': True})
-            open_access = dict(term={'licensepools.open_access': True})
             expect = {'bool': {'filter': [{'bool': {'should': [owned, open_access]}}]}}
             eq_(expect, unowned_filter['query'].to_dict())
 
@@ -1352,9 +1352,8 @@ class TestQuery(DatabaseTest):
         eq_(underlying_query.must, [qu.query()])
         eq_(underlying_query.filter, [main_filter])
 
-        # There are no nested filters, apart from the ownership
-        # filter, and filter() was never called on the mock Search
-        # object.
+        # There are no nested filters (apart from the ownership
+        # filter), and filter() was never called on the mock Search object.
         assert_ownership_filter(built)
         eq_({}, nested_filters)
         eq_([], built.nested_filter_calls)
@@ -1445,7 +1444,6 @@ class TestQuery(DatabaseTest):
 
         # It finds only license pools that are open access.
         nested_filter = available_now['query']
-        open_access = {'term': {'licensepools.open_access': True}}
         eq_(
             nested_filter.to_dict(),
             {'bool': {'filter': [open_access]}}


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-1902

The `Facets` object passed in to the `Filter` constructor is now used to apply restrictions on availability and quality, not just to impose a sort order. This means we can now use ElasticSearch to manage every restriction imposed by the `WorkList` a patron may be browsing, _or_ by the `Facets` they may be using to browse.

This should give us everything we need to build paginated lists using ElasticSearch rather than the materialized view.