### PR TITLE
Cached list size to improve admin interface performance.

### DIFF
--- a/migration/20190617-add-size-to-customlists.sql
+++ b/migration/20190617-add-size-to-customlists.sql
@@ -1,0 +1,13 @@
+DO $$ 
+    BEGIN
+        BEGIN
+            ALTER TABLE customlists ADD COLUMN size integer not null default 0;
+        EXCEPTION
+            WHEN duplicate_column THEN RAISE NOTICE 'column customlists.size already exists, not creating it.';
+        END;
+        UPDATE customlists SET size = COALESCE(
+            (SELECT subq.c FROM
+                (SELECT list_id AS l, count(*) AS c FROM customlistentries GROUP BY list_id)
+                AS subq WHERE subq.l = customlists.id),
+            0);
+    END $$;

--- a/model/customlist.py
+++ b/model/customlist.py
@@ -44,6 +44,10 @@ class CustomList(Base):
     responsible_party = Column(Unicode)
     library_id = Column(Integer, ForeignKey('libraries.id'), index=True, nullable=True)
 
+    # How many titles are in this list? This is calculated and
+    # cached when the list contents change.
+    size = Column(Integer, nullable=False, default=0)
+
     entries = relationship(
         "CustomListEntry", backref="customlist")
 
@@ -154,6 +158,7 @@ class CustomList(Base):
 
         if was_new:
             self.updated = datetime.datetime.utcnow()
+            self.size += 1
 
         # Make sure the Work's search document is updated to reflect its new
         # list membership.
@@ -179,6 +184,7 @@ class CustomList(Base):
 
         if existing_entries:
             self.updated = datetime.datetime.utcnow()
+            self.size -= len(existing_entries)
         _db.commit()
 
     def entries_for_work(self, work_or_edition):
@@ -214,6 +220,9 @@ class CustomList(Base):
                 clause
             )
         return qu
+
+    def update_size(self):
+        self.size = len(self.entries)
 
 
 class CustomListEntry(Base):

--- a/scripts.py
+++ b/scripts.py
@@ -810,6 +810,18 @@ class LaneSweeperScript(LibraryInputScript):
     def process_lane(self, lane):
         pass
 
+class CustomListSweeperScript(LibraryInputScript):
+    """Do something to each custom list in a library."""
+
+    def process_library(self, library):
+        lists = self._db.query(CustomList).filter(CustomList.library_id==library.id)
+        for l in lists:
+            self.process_custom_list(self, l)
+        self._db.commit()
+
+    def process_custom_list(self, custom_list):
+        pass
+
 
 class SubjectInputScript(Script):
     """A script whose command line filters the set of Subjects.
@@ -3224,6 +3236,9 @@ class ListCollectionMetadataIdentifiersScript(CollectionInputScript):
 
         self.output.write('\n%d collections found.\n' % count)
 
+class UpdateCustomListSizeScript(CustomListSweeperScript):
+    def process_custom_list(self, custom_list):
+        custom_list.update_size()
 
 class MockStdin(object):
     """Mock a list of identifiers passed in on standard input."""


### PR DESCRIPTION
This is an optimization for Open Bookshelf, which uses lists heavily. The admin interface makes a lot of requests that get the sizes of all lists.