### PR TITLE
Allow case-insensitive sort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
   # a low-resource development environment.
   - "echo 'transport.host: 127.0.0.1' >> ./${ES_PATH}/config/elasticsearch.yml"
   - "echo 'http.host: 0.0.0.0' >> ./${ES_PATH}/config/elasticsearch.yml"
+  - ./${ES_PATH}/bin/elasticsearch-plugin install analysis-icu
   - ./${ES_PATH}/bin/elasticsearch &
   - pip install -r requirements.txt
   - python -m textblob.download_corpora

--- a/external_search.py
+++ b/external_search.py
@@ -690,7 +690,8 @@ class ExternalSearchIndexVersions(object):
         # by title, not by the other contributors.
         ("primary_author_only", "\s+;.*", ""),
 
-        # Remove periods from consideration.
+        # Remove parentheticals (e.g. the full name of someone who
+        # goes by initials).
         ("strip_parentheticals", "\s+\([^)]+\)", ""),
 
         # Remove periods from consideration.

--- a/external_search.py
+++ b/external_search.py
@@ -774,7 +774,7 @@ class ExternalSearchIndexVersions(object):
         basic_string_plus_keyword["keyword"] = {
             "type": "text",
             "fielddata" : True,
-            "index": False,
+            "index": True,
             "store": False,
             # This uses the 'keyword' tokenizer, so we end up
             # with a keyword even though type=text.

--- a/external_search.py
+++ b/external_search.py
@@ -659,6 +659,9 @@ class ExternalSearchIndexVersions(object):
                 "index": True,
                 "store": False,
             }
+            if type == 'icu_collation_keyword':
+                description['language'] = 'en'
+                description['country'] = 'US'
             mapping = cls.map_fields(
                 fields=fields,
                 mapping=mapping,

--- a/external_search.py
+++ b/external_search.py
@@ -778,7 +778,7 @@ class ExternalSearchIndexVersions(object):
         licensepool_fields_by_type = {
             'integer': ['collection_id', 'data_source_id'],
             'date': ['availability_time'],
-            'boolean': ['availability', 'open_access', 'suppressed', 'licensed'],
+            'boolean': ['availabile', 'open_access', 'suppressed', 'licensed'],
             'keyword': ['medium'],
         }
         licensepool_definition = cls.map_fields_by_type(

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1035,7 +1035,7 @@ class TestSearchOrder(EndToEndExternalSearchTest):
         if self.search:
 
             # Create two works -- this part is straightforward.
-            self.moby_dick = _work(title="Moby Dick", authors="Herman Melville", fiction=True)
+            self.moby_dick = _work(title="moby dick", authors="Herman Melville", fiction=True)
             self.moby_dick.presentation_edition.subtitle = "Or, the Whale"
             self.moby_dick.presentation_edition.series = "Classics"
             self.moby_dick.presentation_edition.series_position = 10

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -108,8 +108,10 @@ class ExternalSearchTest(DatabaseTest):
             self.search = ClientForTesting(self._db)
         except Exception as e:
             self.search = None
-            print "Unable to set up elasticsearch index, search tests will be skipped."
-            print e
+            logging.error(
+                "Unable to set up elasticsearch index, search tests will be skipped.",
+                exc_info=e
+            )
 
     def teardown(self):
         if self.search:

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1045,7 +1045,7 @@ class TestSearchOrder(EndToEndExternalSearchTest):
             self.moby_dick.random = 0.1
             self.moby_dick.last_update_time = datetime.datetime.now()
 
-            self.moby_duck = _work(title="Moby Duck", authors="Donovan Hohn", fiction=False)
+            self.moby_duck = _work(title="Moby Duck", authors="donovan hohn", fiction=False)
             self.moby_duck.presentation_edition.subtitle = "The True Story of 28,800 Bath Toys Lost at Sea"
             self.moby_duck.summary_text = "A compulsively readable narrative"
             self.moby_duck.presentation_edition.series_position = 1


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-1986 by using the ICU collation algorithm to order `sort_title` and `sort_author` rather than relying on the default Elasticsearch sort. There are some differences between the default Elasticsearch algorithm and how feeds have been sorted up to this point, but only two of them are a big deal: 

1. Sorting is case-sensitive: `van Vogt` sorts after `Zelazny`.
2. `[Unknown]` used to sort near the end of a list and now it sorts at the very top.

To fix these problems I introduced a custom `analyzer` with a custom `char_filter` that removes square brackets. It also removes periods, so that "H.G. Wells" and "HG Wells" sort the same. ("H. G. Wells" is a whole other problem which I wasn't able to solve.) I used https://www.elastic.co/guide/en/elasticsearch/guide/current/sorting-collations.html and https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-pattern-replace-charfilter.html as my guides.

There's a much simpler solution that _almost_ works. You can define a `keyword` field as a `icu_collation_keyword` instead and get that collation algorithm without having to define any custom behavior. https://www.elastic.co/guide/en/elasticsearch/plugins/6.4/analysis-icu-collation-keyword-field.html

But an `icu_collation_keyword` field can't have a custom `normalizer`, so to get the `char_filter` you have to define a custom `analyzer`. But an `icu_collation_keyword` also can't have a custom `analyzer`, so I had to also effectively reproduce what `icu_collation_keyword` does within a `text` field. It looks like this is  just an oversight.

A simpler way of doing this would be to remove the square brackets and any other undesirable characters while building the search document. Then we could use normal `icu_collation_keyword`. Let me know if you'd rather do things this way.