### PR TITLE
Give Enki collections a unique account ID named after the data source.

### DIFF
--- a/model/collection.py
+++ b/model/collection.py
@@ -381,7 +381,8 @@ class Collection(Base, HasFullTableCache):
     @property
     def unique_account_id(self):
         """Identifier that uniquely represents this Collection of works"""
-        if (self.data_source.name in self.GLOBAL_COLLECTION_DATA_SOURCES
+        if (self.data_source
+            and self.data_source.name in self.GLOBAL_COLLECTION_DATA_SOURCES
             and not self.parent):
             # Every top-level collection from this data source has the
             # same catalog. Treat them all as one collection named

--- a/model/collection.py
+++ b/model/collection.py
@@ -153,6 +153,11 @@ class Collection(Base, HasFullTableCache):
     _cache = HasFullTableCache.RESET
     _id_cache = HasFullTableCache.RESET
 
+    # Most data sources offer different catalogs to different
+    # libraries.  Data sources in this list offer the same catalog to
+    # every library.
+    GLOBAL_COLLECTION_DATA_SOURCES = [DataSource.ENKI]
+
     def __repr__(self):
         return (u'<Collection "%s"/"%s" ID=%d>' %
                 (self.name, self.protocol, self.id)).encode('utf8')
@@ -376,7 +381,14 @@ class Collection(Base, HasFullTableCache):
     @property
     def unique_account_id(self):
         """Identifier that uniquely represents this Collection of works"""
-        unique_account_id = self.external_account_id
+        if (self.data_source.name in self.GLOBAL_COLLECTION_DATA_SOURCES
+            and not self.parent):
+            # Every top-level collection from this data source has the
+            # same catalog. Treat them all as one collection named
+            # after the data source.
+            unique_account_id = self.data_source.name
+        else:
+            unique_account_id = self.external_account_id
 
         if not unique_account_id:
             raise ValueError("Unique account identifier not set")

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -167,6 +167,42 @@ class TestCollection(DatabaseTest):
             protocol="blah"
         )
 
+    def test_unique_account_id(self):
+
+        # Most collections work like this:
+        overdrive = self._collection(
+            external_account_id="od1", data_source_name=DataSource.OVERDRIVE
+        )
+        od_child = self._collection(
+            external_account_id="odchild", data_source_name=DataSource.OVERDRIVE
+        )
+        od_child.parent = overdrive
+
+        # The unique account ID of a primary collection is the
+        # external account ID.
+        eq_("od1", overdrive.unique_account_id)
+
+        # For children of those collections, the unique account ID is scoped
+        # to the parent collection.
+        eq_("od1+odchild", od_child.unique_account_id)
+
+        # Enki works a little differently. Enki collections don't have
+        # an external account ID, because all Enki collections are
+        # identical.
+        enki = self._collection(data_source_name=DataSource.ENKI)
+
+        # So the unique account ID is the name of the data source.
+        eq_(DataSource.ENKI, enki.unique_account_id)
+
+        # A (currently hypothetical) library-specific subcollection of
+        # the global Enki collection must have an external_account_id,
+        # and its name is scoped to the parent collection as usual.
+        enki_child = self._collection(
+            external_account_id="enkichild", data_source_name=DataSource.ENKI
+        )
+        enki_child.parent = enki
+        eq_(DataSource.ENKI + "+enkichild", enki_child.unique_account_id)
+
     def test_change_protocol(self):
         overdrive = ExternalIntegration.OVERDRIVE
         bibliotheca = ExternalIntegration.BIBLIOTHECA


### PR DESCRIPTION
This branch resolves https://jira.nypl.org/browse/SIMPLY-1929.