### PR TITLE
When searching for works, return search results annotated with the original Elasticsearch Hit objects

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -2387,6 +2387,10 @@ class WorkSearchResult(object):
     This object acts just like a Work (though isinstance(x, Work) will
     fail), with one exception: you can access the raw ElasticSearch Hit
     result as ._hit.
+
+    This is useful when a Work needs to be 'tagged' with information
+    obtained through Elasticsearch, such as its 'last modified' date
+    the context of a specific lane.
     """
     def __init__(self, work, hit):
         self._work = work

--- a/external_search.py
+++ b/external_search.py
@@ -1655,6 +1655,7 @@ class Filter(SearchBase):
         fiction = inherit_one('fiction')
         audiences = inherit_one('audiences')
         target_age = inherit_one('target_age')
+        collections = inherit_one('collection_ids') or library
 
         # For genre IDs and CustomList IDs, we might get a separate
         # set of restrictions from every item in the WorkList hierarchy.
@@ -1671,13 +1672,16 @@ class Filter(SearchBase):
         excluded_audiobook_data_sources = [
             DataSource.lookup(_db, x) for x in excluded
         ]
-
+        if library is None:
+            allow_holds = True
+        else:
+            allow_holds = library.allow_holds
         return cls(
-            library, media, languages, fiction, audiences,
+            collections, media, languages, fiction, audiences,
             target_age, genre_id_restrictions, customlist_id_restrictions,
             facets,
             excluded_audiobook_data_sources=excluded_audiobook_data_sources,
-            allow_holds=library.allow_holds,
+            allow_holds=allow_holds,
         )
 
 

--- a/external_search.py
+++ b/external_search.py
@@ -186,7 +186,7 @@ class ExternalSearchIndex(HasSelfTests):
         if not url or not works_index:
             integration = self.search_integration(_db)
             if not integration:
-               raise CannotLoadConfiguration(
+                raise CannotLoadConfiguration(
                     "No Elasticsearch integration configured."
                 )
             url = url or integration.url

--- a/external_search.py
+++ b/external_search.py
@@ -2451,14 +2451,13 @@ class MockExternalSearchIndex(ExternalSearchIndex):
             stop = start_at + pagination.size
             docs = docs[start_at:stop]
 
-        results = docs
+        results = [
+            MockSearchResult("title", "author", {}, x['_id'])
+            for x in docs
+        ]
 
         if pagination:
-            result_objs = [
-                MockSearchResult("title", "author", {}, x['_id'])
-                for x in docs
-            ]
-            pagination.page_loaded(result_objs)
+            pagination.page_loaded(results)
         return results
 
 
@@ -2483,6 +2482,7 @@ class MockSearchResult(object):
         meta["id"] = id
         meta["_sort"] = [title, author, id]
         self.meta = MockMeta(meta)
+        self.work_id = id
 
     def to_dict(self):
         return {

--- a/external_search.py
+++ b/external_search.py
@@ -440,10 +440,10 @@ return champion;
             # results we do get.
             fields = ['*']
         else:
-            # All we absolutely need is the document ID, which is a
+            # All we absolutely need is the work ID, which is a
             # key into the database, plus the values of any script fields,
             # which represent data not available through the database.
-            fields = ["_id"]
+            fields = ["work_id"]
             if filter:
                 fields += filter.script_fields.keys()
 
@@ -1282,7 +1282,7 @@ class Query(SearchBase):
 
             # Add any necessary script fields.
             script_fields = self.filter.script_fields
-            if script_fields and False:
+            if script_fields:
                 search = search.script_fields(**script_fields)
         # Apply any necessary query restrictions imposed by the
         # Pagination object. This may happen through modification or
@@ -2386,14 +2386,14 @@ class WorkSearchResult(object):
 
     This object acts just like a Work (though isinstance(x, Work) will
     fail), with one exception: you can access the raw ElasticSearch Hit
-    result as .hit.
+    result as ._hit.
     """
     def __init__(self, work, hit):
-        self.work = work
-        self.hit = hit
+        self._work = work
+        self._hit = hit
 
     def __getattr__(self, k):
-        return getattr(self.work, k)
+        return getattr(self._work, k)
 
 
 class MockExternalSearchIndex(ExternalSearchIndex):

--- a/external_search.py
+++ b/external_search.py
@@ -2174,11 +2174,6 @@ class Filter(SearchBase):
             ),
         )
 
-
-        # Configure the script and its parameters for use by
-        # Elasticsearch.
-        return { "last_update": {"order": self.asc, } }
-
     @property
     def target_age_filter(self):
         """Helper method to generate the target age subfilter.

--- a/facets.py
+++ b/facets.py
@@ -53,6 +53,12 @@ class FacetConstants(object):
     ORDER_ASCENDING = "asc"
     ORDER_DESCENDING = "desc"
 
+    # Most facets should be ordered in ascending order by default (A>-Z), but
+    # these dates should be ordered descending by default (new->old).
+    ORDER_DESCENDING_BY_DEFAULT = [
+        self.ORDER_ADDED_TO_COLLECTION, self.ORDER_LAST_UPDATE
+    ]
+
     FACETS_BY_GROUP = {
         COLLECTION_FACET_GROUP_NAME: COLLECTION_FACETS,
         AVAILABILITY_FACET_GROUP_NAME: AVAILABILITY_FACETS,

--- a/facets.py
+++ b/facets.py
@@ -56,7 +56,7 @@ class FacetConstants(object):
     # Most facets should be ordered in ascending order by default (A>-Z), but
     # these dates should be ordered descending by default (new->old).
     ORDER_DESCENDING_BY_DEFAULT = [
-        self.ORDER_ADDED_TO_COLLECTION, self.ORDER_LAST_UPDATE
+        ORDER_ADDED_TO_COLLECTION, ORDER_LAST_UPDATE
     ]
 
     FACETS_BY_GROUP = {

--- a/lane.py
+++ b/lane.py
@@ -944,6 +944,7 @@ class Pagination(object):
     DEFAULT_SIZE = 50
     DEFAULT_SEARCH_SIZE = 10
     DEFAULT_FEATURED_SIZE = 10
+    DEFAULT_CRAWLABLE_SIZE = 100
 
     @classmethod
     def default(cls):
@@ -1409,7 +1410,7 @@ class WorkList(object):
             yield work, worklist
 
     def default_featured_facets(self, _db):
-        """Helper method to create a FeaturedFacets object."""
+        """DEPRECATED - Used only in a deprecated method."""
         library = self.get_library(_db)
         return FeaturedFacets(
             minimum_featured_quality=library.minimum_featured_quality,

--- a/lane.py
+++ b/lane.py
@@ -1563,7 +1563,6 @@ class WorkList(object):
             query_string=None, filter=filter, pagination=pagination,
             debug=debug
         )
-        set_trace()
         return self.works_for_specific_ids(_db, work_ids, Work)
 
     def works_for_specific_ids(self, _db, hits, work_model=mw):

--- a/lane.py
+++ b/lane.py
@@ -1963,7 +1963,7 @@ class WorkList(object):
         from external_search import Filter
         filter = Filter.from_worklist(_db, self, facets)
         try:
-            work_ids = search_client.query_works(
+            hits = search_client.query_works(
                 query, filter, pagination, debug
             )
         except elasticsearch.exceptions.ElasticsearchException, e:
@@ -1971,8 +1971,8 @@ class WorkList(object):
                 "Problem communicating with ElasticSearch. Returning empty list of search results.",
                 exc_info=e
             )
-        if work_ids:
-            results = self.works_for_specific_ids(_db, work_ids, Work)
+        if hits:
+            results = self.works_for_hits(_db, hits, Work)
 
         return results
 

--- a/lane.py
+++ b/lane.py
@@ -1558,15 +1558,15 @@ class WorkList(object):
         )
         search_engine = search_engine or ExternalSearchIndex.load(_db)
         filter = Filter.from_worklist(_db, self, facets)
-        work_ids = search_engine.query_works(
+        hits = search_engine.query_works(
             query_string=None, filter=filter, pagination=pagination,
             debug=debug
         )
-        return self.works_for_specific_ids(_db, work_ids, Work)
+        return self.works_for_hits(_db, hits, Work)
 
-    def works_for_specific_ids(self, _db, hits, work_model=mw):
+    def works_for_hits(self, _db, hits, work_model=mw):
         """Create the appearance of having called works(), but return the
-        specific MaterializedWorks or Works identified by `work_ids`.
+        specific MaterializedWorks or Works identified by `hits`.
 
         :param _db: A database connection
         :param hits: A list of Hit objects from ElasticSearch.

--- a/lane.py
+++ b/lane.py
@@ -406,12 +406,6 @@ class Facets(FacetsWithEntryPoint):
         a per-library basis.
         """
         super(Facets, self).__init__(entrypoint, entrypoint_is_default)
-        if order_ascending is None:
-            if order == self.ORDER_ADDED_TO_COLLECTION:
-                order_ascending = self.ORDER_DESCENDING
-            else:
-                order_ascending = self.ORDER_ASCENDING
-
         collection = collection or self.default_facet(
             library, self.COLLECTION_FACET_GROUP_NAME
         )
@@ -419,6 +413,11 @@ class Facets(FacetsWithEntryPoint):
             library, self.AVAILABILITY_FACET_GROUP_NAME
         )
         order = order or self.default_facet(library, self.ORDER_FACET_GROUP_NAME)
+        if order_ascending is None:
+            if order in Facets.ORDER_DESCENDING_BY_DEFAULT:
+                order_ascending = self.ORDER_DESCENDING
+            else:
+                order_ascending = self.ORDER_ASCENDING
 
         if (availability == self.AVAILABLE_ALL and (library and not library.allow_holds)
             and (self.AVAILABLE_NOW in self.available_facets(library, self.AVAILABILITY_FACET_GROUP_NAME))):

--- a/opds.py
+++ b/opds.py
@@ -162,7 +162,9 @@ class Annotator(object):
                 title=unicode(group_title)
             )
 
-        # TODO: maybe we can do better than this in calculating updated()
+        # NOTE: This is a default that works in most cases. When
+        # ordering ElasticSearch results by last update time, you get
+        # a more reliable value that you can use instead.
         if not updated and work.last_update_time:
             updated = work.last_update_time
         if updated:
@@ -819,7 +821,7 @@ class AcquisitionFeed(OPDSFeed):
                 url_generator, entrypoint, selected_entrypoint, is_default,
                 group_name
             )
-            if link:
+            if link is not None:
                 cls.add_link_to_feed(feed.feed, **link)
                 is_default = False
 

--- a/opds.py
+++ b/opds.py
@@ -162,10 +162,11 @@ class Annotator(object):
                 title=unicode(group_title)
             )
 
-        # NOTE: This is a default that works in most cases. When
-        # ordering ElasticSearch results by last update time, you get
-        # a more reliable value that you can use instead.
         if not updated and work.last_update_time:
+            # NOTE: This is a default that works in most cases. When
+            # ordering ElasticSearch results by last update time,
+            # `work` is a WorkSearchResult object containing a more
+            # reliable value that you can use if you want.
             updated = work.last_update_time
         if updated:
             entry.extend([AtomFeed.updated(AtomFeed._strftime(updated))])

--- a/testing.py
+++ b/testing.py
@@ -1082,10 +1082,7 @@ class EndToEndSearchTest(ExternalSearchTest):
         raise NotImplementedError()
 
     def _assert_works(self, description, expect, actual, should_be_ordered=True):
-        # Verify that two lists of works are the same.
-        if not should_be_ordered:
-            expect = set(expect)
-            actual = set(actual)
+        "Verify that two lists of works are the same."
 
         # Get the titles of the works that were actually returned, to
         # make comparisons easier.
@@ -1101,8 +1098,16 @@ class EndToEndSearchTest(ExternalSearchTest):
             expect_titles.append(work.title)
             expect_ids.append(work.id)
 
+        # We compare IDs rather than objects because the Works may
+        # actually be WorkSearchResults.
+        expect_compare = expect_ids
+        actual_compare = actual_ids
+        if not should_be_ordered:
+            expect_compare = set(expect_compare)
+            actual_compare = set(actual_compare)
+
         eq_(
-            expect, actual,
+            expect_compare, actual_compare,
             "%r did not find %d works\n (%s/%s).\nInstead found %d\n (%s/%s)" % (
                 description,
                 len(expect), ", ".join(map(str, expect_ids)),

--- a/testing.py
+++ b/testing.py
@@ -1127,7 +1127,8 @@ class EndToEndSearchTest(ExternalSearchTest):
 
         should_be_ordered = kwargs.pop('ordered', True)
 
-        results = self.search.query_works(*query_args, debug=True, **kwargs)
+        hits = self.search.query_works(*query_args, debug=True, **kwargs)
+        results = [x.work_id for x in hits]
         actual = self._db.query(Work).filter(Work.id.in_(results)).all()
         if should_be_ordered:
             # Put the Work objects in the same order as the IDs returned

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -2968,25 +2968,19 @@ class TestFilter(DatabaseTest):
         script = sort.pop('script')
         eq_({}, sort)
 
-        # The script is written in the Painless language.
-        eq_('painless', script.pop('lang'))
+        # The script is the 'simplified.work_last_update' stored script.
+        eq_('simplified.work_last_update', script.pop('stored'))
 
         # Two parameters are passed into the script -- the IDs of the
         # collections and the lists relevant to the query. This is so
         # the query knows which updates should actually be considered
         # for purposes of this query.
         params = script.pop('params')
+        eq_({}, script)
+
         eq_([self._default_collection.id], params.pop('collection_ids'))
         eq_([1,2], params.pop('list_ids'))
         eq_({}, params)
-
-        # The script is written in another programming language, so we
-        # can only verify its functionality during an end-to-end test,
-        # which happens in TestSearchOrder.
-        source = script.pop('source')
-        assert 'return champion;' in source
-
-        eq_({}, script)
 
     def test_target_age_filter(self):
         # Test an especially complex subfilter.

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -710,7 +710,7 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
         # There are a number of results, but the top one is a presidential
         # biography for 8-year-olds.
         eq_(5, len(results))
-        eq_(self.obama.id, results[0])
+        eq_(self.obama.id, results[0].work_id)
 
         # Now we'll test filters.
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -94,8 +94,8 @@ class TestExternalSearch(ExternalSearchTest):
         # The configuration of the search ExternalIntegration becomes the
         # configuration of the ExternalSearchIndex.
         #
-        # This basically just verifies that the test search term is taken
-        # from the ExternalIntegration.
+        # This basically just verifies that the test search term is
+        # taken from the ExternalIntegration.
         class MockIndex(ExternalSearchIndex):
             def set_works_index_and_alias(self, _db):
                 self.set_works_index_and_alias_called_with = _db
@@ -103,6 +103,9 @@ class TestExternalSearch(ExternalSearchTest):
         index = MockIndex(self._db)
         eq_(self._db, index.set_works_index_and_alias_called_with)
         eq_("test_search_term", index.test_search_term)
+
+    # TODO: would be good to check the put_script calls, but the
+    # current constructor makes put_script difficult to mock.
 
     def test_elasticsearch_error_in_constructor_becomes_cannotloadconfiguration(self):
         """If we're unable to establish a connection to the Elasticsearch

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -511,6 +511,36 @@ class TestFacets(DatabaseTest):
         actual = order(Facets.ORDER_ADDED_TO_COLLECTION, None)
         compare(expect, actual)
 
+        expect = [m.availability_time.desc(), m.sort_author.asc(), m.sort_title.asc(), m.works_id.asc()]
+        actual = order(Facets.ORDER_LAST_UPDATE, None)
+        set_trace()
+        compare(expect, actual)
+
+    def test_default_order_ascending(self):
+
+        # Most fields are ordered ascending by default (A-Z).
+        for order in (Facets.ORDER_TITLE, Facets.ORDER_RANDOM):
+            f = Facets(
+                self._default_library,
+                collection=Facets.COLLECTION_FULL,
+                availability=Facets.AVAILABLE_ALL,
+                order=order
+            )
+            eq_(True, f.order_ascending)
+
+        # But the time-based facets are ordered descending by default
+        # (newest->oldest)
+        eq_(set([Facets.ORDER_ADDED_TO_COLLECTION, Facets.ORDER_LAST_UPDATE]),
+            set(Facets.ORDER_DESCENDING_BY_DEFAULT))
+        for order in Facets.ORDER_DESCENDING_BY_DEFAULT:
+            f = Facets(
+                self._default_library,
+                collection=Facets.COLLECTION_FULL,
+                availability=Facets.AVAILABLE_ALL,
+                order=order
+            )
+            eq_(False, f.order_ascending)
+
     def test_navigate(self):
         """Test the ability of navigate() to move between slight
         variations of a FeaturedFacets object.

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -512,10 +512,6 @@ class TestFacets(DatabaseTest):
         actual = order(Facets.ORDER_ADDED_TO_COLLECTION, None)
         compare(expect, actual)
 
-        expect = [m.availability_time.desc(), m.sort_author.asc(), m.sort_title.asc(), m.works_id.asc()]
-        actual = order(Facets.ORDER_LAST_UPDATE, None)
-        compare(expect, actual)
-
     def test_default_order_ascending(self):
 
         # Most fields are ordered ascending by default (A-Z).

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -32,6 +32,7 @@ from ..entrypoint import (
 from ..external_search import (
     Filter,
     MockExternalSearchIndex,
+    WorkSearchResult,
 )
 
 from ..lane import (
@@ -1807,8 +1808,8 @@ class TestWorkList(DatabaseTest):
         eq_(facets, wl.apply_filters_called_with)
 
     def test_works_from_search_index(self):
-        """Test the method that uses the search index to fetch a list of Works
-        appropriate for a given WorkList.
+        """Test the method that uses the search index to fetch a list of
+        results appropriate for a given WorkList.
         """
 
         class MockSearchClient(object):
@@ -1819,9 +1820,10 @@ class TestWorkList(DatabaseTest):
                 return self.fake_work_ids
 
         class MockWorkList(WorkList):
-            """Mock the process of turning work IDs into Work objects."""
+            """Mock the process of turning work IDs into WorkSearchResult
+            objects."""
             fake_work_list = "a list of works"
-            def works_for_specific_ids(self, _db, work_ids, work_model):
+            def works_for_hits(self, _db, work_ids, work_model):
                 self.called_with = (_db, work_ids, work_model)
                 return self.fake_work_list
 
@@ -1861,63 +1863,90 @@ class TestWorkList(DatabaseTest):
         )
 
         # The fake work IDs returned from query_works() were passed into
-        # works_for_specific_ids().
+        # works_for_hits().
         eq_(
             (self._db, search_client.fake_work_ids, Work),
             wl.called_with
         )
 
-        # And the fake return value of works_for_specific_ids() was
+        # And the fake return value of works_for_hits() was
         # used as the return value of works_from_search_index(), the
         # method we're testing.
         eq_(wl.fake_work_list, result)
 
-    def test_works_for_specific_ids(self):
+    def test_works_for_hits(self):
+        # Verify that WorkList.works_for_hits turns (mocked) Hit objects
+        # into WorkSearchResults.
+
         # Create two works.
         w1 = self._work(with_license_pool=True)
         w2 = self._work(with_license_pool=True)
 
-        # Right now, works_for_specific_ids won't return anything,
+        class MockHit(object):
+            def __init__(self, work_id):
+                if isinstance(work_id, Work):
+                    self.work_id=work_id.id
+                else:
+                    self.work_id=work_id
+
+        hit1 = MockHit(w1)
+        hit2 = MockHit(w2)
+        hits_for_works = { w1 : hit1,
+                           w2 : hit2}
+
+        # Right now, works_for_hits won't return anything,
         # because the works aren't in the materialized view.
         wl = WorkList()
         wl.initialize(self._default_library)
-        eq_([], wl.works_for_specific_ids(self._db, [w2.id]))
+        eq_([], wl.works_for_hits(self._db, [hit2]))
 
         # We can get results by telling it to use Work as the work model
         # instead.
-        eq_([w2], wl.works_for_specific_ids(self._db, [w2.id], Work))
+        def matches(works, *args):
+            # Verify that:
+            # * works_for_hits(*args) returns a bunch of WorkSearchResults
+            # * The Works associated with those WorkSearchResults are
+            #   the ones in `works`.
+            # * The result for each Work is also associated with the
+            #   corresponding MockHit from the hits_for_works
+            #   dictionary defined earlier in the test.
+            actual = wl.works_for_hits(self._db, *args)
+            for i, result in enumerate(actual):
+                assert isinstance(result, WorkSearchResult)
+                eq_(result._work, works[i])
+                eq_(hits_for_works[result._work], result._hit)
+
+        matches([w2], [hit2], Work)
 
         # Works are returned in the order we ask for.
-        for ordering in ([w1, w2], [w2, w1]):
-            ids = [x.id for x in ordering]
-            eq_(ordering, wl.works_for_specific_ids(self._db, ids, Work))
+        matches([w1, w2], [hit1, hit2], Work)
+        matches([w2, w1], [hit2, hit1], Work)
 
         # If we ask for a work ID that's not in the materialized view,
         # we don't get it.
-        eq_([], wl.works_for_specific_ids(self._db, [-100], Work))
+        eq_([], wl.works_for_hits(self._db, [MockHit(-100)], Work))
 
         # Now add the works to the materialized view, and verify that
-        # similar tests pass when works_for_specific_ids is told to
+        # similar tests pass when works_for_hits is told to
         # look for MaterializedWork objects (this is the default).
         self.add_to_materialized_view([w1, w2])
 
         # If we ask for w2 only, we get (the materialized view's
         # version of) w2 only.
-        [w2_mv] = wl.works_for_specific_ids(self._db, [w2.id])
+        [w2_mv] = wl.works_for_hits(self._db, [hit2])
         eq_(w2_mv.sort_title, w2.sort_title)
 
         # Works are returned in the order we ask for.
-        for ordering in ([w1, w2], [w2, w1]):
-            ids = [x.id for x in ordering]
-            mv_works = wl.works_for_specific_ids(self._db, ids)
-            eq_(ids, [x.works_id for x in mv_works])
+        for ordering in ([hit1, hit2], [hit2, hit1]):
+            mv_works = wl.works_for_hits(self._db, ordering)
+            eq_([x.work_id for x in ordering], [x.works_id for x in mv_works])
 
         # Finally, test that undeliverable works are filtered out.
         for lpdm in w2.license_pools[0].delivery_mechanisms:
             self._db.delete(lpdm)
             from ..model import MaterializedWorkWithGenre
             for m in (Work, MaterializedWorkWithGenre):
-                eq_([], wl.works_for_specific_ids(self._db, [w2.id], m))
+                eq_([], wl.works_for_hits(self._db, [hit2], m))
 
     def test_apply_filters(self):
 
@@ -2416,8 +2445,8 @@ class TestWorkList(DatabaseTest):
         # Test the successful execution of WorkList.search()
 
         class MockWorkList(WorkList):
-            def works_for_specific_ids(self, _db, work_ids, work_model):
-                self.works_for_specific_ids_called_with = (_db, work_ids, work_model)
+            def works_for_hits(self, _db, work_ids, work_model):
+                self.works_for_hits_called_with = (_db, work_ids, work_model)
                 return "A bunch of Works"
 
         wl = MockWorkList()
@@ -2438,13 +2467,13 @@ class TestWorkList(DatabaseTest):
         results = wl.search(self._db, query, client)
 
         # The results of query_works were passed into
-        # MockWorkList.works_for_specific_ids.
+        # MockWorkList.works_for_hits.
         eq_(
             (self._db, "A bunch of work IDs", Work),
-            wl.works_for_specific_ids_called_with
+            wl.works_for_hits_called_with
         )
 
-        # The return value of MockWorkList.works_for_specific_ids is
+        # The return value of MockWorkList.works_for_hits is
         # used as the return value of query_works().
         eq_("A bunch of Works", results)
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -514,7 +514,6 @@ class TestFacets(DatabaseTest):
 
         expect = [m.availability_time.desc(), m.sort_author.asc(), m.sort_title.asc(), m.works_id.asc()]
         actual = order(Facets.ORDER_LAST_UPDATE, None)
-        set_trace()
         compare(expect, actual)
 
     def test_default_order_ascending(self):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -991,9 +991,8 @@ class TestOPDS(DatabaseTest):
         eq_(sorted(parsed.entries), sorted(feedparser.parse(raw_page).entries))
 
     def test_page_feed_for_worklist(self):
-        """Test the ability to create a paginated feed of works for a
-        WorkList instead of a Lane.
-        """
+        # Test the ability to create a paginated feed of works for a
+        # WorkList instead of a Lane.
         lane = self.conf
         work1 = self._work(genre=Contemporary_Romance, with_open_access_download=True)
         work2 = self._work(genre=Contemporary_Romance, with_open_access_download=True)


### PR DESCRIPTION
This should complete https://jira.nypl.org/browse/SIMPLY-2048. It makes a number of changes -- two big, a few small -- necessary to support https://jira.nypl.org/browse/SIMPLY-1984 (getting the crawlable lanes from Elasticsearch rather than the materialized view).

The two big changes:

* The script for calculating the last update time of a work (in the context of whatever collections or custom lists are relevant) is now stored in the Elasticsearch server every time a client starts up. (So it's more important than ever not to create a million clients.) Once this script is a stored script with a name, we can use it both to order a list and as the one and only field in `script_fields` -- fields whose values are calculated for each search result and returned as part of the `Hit` object.

* When it's time to look up `Work`s in the database based on the work IDs found in the `Hit` objects, we don't always return the `Work`s. If the `Hit` contains values from script fields, we bundle each `Work` with its `Hit` in a new class called `WorkSearchResult`. These objects defer most attribute access to the underlying `Work`, but the search result data is also available. We only do this when script fields are present, for two reasons: 1) performance, 2) if you think you have a `Work` but you actually have a `WorkSearchResult`, any attempt to modify the supposed `Work` will fail.

Small changes are described inline.