### PR TITLE
Build paginated feeds from the search index instead of the materialized view

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -763,7 +763,7 @@ class ExternalSearchIndexVersions(object):
         licensepool_fields_by_type = {
             'integer': ['collection_id', 'data_source_id'],
             'date': ['availability_time'],
-            'boolean': ['availability', 'open_access', 'suppressed'],
+            'boolean': ['availability', 'open_access', 'suppressed', 'licensed'],
             'keyword': ['medium'],
         }
         licensepool_definition = cls.map_fields_by_type(

--- a/external_search.py
+++ b/external_search.py
@@ -1774,7 +1774,7 @@ class Filter(SearchBase):
         not_suppressed = F('term', **{'licensepools.suppressed' : False})
         nested_filters['licensepools'].append(not_suppressed)
 
-        owns_licenses = F('term', **{'licensepools.owned' : True})
+        owns_licenses = F('term', **{'licensepools.licensed' : True})
         open_access = F('term', **{'licensepools.open_access' : True})
         currently_owned = F('bool', should=[owns_licenses, open_access])
         nested_filters['licensepools'].append(currently_owned)

--- a/external_search.py
+++ b/external_search.py
@@ -396,7 +396,6 @@ class ExternalSearchIndex(HasSelfTests):
         search = self.create_search_doc(query_string, filter=filter, pagination=pagination, debug=debug, return_raw_results=return_raw_results)
         start = pagination.offset
         stop = start + pagination.size
-
         a = time.time()
         # NOTE: This is the code that actually executes the ElasticSearch
         # request.

--- a/external_search.py
+++ b/external_search.py
@@ -396,6 +396,7 @@ class ExternalSearchIndex(HasSelfTests):
         search = self.create_search_doc(query_string, filter=filter, pagination=pagination, debug=debug, return_raw_results=return_raw_results)
         start = pagination.offset
         stop = start + pagination.size
+
         a = time.time()
         # NOTE: This is the code that actually executes the ElasticSearch
         # request.

--- a/lane.py
+++ b/lane.py
@@ -1413,7 +1413,6 @@ class WorkList(object):
             _db, qu, work_model=work_model, edition_model=edition_model
         )
         qu = qu.distinct(work_id_field)
-        from model import dump_query as dq
 
         work_by_id = dict()
         a = time.time()
@@ -1430,7 +1429,7 @@ class WorkList(object):
 
         b = time.time()
         logging.info(
-            "Obtained %s x %d in %.2fsec", work_model.__name__, len(results), b-a
+            "Obtained %sx%d in %.2fsec", work_model.__name__, len(results), b-a
         )
         return results
 

--- a/lane.py
+++ b/lane.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from collections import defaultdict
 from nose.tools import set_trace
 import datetime

--- a/lane.py
+++ b/lane.py
@@ -1358,7 +1358,7 @@ class WorkList(object):
         return qu
 
     def works_from_search_index(
-        self, _db, facets, pagination, search_client=None, debug=False
+        self, _db, facets, pagination, search_engine=None, debug=False
     ):
         """Retrieve a list of Work objects, the way works() does,
         but use the search index instead of the materialized view.
@@ -1367,9 +1367,9 @@ class WorkList(object):
             Filter,
             ExternalSearchIndex,
         )
-        search_client = search_client or ExternalSearchIndex(_db)
+        search_engine = search_engine or ExternalSearchIndex(_db)
         filter = Filter.from_worklist(_db, self, facets)
-        work_ids = search_client.query_works(
+        work_ids = search_engine.query_works(
             query_string=None, filter=filter, pagination=pagination,
             debug=debug
         )

--- a/lane.py
+++ b/lane.py
@@ -1680,8 +1680,8 @@ class WorkList(object):
 
     @classmethod
     def _modify_loading(cls, qu, work_model=mw):
-        """Optimize a query by modifying which the related objects that get
-        pulled from the database.
+        """Optimize a query for use in generating OPDS feeds, by modifying
+        which related objects get pulled from the database.
         """
         # Avoid eager loading of objects that are already being loaded
         # -- whether through the materialized view or through a join
@@ -1703,9 +1703,8 @@ class WorkList(object):
             )
             license_pool_name = 'license_pools'
 
-        # Load some objects that wouldn't normally be loaded. This
-        # will speed up the process of generating OPDS feeds, which is
-        # the main reason this method is called.
+        # Load some objects that wouldn't normally be loaded, but
+        # which are necessary when generating OPDS feeds.
 
         # TODO: Strictly speaking, these joinedload calls are
         # only needed by the circulation manager. This code could

--- a/lane.py
+++ b/lane.py
@@ -1412,7 +1412,6 @@ class WorkList(object):
             _db, qu, work_model=work_model, edition_model=edition_model
         )
         qu = qu.distinct(work_id_field)
-
         work_by_id = dict()
         a = time.time()
         works = qu.all()
@@ -1428,7 +1427,7 @@ class WorkList(object):
 
         b = time.time()
         logging.info(
-            "Obtained %sx%d in %.2fsec", work_model.__name__, len(results), b-a
+            u"Obtained %s×%d in %.2fsec", work_model.__name__, len(results), b-a
         )
         return results
 
@@ -1680,6 +1679,9 @@ class WorkList(object):
 
     @classmethod
     def _modify_loading(cls, qu, work_model=mw):
+        """Optimize a query by modifying which the related objects that get
+        pulled from the database.
+        """
         # Avoid eager loading of objects that are already being loaded
         # -- whether through the materialized view or through a join
         # within the query.
@@ -1700,9 +1702,9 @@ class WorkList(object):
             )
             license_pool_name = 'license_pools'
 
-        # Load some objects associated with the license pool to speed
-        # up the process of generating OPDS feeds -- the main reason
-        # this method is called.
+        # Load some objects that wouldn't normally be loaded. This
+        # will speed up the process of generating OPDS feeds, which is
+        # the main reason this method is called.
 
         # TODO: Strictly speaking, these joinedload calls are
         # only needed by the circulation manager. This code could

--- a/lane.py
+++ b/lane.py
@@ -1353,7 +1353,6 @@ class WorkList(object):
                 mw.collection_id.in_(self.collection_ids)
             )
         qu = self.apply_filters(_db, qu, facets, pagination)
-
         qu = self._modify_loading(qu)
         qu = self._defer_unused_fields(qu)
         return qu
@@ -1774,7 +1773,7 @@ class WorkList(object):
                 exc_info=e
             )
         if work_ids:
-            results = self.works_for_specific_ids(_db, work_ids)
+            results = self.works_for_specific_ids(_db, work_ids, Work)
 
         return results
 

--- a/lane.py
+++ b/lane.py
@@ -1359,7 +1359,7 @@ class WorkList(object):
         return qu
 
     def works_from_search_index(
-        self, _db, facets, pagination, search_client=None, debug=True
+        self, _db, facets, pagination, search_client=None, debug=False
     ):
         """Retrieve a list of Work objects, the way works() does,
         but use the search index instead of the materialized view.

--- a/model/work.py
+++ b/model/work.py
@@ -1442,7 +1442,7 @@ class Work(Base):
                 LicensePool.open_access.label('open_access'),
                 LicensePool.suppressed,
                 (LicensePool.licenses_available > 0).label('available'),
-                (LicensePool.licenses_owned > 0).label('owned'),
+                (LicensePool.licenses_owned > 0).label('licensed'),
                 work_quality_column,
                 Edition.medium,
                 func.to_char(

--- a/opds.py
+++ b/opds.py
@@ -660,7 +660,8 @@ class AcquisitionFeed(OPDSFeed):
     @classmethod
     def page(cls, _db, title, url, lane, annotator,
              cache_type=None, facets=None, pagination=None,
-             force_refresh=False
+             force_refresh=False, search_client=None,
+             search_debug=False
     ):
         """Create a feed representing one page of works from a given lane.
 
@@ -691,13 +692,11 @@ class AcquisitionFeed(OPDSFeed):
             if usable:
                 return cached.content
 
-        works_q = lane.works(_db, facets, pagination)
-        if not works_q:
-            # The Lane believes that creating this feed is a bad idea.
-            works = []
-        else:
-            works = works_q.all()
-            pagination.page_loaded(works)
+        works = lane.works_from_search_index(
+            _db, facets, pagination, search_client=search_client,
+            debug=search_debug
+        )
+        pagination.page_loaded(works)
         feed = cls(_db, title, url, works, annotator)
 
         entrypoints = facets.selectable_entrypoints(lane)

--- a/opds.py
+++ b/opds.py
@@ -547,7 +547,7 @@ class AcquisitionFeed(OPDSFeed):
     @classmethod
     def groups(cls, _db, title, url, lane, annotator,
                cache_type=None, force_refresh=False, facets=None,
-               search_client=None, search_debug=False
+               search_engine=None, search_debug=False
     ):
         """The acquisition feed for 'featured' items from a given lane's
         sublanes, organized into per-lane groups.
@@ -602,7 +602,7 @@ class AcquisitionFeed(OPDSFeed):
                 _db, title, url, lane, annotator,
                 cache_type=cache_type,
                 force_refresh=force_refresh,
-                facets=None, search_client=search_client,
+                facets=None, search_engine=search_engine,
                 search_debug=search_debug
             )
             return cached
@@ -663,7 +663,7 @@ class AcquisitionFeed(OPDSFeed):
     @classmethod
     def page(cls, _db, title, url, lane, annotator,
              cache_type=None, facets=None, pagination=None,
-             force_refresh=False, search_client=None,
+             force_refresh=False, search_engine=None,
              search_debug=False
     ):
         """Create a feed representing one page of works from a given lane.
@@ -696,7 +696,7 @@ class AcquisitionFeed(OPDSFeed):
                 return cached.content
 
         works = lane.works_from_search_index(
-            _db, facets, pagination, search_client=search_client,
+            _db, facets, pagination, search_engine=search_engine,
             debug=search_debug
         )
         pagination.page_loaded(works)

--- a/opds.py
+++ b/opds.py
@@ -546,7 +546,9 @@ class AcquisitionFeed(OPDSFeed):
 
     @classmethod
     def groups(cls, _db, title, url, lane, annotator,
-               cache_type=None, force_refresh=False, facets=None):
+               cache_type=None, force_refresh=False, facets=None,
+               search_client=None, search_debug=False
+    ):
         """The acquisition feed for 'featured' items from a given lane's
         sublanes, organized into per-lane groups.
 
@@ -600,7 +602,8 @@ class AcquisitionFeed(OPDSFeed):
                 _db, title, url, lane, annotator,
                 cache_type=cache_type,
                 force_refresh=force_refresh,
-                facets=None,
+                facets=None, search_client=search_client,
+                search_debug=search_debug
             )
             return cached
 

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -918,7 +918,7 @@ class TestWork(DatabaseTest):
             eq_(pool.data_source_id, match['data_source_id'])
 
             eq_(pool.licenses_available > 0, match['available'])
-            eq_(pool.licenses_owned > 0, match['owned'])
+            eq_(pool.licenses_owned > 0, match['licensed'])
 
             # The work quality is stored in the main document, but
             # it's also stored in the license pool subdocument so that

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -2818,7 +2818,7 @@ class TestFilter(DatabaseTest):
             not_suppressed)
 
         # The second one is a little more complex
-        owned = Term(**{"licensepools.owned": True})
+        owned = Term(**{"licensepools.licensed": True})
         open_access = Term(**{"licensepools.open_access": True})
 
         # We only count license pools that are open-access _or_ that have

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -890,6 +890,14 @@ class TestExternalSearchWithWorks(EndToEndExternalSearchTest):
         )
         expect([self.pride], "pride and prejudice", f)
 
+        # Here, a different data source is excluded, and it shows up.
+        f = Filter(
+            excluded_audiobook_data_sources=[
+                DataSource.lookup(self._db, DataSource.BIBLIOTHECA)
+            ]
+        )
+        expect([self.pride, self.pride_audio], "pride and prejudice", f)
+
         # "Moby Duck" is not currently available, so it won't show up in
         # search results if allow_holds is False.
         f = Filter(allow_holds=False)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -2326,9 +2326,9 @@ class TestWorkList(DatabaseTest):
         # Test the successful execution of WorkList.search()
 
         class MockWorkList(WorkList):
-            def works_for_specific_ids(self, _db, work_ids):
-                self.works_for_specific_ids_called_with = (_db, work_ids)
-                return "A bunch of MaterializedWorkWithGenres"
+            def works_for_specific_ids(self, _db, work_ids, work_model):
+                self.works_for_specific_ids_called_with = (_db, work_ids, work_model)
+                return "A bunch of Works"
 
         wl = MockWorkList()
         wl.initialize(
@@ -2350,13 +2350,13 @@ class TestWorkList(DatabaseTest):
         # The results of query_works were passed into
         # MockWorkList.works_for_specific_ids.
         eq_(
-            (self._db, "A bunch of work IDs"),
+            (self._db, "A bunch of work IDs", Work),
             wl.works_for_specific_ids_called_with
         )
 
         # The return value of MockWorkList.works_for_specific_ids is
         # used as the return value of query_works().
-        eq_("A bunch of MaterializedWorkWithGenres", results)
+        eq_("A bunch of Works", results)
 
         # From this point on we are only interested in the arguments
         # passed in to query_works, since MockSearchClient always
@@ -2924,10 +2924,9 @@ class TestLane(DatabaseTest):
         )
         eq_(results, target_results)
 
-        # The single search result was converted to a MaterializedWorkWithGenre.
+        # The single search result was returned as a Work.
         [result] = results
-        assert isinstance(result, work_model)
-        eq_(work.id, result.works_id)
+        eq_(work, result)
 
         # This still works if the lane is its own search_target.
         lane.root_for_patron_type = ["A"]

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1709,6 +1709,7 @@ class TestWorkList(DatabaseTest):
         class Mock(WorkList):
             def apply_filters(self, _db, qu, facets, pagination):
                 self.apply_filters_called_with = facets
+                return qu
         wl = Mock()
         wl.initialize(self._default_library)
         facets = FacetsWithEntryPoint()

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -921,14 +921,16 @@ class TestOPDS(DatabaseTest):
         work1 = self._work(genre=Contemporary_Romance, with_open_access_download=True)
         work2 = self._work(genre=Contemporary_Romance, with_open_access_download=True)
 
-        self.add_to_materialized_view([work1, work2], True)
+        search_engine = MockExternalSearchIndex()
+        search_engine.bulk_update([work1, work2])
+
         facets = Facets.default(self._default_library)
         pagination = Pagination(size=1)
 
         def make_page(pagination):
             return AcquisitionFeed.page(
                 self._db, "test", self._url, lane, TestAnnotator,
-                pagination=pagination
+                pagination=pagination, search_engine=search_engine
             )
         cached_works = make_page(pagination)
         parsed = feedparser.parse(unicode(cached_works))
@@ -976,7 +978,8 @@ class TestOPDS(DatabaseTest):
         old_cache_count = self._db.query(CachedFeed).count()
         raw_page = AcquisitionFeed.page(
             self._db, "test", self._url, lane, TestAnnotator,
-            pagination=pagination.next_page, cache_type=AcquisitionFeed.NO_CACHE
+            pagination=pagination.next_page, cache_type=AcquisitionFeed.NO_CACHE,
+            search_engine=search_engine
         )
 
         # Unicode is returned instead of a CachedFeed object.
@@ -995,14 +998,16 @@ class TestOPDS(DatabaseTest):
         work1 = self._work(genre=Contemporary_Romance, with_open_access_download=True)
         work2 = self._work(genre=Contemporary_Romance, with_open_access_download=True)
 
-        self.add_to_materialized_view([work1, work2], True)
+        search_engine = MockExternalSearchIndex()
+        search_engine.bulk_update([work1, work2])
+
         facets = Facets.default(self._default_library)
         pagination = Pagination(size=1)
 
         def make_page(pagination):
             return AcquisitionFeed.page(
                 self._db, "test", self._url, lane, TestAnnotator,
-                pagination=pagination
+                pagination=pagination, search_engine=search_engine
             )
         cached_works = make_page(pagination)
         parsed = feedparser.parse(unicode(cached_works))
@@ -1039,7 +1044,8 @@ class TestOPDS(DatabaseTest):
         old_cache_count = self._db.query(CachedFeed).count()
         raw_page = AcquisitionFeed.page(
             self._db, "test", self._url, lane, TestAnnotator,
-            pagination=pagination.next_page, cache_type=AcquisitionFeed.NO_CACHE
+            pagination=pagination.next_page, cache_type=AcquisitionFeed.NO_CACHE,
+            search_engine=search_engine
         )
 
         # Unicode is returned instead of a CachedFeed object.
@@ -1209,14 +1215,15 @@ class TestOPDS(DatabaseTest):
         work1.quality = 0.75
         work2 = self._work(genre=Mystery, with_open_access_download=True)
         work2.quality = 0.75
-        self.add_to_materialized_view([work1, work2], True)
+        search_engine = MockExternalSearchIndex()
+        search_engine.bulk_update([work1, work2])
 
         library.setting(library.FEATURED_LANE_SIZE).value = 2
         annotator = TestAnnotator()
 
         feed = AcquisitionFeed.groups(
             self._db, "test", self._url, test_lane, annotator,
-            force_refresh=True
+            force_refresh=True, search_engine=search_engine
         )
 
         # The lane has no sublanes, so a page feed was created for it
@@ -1241,7 +1248,7 @@ class TestOPDS(DatabaseTest):
         sublane = self._lane(parent=test_lane)
         feed = AcquisitionFeed.groups(
             self._db, "test", self._url, test_lane, annotator,
-            force_refresh=True
+            force_refresh=True, search_engine=search_engine
         )
         assert mock.called_with is not None
 
@@ -1317,12 +1324,14 @@ class TestOPDS(DatabaseTest):
         work1 = self._work(title="The Original Title",
                            genre=Epic_Fantasy, with_open_access_download=True)
         fantasy_lane = self.fantasy
-        self.add_to_materialized_view([work1], True)
+
+        search_engine = MockExternalSearchIndex()
+        search_engine.bulk_update([work1])
 
         def make_page():
             return AcquisitionFeed.page(
                 self._db, "test", self._url, fantasy_lane, TestAnnotator,
-                pagination=Pagination.default()
+                pagination=Pagination.default(), search_engine=search_engine
             )
 
         af = AcquisitionFeed
@@ -1339,7 +1348,7 @@ class TestOPDS(DatabaseTest):
             title="A Brand New Title",
             genre=Epic_Fantasy, with_open_access_download=True
         )
-        self.add_to_materialized_view([work2], True)
+        search_engine.bulk_update([work2])
 
         # The new work does not show up in the feed because
         # we get the old cached version.

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1259,7 +1259,6 @@ class TestOPDS(DatabaseTest):
         fantasy_lane = self.fantasy
         work1 = self._work(genre=Epic_Fantasy, with_open_access_download=True)
         work2 = self._work(genre=Epic_Fantasy, with_open_access_download=True)
-        self.add_to_materialized_view([work1, work2], True)
 
         pagination = Pagination(size=1)
         search_client = MockExternalSearchIndex()


### PR DESCRIPTION
This branch resolves https://jira.nypl.org/browse/SIMPLY-1972.

In some simple tests, I found that this change speeds up the creation of paginated OPDS feeds by about 40%.