### PR TITLE
Make it possible to get works from search index rather than database

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -1378,6 +1378,9 @@ class WorkList(object):
     def works_from_search_index(
         self, _db, facets, pagination, search_client=None, debug=True
     ):
+        """Retrieve a list of Work objects, the way works() does,
+        but use the search index instead of the materialized view.
+        """
         from external_search import (
             Filter,
             ExternalSearchIndex,

--- a/lane.py
+++ b/lane.py
@@ -1375,6 +1375,20 @@ class WorkList(object):
             )
         return qu
 
+    def works_from_search_index(
+        self, _db, facets, pagination, search_client=None, debug=True
+    ):
+        from external_search import (
+            Filter,
+            ExternalSearchIndex,
+        )
+        search_client = search_client or ExternalSearchIndex(_db)
+        filter = Filter.from_worklist(_db, self, facets)
+        work_ids = search_client.query_works(
+            None, filter, pagination, debug=debug
+        )
+        return self.works_for_specific_ids(_db, work_ids, Work)
+
     def works_for_specific_ids(self, _db, work_ids, work_model=mw):
         """Create the appearance of having called works(), but return the
         specific MaterializedWorks or Works identified by `work_ids`.

--- a/lane.py
+++ b/lane.py
@@ -1385,7 +1385,8 @@ class WorkList(object):
         search_client = search_client or ExternalSearchIndex(_db)
         filter = Filter.from_worklist(_db, self, facets)
         work_ids = search_client.query_works(
-            None, filter, pagination, debug=debug
+            query_string=None, filter=filter, pagination=pagination,
+            debug=debug
         )
         return self.works_for_specific_ids(_db, work_ids, Work)
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -892,6 +892,18 @@ class TestExternalSearchWithWorks(EndToEndExternalSearchTest):
         f = Filter(allow_holds=False)
         expect([self.moby_dick], "moby duck", f)
 
+        # Finally, let's do some end-to-end tests of
+        # WorkList.works_from_search_index.
+        #
+        # This is a simple method that puts together a few pieces
+        # tested separately, so we don't need to go all-out.
+        fiction = WorkList()
+        fiction.initialize(self._default_library, languages=["eng"])
+
+        facets = Facets(
+            self._default_library, order=Facets.ORDER_TITLE
+        )
+        fiction.works_from_search_index(facets, pagination, self.search)
 
 class TestFacetFilters(EndToEndExternalSearchTest):
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -493,7 +493,9 @@ class TestExternalSearchWithWorks(EndToEndExternalSearchTest):
             self.age_5_6 = _work(fiction=False)
             self.age_5_6.target_age = NumericRange(5, 6, '[]')
 
-            self.obama = _work(genre="Biography & Memoir")
+            self.obama = _work(
+                title="Barack Obama", genre="Biography & Memoir"
+            )
             self.obama.target_age = NumericRange(8, 8, '[]')
             self.obama.summary_text = "President Barack Obama's election in 2008 energized the United States"
 
@@ -518,10 +520,10 @@ class TestExternalSearchWithWorks(EndToEndExternalSearchTest):
                 title="The Adventures of Sherlock Holmes",
                 with_open_access_download=True
             )
-            self.sherlock.presentation_edition.language = "en"
+            self.sherlock.presentation_edition.language = "eng"
 
             self.sherlock_spanish = _work(title="Las Aventuras de Sherlock Holmes")
-            self.sherlock_spanish.presentation_edition.language = "es"
+            self.sherlock_spanish.presentation_edition.language = "spa"
 
             # Create a custom list that contains a few books.
             self.presidential, ignore = self._customlist(
@@ -767,9 +769,9 @@ class TestExternalSearchWithWorks(EndToEndExternalSearchTest):
         expect(self.pride_audio, "pride and prejudice", audio_filter)
 
         # Filters on languages
-        english = Filter(languages="en")
-        spanish = Filter(languages="es")
-        both = Filter(languages=["en", "es"])
+        english = Filter(languages="eng")
+        spanish = Filter(languages="spa")
+        both = Filter(languages=["eng", "spa"])
 
         expect(self.sherlock, "sherlock", english)
         expect(self.sherlock_spanish, "sherlock", spanish)
@@ -873,7 +875,7 @@ class TestExternalSearchWithWorks(EndToEndExternalSearchTest):
         # being searched, it only shows up in search results once.
         f = Filter(
             collections=[self._default_collection, self.tiny_collection],
-            languages="en"
+            languages="eng"
         )
         expect(self.sherlock, "sherlock holmes", f)
 
@@ -896,19 +898,48 @@ class TestExternalSearchWithWorks(EndToEndExternalSearchTest):
         # Finally, let's do some end-to-end tests of
         # WorkList.works_from_search_index.
         #
-        # This is a simple method that puts together a few pieces
-        # tested separately, so we don't need to go all-out.
-        fiction = WorkList()
-        fiction.initialize(self._default_library, languages=["eng"])
+        # That's a simple method that puts together a few pieces
+        # which are tested separately, so we don't need to go all-out.
+        def pages(worklist):
+            """Iterate over a WorkList until it ends, and return all of the
+            pages.
+            """
+            pagination = SortKeyPagination(size=2)
+            facets = Facets(
+                self._default_library, None, None, order=Facets.ORDER_TITLE
+            )
+            pages = []
+            while pagination:
+                pages.append(worklist.works_from_search_index(
+                    self._db, facets, pagination, self.search
+                ))
+                pagination = pagination.next_page
 
-        facets = Facets(
-            self._default_library, None, None, order=Facets.ORDER_TITLE
+            # The last page should always be empty -- that's how we
+            # knew we'd reached the end.
+            eq_([], pages[-1])
+
+            # Return all the other pages for verification.
+            return pages[:-1]
+
+        # Test a WorkList based on a custom list.
+        presidential = WorkList()
+        presidential.initialize(
+            self._default_library, customlists=[self.presidential]
         )
-        pagination = SortKeyPagination(size=2)
-        works = fiction.works_from_search_index(
-            self._db, facets, pagination, self.search
-        )
-        pass
+        p1, p2 = pages(presidential)
+        eq_([self.lincoln, self.obama], p1)
+        eq_([self.washington], p2)
+
+        # Test a WorkList based on a language.
+        spanish = WorkList()
+        spanish.initialize(self._default_library, languages=['spa'])
+        eq_([[self.sherlock_spanish]], pages(spanish))
+
+        # Test a WorkList based on a genre.
+        biography_wl = WorkList()
+        biography_wl.initialize(self._default_library, genres=[biography])
+        eq_([[self.lincoln, self.obama]], pages(biography_wl))
 
 
 class TestFacetFilters(EndToEndExternalSearchTest):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -31,6 +31,7 @@ from ..lane import (
     Facets,
     Lane,
     Pagination,
+    WorkList,
 )
 from ..model import (
     ConfigurationSetting,
@@ -901,9 +902,14 @@ class TestExternalSearchWithWorks(EndToEndExternalSearchTest):
         fiction.initialize(self._default_library, languages=["eng"])
 
         facets = Facets(
-            self._default_library, order=Facets.ORDER_TITLE
+            self._default_library, None, None, order=Facets.ORDER_TITLE
         )
-        fiction.works_from_search_index(facets, pagination, self.search)
+        pagination = SortKeyPagination(size=2)
+        works = fiction.works_from_search_index(
+            self._db, facets, pagination, self.search
+        )
+        pass
+
 
 class TestFacetFilters(EndToEndExternalSearchTest):
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1715,6 +1715,70 @@ class TestWorkList(DatabaseTest):
         wl.works(self._db, facets=facets)
         eq_(facets, wl.apply_filters_called_with)
 
+    def test_works_from_search_index(self):
+        """Test the method that fetches """
+
+        class MockSearchClient(object):
+            """Respond to search requests with some fake work IDs."""
+            fake_work_ids = [1, 10, 100, 1000]
+            def query_works(self, **kwargs):
+                self.called_with = kwargs
+                return self.fake_work_ids
+
+        class MockWorkList(WorkList):
+            """Mock the process of turning work IDs into Work objects."""
+            fake_work_list = "a list of works"
+            def works_for_specific_ids(self, _db, work_ids, work_model):
+                self.called_with = (_db, work_ids, work_model)
+                return self.fake_work_list
+
+        # Here's a WorkList.
+        wl = MockWorkList()
+        wl.initialize(self._default_library, languages=["eng"])
+        facets = Facets(
+            self._default_library, None, None, order=Facets.ORDER_TITLE
+        )
+        mock_pagination = object()
+        mock_debug = object()
+        search_client = MockSearchClient()
+
+        # Ask the WorkList for a page of works, using the search index
+        # to drive the query instead of the database.
+        result = wl.works_from_search_index(
+            self._db, facets, mock_pagination, search_client, mock_debug
+        )
+
+        # MockSearchClient.query_works was used to grab a list of work
+        # IDs.
+        query_works_kwargs = search_client.called_with
+
+        # Our facets and the requirements of the WorkList were used to
+        # make a Filter object, which was passed as the 'filter'
+        # keyword argument.
+        filter = query_works_kwargs.pop('filter')
+        eq_(Filter.from_worklist(self._db, wl, facets).build(),
+            filter.build())
+
+        # The other arguments to query_works are either constants or
+        # our mock objects.
+        eq_(dict(query_string=None,
+                 pagination=mock_pagination,
+                 debug=mock_debug),
+            query_works_kwargs
+        )
+
+        # The fake work IDs returned from query_works() were passed into
+        # works_for_specific_ids().
+        eq_(
+            (self._db, search_client.fake_work_ids, Work),
+            wl.called_with
+        )
+
+        # And the fake return value of works_for_specific_ids() was
+        # used as the return value of works_from_search_index(), the
+        # method we're testing.
+        eq_(wl.fake_work_list, result)
+
     def test_works_for_specific_ids(self):
         # Create two works.
         w1 = self._work(with_license_pool=True)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1716,7 +1716,9 @@ class TestWorkList(DatabaseTest):
         eq_(facets, wl.apply_filters_called_with)
 
     def test_works_from_search_index(self):
-        """Test the method that fetches """
+        """Test the method that uses the search index to fetch a list of Works
+        appropriate for a given WorkList.
+        """
 
         class MockSearchClient(object):
             """Respond to search requests with some fake work IDs."""


### PR DESCRIPTION
This branch completes https://jira.nypl.org/browse/SIMPLY-1903 work. It implements a method which gives the same results as `WorkList.works` but uses the search index instead of the materialized view. 

This method is tested thoroughly with a mocked-up method, and there's also some simple end-to-end tests in `test_external_search` where we have a bunch of works in the search index.

At this point I think we can just switch out `works_from_search_index` wherever we were using `works` to make a sorted list of works. It seems to work fine, but it's significantly slower, so I need to look into that. I filed https://jira.nypl.org/browse/SIMPLY-1972 to take care of the switchover.

`WorkList.works` is still used to build the (differently complicated) query for _featured_ works, so even discounting the performance problems we can't get rid of it yet.
