### PR TITLE
Generate MARC records through Elasticsearch, not materialized view

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -1659,7 +1659,7 @@ class Filter(SearchBase):
         :param allow_holds: If this is False, books with no available
         copies will be excluded from results.
 
-        :param last_update_time: If this is set to a datetime, only books
+        :param updated_after: If this is set to a datetime, only books
         whose Work records (~bibliographic metadata) have been updated since
         that time will be included in results.
         """
@@ -1709,7 +1709,7 @@ class Filter(SearchBase):
         )
         self.allow_holds = kwargs.pop('allow_holds', True)
 
-        self.last_update_time = kwargs.pop('last_update_time', None)
+        self.updated_after = kwargs.pop('updated_after', None)
 
         # At this point there should be no keyword arguments -- you can't pass
         # whatever you want into this method.
@@ -1842,9 +1842,9 @@ class Filter(SearchBase):
 
         # Perhaps only books whose bibliographic metadata was updated
         # recently should be included.
-        if self.last_update_time:
+        if self.updated_after:
             last_update_time_query = self._match_range(
-                'last_update_time', 'gte', self.last_update_time
+                'last_update_time', 'gte', self.updated_after
             )
             f = chain(f, F('bool', must=last_update_time_query))
 

--- a/external_search.py
+++ b/external_search.py
@@ -2230,7 +2230,7 @@ class MockExternalSearchIndex(ExternalSearchIndex):
                             start_at = i + 1
                             break
             else:
-                start_at = pagination.start
+                start_at = pagination.offset
             stop = start_at + pagination.size
             docs = docs[start_at:stop]
 

--- a/facets.py
+++ b/facets.py
@@ -111,6 +111,16 @@ class FacetConstants(object):
         COLLECTION_FACET_GROUP_NAME : COLLECTION_MAIN,
     }
 
+    SORT_ORDER_TO_ELASTICSEARCH_FIELD_NAME = {
+        ORDER_TITLE : "sort_title",
+        ORDER_AUTHOR : "sort_author",
+        ORDER_LAST_UPDATE : 'last_update_time',
+        ORDER_ADDED_TO_COLLECTION : 'licensepools.availability_time',
+        ORDER_SERIES_POSITION : 'series_position',
+        ORDER_WORK_ID : '_id',
+        ORDER_RANDOM : 'random',
+    }
+
 
 class FacetConfig(object):
     """A class that implements the facet-related methods of

--- a/lane.py
+++ b/lane.py
@@ -103,15 +103,24 @@ from sqlalchemy.dialects.postgresql import (
 )
 
 class BaseFacets(FacetConstants):
-    """Basic Facets class that doesn't modify a search filter at all.
+    """Basic faceting class that doesn't modify a search filter at all.
 
     This is intended solely for use as a base class.
     """
 
     def modify_search_filter(self, filter):
+        """Modify an external_search.Filter object to filter out works
+        excluded by the business logic of this faceting class.
+        """
         return filter
 
     def scoring_functions(self, filter):
+        """Create a list of ScoringFunction objects that modify how
+        works in the given WorkList should be ordered.
+
+        Most subclasses will not use this because they order
+        works using the 'order' feature.
+        """
         return []
 
 

--- a/lane.py
+++ b/lane.py
@@ -574,16 +574,6 @@ class Facets(FacetsWithEntryPoint):
             order_by_sorted = [order_by[0].desc()] + [x.asc() for x in order_by[1:]]
         return order_by_sorted, order_by
 
-    SORT_ORDER_TO_ELASTICSEARCH_FIELD_NAME = {
-        FacetConstants.ORDER_TITLE : "sort_title",
-        FacetConstants.ORDER_AUTHOR : "sort_author",
-        FacetConstants.ORDER_LAST_UPDATE : 'last_update_time',
-        FacetConstants.ORDER_ADDED_TO_COLLECTION : 'licensepools.availability_time',
-        FacetConstants.ORDER_SERIES_POSITION : 'series_position',
-        FacetConstants.ORDER_WORK_ID : '_id',
-        FacetConstants.ORDER_RANDOM : 'random',
-    }
-
     def modify_search_filter(self, filter):
         """Modify the given external_search.Filter object
         so that it reflects the settings of this Facets object.

--- a/lane.py
+++ b/lane.py
@@ -102,7 +102,20 @@ from sqlalchemy.dialects.postgresql import (
     INT4RANGE,
 )
 
-class FacetsWithEntryPoint(FacetConstants):
+class BaseFacets(FacetConstants):
+    """Basic Facets class that doesn't modify a search filter at all.
+
+    This is intended solely for use as a base class.
+    """
+
+    def modify_search_filter(self, filter):
+        return filter
+
+    def scoring_functions(self, filter):
+        return []
+
+
+class FacetsWithEntryPoint(BaseFacets):
     """Basic Facets class that knows how to filter a query based on a
     selected EntryPoint.
     """
@@ -262,15 +275,6 @@ class FacetsWithEntryPoint(FacetConstants):
         if self.entrypoint:
             self.entrypoint.modify_search_filter(filter)
         return filter
-
-    def scoring_functions(self, filter):
-        """Create a list of ScoringFunction objects that modify how
-        works in the given WorkList should be ordered.
-
-        Most subclasses will not use this because they order
-        works using the 'order' feature.
-        """
-        return []
 
 
 class Facets(FacetsWithEntryPoint):

--- a/marc.py
+++ b/marc.py
@@ -13,6 +13,11 @@ from config import (
     Configuration,
     CannotLoadConfiguration,
 )
+from lane import BaseFacets
+from external_search import (
+    ExternalSearchIndex,
+    SortKeyPagination,
+)
 from model import (
     get_one,
     get_one_or_create,
@@ -453,6 +458,16 @@ class Annotator(object):
                 ]))
 
 
+class MARCExporterFacets(BaseFacets):
+
+    def __init__(self, start_time):
+        self.start_time = start_time
+
+    def modify_search_filter(self, filter):
+        filter.order = 'last_update_time'
+        filter.last_update_time = self.start_time
+
+
 class MARCExporter(object):
     """Turn a work into a record for a MARC file."""
 
@@ -593,7 +608,10 @@ class MARCExporter(object):
 
         return record
 
-    def records(self, lane, annotator, start_time=None, force_refresh=False, mirror=None, query_batch_size=500, upload_batch_size=7500):
+    def records(self, lane, annotator, start_time=None, force_refresh=False,
+                mirror=None, search_engine=None, query_batch_size=500,
+                upload_batch_size=7500
+    ):
         """
         Create and export a MARC file for the books in a lane.
 
@@ -602,7 +620,7 @@ class MARCExporter(object):
         :param start_time: Only include records that were created or modified after this time.
         :param force_refresh: Create new records even when cached records are available.
         :param mirror: Optional mirror to use instead of loading one from configuration.
-        :param query_batch_size: Number of works to retrieve with a single database query.
+        :param query_batch_size: Number of works to retrieve with a single Elasticsearch query.
         :param upload_batch_size: Number of records to mirror at a time. This is different
           from query_batch_size because S3 enforces a minimum size of 5MB for all parts
           of a multipart upload except the last, but 5MB of records would be too many
@@ -620,53 +638,51 @@ class MARCExporter(object):
         if not mirror:
             raise Exception("No mirror integration is configured")
 
+        search_engine = search_engine or ExternalSearchIndex(self._db)
+
         # End time is before we start the query, because if any records are changed
         # during the processing we may not catch them, and they should be handled
         # again on the next run.
         end_time = datetime.datetime.utcnow()
 
-        # TODO - Before we can get rid of the materialized view we'll
-        # need to change this to get works from the search index.
-        works_q = lane.works_from_database(self._db)
-        if start_time:
-            works_q = works_q.filter(MaterializedWorkWithGenre.last_update_time>=start_time)
-
-        total = works_q.count()
-        offset = 0
+        facets = MARCExporterFacets(start_time=start_time)
+        pagination = SortKeyPagination(size=query_batch_size)
 
         url = mirror.marc_file_url(self.library, lane, end_time, start_time)
         representation, ignore = get_one_or_create(
-            self._db, Representation, url=url, media_type=Representation.MARC_MEDIA_TYPE)
+            self._db, Representation, url=url,
+            media_type=Representation.MARC_MEDIA_TYPE
+        )
 
         with mirror.multipart_upload(representation, url) as upload:
-            output = StringIO()
-            current_count = 0
-            while offset < total:
-                batch_q = works_q.order_by(
-                    MaterializedWorkWithGenre.works_id).offset(
-                    offset).limit(query_batch_size)
-
-                for work in batch_q:
+            this_batch = StringIO()
+            this_batch_size = 0
+            while pagination is not None:
+                # Retrieve one 'page' of works from the search index.
+                works = lane.works_from_search_index(
+                    self._db, pagination=pagination, facets=facets,
+                    search_engine=search_engine
+                )
+                for work in works:
+                    # Create a record for each work and add it to the
+                    # MARC file in progress.
                     record = self.create_record(
-                        work, annotator, force_refresh, self.integration)
+                        work, annotator, force_refresh, self.integration
+                    )
                     if record:
-                        output.write(record.as_marc())
-                        current_count += 1
+                        this_batch.write(record.as_marc())
+                this_batch_size += pagination.this_page_size
+                if this_batch_size >= upload_batch_size:
+                    # We've reached or exceeded the upload threshold.
+                    # Upload one part of the multi-part document.
+                    self._upload_batch(this_batch, upload)
+                    this_batch = StringIO()
+                    this_batch_size = 0
+                pagination = pagination.next_page
 
-                if current_count == upload_batch_size:
-                    content = output.getvalue()
-                    if content:
-                        upload.upload_part(content)
-                    output.close()
-                    output = StringIO()
-                    current_count = 0
-                offset += query_batch_size
-
-            # Upload anything left over.
-            content = output.getvalue()
-            if content:
-                upload.upload_part(content)
-            output.close()
+            # Upload the final part of the multi-document, if
+            # necessary.
+            self._upload_batch(this_batch, upload)
 
         representation.fetched_at = end_time
         if not representation.mirror_exception:
@@ -679,5 +695,9 @@ class MARCExporter(object):
                 cached.representation = representation
             cached.end_time = end_time
 
-        
-
+    def _upload_batch(self, output, upload):
+        "Upload a batch of MARC records as one part of a multi-part upload."
+        content = output.getvalue()
+        if content:
+            upload.upload_part(content)
+        output.close()

--- a/marc.py
+++ b/marc.py
@@ -467,6 +467,7 @@ class MARCExporterFacets(BaseFacets):
         filter.order = self.SORT_ORDER_TO_ELASTICSEARCH_FIELD_NAME[
             self.ORDER_LAST_UPDATE
         ]
+        filter.order_ascending = True
         filter.updated_after = self.start_time
 
 

--- a/marc.py
+++ b/marc.py
@@ -459,6 +459,9 @@ class Annotator(object):
 
 
 class MARCExporterFacets(BaseFacets):
+    """A faceting object used to configure the search engine so that
+    it only works updated since a certain time.
+    """
 
     def __init__(self, start_time):
         self.start_time = start_time

--- a/marc.py
+++ b/marc.py
@@ -464,8 +464,10 @@ class MARCExporterFacets(BaseFacets):
         self.start_time = start_time
 
     def modify_search_filter(self, filter):
-        filter.order = 'last_update_time'
-        filter.last_update_time = self.start_time
+        filter.order = self.SORT_ORDER_TO_ELASTICSEARCH_FIELD_NAME[
+            self.ORDER_LAST_UPDATE
+        ]
+        filter.updated_after = self.start_time
 
 
 class MARCExporter(object):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -372,11 +372,13 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
         self.moby_dick.presentation_edition.series = "Classics"
         self.moby_dick.summary_text = "Ishmael"
         self.moby_dick.presentation_edition.publisher = "Project Gutenberg"
+        self.moby_dick.last_update_time = datetime.datetime(2019, 1, 1)
 
         self.moby_duck = _work(title="Moby Duck", authors="Donovan Hohn", fiction=False)
         self.moby_duck.presentation_edition.subtitle = "The True Story of 28,800 Bath Toys Lost at Sea"
         self.moby_duck.summary_text = "A compulsively readable narrative"
         self.moby_duck.presentation_edition.publisher = "Penguin"
+        self.moby_duck.last_update_time = datetime.datetime(2019, 1, 2)
         # This book is not currently loanable. It will still show up
         # in search results unless the library's settings disable it.
         self.moby_duck.license_pools[0].licenses_available = 0
@@ -765,6 +767,15 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
             [self.no_age, self.obama, self.dodger, self.age_9_10],
             "president", age_8_10, ordered=False
         )
+
+        # Filters on last modified time.
+
+        # Obviously this query string matches "Moby-Dick", but it's
+        # filtered out because its last update time is before the
+        # `updated_after`. "Moby Duck" shows up because its last update
+        # time is right on the edge.
+        after_moby_duck = Filter(updated_after=self.moby_duck.last_update_time)
+        expect([self.moby_duck], "moby dick", after_moby_duck)
 
         # Filters on genre
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -283,12 +283,13 @@ class TestExternalSearch(ExternalSearchTest):
         eq_("Search document for 'a search term':", test_results[1].name)
         eq_(True, test_results[1].success)
         result = json.loads(test_results[1].result)
-        eq_({"author": "author", "meta": {"id": "id"}, "id": "id", "title": "Sample Book Title"}, result)
+        sample_book = {"author": "author", "meta": {"id": "id", "_sort": [u'Sample Book Title', u'author', u'id']}, "id": "id", "title": "Sample Book Title"}
+        eq_(sample_book, result)
 
         eq_("Raw search results for 'a search term':", test_results[2].name)
         eq_(True, test_results[2].success)
         result = json.loads(test_results[2].result[0])
-        eq_({"author": "author", "meta": {"id": "id"}, "id": "id", "title": "Sample Book Title"}, result)
+        eq_(sample_book, result)
 
         eq_("Total number of search results for 'a search term':", test_results[3].name)
         eq_(True, test_results[3].success)

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -644,3 +644,8 @@ class TestMARCExporterFacets(object):
         eq_("last_update_time", filter.order)
         eq_(True, filter.order_ascending)
         eq_("some start time", filter.updated_after)
+
+    def test_scoring_functions(self):
+        # A no-op.
+        facets = MARCExporterFacets("some start time")
+        eq_([], facets.scoring_functions(object()))

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -25,10 +25,14 @@ from ..model import (
     RightsStatus,
 )
 from ..config import CannotLoadConfiguration
-from ..external_search import MockExternalSearchIndex
+from ..external_search import (
+    MockExternalSearchIndex,
+    Filter,
+)
 from ..marc import (
   Annotator,
   MARCExporter,
+  MARCExporterFacets,
 )
 
 from ..s3 import (
@@ -622,3 +626,21 @@ class TestMARCExporter(DatabaseTest):
 
         self._db.delete(cache)
 
+
+class TestMARCExporterFacets(object):
+    def test_modify_search_filter(self):
+
+        # A facet object.
+        facets = MARCExporterFacets("some start time")
+
+        # A filter about to be modified by the facet object.
+        filter = Filter()
+        filter.order_ascending = False
+
+        facets.modify_search_filter(filter)
+
+        # updated_after has been set and results are to be returned in
+        # order of increasing last_update_time.
+        eq_("last_update_time", filter.order)
+        eq_(True, filter.order_ascending)
+        eq_("some start time", filter.updated_after)


### PR DESCRIPTION
This branch resolves https://jira.nypl.org/browse/SIMPLY-2017.

The loop that pulls works from the database and converts them to MARC records now uses Elasticsearch and `SortKeyPagination` rather than the materialized view and regular `Pagination`.

In addition to the unit tests, I've tested the loop code on a large, real dataset. This is not the full MARC mirroring code -- I made a copy of the loop code and changed it to print out the titles of the books it found in each batch.

I don't think we should change the `query_batch_size` because we still go to the database to look up the work objects based on the IDs we get from Elasticsearch. 500 Works from the database is still a lot.

In the future, I think we could dramatically speed this up by storing a Work's MARC record in the search index. It would be easier to do this kind of speedup than to speed up the generation of OPDS feeds.