### PR TITLE
Added a hack to re-associate lanes with a database session after they're disconnected.

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -581,7 +581,7 @@ class AcquisitionFeed(OPDSFeed):
                 if usable:
                     return cached.content
             works_and_lanes = lane.groups(
-                _db, facets=facets, search_engine=search_engine,
+                _db=_db, facets=facets, search_engine=search_engine,
                 debug=search_debug
             )
 


### PR DESCRIPTION
Changes in https://github.com/NYPL-Simplified/circulation/pull/1243/ exposed what I think is a preexisting problem. We know that when you run one of the circ manager's `CacheOPDSGroupFeedPerLane` scripts, all the `Lane` objects get disconnected from their original database session as soon as the app server starts up. So we added a hack to, e.g. `WorkList.groups()` that merges each lane back into the current database session.

Apparently, by the time the app server starts up, each lane also has a cached value for `.parent`. When the app server starts up, those cached values are _also_ disconnected from their database session. When we try to access `Lane.hierarchy` after the app server starts up, we end up using those cached values, and we're back to trying to do stuff to `Lane` objects that aren't connected to the session.

This wasn't a problem before because the process of making OPDS feeds for a Lane didn't, apparently, involve looking at `Lane.parent`. Now it does look at `Lane.parent` while it's building the `Filter` for the search engine.

This branch extends the hack to `Lane.hierarchy` so that all outgoing `Lane`s are associated with the correct database session.

I would prefer to fix the underlying problem, but I don't know why that disconnect happens. I'll look into it a bit.