### PR TITLE
Choose featureable works through Elasticsearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
   # a low-resource development environment.
   - "echo 'transport.host: 127.0.0.1' >> ./${ES_PATH}/config/elasticsearch.yml"
   - "echo 'http.host: 0.0.0.0' >> ./${ES_PATH}/config/elasticsearch.yml"
+  - ./${ES_PATH}/bin/elasticsearch-plugin install analysis-icu
   - ./${ES_PATH}/bin/elasticsearch &
   - pip install -r requirements.txt
   - python -m textblob.download_corpora

--- a/external_search.py
+++ b/external_search.py
@@ -404,7 +404,7 @@ class ExternalSearchIndex(HasSelfTests):
         start = pagination.offset
         stop = start + pagination.size
 
-        constant_scores, function_scores = filter.scoring_functions
+        function_scores = filter.scoring_functions
         if function_scores:
             function_score = Q(
                 'function_score',
@@ -413,10 +413,6 @@ class ExternalSearchIndex(HasSelfTests):
                 boost_mode="sum"
             )
             search = search.query(function_score)
-
-        if constant_scores:
-            for constant_score in constant_scores:
-                search = search.query(constant_score)
         a = time.time()
 
         # NOTE: This is the code that actually executes the ElasticSearch
@@ -2178,7 +2174,7 @@ class SortKeyPagination(Pagination):
         """
         super(SortKeyPagination, self).page_loaded(page)
         if page:
-            last_item = page[-1].meta
+            last_item = page[-1]
             values = list(last_item.meta.sort)
         else:
             # There's nothing on this page, so there's no next page

--- a/external_search.py
+++ b/external_search.py
@@ -11,7 +11,6 @@ from elasticsearch_dsl import (
     Index,
     Search,
     Q,
-    SF,
 )
 try:
     from elasticsearch_dsl import F
@@ -373,6 +372,7 @@ class ExternalSearchIndex(HasSelfTests):
                 search = search.fields(fields)
             else:
                 search = search.source(fields)
+
         return search
 
     def query_works(self, query_string, filter=None, pagination=None,

--- a/external_search.py
+++ b/external_search.py
@@ -2175,7 +2175,6 @@ class SortKeyPagination(Pagination):
         if page:
             last_item = page[-1]
             values = list(last_item.meta.sort)
-            values = None
         else:
             # There's nothing on this page, so there's no next page
             # either.

--- a/external_search.py
+++ b/external_search.py
@@ -404,7 +404,7 @@ class ExternalSearchIndex(HasSelfTests):
         start = pagination.offset
         stop = start + pagination.size
 
-        function_scores = filter.scoring_functions
+        function_scores = filter.scoring_functions if filter else None
         if function_scores:
             function_score = Q(
                 'function_score',

--- a/external_search.py
+++ b/external_search.py
@@ -410,7 +410,7 @@ class ExternalSearchIndex(HasSelfTests):
                 'function_score',
                 query=dict(match_all=dict()),
                 functions=function_scores,
-                boost_mode="sum"
+                score_mode="sum"
             )
             search = search.query(function_score)
         a = time.time()

--- a/external_search.py
+++ b/external_search.py
@@ -428,9 +428,14 @@ class ExternalSearchIndex(HasSelfTests):
             for i, result in enumerate(results):
                 self.log.debug(
                     '%02d "%s" (%s) work=%s score=%.3f shard=%s',
-                    i, result.title, result.author, result.meta['id'],
+                    i, result.sort_title, result.sort_author, result.meta['id'],
                     result.meta['score'] or 0, result.meta['shard']
                 )
+
+                print(
+                    '%.3f "%s" (%s) work=%s' % (
+                    result.meta['score'] or 0, result.sort_title, result.sort_author, result.meta['id'],
+                ))
 
         # Convert the Search object into a list of hits.
         results = [x for x in results]
@@ -2173,7 +2178,7 @@ class SortKeyPagination(Pagination):
         """
         super(SortKeyPagination, self).page_loaded(page)
         if page:
-            last_item = page[-1]
+            last_item = page[-1].meta
             values = list(last_item.meta.sort)
         else:
             # There's nothing on this page, so there's no next page

--- a/external_search.py
+++ b/external_search.py
@@ -428,11 +428,6 @@ class ExternalSearchIndex(HasSelfTests):
                     result.meta['score'] or 0, result.meta['shard']
                 )
 
-                print(
-                    '%.3f "%s" (%s) work=%s' % (
-                    result.meta['score'] or 0, result.sort_title, result.sort_author, result.meta['id'],
-                ))
-
         # Convert the Search object into a list of hits.
         results = [x for x in results]
 
@@ -2277,26 +2272,6 @@ class SearchIndexMonitor(WorkSweepMonitor):
         # We got a generic service name. Replace it with a more
         # specific one.
         self.service_name = "Search index update (%s)" % index_name
-
-    def item_query_2(self):
-        # TEST METHOD
-
-        # This method indexes the works that belong in the 'Science
-        # Fiction' lane and leaves all other works alone. I use this
-        # to improve turnaround when testing with a large real
-        # collection.
-
-        from model.classification import Genre
-        from model.work import WorkGenre
-        genre_ids = []
-        for name in ('Fantasy', 'Science Fiction'):
-            g, ignore = Genre.lookup(self._db, name)
-            genre_ids.extend([x.id for x in g.self_and_subgenres])
-        qu = self._db.query(Work).join(Work.work_genres).filter(WorkGenre.genre_id.in_(genre_ids))
-        if self.collection:
-            qu = self.scope_to_collection(qu, self.collection)
-        qu = qu.order_by(self.model_class.id)
-        return qu
 
     def process_batch(self, offset):
         """Update the search index for a set of Works."""

--- a/lane.py
+++ b/lane.py
@@ -653,14 +653,16 @@ class FeaturedFacets(FacetsWithEntryPoint):
         # there are no high-quality works, we want medium-quality to
         # outrank low-quality.
         #
-        # So we calculate a score based on the _square_ of the work's
-        # quality. This disproportionately privileges higher-quality
-        # works.  But there's a cutoff -- the minimum featured quality
-        # -- beyond which a work is 'featurable' and higher quality no
-        # longer increases its score.
+        # So we establish a cutoff -- the minimum featured quality --
+        # beyond which a work is considered 'featurable'. All featurable
+        # works get the same (high) score.
+        #
+        # Below that point, we prefer higher-quality works to lower-quality
+        # works, so a work's score is proportional to the square of its
+        # quality.
         exponent = 2
         cutoff = (self.minimum_featured_quality ** exponent)
-        script = ("Math.min(%.5f, Math.pow(doc['quality'].value, %.5f)) * 5"
+        script = ("Math.pow(Math.min(%.5f, doc['quality'].value), %.5f) * 5"
                   % (cutoff, exponent))
         quality_field = SF('script_score', script=dict(source=script))
 

--- a/lane.py
+++ b/lane.py
@@ -660,7 +660,7 @@ class FeaturedFacets(FacetsWithEntryPoint):
         # Currently available works are more featurable.
         available = Q('term', **{'licensepools.available' : True})
         nested = Q('nested', path='licensepools', query=available)
-        available_now = dict(filter=nested, weight=1.1)
+        available_now = dict(filter=nested, weight=3)
 
         function_scores = [quality_field, available_now]
 
@@ -670,7 +670,7 @@ class FeaturedFacets(FacetsWithEntryPoint):
         if self.random_seed != self.DETERMINISTIC:
             random = SF(
                 'random_score',
-                seed=self.random_seed or int(time.time()), weight=1
+                seed=self.random_seed or int(time.time()), weight=1.5
             )
             function_scores.append(random)
 

--- a/lane.py
+++ b/lane.py
@@ -657,11 +657,6 @@ class FeaturedFacets(FacetsWithEntryPoint):
             missing=0,
         )
 
-        #quality_field = SF(
-        #    'script_score',
-        #    script=dict(source="doc['quality'].value * 5")
-        #)
-
         # Currently available works are more featurable.
         available = Q('term', **{'licensepools.available' : True})
         nested = Q('nested', path='licensepools', query=available)

--- a/lane.py
+++ b/lane.py
@@ -650,8 +650,8 @@ class FeaturedFacets(FacetsWithEntryPoint):
         quality_field = SF(
             'field_value_factor',
             field='quality',
-            factor=1,
-            modifier='ln1p',
+            factor=5,
+            modifier='ln2p',
             missing=0,
         )
 

--- a/lane.py
+++ b/lane.py
@@ -657,6 +657,11 @@ class FeaturedFacets(FacetsWithEntryPoint):
             missing=0,
         )
 
+        #quality_field = SF(
+        #    'script_score',
+        #    script=dict(source="doc['quality'].value * 5")
+        #)
+
         # Currently available works are more featurable.
         available = Q('term', **{'licensepools.available' : True})
         nested = Q('nested', path='licensepools', query=available)
@@ -670,7 +675,7 @@ class FeaturedFacets(FacetsWithEntryPoint):
         if self.random_seed != self.DETERMINISTIC:
             random = SF(
                 'random_score',
-                seed=self.random_seed or int(time.time()), weight=1.5
+                seed=self.random_seed or int(time.time()), weight=1.1
             )
             function_scores.append(random)
 
@@ -687,7 +692,6 @@ class FeaturedFacets(FacetsWithEntryPoint):
             nested = Q('nested', path='customlists', query=featured_on_list)
             featured_on_relevant_list = dict(filter=nested, weight=11)
             function_scores.append(featured_on_relevant_list)
-        set_trace()
         return function_scores
 
     def apply(self, _db, qu):

--- a/lane.py
+++ b/lane.py
@@ -263,14 +263,14 @@ class FacetsWithEntryPoint(FacetConstants):
             self.entrypoint.modify_search_filter(filter)
         return filter
 
-    def scoring_functions(self, worklist):
+    def scoring_functions(self, filter):
         """Create a list of ScoringFunction objects that modify how
         works in the given WorkList should be ordered.
 
         Most subclasses will not use this because they order
         works using the 'order' feature.
         """
-        return []
+        return [], []
 
 
 class Facets(FacetsWithEntryPoint):
@@ -614,7 +614,7 @@ class FeaturedFacets(FacetsWithEntryPoint):
     """
 
     def __init__(self, minimum_featured_quality, uses_customlists=False,
-                 entrypoint=None, **kwargs):
+                 entrypoint=None, random_seed=None, **kwargs):
         """Set up an object that finds featured books in a given
         WorkList.
 
@@ -624,6 +624,7 @@ class FeaturedFacets(FacetsWithEntryPoint):
         super(FeaturedFacets, self).__init__(entrypoint=entrypoint, **kwargs)
         self.minimum_featured_quality = minimum_featured_quality
         self.uses_customlists = uses_customlists
+        self.random_seed=random_seed
 
     def navigate(self, minimum_featured_quality=None, uses_customlists=None,
                  entrypoint=None):
@@ -638,61 +639,55 @@ class FeaturedFacets(FacetsWithEntryPoint):
             minimum_featured_quality, uses_customlists, entrypoint
         )
 
-    def scoring_functions(self, worklist):
+    def scoring_functions(self, filter):
         """Generate scoring functions that weight works randomly, but
         with 'more featurable' works tending to be at the top.
         """
-        from external_search import ScoringFunction
+        from elasticsearch_dsl import SF, Q
+        from external_search import SearchBase
+
         # A higher-quality work is more featurable.
-        # TODO: It shouldn't be necessary to use a cutoff -- we should
-        # be able to boost based on the .quality field directly.
-        featurable_quality = ScoringFunction(
-            filter=ScoringFunction._match_range(
-                "quality", "gte", self.minimum_featured_quality
-            ),
-            weight=5
+        quality_field = SF(
+            'field_value_factor',
+            field='quality',
+            factor=1,
+            modifier='ln1p',
+            missing=0,
         )
 
-        # Low-quality open-access works are penalized.
-        not_open_access = F('term', **{'licensepools.open_access' : False})
-        decent_quality = ScoringFunction._match_range(
-            'licensepools.quality', 'gte', 0.3
-        )
-        licensed_or_high_quality_open_access = ScoringFunction(
-            filter=F('bool', should=[not_open_access, decent_quality]),
-            weight=2
+        # Random chance can boost a lower-quality work, but not by
+        # much -- this mainly ensures we don't get the exact same
+        # books every time.
+        random = SF(
+            'random_score',
+            seed=self.random_seed or int(time.time()), weight=1
         )
 
         # Currently available works are more featurable.
-        available_f = F('term', **{'licensepools.available' : True})
-        available_now = ScoringFunction(filter=available_f, weight=1)
+        available = Q('term', **{'licensepools.available' : True})
+        nested = Q('nested', path='licensepools', query=available)
+        available_now = Q('constant_score', filter=nested, boost=3)
 
-        # Random chance can boost a lower-quality work, but not by
-        # much.
-        random = ScoringFunction(
-            random_score={}, seed=int(time.time()), weight=0.5
-        )
+        constant_scores = [available_now]
+        function_scores = [quality_field, random]
 
-        # These scoring functions are always applied. There's one more
-        # below.
-        functions = [
-            featurable_quality, licensed_or_high_quality_open_access,
-            available_now, random
-        ]
-
-        if worklist._customlist_ids:
-            # This WorkList is based on custom lists. A work that's
-            # _featured_ on the list will be boosted quite a lot
-            # versus one that's not.
-            featured = F('term', **{'customlists.featured' : True})
-            on_list = F('terms', **{'customlists.list_id' : worklist._customlist_ids})
-            featured_f = Bool(must=[featured, on_list])
-            featured_on_relevant_list = ScoringFunction(
-                filter=featured_f, weight=11
+        if filter.customlist_restriction_sets:
+            list_ids = set()
+            for restriction in filter.customlist_restriction_sets:
+                list_ids.update(restriction)
+            # The provided Filter is looking for works on certain
+            # custom lists. A work that's _featured_ on one of these
+            # lists will be boosted quite a lot versus one that's not.
+            featured = Q('term', **{'customlists.featured' : True})
+            on_list = Q('terms', **{'customlists.list_id' : list(list_ids)})
+            featured = Q('bool', must=[featured, on_list])
+            nested = Q('nested', path='customlists', query=featured)
+            featured_on_relevant_list = Q(
+                'constant_score', filter=nested, boost=11
             )
-            functions.append(featured_on_relevant_list)
+            #constant_scores.append(featured_on_relevant_list)
 
-        return functions
+        return constant_scores, function_scores
 
     def apply(self, _db, qu):
         """Order a query by quality tier, and then randomly.

--- a/lane.py
+++ b/lane.py
@@ -660,7 +660,7 @@ class FeaturedFacets(FacetsWithEntryPoint):
         # Currently available works are more featurable.
         available = Q('term', **{'licensepools.available' : True})
         nested = Q('nested', path='licensepools', query=available)
-        available_now = dict(filter=nested, weight=1)
+        available_now = dict(filter=nested, weight=1.1)
 
         function_scores = [quality_field, available_now]
 
@@ -687,7 +687,7 @@ class FeaturedFacets(FacetsWithEntryPoint):
             nested = Q('nested', path='customlists', query=featured_on_list)
             featured_on_relevant_list = dict(filter=nested, weight=11)
             function_scores.append(featured_on_relevant_list)
-
+        set_trace()
         return function_scores
 
     def apply(self, _db, qu):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1428,13 +1428,13 @@ class TestFeaturedFacets(EndToEndExternalSearchTest):
         self.hq_available.quality = 1
 
         self.hq_available_2 = _work(title="Also HQ and available")
-        self.hq_available.quality = 1
+        self.hq_available_2.quality = 1
 
         self.not_featured_on_list = _work(title="On a list but not featured")
-        self.not_featured_on_list.quality = 0.79999
+        self.not_featured_on_list.quality = 0.19
 
         self.featured_on_list = _work(title="Featured on a list")
-        self.featured_on_list.quality = 0.79998
+        self.featured_on_list.quality = 0.18
 
         self.best_seller_list, ignore = self._customlist(num_entries=0)
         self.best_seller_list.add_entry(self.featured_on_list, featured=True)
@@ -1486,13 +1486,13 @@ class TestFeaturedFacets(EndToEndExternalSearchTest):
 
         # Up to this point we've been avoiding the random element,
         # but we can introduce that now by passing in a numeric seed.
-        random_facets = FeaturedFacets(0, random_seed=49)
+        random_facets = FeaturedFacets(0, random_seed=42)
         works = worklist.works_from_search_index(
-            self._db, facets, None, self.search, debug=True
+            self._db, random_facets, None, self.search, debug=True
         )
         eq_(
-            [self.hq_available, self.not_featured_on_list,
-             self.featured_on_list, self.hq_not_available],
+            [self.hq_available, self.hq_available_2, self.featured_on_list,
+             self.not_featured_on_list, self.hq_not_available],
             works
         )
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1523,7 +1523,7 @@ class TestFeaturedFacets(EndToEndExternalSearchTest):
 
         # Up to this point we've been avoiding the random element,
         # but we can introduce that now by passing in a numeric seed.
-        # In normal usage, the current time is the
+        # In normal usage, the current time is used as the seed.
         #
         # The random element is relatively small, so it mainly acts
         # to rearrange works whose scores were similar before.

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -2481,6 +2481,9 @@ class TestFilter(DatabaseTest):
             def modify_search_filter(self, filter):
                 self.called_with = filter
 
+            def scoring_functions(self, filter):
+                return []
+
         facets = Mock()
         filter = Filter(facets=facets)
         eq_(filter, facets.called_with)
@@ -2529,6 +2532,8 @@ class TestFilter(DatabaseTest):
         class Mock(object):
             def modify_search_filter(self, filter):
                 self.called_with = filter
+            def scoring_functions(self, filter):
+                return []
         facets = Mock()
 
         filter = Filter.from_worklist(self._db, inherits, facets)

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -2476,17 +2476,20 @@ class TestFilter(DatabaseTest):
         )
 
         # If you pass in a Facets object, its modify_search_filter()
-        # is called.
+        # and scoring_functions() methods are called.
         class Mock(object):
             def modify_search_filter(self, filter):
-                self.called_with = filter
+                self.modify_search_filter_called_with = filter
 
             def scoring_functions(self, filter):
-                return []
+                self.scoring_functions_called_with = filter
+                return ["some scoring functions"]
 
         facets = Mock()
         filter = Filter(facets=facets)
-        eq_(filter, facets.called_with)
+        eq_(filter, facets.modify_search_filter_called_with)
+        eq_(filter, facets.scoring_functions_called_with)
+        eq_(["some scoring functions"], filter.scoring_functions)
 
         # Some arguments to the constructor only exist as keyword
         # arguments, but you can't pass in whatever keywords you want.


### PR DESCRIPTION
This branch makes it possible to use `FeaturedFacets` with Elasticsearch. The complex SQL that creates the 'quality tier field' is duplicated with much simpler Elasticsearch code that creates a number of function scores (https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html). All function scores are applied to each document and their sum is used as the score for that document.

We have function scores for work quality, current availability, being featured on a relevant custom list, and a random element that ensures variety.

Early tests against a full-sized index give results similar to what is currently seen in the circulation manager.