### PR TITLE
Make it possible to filter on author identity while searching

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -1779,7 +1779,8 @@ class Filter(SearchBase):
                  genre_restriction_sets=None, customlist_restriction_sets=None,
                  facets=None, script_fields=None, **kwargs
     ):
-        """These minor arguments were made into unnamed keyword arguments to
+        """
+        These minor arguments were made into unnamed keyword arguments to
         avoid cluttering the method signature:
 
         :param excluded_audiobook_data_sources: A list of DataSources that
@@ -1907,7 +1908,7 @@ class Filter(SearchBase):
             nested_filters['licensepools'].append(collection_match)
 
         if self.author is not None:
-            nested_filters['contributors'].append(self.author_match)
+            nested_filters['contributors'].append(self.author_filter)
 
         if self.media:
             f = chain(f, F('terms', medium=scrub_list(self.media)))
@@ -2259,19 +2260,21 @@ class Filter(SearchBase):
         return F('bool', must=clauses)
 
     @property
-    def author_match(self):
-        """Build a query that matches a 'contributors' subdocument only
+    def author_filter(self):
+        """Build a filter that matches a 'contributors' subdocument only
         if it represents an author-level contribution by self.author.
         """
+        if not self.author:
+            return None
         authorship_role = F(
             'terms', **{'contributors.role' : self.AUTHOR_MATCH_ROLES}
         )
         clauses = []
         for field, value in [
-                ('sort_name', self.author.sort_name),
-                ('display_name', self.author.display_name),
-                ('viaf', self.author.viaf),
-                ('lc', self.author.lc)
+            ('sort_name', self.author.sort_name),
+            ('display_name', self.author.display_name),
+            ('viaf', self.author.viaf),
+            ('lc', self.author.lc)
         ]:
             if not value or value == Edition.UNKNOWN_AUTHOR:
                 continue

--- a/external_search.py
+++ b/external_search.py
@@ -1722,8 +1722,8 @@ class Filter(SearchBase):
     # In general, someone looking for things "by this person" is
     # probably looking for one of these roles.
     AUTHOR_MATCH_ROLES = list(Contributor.AUTHOR_ROLES) + [
-        Contributor.EDITOR_ROLE, Contributor.DIRECTOR_ROLE,
-        Contributor.ACTOR_ROLE
+        Contributor.NARRATOR_ROLE, Contributor.EDITOR_ROLE,
+        Contributor.DIRECTOR_ROLE, Contributor.ACTOR_ROLE
     ]
 
     @classmethod

--- a/model/work.py
+++ b/model/work.py
@@ -1490,7 +1490,10 @@ class Work(Base):
         # This subquery gets Contributors, filtered on edition_id.
         contributors = select(
             [Contributor.sort_name,
+             Contributor.display_name,
              Contributor.family_name,
+             Contributor.lc,
+             Contributor.viaf,
              Contribution.role,
             ]
         ).where(

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -804,7 +804,10 @@ class TestWork(DatabaseTest):
 
         # These are the edition's authors.
         [contributor1] = [c.contributor for c in edition.contributions if c.role == Contributor.PRIMARY_AUTHOR_ROLE]
+        contributor1.display_name = self._str
         contributor1.family_name = self._str
+        contributor1.viaf = self._str
+        contributor1.lc = self._str
         [contributor2] = [c.contributor for c in edition.contributions if c.role == Contributor.AUTHOR_ROLE]
 
         data_source = DataSource.lookup(self._db, DataSource.THREEM)
@@ -964,10 +967,22 @@ class TestWork(DatabaseTest):
 
         contributors = search_doc['contributors']
         eq_(2, len(contributors))
+
         [contributor1_doc] = [c for c in contributors if c['sort_name'] == contributor1.sort_name]
         [contributor2_doc] = [c for c in contributors if c['sort_name'] == contributor2.sort_name]
+
+        eq_(contributor1.display_name, contributor1_doc['display_name'])
+        eq_(None, contributor2_doc['display_name'])
+
         eq_(contributor1.family_name, contributor1_doc['family_name'])
         eq_(None, contributor2_doc['family_name'])
+
+        eq_(contributor1.viaf, contributor1_doc['viaf'])
+        eq_(None, contributor2_doc['viaf'])
+
+        eq_(contributor1.lc, contributor1_doc['lc'])
+        eq_(None, contributor2_doc['lc'])
+
         eq_(Contributor.PRIMARY_AUTHOR_ROLE, contributor1_doc['role'])
         eq_(Contributor.AUTHOR_ROLE, contributor2_doc['role'])
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1427,12 +1427,6 @@ class TestContributorFilter(EndToEndSearchTest):
             )
             return
 
-        # Verify that all works were indexed.
-        self._expect_results(
-            self.works + [self.ubik, self.literary_wonderlands],
-            None, None, ordered=False
-        )
-
         # By providing a Contributor object with all the identifiers,
         # we get every work with an author-type contribution from
         # someone who can be identified with that Contributor.

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1401,8 +1401,8 @@ class TestAuthorFilter(EndToEndSearchTest):
         # contributed to the work in an ineligible role, so it will
         # always be filtered out.
         edition, ignore = self._edition(
-            title="Literary Wonderlands", authors=[],
-            with_license_pool=True
+            title="Science Fiction: The Best of the Year (2007 Edition)",
+            authors=[], with_license_pool=True
         )
         contribution, is_new = get_one_or_create(
             self._db, Contribution, edition=edition, contributor=self.full,

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1347,7 +1347,7 @@ class TestSearchOrder(EndToEndSearchTest):
         )
 
 
-class TestContributorFilter(EndToEndSearchTest):
+class TestAuthorFilter(EndToEndSearchTest):
     # Test the various techniques used to find books where a certain
     # person had an authorship role.
 
@@ -1389,8 +1389,7 @@ class TestContributorFilter(EndToEndSearchTest):
             contribution, was_new = get_one_or_create(
                 self._db, Contribution, edition=edition,
                 contributor=contributor,
-                role=roles[0]
-                #role=roles[i % len(roles)]
+                role=roles[i % len(roles)]
             )
             work = self.default_work(
                 presentation_edition=edition,

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -2969,7 +2969,7 @@ class TestFilter(DatabaseTest):
 
         # It's value is the value of .author_filter, which is tested
         # separately in test_author_filter.
-        assert isinstance(filter.author_filter, F)
+        assert isinstance(filter.author_filter, Bool)
         eq_(filter.author_filter, contributor_filter)
 
         # There are no other nested filters.
@@ -3235,23 +3235,27 @@ class TestFilter(DatabaseTest):
             )
             eq_(expect, actual)
 
-        # You can apply the filter on any one of these four fields.
+        # You can apply the filter on any one of these four fields,
+        # using a Contributor or a ContributorData
         for field in ('sort_name', 'display_name', 'viaf', 'lc'):
-            contributor = ContributorData(**{field:"value"})
-            check_filter(contributor, {"contributors.%s" % field: "value"})
+            for cls in Contributor, ContributorData:
+                contributor = cls(**{field:"value"})
+                check_filter(contributor, {"contributors.%s" % field: "value"})
 
-        # Or a combination of these fields.
-        contributor = Contributor(
-            display_name='Ann Leckie', sort_name='Leckie, Ann', viaf="73520345",
-            lc="n2013008575"
-        )
-        check_filter(
-            contributor,
-            {"contributors.sort_name": contributor.sort_name},
-            {"contributors.display_name": contributor.display_name},
-            {"contributors.viaf": contributor.viaf},
-            {"contributors.lc": contributor.lc},
-        )
+        # You can also apply the filter using a combination of these
+        # fields.  At least one of the provided fields must match.
+        for cls in Contributor, ContributorData:
+            contributor = cls(
+                display_name='Ann Leckie', sort_name='Leckie, Ann',
+                viaf="73520345", lc="n2013008575"
+            )
+            check_filter(
+                contributor,
+                {"contributors.sort_name": contributor.sort_name},
+                {"contributors.display_name": contributor.display_name},
+                {"contributors.viaf": contributor.viaf},
+                {"contributors.lc": contributor.lc},
+            )
 
         # If an author's name is Edition.UNKNOWN_AUTHOR, matches
         # against that field are not counted; otherwise all works with


### PR DESCRIPTION
This completes https://jira.nypl.org/browse/SIMPLY-1985, the core portion of https://jira.nypl.org/browse/SIMPLY-1983.

This branch adds some fields to the 'contributors' subdocument indexed as part of a Work's ElasticSearch document. It also adds a subdocument definition for 'contributors' to the document body definition, so that the document is indexed _as_ a subdocument and not as a bunch of unrelated fields. This lets us create nested filters based on the 'contributors' subdocument, to find only those works whose contributors meet certain criteria.

This functionality is exposed when you pass an `author` into the `Filter` constructor. The `author` can be a `Contributor` or `ContributorData`, and the `Filter` will restrict the query to works with that individual listed in an author-type role.

A month ago I was afraid of doing this, but other ElasticSearch stuff I've done since then was a lot worse, so it was pretty easy.