### PR TITLE
Add hook methods to make it easier to customize lanes and facets

### DIFF
--- a/facets.py
+++ b/facets.py
@@ -116,7 +116,7 @@ class FacetConstants(object):
         ORDER_AUTHOR : "sort_author",
         ORDER_LAST_UPDATE : 'last_update_time',
         ORDER_ADDED_TO_COLLECTION : 'licensepools.availability_time',
-        ORDER_SERIES_POSITION : 'series_position',
+        ORDER_SERIES_POSITION : ['series_position', 'sort_title'],
         ORDER_WORK_ID : '_id',
         ORDER_RANDOM : 'random',
     }

--- a/lane.py
+++ b/lane.py
@@ -448,14 +448,18 @@ class Facets(FacetsWithEntryPoint):
     def navigate(self, collection=None, availability=None, order=None,
                  entrypoint=None):
         """Create a slightly different Facets object from this one."""
-        return self.__class__(self.library,
-                              collection or self.collection,
-                              availability or self.availability,
-                              order or self.order,
-                              enabled_facets=self.facets_enabled_at_init,
-                              entrypoint=(entrypoint or self.entrypoint),
-                              entrypoint_is_default=False,
+        destination = self.__class__(
+            self.library,
+            collection or self.collection,
+            availability or self.availability,
+            order or self.order,
+            enabled_facets=self.facets_enabled_at_init,
+            entrypoint=(entrypoint or self.entrypoint),
+            entrypoint_is_default=False,
         )
+        destination.finalize_navigate(self)
+        return destination
+
 
     def items(self):
         for k,v in super(Facets, self).items():
@@ -1188,13 +1192,25 @@ class WorkList(object):
         self.fiction = None
         self.target_age = None
 
-        self.children = children or []
+        self.children = []
+        if children:
+            for child in children:
+                self.append_child(child)
         self.priority = priority or 0
 
         if entrypoints:
             self.entrypoints = list(entrypoints)
         else:
             self.entrypoints = []
+
+    def append_child(self, child):
+        """Add one child to the list of children in this WorkList.
+
+        This hook method can be overridden to modify the child's
+        configuration so as to make it fit with what the parent is
+        offering.
+        """
+        self.children.append(child)
 
     @property
     def customlist_ids(self):

--- a/lane.py
+++ b/lane.py
@@ -194,10 +194,12 @@ class FacetsWithEntryPoint(BaseFacets):
         """Create a very similar FacetsWithEntryPoint that points to
         a different EntryPoint.
         """
-        return self.__class__(
+        destination = self.__class__(
             entrypoint=entrypoint, entrypoint_is_default=False,
             **self.constructor_kwargs
         )
+        destination.finalize_navigate(self)
+        return destination
 
     @classmethod
     def from_request(
@@ -269,6 +271,15 @@ class FacetsWithEntryPoint(BaseFacets):
 
         This allows subclasses to do pull additional configuration from
         request data without having to override class methods.
+        """
+        pass
+
+    def finalize_navigate(self, old_facets):
+        """A hook method invoked on a FacetsWithEntryPoint object immediately
+        after navigating to it from some other FacetsWithEntryPoint.
+
+        This allows subclasses to do copy additional configuration
+        data without having to override class methods.
         """
         pass
 

--- a/lane.py
+++ b/lane.py
@@ -1024,8 +1024,7 @@ class Pagination(object):
         that would be useful to know when reasoning about earlier or
         later pages.
         """
-        size = len(page)
-        self.this_page_size = size
+        self.this_page_size = len(page)
         self.page_has_loaded = True
 
 

--- a/lane.py
+++ b/lane.py
@@ -1538,7 +1538,7 @@ class WorkList(object):
             Filter,
             ExternalSearchIndex,
         )
-        search_engine = search_engine or ExternalSearchIndex(_db)
+        search_engine = search_engine or ExternalSearchIndex.load(_db)
         filter = Filter.from_worklist(_db, self, facets)
         work_ids = search_engine.query_works(
             query_string=None, filter=filter, pagination=pagination,
@@ -1977,7 +1977,7 @@ class WorkList(object):
         pagination = Pagination(size=ask_for_size)
 
         from external_search import ExternalSearchIndex
-        search_engine = search_engine or ExternalSearchIndex(_db)
+        search_engine = search_engine or ExternalSearchIndex.load(_db)
 
         if isinstance(self, Lane):
             parent_lane = self

--- a/lane.py
+++ b/lane.py
@@ -236,6 +236,7 @@ class FacetsWithEntryPoint(BaseFacets):
             default_entrypoint, **extra_kwargs
         )
 
+
     @classmethod
     def _from_request(
             cls, facet_config, get_argument, get_header, worklist,
@@ -257,8 +258,19 @@ class FacetsWithEntryPoint(BaseFacets):
         if isinstance(entrypoint, ProblemDetail):
             return entrypoint
         entrypoint, is_default = entrypoint
-        return cls(entrypoint=entrypoint, entrypoint_is_default=is_default,
-                   **extra_kwargs)
+        obj = cls(entrypoint=entrypoint, entrypoint_is_default=is_default,
+                  **extra_kwargs)
+        obj.finalize_from_request(facet_config, worklist)
+        return obj
+
+    def finalize_from_request(self, facet_config, worklist):
+        """A hook method invoked on a FacetsWithEntryPoint object immediately
+        after it was instantiated from request data.
+
+        This allows subclasses to do pull additional configuration from
+        request data without having to override class methods.
+        """
+        pass
 
     @classmethod
     def load_entrypoint(cls, name, valid_entrypoints, default=None):

--- a/lane.py
+++ b/lane.py
@@ -238,7 +238,6 @@ class FacetsWithEntryPoint(BaseFacets):
             default_entrypoint, **extra_kwargs
         )
 
-
     @classmethod
     def _from_request(
             cls, facet_config, get_argument, get_header, worklist,
@@ -348,12 +347,26 @@ class Facets(FacetsWithEntryPoint):
 
     @classmethod
     def available_facets(cls, config, facet_group_name):
-        """Which facets are enabled for the given facet group?"""
+        """Which facets are enabled for the given facet group?
+
+        You can override this to forcible enable or disable facets
+        that might not be enabled in library configuration, but you
+        can't make up totally new facets.
+
+        TODO: This sytem would make more sense if you _could_ make up
+        totally new facets, maybe because each facet was represented
+        as a policy object rather than a key to code implemented
+        elsewhere in this class. Right now this method implies more
+        flexibility than actually exists.
+        """
         return config.enabled_facets(facet_group_name)
 
     @classmethod
     def default_facet(cls, config, facet_group_name):
-        """The default value for the given facet group."""
+        """The default value for the given facet group.
+
+        The default value must be one of the values returned by available_facets() above.
+        """
         return config.default_facet(facet_group_name)
 
     @classmethod

--- a/opds.py
+++ b/opds.py
@@ -703,6 +703,12 @@ class AcquisitionFeed(OPDSFeed):
             search_engine=search_engine, debug=search_debug
         )
 
+        if not isinstance(works, list):
+            # It's possible that works() returned a database query or
+            # other generator-like object, but at this point we want
+            # an actual list of Work objects.
+            works = [x for x in works]
+
         if not pagination.page_has_loaded:
             # Depending on how the works were obtained,
             # Pagination.page_loaded may or may not have been called

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -82,7 +82,7 @@ class TestExternalSearch(ExternalSearchTest):
         # Normally, load() returns a brand new ExternalSearchIndex
         # object.
         loaded = ExternalSearchIndex.load(self._db, in_testing=True)
-        assert isinstance(ExternalSearchIndex, loaded)
+        assert isinstance(loaded, ExternalSearchIndex)
 
         # However, inside the mock_search_index context manager,
         # load() returns whatever object was mocked.
@@ -100,7 +100,7 @@ class TestExternalSearch(ExternalSearchTest):
             def set_works_index_and_alias(self, _db):
                 self.set_works_index_and_alias_called_with = _db
 
-        index = MockIndex(self._db, in_testing=True)
+        index = MockIndex(self._db)
         eq_(self._db, index.set_works_index_and_alias_called_with)
         eq_("test_search_term", index.test_search_term)
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -2649,14 +2649,14 @@ class TestFilter(DatabaseTest):
 
         # When multiple fields are given, they are put at the
         # beginning and any remaining tiebreaker fields are added.
-        f.order=['series_position', 'sort_title', 'some_other_field']
+        f.order=['series_position', 'work_id', 'some_other_field']
         eq_(
             [
                 dict(series_position='asc'),
-                dict(sort_title='asc'),
+                dict(work_id='asc'),
                 dict(some_other_field='asc'),
                 dict(sort_author='asc'),
-                dict(work_id='asc'),
+                dict(sort_title='asc'),
             ],
             f.sort_order
         )
@@ -2676,15 +2676,29 @@ class TestFilter(DatabaseTest):
         # Facets.SORT_ORDER_TO_ELASTICSEARCH_FIELD_NAME.
         used_orders = Facets.SORT_ORDER_TO_ELASTICSEARCH_FIELD_NAME
         added_to_collection = used_orders[Facets.ORDER_ADDED_TO_COLLECTION]
+        series_position = used_orders[Facets.ORDER_SERIES_POSITION]
         for sort_field in used_orders.values():
-            if sort_field == added_to_collection:
-                # This is the complicated case, tested below.
+            if sort_field in (added_to_collection, series_position):
+                # These are complicated cases, tested below.
                 continue
             f.order = sort_field
             first_field = validate_sort_order(f, sort_field)
             eq_({sort_field: 'asc'}, first_field)
 
-        # The only complicated case is when a feed is ordered by date
+        # A slightly more complicated case is when a feed is ordered by
+        # series position -- there the second field is title rather than
+        # author.
+        f.order = series_position
+        eq_(
+            [
+                {x:'asc'} for x in [
+                    'series_position', 'sort_title', 'sort_author', 'work_id'
+                ]
+            ],
+            f.sort_order
+        )
+
+        # A more complicated case is when a feed is ordered by date
         # added to the collection. This requires an aggregate function
         # and potentially a nested filter.
         f.order = added_to_collection

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -140,9 +140,8 @@ class TestFacetsWithEntryPoint(DatabaseTest):
         eq_(expect, result)
 
     def test__from_request(self):
-        # _from_request calls load_entrypoint(), instantiates the
-        # class with the result, and calls finalize_from_request to
-        # complete setup.
+        # _from_request calls load_entrypoint() and instantiates the
+        # class with the result.
 
         # Mock load_entrypoint() to return whatever value we have set up
         # ahead of time.
@@ -158,11 +157,6 @@ class TestFacetsWithEntryPoint(DatabaseTest):
             def load_entrypoint(cls, entrypoint_name, entrypoints, default=None):
                 cls.load_entrypoint_called_with = (entrypoint_name, entrypoints, default)
                 return cls.expect
-
-            def finalize_from_request(self, facet_config, worklist):
-                self.finalize_from_request_called_with = (
-                    facet_config, worklist
-                )
 
         # Mock the functions that pull information out of an HTTP
         # request.

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -91,23 +91,18 @@ class TestFacetsWithEntryPoint(DatabaseTest):
         eq_(qu, ep.called_with)
 
     def test_navigate(self):
-        # navigate creates a new FacetsWithEntryPoint and calls
-        # finalize_navigate() to complete any setup.
-
-        class MockFacetsWithEntryPoint(FacetsWithEntryPoint):
-            def finalize_navigate(self, old_facets):
-                self.finalize_navigate_called_with = old_facets
+        # navigate creates a new FacetsWithEntryPoint.
 
         old_entrypoint = object()
         kwargs = dict(extra_key="extra_value")
-        facets = MockFacetsWithEntryPoint(
+        facets = FacetsWithEntryPoint(
             old_entrypoint, entrypoint_is_default=True, **kwargs
         )
         new_entrypoint = object()
         new_facets = facets.navigate(new_entrypoint)
 
-        # A new MockFacetsWithEntryPoint was created.
-        assert isinstance(new_facets, MockFacetsWithEntryPoint)
+        # A new FacetsWithEntryPoint was created.
+        assert isinstance(new_facets, FacetsWithEntryPoint)
 
         # It has the new entry point.
         eq_(new_entrypoint, new_facets.entrypoint)
@@ -119,10 +114,6 @@ class TestFacetsWithEntryPoint(DatabaseTest):
         # The keyword arguments used to create the original faceting
         # object were propagated to its constructor.
         eq_(kwargs, new_facets.constructor_kwargs)
-
-        # The original faceting object was passed into finalize_navigate()
-        # to perform any class-specific setup.
-        eq_(facets, new_facets.finalize_navigate_called_with)
 
     def test_from_request(self):
         # from_request just calls the _from_request class method
@@ -226,10 +217,6 @@ class TestFacetsWithEntryPoint(DatabaseTest):
         )
         eq_(dict(extra="extra kwarg"), facets.constructor_kwargs)
         eq_(MockFacetsWithEntryPoint.selectable_entrypoints_called_with, config)
-
-        # finalize_from_request was given the current facet configuration
-        # and the active worklist.
-        eq_((config, mock_worklist), facets.finalize_from_request_called_with)
 
     def test_load_entrypoint(self):
         audio = AudiobooksEntryPoint
@@ -1648,7 +1635,7 @@ class TestWorkList(DatabaseTest):
         """
         class MockWorkList(WorkList):
 
-            def featured_works(self, _db, facets):
+            def works(self, _db, facets):
                 self.featured_called_with = facets
                 return []
 
@@ -3696,7 +3683,7 @@ class TestWorkListGroups(DatabaseTest):
             def __init__(self, mock_works):
                 self.mock_works = mock_works
 
-            def works_from_search_index(self, _db, facets, pagination, *args, **kwargs):
+            def works(self, _db, facets, pagination, *args, **kwargs):
                 self.called_with = [_db, facets, pagination]
                 return [self.mock_works]
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -636,9 +636,7 @@ class TestFacets(DatabaseTest):
     def test_from_request_gets_available_facets_through_hook_methods(self):
         # Available and default facets are determined by calling the
         # available_facets() and default_facets() methods. This gives
-        # subclasses a chance to add extra facets or change defaults,
-        # so long as those extras are allowed by the library
-        # configuration.
+        # subclasses a chance to add extra facets or change defaults.
         class Mock(Facets):
             available_facets_calls = []
             default_facet_calls = []

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1481,8 +1481,11 @@ class TestWorkList(DatabaseTest):
         child = WorkList()
         parent = Mock()
         parent.initialize(self._default_library, children=[child])
-        eq_([child], parent.children)
         eq_([child], parent.append_child_calls)
+
+        # They do end up in WorkList.children, since that's what the
+        # default append_child() implementation does.
+        eq_([child], parent.children)
 
     def test_top_level_for_library(self):
         """Test the ability to generate a top-level WorkList."""

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1468,6 +1468,22 @@ class TestWorkList(DatabaseTest):
         eq_(set(wl.genre_ids),
             set([x.id for x in [sf, romance]]))
 
+    def test_initialize_uses_append_child_hook_method(self):
+        # When a WorkList is initialized with children, the children
+        # are passed individually through the append_child() hook
+        # method, not simply set to WorkList.children.
+        class Mock(WorkList):
+            append_child_calls = []
+            def append_child(self, child):
+                self.append_child_calls.append(child)
+                return super(Mock, self).append_child(child)
+
+        child = WorkList()
+        parent = Mock()
+        parent.initialize(self._default_library, children=[child])
+        eq_([child], parent.children)
+        eq_([child], parent.append_child_calls)
+
     def test_top_level_for_library(self):
         """Test the ability to generate a top-level WorkList."""
         # These two top-level lanes should be children of the WorkList.


### PR DESCRIPTION
This is a helper branch in service of https://jira.nypl.org/browse/SIMPLY-1982.

In my circulation branch, I'm trying to take redundant code out of the `FeaturedSeriesFacets` and `SeriesLane` classes and the controller that uses them, making them work more like regular `Facets` and `WorkList` objects and making the controller work more like a normal OPDS feed generation controller.

The simplest way to do this is to add a number of hook methods to `Facets` and `WorkList`, which do nothing special by default, but which the series-specific code can override to plug in extra behavior:

* `FacetsWithEntryPoint.finalize_navigate` is called after navigating from one faceting object to another. In my `SeriesFacets` class, this is used to propagate the series between `SeriesFacets` objects.
* `FacetsWithEntryPoint.finalize_from_request` is called after instantiating a faceting object from request data. In `SeriesFacets`, this is where the series -- an extra bit of data -- is pulled from the request.
* `Facets.available_facets` and `Facets.default_facet` are class methods that let a subclass enable or disable facets for a given facet group, overriding the library's configuration. `SeriesFacets` uses this to add the option to sort a list by series position, and to make this option the default.
* `WorkList.append_child` is used to give a `WorkList` subclass the chance to modify its child `WorkList`s as they come in. In circulation, we can create a `RelatedBooksLane` for a specific book. This `WorkList` has children for different ways in which other books might be related to this one: `ContributorLane`, `SeriesLane`, `RecommendationLane`. We want the language and audience of the original book to put restrictions on all the child lanes. Extending `RelatedBooksLane.append_child` makes it easy to put that logic in `RelatedBooksLane` instead of duplicating it in every class that might be used as a child of such a `WorkList`.

The number of hook methods I had to add makes me think the whole faceting system needs to be redone. We can tackle this as part of our OPDS 2 work.

There are two other changes in this branch which are not hook methods:

1. When a feed is ordered by "series position", it's now ordered by series position _and then title_. Previously it was ordered by series position _and then author_. This ordering seemed random for series like "For Dummies", where there is no ordering and each book has a different author. Theoretically, it can also help for series like "Best Science Fiction", where the series position is implicit in the title as a year.
2. I added a context manager that lets you mock the search engine implementation used by `Lane.works_from_search_index`. This way you can test code that calls `works_from_search_index` (e.g. to generate an OPDS feed) without having to pass in the search engine through many layers of method calls. With this in place, we might be able to completely get rid of the `search_engine` arguments in  `works_for_search_index` and the methods that call it. But we might also be using this to improve performance by reusing search engine objects -- I'm not sure.