### PR TITLE
Make it possible to paginate search results using Elasticsearch's search_after feature

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -1019,7 +1019,7 @@ class Query(SearchBase):
         self.query_string = query_string
         self.filter = filter
 
-    def build(self, elasticsearch, pagination):
+    def build(self, elasticsearch, pagination=None):
         """Make an Elasticsearch-DSL Search object out of this query.
 
         :param elasticsearch: An Elasticsearch-DSL Search object. This
@@ -1077,8 +1077,12 @@ class Query(SearchBase):
                 search = search.sort(*order_fields)
 
         # Apply any necessary query restrictions imposed by the
-        # Pagination object.
-        pagination.modify_search_query(search)
+        # Pagination object. This may happen through modification or
+        # by returning an entirely new Search object.
+        if pagination:
+            result = pagination.modify_search_query(search)
+            if result is not None:
+                search = result
 
         # All done!
         return search

--- a/lane.py
+++ b/lane.py
@@ -891,8 +891,8 @@ class Pagination(object):
         # offset and size, which external_search knows how to apply.
         return search
 
-    def learn_about_page(self, page):
-        """Now that the actual page has been fetched, keep any internal state
+    def page_loaded(self, page):
+        """An actual page of results has been fetched. Keep any internal state
         that would be useful to know when reasoning about earlier or
         later pages.
         """

--- a/lane.py
+++ b/lane.py
@@ -1376,22 +1376,6 @@ class WorkList(object):
             )
         return qu
 
-    def works_from_search(self, _db, facets=None, pagination=None, search_client=None):
-        """Create a query against a search index that finds the work IDs
-        corresponding to all the Works that belong in this
-        WorkList. Then convert those IDs into Work objects.
-        """
-        from external_search import Filter
-        filter = Filter.from_worklist(_db, self, facets)
-        work_ids = search_client.query_works(
-            None, filter, pagination, debug=True
-        )
-        if work_ids:
-            results = self.works_for_specific_ids(_db, work_ids)
-        else:
-            results = []
-        return results
-
     def works_for_specific_ids(self, _db, work_ids):
         """Create the appearance of having called works(),
         but return the specific MaterializedWorks identified by `work_ids`.

--- a/lane.py
+++ b/lane.py
@@ -888,6 +888,27 @@ class Pagination(object):
         """Modify the given query with OFFSET and LIMIT."""
         return qu.offset(self.offset).limit(self.size)
 
+    def modify_search_query(self, search):
+        # Do nothing -- all necessary pagination information is kept in
+        # offset and size, which external_search knows how to apply.
+        return search
+
+class SearchAfterPagination(Pagination):
+    """A Pagination implementation that starts a page in terms of the
+    last item on the previous page, rather than in terms of an index into
+    a paginated list.
+    """
+    def __init__(self, previous_id, limit):
+        self.previous_id = previous_id
+        self.limit = limit
+
+    @property
+    def offset(self):
+        return 0
+
+    def modify_search_query(self, search):
+        return search
+
 
 class WorkList(object):
     """An object that can obtain a list of Work/MaterializedWorkWithGenre

--- a/lane.py
+++ b/lane.py
@@ -909,6 +909,18 @@ class SearchAfterPagination(Pagination):
     def modify_search_query(self, search):
         return search
 
+    def previous_page(self):
+        # TODO: We can get the previous page by reversing the sort
+        # order and finding the _next_ page of the reversed list. But
+        # this requires more context than Pagination currently has.
+        return None
+
+    def next_page(self, this_page):
+        if not this_page:
+            # This page is empty; there is no next page.
+            return None
+        return SearchAfterPagination(this_page[-1].sort_values, self.limit)
+
 
 class WorkList(object):
     """An object that can obtain a list of Work/MaterializedWorkWithGenre

--- a/lane.py
+++ b/lane.py
@@ -1366,6 +1366,21 @@ class WorkList(object):
             )
         return qu
 
+    def works_from_search(self, _db, facets=None, pagination=None, search_client=None):
+        """Create a query against a search index that finds the work IDs
+        corresponding to all the Works that belong in this
+        WorkList. Then convert those IDs into Work objects.
+        """
+        filter = Filter.from_worklist(_db, self, facets)
+        work_ids = search_client.query_works(
+            None, filter, pagination, debug=True
+        )
+        if work_ids:
+            results = self.works_for_specific_ids(_db, work_ids)
+        else:
+            results = []
+        return results
+
     def works_for_specific_ids(self, _db, work_ids):
         """Create the appearance of having called works(),
         but return the specific MaterializedWorks identified by `work_ids`.

--- a/lane.py
+++ b/lane.py
@@ -897,10 +897,14 @@ class SearchAfterPagination(Pagination):
     """A Pagination implementation that starts a page in terms of the
     last item on the previous page, rather than in terms of an index into
     a paginated list.
+
+    This only works with Elasticsearch.
     """
     def __init__(self, previous_id, limit):
         self.previous_id = previous_id
         self.limit = limit
+        self.last_item_this_page = None
+        self.sort_fields = None
 
     @property
     def offset(self):
@@ -915,11 +919,14 @@ class SearchAfterPagination(Pagination):
         # this requires more context than Pagination currently has.
         return None
 
-    def next_page(self, this_page):
-        if not this_page:
+    def next_page(self):
+        if not this_page: 
             # This page is empty; there is no next page.
             return None
-        return SearchAfterPagination(this_page[-1].sort_values, self.limit)
+        if not self.last_item_this_page:
+            # This might happen because we forgot to set last_item_this_page.
+            return None
+        return SearchAfterPagination(last_item_this_page, self.limit)
 
 
 class WorkList(object):

--- a/model/work.py
+++ b/model/work.py
@@ -1567,6 +1567,7 @@ class Work(Base):
         # search document.
         search_data = select(
             [works_alias.c.work_id.label("_id"),
+             works_alias.c.work_id.label("work_id"),
              works_alias.c.title,
              works_alias.c.sort_title,
              works_alias.c.subtitle,

--- a/opds.py
+++ b/opds.py
@@ -697,7 +697,7 @@ class AcquisitionFeed(OPDSFeed):
             works = []
         else:
             works = works_q.all()
-            pagination.this_page_size = len(works)
+            pagination.page_loaded(works)
         feed = cls(_db, title, url, works, annotator)
 
         entrypoints = facets.selectable_entrypoints(lane)

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -878,6 +878,7 @@ class TestWork(DatabaseTest):
 
         search_doc = work.to_search_document()
         eq_(work.id, search_doc['_id'])
+        eq_(work.id, search_doc['work_id'])
         eq_(work.title, search_doc['title'])
         eq_(edition.subtitle, search_doc['subtitle'])
         eq_(edition.series, search_doc['series'])

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1042,26 +1042,31 @@ class TestSearchOrder(EndToEndExternalSearchTest):
             # that pagination based on SortKeyPagination works for this
             # sort order.
             facets.order_ascending = True
-            to_process = list(order)
+            to_process = list(order) + [[]]
             results = []
             pagination = SortKeyPagination(size=1)
             while to_process:
                 filter = Filter(facets=facets, **filter_kwargs)
-                expect_page = [to_process.pop(0)]
-                expect(expect_page, None, filter, pagination=pagination)
+                expect_result = to_process.pop(0)
+                expect(expect_result, None, filter, pagination=pagination)
                 pagination = pagination.next_page
+            # We are now off the edge of the list -- we got an empty page
+            # of results and there is no next page.
+            eq_(None, pagination)
 
             # Now try the same test in reverse order.
             facets.order_ascending = False
-            to_process = list(reversed(order))
+            to_process = list(reversed(order)) + [[]]
             results = []
             pagination = SortKeyPagination(size=1)
             while to_process:
                 filter = Filter(facets=facets, **filter_kwargs)
-                expect_page = [to_process.pop(0)]
-                expect(expect_page, None, filter, pagination=pagination)
+                expect_result = to_process.pop(0)
+                expect(expect_result, None, filter, pagination=pagination)
                 pagination = pagination.next_page
-
+            # We are now off the edge of the list -- we got an empty page
+            # of results and there is no next page.
+            eq_(None, pagination)
 
         # We can sort by title.
         assert_order(Facets.ORDER_TITLE, [self.moby_dick, self.moby_duck])

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -2610,6 +2610,48 @@ class TestFilter(DatabaseTest):
         eq_(chained, f1 & f2)
 
 
+class TestSortKeyPagination(DatabaseTest):
+    """Test the Elasticsearch-implementation of Pagination that does
+    pagination by tracking the last item on the previous page,
+    rather than by tracking the number of items seen so far.
+    """
+    def test_unimplemented_features(self):
+        # Check certain features of a normal Pagination object that
+        # are not implemented in SortKeyPagination.
+
+        # Set up a realistic SortKeyPagination -- certain things
+        # will remain undefined.
+        pagination = SortKeyPagination(last_item_on_previous_page=object())
+        pagination.this_page_size = 100
+        pagination.last_item_on_this_page = object()
+
+        # The offset is always zero.
+        eq_(0, pagination.offset)
+
+        # The total size is always undefined, even though we could
+        # theoretically track it.
+        eq_(None, pagination.total_size)
+
+        # The previous page is always undefined, through theoretically
+        # we could navigate backwards.
+        eq_(None, pagination.previous_page)
+
+        assert_raises_regexp(
+            NotImplementedError,
+            "SortKeyPagination does not work with database queries.",
+            pagination.apply, object()
+        )
+
+    def test_modify_search_query(self):
+        pass
+
+    def test_next_page(self):
+        pass
+
+    def test_page_loaded(self):
+        pass
+
+
 class TestBulkUpdate(DatabaseTest):
 
     def test_works_not_presentation_ready_removed_from_index(self):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -2677,7 +2677,31 @@ class TestSortKeyPagination(DatabaseTest):
         eq_(dict(search_after=last_item), search.called_with)
 
     def test_next_page(self):
-        pass
+
+        # To start off, we can't say anything about the next page,
+        # because we don't know anything about _this_ page.
+        first_page = SortKeyPagination()
+        eq_(None, first_page.next_page)
+
+        # Let's learn about this page.
+        first_page.this_page_size = 10
+        last_item = object()
+        first_page.last_item_on_this_page = last_item
+
+        # When we call next_page, the last item on this page becomes the
+        # next page's "last item on previous_page"
+        next_page = first_page.next_page
+        eq_(last_item, next_page.last_item_on_previous_page)
+
+        # Again, we know nothing about this page, since we haven't
+        # loaded it yet.
+        eq_(None, next_page.this_page_size)
+        eq_(None, next_page.last_item_on_this_page)
+
+        # In the unlikely event that we know the last item on the
+        # page, but the page size is zero, there is no next page.
+        first_page.this_page_size = 0
+        eq_(None, first_page.next_page)
 
     def test_page_loaded(self):
         pass

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1213,10 +1213,12 @@ class TestPagination(DatabaseTest):
         # Here, the last item on this page is the last item in the dataset.
         pagination.offset = 1
         eq_(False, pagination.has_next_page)
+        eq_(None, pagination.next_page)
 
         # If we somehow go over the end of the dataset, there is no next page.
         pagination.offset = 400
         eq_(False, pagination.has_next_page)
+        eq_(None, pagination.next_page)
 
         # If both total_size and this_page_size are set, total_size
         # takes precedence.
@@ -1228,6 +1230,7 @@ class TestPagination(DatabaseTest):
         pagination.total_size = 0
         pagination.this_page_size = 10
         eq_(False, pagination.has_next_page)
+        eq_(None, pagination.next_page)
 
     def test_has_next_page_this_page_size(self):
         """Test the ability of Pagination.this_page_size to control whether there is a next page."""
@@ -1254,6 +1257,20 @@ class TestPagination(DatabaseTest):
         # next page when there actually is.
         pagination.this_page_size = 1
         eq_(True, pagination.has_next_page)
+
+    def test_page_loaded(self):
+        # Test page_loaded(), which lets the Pagination object see the
+        # size of the current page.
+        pagination = Pagination()
+        eq_(None, pagination.this_page_size)
+        pagination.page_loaded([1,2,3])
+        eq_(3, pagination.this_page_size)
+
+    def test_modify_search_query(self):
+        # The default implementation of modify_search_query is a no-op.
+        pagination = Pagination()
+        o = object()
+        eq_(o, pagination.modify_search_query(o))
 
 
 class MockFeaturedWorks(object):


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-1923.

When used to paginate Elasticsearch hits, the normal `Pagination` object uses numeric offsets to reach further and further into the list of hits. Unfortunately, Elasticsearch has a limit on how far this can work -- by default it's 10000 items, or 200 pages the way we paginate things. We need a solution that doesn't cut out at an arbitrary point.

This branch introduces the `SortKeyPagination` class, a subclass of `Pagination` which takes advantage of Elasticsearch's [search_after](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-after.html) parameter. It works by storing the sort key of the last item in the current page. When the current page becomes the next page, this sort key is used to tell Elasticsearch where to start fetching results.

Normal `Pagination` still works fine to paginate Elasticsearch hits -- that's how we paginate normal search results, which don't have sort fields since they're ordered by relevance to the search.

Getting this to work requires that the `Pagination` object be notified once the results have been loaded (so that it can store the sort fields for the last item) and that it get a chance to modify the Elasticsearch query before the query runs (similar to the way it currently gets a chance to modify a database query before that query runs).

The other big change in this branch: I introduced to Elasticsearch lists the multi-layered sort field approach currently used in queries against the materialized view. In both cases the default sort order for books is (sort author, sort title, work ID), and it's subject to amendment or modification by the specific field you ask to sort by. So if you sort books by availability time, you're actually sorting them by availability time, sort author, sort title, work ID. If you sort books by title, you're actually sorting them by sort title, sort author, work ID.

This guarantees that every book in the index has a unique sort key (because of the inclusion of work ID) and it guarantees that when you sort by author, you see a given author's books in an order that makes sense (sorted by title)

