### PR TITLE
`WorkList.works()` now goes to search engine, not database

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -1352,6 +1352,9 @@ class WorkList(object):
 
         Used when building a grouped OPDS feed for this WorkList's parent.
 
+        DEPRECATED - Pass a FeaturedFacets object into
+        works_from_search_index instead.
+
         :param facets: A FeaturedFacets object.
 
         :return: A list of MaterializedWorkWithGenre objects.  Under
@@ -1366,7 +1369,7 @@ class WorkList(object):
         target_size = library.featured_lane_size
 
         facets = facets or self.default_featured_facets(_db)
-        query = self.works(_db, facets=facets)
+        query = self.works_from_database(_db, facets=facets)
         if not query:
             # works() may return None, indicating that the whole
             # thing is a bad idea and the query should not even be
@@ -2041,7 +2044,7 @@ class WorkList(object):
         items. There may be more or less; this controls the size of
         the window and the LIMIT on the query.
         """
-        lane_query = self.works(_db, facets=facets)
+        lane_query = self.works_from_database(_db, facets=facets)
 
         # Make sure this query finds a number of works proportinal
         # to the expected size of the lane.
@@ -2475,7 +2478,7 @@ class Lane(Base, WorkList):
 
     def update_size(self, _db):
         """Update the stored estimate of the number of Works in this Lane."""
-        query = self.works(_db).limit(None)
+        query = self.works_from_database(_db).limit(None)
         query = query.distinct(mw.works_id)
 
         # Do the estimate for every known entry point.

--- a/marc.py
+++ b/marc.py
@@ -625,7 +625,9 @@ class MARCExporter(object):
         # again on the next run.
         end_time = datetime.datetime.utcnow()
 
-        works_q = lane.works(self._db)
+        # TODO - Before we can get rid of the materialized view we'll
+        # need to change this to get works from the search index.
+        works_q = lane.works_from_database(self._db)
         if start_time:
             works_q = works_q.filter(MaterializedWorkWithGenre.last_update_time>=start_time)
 


### PR DESCRIPTION
This simple branch changes the default implementation of `WorkList.works()` to go against the search engine rather than the materialized view. The materialized view code is moved to `WorkList.works_from_database` and it will eventually be modified to go against the `works` table rather than the materialized view. At that point we'll be able to remove the materialized view altogether.

For now, this allows me to modify the various `DynamicLane` classes in `api/lanes.py` one at a time, reimplementing `works` if necessary, rather than having to figure them all out at once.