### PR TITLE
Create OPDS grouped feeds through Elasticsearch, not materialized view

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -446,16 +446,9 @@ class ExternalSearchIndex(HasSelfTests):
         needs_add = []
         successes = []
         for work in works:
-            if work.presentation_ready:
-                needs_add.append(work)
-            else:
-                # Works are removed one at a time, which shouldn't
-                # pose a performance problem because works almost never
-                # stop being presentation ready.
-                self.remove_work(work)
-                successes.append(work)
+            needs_add.append(work)
 
-        # Add any works that need adding.
+        # Add/update any works that need adding/updating.
         docs = Work.to_search_documents(needs_add)
 
         for doc in docs:
@@ -471,8 +464,6 @@ class ExternalSearchIndex(HasSelfTests):
 
         # If the entire update failed, try it one more time before
         # giving up on the batch.
-        #
-        # Removed works were already removed, so no need to try them again.
         if len(errors) == len(docs):
             if retry_on_batch_failure:
                 self.log.info("Elasticsearch bulk update timed out, trying again.")

--- a/lane.py
+++ b/lane.py
@@ -653,14 +653,16 @@ class FeaturedFacets(FacetsWithEntryPoint):
         # there are no high-quality works, we want medium-quality to
         # outrank low-quality.
         #
-        # So we calculate a score based on the _square_ of the work's
-        # quality. This disproportionately privileges higher-quality
-        # works.  But there's a cutoff -- the minimum featured quality
-        # -- beyond which a work is 'featurable' and higher quality no
-        # longer increases its score.
+        # So we establish a cutoff -- the minimum featured quality --
+        # beyond which a work is considered 'featurable'. All featurable
+        # works get the same (high) score.
+        #
+        # Below that point, we prefer higher-quality works to lower-quality
+        # works, so a work's score is proportional to the square of its
+        # quality.
         exponent = 2
         cutoff = (self.minimum_featured_quality ** exponent)
-        script = ("Math.min(%.5f, Math.pow(doc['quality'].value, %.5f)) * 5"
+        script = ("Math.pow(Math.min(%.5f, doc['quality'].value), %.5f) * 5"
                   % (cutoff, exponent))
         quality_field = SF('script_score', script=dict(source=script))
 

--- a/lane.py
+++ b/lane.py
@@ -1859,11 +1859,11 @@ class WorkList(object):
         target_size = library.featured_lane_size
         facets = facets or self.default_featured_facets(_db)
 
-        # We want to get an extra work or two for each lane, to reduce
-        # the risk that we'll end up reusing a book in two different
+        # We ask for a few extra works for each lane, to reduce the
+        # risk that we'll end up reusing a book in two different
         # lanes.
-        target_size = max(target_size+1, int(target_size * 1.10))
-        pagination = Pagination(size=target_size)
+        ask_for_size = max(target_size+1, int(target_size * 1.10))
+        pagination = Pagination(size=ask_for_size)
 
         from external_search import ExternalSearchIndex
         search_engine = search_engine or ExternalSearchIndex(_db)
@@ -2633,7 +2633,8 @@ class Lane(Base, WorkList):
             size = self.size_by_entrypoint[entrypoint_name]
         return size
 
-    def groups(self, _db, include_sublanes=True, facets=None):
+    def groups(self, _db, include_sublanes=True, facets=None,
+               search_engine=None, debug=False):
         """Return a list of (MaterializedWorkWithGenre, Lane) 2-tuples
         describing a sequence of featured items for this lane and
         (optionally) its children.
@@ -2660,7 +2661,8 @@ class Lane(Base, WorkList):
         queryable_lanes = [x for x in relevant_lanes
                            if x == self or x.inherit_parent_restrictions]
         return self._groups_for_lanes(
-            _db, relevant_lanes, queryable_lanes, facets=facets
+            _db, relevant_lanes, queryable_lanes, facets=facets,
+            search_engine=search_engine, debug=debug
         )
 
     def search(self, _db, query_string, search_client, pagination=None,

--- a/opds.py
+++ b/opds.py
@@ -580,7 +580,10 @@ class AcquisitionFeed(OPDSFeed):
                 )
                 if usable:
                     return cached.content
-            works_and_lanes = lane.groups(_db, facets=facets)
+            works_and_lanes = lane.groups(
+                _db, facets=facets, search_engine=search_engine,
+                debug=search_debug
+            )
 
         if not works_and_lanes:
             # We cannot generate a groups feed, either because we

--- a/testing.py
+++ b/testing.py
@@ -446,7 +446,7 @@ class DatabaseTest(object):
         identifier = license_pool.identifier
         content_type = Representation.EPUB_MEDIA_TYPE
         drm_scheme = DeliveryMechanism.NO_DRM
-        LicensePoolDeliveryMechanism.set(
+        return LicensePoolDeliveryMechanism.set(
             data_source, identifier, content_type, drm_scheme,
             RightsStatus.IN_COPYRIGHT
         )

--- a/testing.py
+++ b/testing.py
@@ -1050,7 +1050,7 @@ class EndToEndSearchTest(ExternalSearchTest):
 
     def setup(self):
         super(EndToEndSearchTest, self).setup()
-        
+
         # Create some works.
         if not self.search:
             # No search index is configured -- nothing to do.

--- a/tests/models/test_licensing.py
+++ b/tests/models/test_licensing.py
@@ -1174,8 +1174,8 @@ class TestLicensePoolDeliveryMechanism(DatabaseTest):
         # media types.
         edition, pool = self._edition(with_license_pool=True,
                                       with_open_access_download=True)
-        self._add_generic_delivery_mechanism(pool)
-        [mech1, mech2] = pool.delivery_mechanisms
+        [mech1] = pool.delivery_mechanisms
+        mech2 = self._add_generic_delivery_mechanism(pool)
         mech2.delivery_mechanism, ignore = DeliveryMechanism.lookup(
             self._db, Representation.PDF_MEDIA_TYPE, DeliveryMechanism.NO_DRM
         )

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -419,6 +419,21 @@ class EndToEndExternalSearchTest(ExternalSearchTest):
     search index and run searches against it.
     """
 
+    def setup(self):
+        super(EndToEndExternalSearchTest, self).setup()
+        
+        # Create some works.
+        self.populate_works()
+
+        # Add all the works created in the setup to the search index.
+        SearchIndexCoverageProvider(
+            self._db, search_index_client=self.search
+        ).run_once_and_update_timestamp()
+
+        # Sleep to give the index time to catch up.
+        time.sleep(2)
+
+
     def _assert_works(self, description, expect, actual, should_be_ordered=True):
         # Verify that two lists of works are the same.
         if not should_be_ordered:
@@ -655,14 +670,6 @@ class TestExternalSearchWithWorks(EndToEndExternalSearchTest):
         eq_(1, len(self.moby_dick.to_search_document()['licensepools']))
         eq_("Audio",
             self.pride_audio.to_search_document()['licensepools'][0]['medium'])
-
-        # Add all the works created in the setup to the search index.
-        SearchIndexCoverageProvider(
-            self._db, search_index_client=self.search
-        ).run_once_and_update_timestamp()
-
-        # Sleep to give the index time to catch up.
-        time.sleep(2)
 
         # Set up convenient aliases for methods we'll be calling a
         # lot.

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -3013,7 +3013,7 @@ class TestSortKeyPagination(DatabaseTest):
 
 class TestBulkUpdate(DatabaseTest):
 
-    def test_works_not_presentation_ready_removed_from_index(self):
+    def test_works_not_presentation_ready_kept_in_index(self):
         w1 = self._work()
         w1.set_presentation_ready()
         w2 = self._work()
@@ -3027,16 +3027,16 @@ class TestBulkUpdate(DatabaseTest):
         eq_(set([w1, w2, w3]), set(successes))
         eq_([], failures)
 
-        # But only the presentation-ready works are actually inserted
-        # into the index.
+        # All three works were inserted into the index, even the one
+        # that's not presentation-ready.
         ids = set(x[-1] for x in index.docs.keys())
-        eq_(set([w1.id, w2.id]), ids)
+        eq_(set([w1.id, w2.id, w3.id]), ids)
 
-        # If a work stops being presentation-ready, it is removed from
-        # the index, and its removal is treated as a success.
+        # If a work stops being presentation-ready, it is kept in the
+        # index.
         w2.presentation_ready = False
         successes, failures = index.bulk_update([w1, w2, w3])
-        eq_([w1.id], [x[-1] for x in index.docs.keys()])
+        eq_(set([w1.id, w2.id, w3.id]), set([x[-1] for x in index.docs.keys()]))
         eq_(set([w1, w2, w3]), set(successes))
         eq_([], failures)
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -124,7 +124,9 @@ class TestExternalSearch(ExternalSearchTest):
             return
 
         current_index = self.search.works_index
-        self.search.setup_index(new_index='the_other_index')
+        # This calls self.search.setup_index (which is what we're testing)
+        # and also registers the index to be torn down at the end of the test.
+        self.setup_index('the_other_index')
 
         # Both indices exist.
         eq_(True, self.search.indices.exists(current_index))
@@ -202,7 +204,7 @@ class TestExternalSearch(ExternalSearchTest):
         self.search.indices.delete_alias(
             index=original_index, name='test_index-current', ignore=[404]
         )
-        self.search.setup_index(new_index='test_index-v9999')
+        self.setup_index(new_index='test_index-v9999')
         self.search.transfer_current_alias(self._db, 'test_index-v9999')
         eq_('test_index-v9999', self.search.works_index)
         eq_('test_index-current', self.search.works_alias)
@@ -215,7 +217,7 @@ class TestExternalSearch(ExternalSearchTest):
 
         # If the -current alias is being used on a different version of the
         # index, it's deleted from that index and placed on the new one.
-        self.search.setup_index(original_index)
+        self.setup_index(original_index)
         self.search.transfer_current_alias(self._db, original_index)
         eq_(original_index, self.search.works_index)
         eq_('test_index-current', self.search.works_alias)

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -360,7 +360,6 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
     """
 
     def populate_works(self):
-        super(TestExternalSearchWithWorks, self).setup()
         _work = self.default_work
 
         self.moby_dick = _work(

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -3413,10 +3413,11 @@ class TestWorkListGroupsEndToEnd(EndToEndSearchTest):
                 # featured earlier. The search index knows about a
                 # title (lq_litfix) that was not previously featured,
                 # but we didn't see it because the Elasticsearch query
-                # didn't happen fetch it. The query for each lane
-                # happens separately and there were too many
-                # high-quality works in 'fiction' for the low-quality
-                # one to show up.
+                # didn't happen to fetch it.
+                #
+                # Each lane gets a separate query, and there were too
+                # many high-quality works in 'fiction' for the
+                # low-quality one to show up.
                 (self.hq_litfic, fiction),
                 (self.hq_sf, fiction),
             ]

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -3301,6 +3301,8 @@ class TestWorkListGroupsEndToEnd(EndToEndSearchTest):
         self.staff_picks_list.add_entry(self.mq_sf)
 
     def test_groups(self):
+        if not self.search:
+            return
 
         # Create a 'Fiction' lane with five sublanes.
         fiction = self._lane("Fiction")

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -3233,10 +3233,9 @@ class TestLane(DatabaseTest):
         )
 
     def test_groups_propagates_facets(self):
-        """Lane.groups propagates a received Facets object into
-        _groups_for_lanes.
-        """
-        def mock(self, _db, relevant_lanes, queryable_lanes, facets):
+        # Lane.groups propagates a received Facets object into
+        # _groups_for_lanes.
+        def mock(self, _db, relevant_lanes, queryable_lanes, facets, *args, **kwargs):
             self.called_with = facets
             return []
         old_value = Lane._groups_for_lanes

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -3269,7 +3269,6 @@ class TestWorkListGroupsEndToEnd(EndToEndSearchTest):
         self.lq_litfic = _w(title="LQ LitFic", fiction=True, genre='Literary Fiction')
         self.lq_litfic.quality = 0
         self.hq_sf = _w(title="HQ SF", genre="Science Fiction", fiction=True)
-        self.hq_sf.random = 0.25
 
         # Add a lot of irrelevant genres to one of the works. This
         # will clutter up the materialized view, but it won't affect
@@ -3285,7 +3284,6 @@ class TestWorkListGroupsEndToEnd(EndToEndSearchTest):
         self.lq_sf.quality = 0.1
         self.hq_ro = _w(title="HQ Romance", genre="Romance", fiction=True)
         self.hq_ro.quality = 0.8
-        self.hq_ro.random = 0.75
         self.mq_ro = _w(title="MQ Romance", genre="Romance", fiction=True)
         self.mq_ro.quality = 0.6
         # This work is in a different language -- necessary to run the

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1200,9 +1200,8 @@ class TestOPDS(DatabaseTest):
         eq_(sorted(parsed.entries), sorted(feedparser.parse(raw_groups).entries))
 
     def test_groups_feed_with_empty_sublanes_is_page_feed(self):
-        """Test that a page feed is returned when the requested groups
-        feed has no books in the groups.
-        """
+        # Test that a page feed is returned when the requested groups
+        # feed has no books in the groups.
         library = self._default_library
 
         test_lane = self._lane("Test Lane", genres=['Mystery'])
@@ -1482,16 +1481,15 @@ class TestAcquisitionFeed(DatabaseTest):
         assert '{http://opds-spec.org/2010/catalog}activeFacet' not in l
 
     def test_groups_propagates_facets(self):
-        """AcquisitionFeed.groups() might call several different
-        methods that each need a facet object.
-        """
+        # AcquisitionFeed.groups() might call several different
+        # methods that each need a facet object.
         class Mock(object):
             """Contains all the mock methods used by this test."""
             def fetch(self, *args, **kwargs):
                 self.fetch_called_with = kwargs['facets']
                 return None, False
 
-            def groups(self, _db, facets):
+            def groups(self, _db, facets, *args, **kwargs):
                 self.groups_called_with = facets
                 return []
 


### PR DESCRIPTION
This branch implements https://jira.nypl.org/browse/SIMPLY-1990.
Elasticsearch, not the materialized view, now drives `WorkList.groups`.
The code to generate grouped lists of works from the materialized view is still present and tested but no longer used.