### PR TITLE
Add collection to credentials table

### DIFF
--- a/migration/20190522-1-add-collection-to-credentials.sql
+++ b/migration/20190522-1-add-collection-to-credentials.sql
@@ -1,0 +1,5 @@
+alter table credentials add column collection_id integer;
+alter table credentials add constraint "credentials_collection_id_fkey" FOREIGN KEY (collection_id) REFERENCES collections(id);
+alter table credentials add constraint "credentials_data_source_id_patron_id_collection_id_type_key" UNIQUE (data_source_id, patron_id, collection_id, type);
+alter table credentials drop constraint credentials_data_source_id_patron_id_type_key;
+create index ix_credentials_collection_id on credentials(collection_id);

--- a/model/collection.py
+++ b/model/collection.py
@@ -124,6 +124,9 @@ class Collection(Base, HasFullTableCache):
         cascade="all, delete-orphan"
     )
 
+    # A Collection can have many associated Credentials.
+    credentials = relationship("Credential", backref="collection", cascade="delete")
+
     # A Collection can be monitored by many Monitors, each of which
     # will have its own Timestamp.
     timestamps = relationship("Timestamp", backref="collection")

--- a/model/credential.py
+++ b/model/credential.py
@@ -31,6 +31,7 @@ class Credential(Base):
     id = Column(Integer, primary_key=True)
     data_source_id = Column(Integer, ForeignKey('datasources.id'), index=True)
     patron_id = Column(Integer, ForeignKey('patrons.id'), index=True)
+    collection_id = Column(Integer, ForeignKey('collections.id'), index=True)
     type = Column(String(255), index=True)
     credential = Column(String)
     expires = Column(DateTime, index=True)
@@ -41,7 +42,7 @@ class Credential(Base):
     )
 
     __table_args__ = (
-        UniqueConstraint('data_source_id', 'patron_id', 'type'),
+        UniqueConstraint('data_source_id', 'patron_id', 'collection_id', 'type'),
     )
 
 
@@ -54,12 +55,12 @@ class Credential(Base):
 
     @classmethod
     def lookup(self, _db, data_source, type, patron, refresher_method,
-               allow_persistent_token=False, allow_empty_token=False):
+               allow_persistent_token=False, allow_empty_token=False, collection=None):
         from datasource import DataSource
         if isinstance(data_source, basestring):
             data_source = DataSource.lookup(_db, data_source)
         credential, is_new = get_one_or_create(
-            _db, Credential, data_source=data_source, type=type, patron=patron)
+            _db, Credential, data_source=data_source, type=type, patron=patron, collection=collection)
         if (is_new
             or (not credential.expires and not allow_persistent_token)
             or (not credential.credential and not allow_empty_token)

--- a/tests/models/test_credential.py
+++ b/tests/models/test_credential.py
@@ -159,6 +159,27 @@ class TestCredentials(DatabaseTest):
             allow_persistent_token=True, allow_empty_token=False
         )
 
+    def test_collection_token(self):
+        # Make sure we can have two tokens from the same data_source with
+        # different collections.
+        data_source = DataSource.lookup(self._db, DataSource.RB_DIGITAL)
+        collection1 = self._collection("test collection 1")
+        collection2 = self._collection("test collection 2")
+        patron = self._patron()
+        type = "super secret"
+
+        # Create our credentials
+        credential1 = Credential.lookup(self._db, data_source, type, patron, None, collection=collection1)
+        credential2 = Credential.lookup(self._db, data_source, type, patron, None, collection=collection2)
+        credential1.credential = 'test1'
+        credential2.credential = 'test2'
+
+        # Make sure the text matches what we expect
+        eq_('test1', Credential.lookup(self._db, data_source, type, patron, None, collection=collection1).credential)
+        eq_('test2', Credential.lookup(self._db, data_source, type, patron, None, collection=collection2).credential)
+
+        # Make sure we don't get anything if we don't pass a collection
+        eq_(None, Credential.lookup(self._db, data_source, type, patron, None).credential)
 
 class TestDelegatedPatronIdentifier(DatabaseTest):
 


### PR DESCRIPTION
## JIRA Ticket
https://jira.nypl.org/browse/SIMPLY-1998

## What does this Pull Request do?

In order to allow a single circulation manager to have multiple RBDigital collections we need to be able to store the credentials returned from RBDigital with the collection they belong to. This PR adds a `collection_id` column to the credentials table.

## Interested parties
@leonardr