### PR TITLE
Add a lookup method to ContributorData which performs basic data remediation

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -176,6 +176,7 @@ class SubjectData(object):
 
 
 class ContributorData(object):
+
     def __init__(self, sort_name=None, display_name=None,
                  family_name=None, wikipedia_name=None, roles=None,
                  lc=None, viaf=None, biography=None, aliases=None, extra=None):
@@ -183,7 +184,8 @@ class ContributorData(object):
         self.display_name = display_name
         self.family_name = family_name
         self.wikipedia_name = wikipedia_name
-        roles = roles or Contributor.AUTHOR_ROLE
+        if roles is None:
+            roles = Contributor.AUTHOR_ROLE
         if not isinstance(roles, list):
             roles = [roles]
         self.roles = roles

--- a/opds.py
+++ b/opds.py
@@ -316,7 +316,7 @@ class Annotator(object):
         return [AtomFeed.author(AtomFeed.name(""))]
 
     @classmethod
-    def contributor_tag(self, contribution, state=None):
+    def contributor_tag(self, contribution):
         """Build an <author> or <contributor> tag for a Contribution.
 
         :param contribution: A Contribution.

--- a/opds.py
+++ b/opds.py
@@ -320,6 +320,10 @@ class Annotator(object):
 
         if authors:
             return authors
+
+        # We have no author information, so we add empty <author> tag
+        # to avoid the implication (per RFC 4287 4.2.1) that this book
+        # was written by whoever wrote the OPDS feed.
         return [AtomFeed.author(AtomFeed.name(""))]
 
     @classmethod

--- a/opds.py
+++ b/opds.py
@@ -302,7 +302,6 @@ class Annotator(object):
         """Create one or more <author> and <contributor> tags for the given
         Work.
 
-        :param entry: A Tag representing the OPDS entry in progress.
         :param work: The Work under consideration.
         :param edition: The Edition to use as a reference
             for bibliographic information, including the list of
@@ -313,7 +312,7 @@ class Annotator(object):
         for contribution in edition.contributions:
             tag = cls.contributor_tag(contribution, state)
             if tag is None:
-                # author_tag decided that this contribution doesn't
+                # contributor_tag decided that this contribution doesn't
                 # need a tag.
                 continue
             authors.append(tag)

--- a/opds.py
+++ b/opds.py
@@ -302,35 +302,63 @@ class Annotator(object):
         """Create one or more <author> and <contributor> tags for the given
         work."""
         authors = list()
-        listed_by_role = defaultdict(set)
+        state = defaultdict(set)
         for contribution in edition.contributions:
-            contributor = contribution.contributor
-            name = contributor.display_name or contributor.sort_name
-            if contribution.role in Contributor.AUTHOR_ROLES:
-                tag_f = AtomFeed.author
-                role = None
-            else:
-                tag_f = AtomFeed.contributor
-                role = Contributor.MARC_ROLE_CODES.get(contribution.role)
-                if not role:
-                    # This contribution is not one that we publish as
-                    # a <atom:contributor> tag. Skip it.
-                    continue
-
-            name_key = name.lower()
-            if name_key in listed_by_role[role]:
+            tag = cls.contributor_tag(contribution, state)
+            if tag is None:
+                # author_tag decided that this contribution doesn't
+                # need a tag.
                 continue
-
-            properties = dict()
-            if role:
-                properties['{%s}role' % AtomFeed.OPF_NS] = role
-            tag = tag_f(AtomFeed.name(name), **properties)
             authors.append(tag)
-            listed_by_role[role].add(name_key)
 
         if authors:
             return authors
         return [AtomFeed.author(AtomFeed.name(""))]
+
+    @classmethod
+    def contributor_tag(self, contribution, state=None):
+        """Build an <author> or <contributor> tag for a Contribution.
+
+        :param contribution: A Contribution.
+        :param state: A defaultdict of sets, which may be used to keep
+            track of what happened during previous calls to
+            contributor_tag for a given Work.
+        :return: A Tag, or None if creating a Tag for this Contribution
+            would be redundant or of low value.
+
+        """
+        contributor = contribution.contributor
+        role = contribution.role
+
+        if role in Contributor.AUTHOR_ROLES:
+            tag_f = AtomFeed.author
+            marc_role = None
+        else:
+            tag_f = AtomFeed.contributor
+            marc_role = Contributor.MARC_ROLE_CODES.get(role)
+            if not marc_role:
+                # This contribution is not one that we publish as
+                # a <atom:contributor> tag. Skip it.
+                return None
+
+        name = contributor.display_name or contributor.sort_name
+        name_key = name.lower()
+        if name_key in state[marc_role]:
+            # We've already credited this person with this
+            # MARC role. Returning a tag would be redundant.
+            return None
+
+        # Okay, we're creating a tag.
+        properties = dict()
+        if marc_role:
+            properties['{%s}role' % AtomFeed.OPF_NS] = marc_role
+        tag = tag_f(AtomFeed.name(name), **properties)
+
+        # Record the fact that we credited this person with this role,
+        # so that we don't do it again on a subsequent call.
+        state[marc_role].add(name_key)
+
+        return tag
 
     @classmethod
     def series(cls, series_name, series_position):

--- a/opds.py
+++ b/opds.py
@@ -300,7 +300,14 @@ class Annotator(object):
     @classmethod
     def authors(cls, work, edition):
         """Create one or more <author> and <contributor> tags for the given
-        work."""
+        Work.
+
+        :param entry: A Tag representing the OPDS entry in progress.
+        :param work: The Work under consideration.
+        :param edition: The Edition to use as a reference
+            for bibliographic information, including the list of
+            Contributions.
+        """
         authors = list()
         state = defaultdict(set)
         for contribution in edition.contributions:
@@ -316,7 +323,7 @@ class Annotator(object):
         return [AtomFeed.author(AtomFeed.name(""))]
 
     @classmethod
-    def contributor_tag(self, contribution):
+    def contributor_tag(cls, contribution, state):
         """Build an <author> or <contributor> tag for a Contribution.
 
         :param contribution: A Contribution.

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -261,7 +261,7 @@ class TestAnnotators(DatabaseTest):
         eq_(tag_string, etree.tostring(same_tag))
 
     def test_duplicate_author_names_are_ignored(self):
-        """Ignores duplicate author names"""
+        # Ignores duplicate author names
         work = self._work(with_license_pool=True)
         duplicate = self._contributor()[0]
         duplicate.sort_name = work.author


### PR DESCRIPTION
This branch moves some code from circulation to core, expands it a bit, and adds standalone tests. The functionality is the ability to go from a person's name, to a `ContributorData` containing the most complete information we can accurately get out of the database. This process may go through multiple `Contributor` objects representing different people with the same name, or multiple inconsistent records of a single person.

I don't know how much of this code we could do without if we had proper contributor reconciliation -- I think some but not all of it. We'd still need a way of taking a name that may refer to multiple people, and (if possible) figuring out which person we're actually talking about.

This whole thing is necessary because `CirculationLane` in the circulation manager takes author name as its input, not contributor ID. For a while I thought it would be easy to just start using contributor ID instead, and I refactored some code in `Annotator` into a hook method that I thought I could subclass. This didn't work out, but I've left the refactored code in place; it doesn't change functionality at all and the new code is better since much of the functionality could have standalone tests written for it.