### PR TITLE
Move all WorkList/Lane code that touches the database into a separate DatabaseBackedWorkList class.

### DIFF
--- a/config.py
+++ b/config.py
@@ -131,6 +131,7 @@ class Configuration(object):
     # Each library may set a minimum quality for the books that show
     # up in the 'featured' lanes that show up on the front page.
     MINIMUM_FEATURED_QUALITY = "minimum_featured_quality"
+    DEFAULT_MINIMUM_FEATURED_QUALITY = 0.65
 
     # Each library may configure the maximum number of books in the
     # 'featured' lanes.
@@ -259,7 +260,7 @@ class Configuration(object):
             "description": _("Between 0 and 1."),
             "type": "number",
             "max": 1,
-            "default": 0.65,
+            "default": DEFAULT_MINIMUM_FEATURED_QUALITY,
             "category": "Lanes & Filters",
         },
     ] + [

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -93,7 +93,7 @@ class EntryPoint(object):
         return filter
 
     @classmethod
-    def modify_database_query(cls, qu):
+    def modify_database_query(cls, _db, qu):
         """Default behavior is to not change a database query at all."""
         return qu
 
@@ -115,7 +115,7 @@ class MediumEntryPoint(EntryPoint):
     """
 
     @classmethod
-    def modify_database_query(cls, qu):
+    def modify_database_query(cls, _db, qu):
         """Modify a query against Work+LicensePool+Edition
         to match only items with the right medium.
         """

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -76,13 +76,6 @@ class EntryPoint(object):
             cls.DEFAULT_ENABLED.remove(entrypoint_class)
 
     @classmethod
-    def modified_materialized_view_query(cls, qu):
-        """Modify a query against the mv_works_for_lanes materialized view
-        so it matches only items that belong in this entry point.
-        """
-        raise NotImplementedError()
-
-    @classmethod
     def modify_search_filter(cls, filter):
         """If necessary modify an ElasticSearch Filter object so that it
         restricts results to items shown through this entry point.

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -100,8 +100,8 @@ class EntryPoint(object):
         return filter
 
     @classmethod
-    def apply(cls, qu):
-        """Default behavior is to not change a query at all."""
+    def modify_database_query(cls, qu):
+        """Default behavior is to not change a database query at all."""
         return qu
 
 
@@ -122,12 +122,12 @@ class MediumEntryPoint(EntryPoint):
     """
 
     @classmethod
-    def apply(cls, qu):
-        """Modify a query against the mv_works_for_lanes materialized view
+    def modify_database_query(cls, qu):
+        """Modify a query against Work+LicensePool+Edition
         to match only items with the right medium.
         """
-        from model import MaterializedWorkWithGenre as mv
-        return qu.filter(mv.medium==cls.INTERNAL_NAME)
+        from model import Edition
+        return qu.filter(Edition.medium==cls.INTERNAL_NAME)
 
     @classmethod
     def modify_search_filter(cls, filter):

--- a/external_search.py
+++ b/external_search.py
@@ -1764,7 +1764,7 @@ class Filter(SearchBase):
             target_age, genre_id_restrictions, customlist_id_restrictions,
             facets,
             excluded_audiobook_data_sources=excluded_audiobook_data_sources,
-            allow_holds=allow_holds, license_datasource_id=license_datasource_id
+            allow_holds=allow_holds, license_datasource=license_datasource_id
         )
 
     def __init__(self, collections=None, media=None, languages=None,
@@ -1906,10 +1906,10 @@ class Filter(SearchBase):
             )
             nested_filters['licensepools'].append(collection_match)
 
-        license_datasource = filter_ids(self.license_datasource)
-        if license_datasource:
+        license_datasources = filter_ids(self.license_datasources)
+        if license_datasources:
             datasource_match = F(
-                'terms', **{'licensepools.data_source_id' : license_datasource}
+                'terms', **{'licensepools.data_source_id' : license_datasources}
             )
             nested_filters['licensepools'].append(datasource_match)
 

--- a/external_search.py
+++ b/external_search.py
@@ -1738,6 +1738,8 @@ class Filter(SearchBase):
         target_age = inherit_one('target_age')
         collections = inherit_one('collection_ids') or library
 
+        license_datasource_id = inherit_one('license_datasource_id')
+
         # For genre IDs and CustomList IDs, we might get a separate
         # set of restrictions from every item in the WorkList hierarchy.
         # _All_ restrictions must be met for a work to match the filter.
@@ -1762,17 +1764,15 @@ class Filter(SearchBase):
             target_age, genre_id_restrictions, customlist_id_restrictions,
             facets,
             excluded_audiobook_data_sources=excluded_audiobook_data_sources,
-            allow_holds=allow_holds,
+            allow_holds=allow_holds, license_datasource_id=license_datasource_id
         )
-
 
     def __init__(self, collections=None, media=None, languages=None,
                  fiction=None, audiences=None, target_age=None,
                  genre_restriction_sets=None, customlist_restriction_sets=None,
                  facets=None, script_fields=None, **kwargs
     ):
-        """
-        These minor arguments were made into unnamed keyword arguments to
+        """These minor arguments were made into unnamed keyword arguments to
         avoid cluttering the method signature:
 
         :param excluded_audiobook_data_sources: A list of DataSources that
@@ -1788,6 +1788,10 @@ class Filter(SearchBase):
         :param author: If this is set to a Contributor or
         ContributorData, then only books where this person had an
         authorship role will be included.
+
+        :param license_datasource: If this is set to a DataSource,
+        only books with LicensePools from that DataSource will be
+        included.
 
         :param updated_after: If this is set to a datetime, only books
         whose Work records (~bibliographic metadata) have been updated since
@@ -1845,6 +1849,9 @@ class Filter(SearchBase):
 
         self.author = kwargs.pop('author', None)
 
+        license_datasources = kwargs.pop('license_datasource', None)
+        self.license_datasources = self._filter_ids(license_datasources)
+
         # At this point there should be no keyword arguments -- you can't pass
         # whatever you want into this method.
         if kwargs:
@@ -1898,6 +1905,13 @@ class Filter(SearchBase):
                 'terms', **{'licensepools.collection_id' : collection_ids}
             )
             nested_filters['licensepools'].append(collection_match)
+
+        license_datasource = filter_ids(self.license_datasource)
+        if license_datasource:
+            datasource_match = F(
+                'terms', **{'licensepools.data_source_id' : license_datasource}
+            )
+            nested_filters['licensepools'].append(datasource_match)
 
         if self.author is not None:
             nested_filters['contributors'].append(self.author_filter)

--- a/lane.py
+++ b/lane.py
@@ -1857,8 +1857,10 @@ class DatabaseBackedWorkList(WorkList):
 
         # If a license source is specified, only show books from that
         # source.
-        if self.license_datasource:
-            clauses.append(LicensePool.data_source==self.license_datasource)
+        if self.license_datasource_id:
+            clauses.append(
+                LicensePool.data_source_id==self.license_datasource_id
+            )
 
         clauses.extend(self.age_range_filter_clauses())
 

--- a/lane.py
+++ b/lane.py
@@ -702,6 +702,10 @@ class FeaturedFacets(FacetsWithEntryPoint):
         self.minimum_featured_quality = minimum_featured_quality
         self.random_seed=random_seed
 
+    @classmethod
+    def default(cls, lane, **lwargs):
+        return cls(library.minimum_featured_quality, **kwargs)
+
     def navigate(self, minimum_featured_quality=None, entrypoint=None):
         """Create a slightly different FeaturedFacets object based on this
         one.

--- a/lane.py
+++ b/lane.py
@@ -683,8 +683,8 @@ class FeaturedFacets(FacetsWithEntryPoint):
 
     DETERMINISTIC = object()
 
-    def __init__(self, minimum_featured_quality, uses_customlists=False,
-                 entrypoint=None, random_seed=None, **kwargs):
+    def __init__(self, minimum_featured_quality, entrypoint=None,
+                 random_seed=None, **kwargs):
         """Set up an object that finds featured books in a given
         WorkList.
 
@@ -693,21 +693,15 @@ class FeaturedFacets(FacetsWithEntryPoint):
         """
         super(FeaturedFacets, self).__init__(entrypoint=entrypoint, **kwargs)
         self.minimum_featured_quality = minimum_featured_quality
-        self.uses_customlists = uses_customlists
         self.random_seed=random_seed
 
-    def navigate(self, minimum_featured_quality=None, uses_customlists=None,
-                 entrypoint=None):
+    def navigate(self, minimum_featured_quality=None, entrypoint=None):
         """Create a slightly different FeaturedFacets object based on this
         one.
         """
         minimum_featured_quality = minimum_featured_quality or self.minimum_featured_quality
-        if uses_customlists is None:
-            uses_customlists = self.uses_customlists
         entrypoint = entrypoint or self.entrypoint
-        return self.__class__(
-            minimum_featured_quality, uses_customlists, entrypoint
-        )
+        return self.__class__(minimum_featured_quality, entrypoint)
 
     def scoring_functions(self, filter):
         """Generate scoring functions that weight works randomly, but

--- a/lane.py
+++ b/lane.py
@@ -964,8 +964,10 @@ class Pagination(object):
 
 
 class WorkList(object):
-    """An object that can obtain a list of Work/MaterializedWorkWithGenre
-    objects for use in generating an OPDS feed.
+    """An object that can obtain a list of Work objects for use
+    in generating an OPDS feed.
+
+    By default, these Work objects come from a search index.
     """
 
     # Unless a sitewide setting intervenes, the set of Works in a
@@ -1615,8 +1617,7 @@ class WorkList(object):
         :param debug: A debug argument passed into `search_engine` when
            running the search.
 
-        :yield: A sequence of (MaterializedWorkWithGenre,
-        quality_tier, Lane) 3-tuples.
+        :yield: A sequence of (Work, Lane) 2-tuples.
         """
         if not lanes:
             # We can't run this query at all.
@@ -2434,7 +2435,7 @@ class Lane(Base, WorkList):
 
     def groups(self, _db, include_sublanes=True, facets=None,
                search_engine=None, debug=False):
-        """Return a list of (MaterializedWorkWithGenre, Lane) 2-tuples
+        """Return a list of (Work, Lane) 2-tuples
         describing a sequence of featured items for this lane and
         (optionally) its children.
 

--- a/lane.py
+++ b/lane.py
@@ -1393,19 +1393,20 @@ class WorkList(object):
         return self.works_for_hits(_db, hits)
 
     def works_for_hits(self, _db, hits):
-        """Create the appearance of having called works to run a search(), but
-        return the specific MaterializedWorks or Works identified by
-        `hits`.
+        """Convert a list of search results into Work objects.
 
         :param _db: A database connection
         :param hits: A list of Hit objects from ElasticSearch.
         :return A list of Work or (if the search results include
             script fields), WorkSearchResult objects.
-
         """
 
         # Get a list of Work objects, using the same rules applied in
         # works() and works_from_search().
+        #
+        # TODO: This could be done with less code by making a DatabaseBackedWorkList,
+        # or by reusing some code from that class. But not so much less code
+        # that the answer is obvious.
         work_id_field = Work.id
         qu = _db.query(Work).join(
             Work.license_pools
@@ -1421,11 +1422,11 @@ class WorkList(object):
         qu = self._defer_unused_fields(qu)
         qu = self.only_show_ready_deliverable_works(_db, qu)
         qu = qu.distinct(Work.id)
-        work_by_id = dict()
         a = time.time()
         works = qu.all()
 
         # Put the results in the same order as the work_ids were.
+        work_by_id = dict()
         for w in works:
             work_by_id[w.id] = w
 

--- a/lane.py
+++ b/lane.py
@@ -589,9 +589,12 @@ class DatabaseBackedFacets(Facets):
         # The default sort order is not supported. Just pick the first
         # enabled sort order.
         enabled = config.enabled_facets(facet_group_name)
-        if enabled:
-            return enabled[0]
-        return enabled
+        for i in enabled:
+            if i in cls.ORDER_FACET_TO_DATABASE_FIELD:
+                return i
+
+        # None of the enabled sort orders are usable. Order by work ID.
+        return cls.ORDER_WORK_ID
 
     def order_by(self):
         """Given these Facets, create a complete ORDER BY clause for queries

--- a/lane.py
+++ b/lane.py
@@ -1737,7 +1737,8 @@ class DatabaseBackedWorkList(WorkList):
 
         return qu
 
-    def base_query(self, _db):
+    @classmethod
+    def base_query(cls, _db):
         """Return a query that contains the joins set up as necessary to
         create OPDS feeds.
         """
@@ -1750,24 +1751,9 @@ class DatabaseBackedWorkList(WorkList):
         )
 
         # Apply optimizations.
-        qu = self._modify_loading(qu)
-        qu = self._defer_unused_fields(qu)
+        qu = cls._modify_loading(qu)
+        qu = cls._defer_unused_fields(qu)
         return qu
-
-    def only_show_ready_deliverable_works(
-        self, _db, query, show_suppressed=False
-    ):
-        """Restrict a query to show only presentation-ready works present in
-        an appropriate collection which the default client can
-        fulfill.
-
-        Note that this assumes the query has an active join against
-        LicensePool.
-        """
-        return Collection.restrict_to_ready_deliverable_works(
-            query, Work, Edition, show_suppressed=show_suppressed,
-            collection_ids=self.collection_ids
-        )
 
     @classmethod
     def _modify_loading(cls, qu):
@@ -1800,6 +1786,21 @@ class DatabaseBackedWorkList(WorkList):
             joinedload(license_pool_name, "delivery_mechanisms", "resource", "representation"),
         )
         return qu
+
+    def only_show_ready_deliverable_works(
+        self, _db, query, show_suppressed=False
+    ):
+        """Restrict a query to show only presentation-ready works present in
+        an appropriate collection which the default client can
+        fulfill.
+
+        Note that this assumes the query has an active join against
+        LicensePool.
+        """
+        return Collection.restrict_to_ready_deliverable_works(
+            query, Work, Edition, show_suppressed=show_suppressed,
+            collection_ids=self.collection_ids
+        )
 
     @classmethod
     def _defer_unused_fields(cls, query):

--- a/lane.py
+++ b/lane.py
@@ -1730,8 +1730,8 @@ class SpecificWorkFacets(DatabaseBackedFacets):
 
 
 class DatabaseBackedWorkList(WorkList):
-    """A WorkList that gets its works from a database query rather than
-    the search index.
+    """A WorkList that can get its works from the database in addition to
+    (or possibly instead of) the search index.
 
     Even when works _are_ obtained through the search index, a
     DatabaseBackedWorkList is then created to look up the Work objects

--- a/lane.py
+++ b/lane.py
@@ -309,7 +309,7 @@ class FacetsWithEntryPoint(BaseFacets):
         facets.
         """
         if self.entrypoint:
-            qu = self.entrypoint.modify_database_query(_db, filter)
+            qu = self.entrypoint.modify_database_query(_db, qu)
         return qu
 
 class Facets(FacetsWithEntryPoint):
@@ -1622,7 +1622,7 @@ class WorkList(object):
                 for x in lane.groups(
                     _db, include_sublanes=False, facets=facets,
                 ):
-                    yield x, lane
+                    yield x
 
     def _featured_works_with_lanes(
         self, _db, lanes, facets, pagination, search_engine, debug=False

--- a/lane.py
+++ b/lane.py
@@ -2336,11 +2336,6 @@ class Lane(Base, DatabaseBackedWorkList):
         """Update the stored estimate of the number of Works in this Lane."""
         library = self.get_library(_db)
 
-        # TODO: We need some way of _converting_ the Lane to a
-        # DatabaseBackedWorkList.
-        wl = DatabaseBackedWorkList()
-        wl.initialize(library)
-
         # Do the estimate for every known entry point.
         by_entrypoint = dict()
         for entrypoint in EntryPoint.ENTRY_POINTS:
@@ -2349,7 +2344,7 @@ class Lane(Base, DatabaseBackedWorkList):
                 FacetConstants.AVAILABLE_ALL,
                 order=FacetConstants.ORDER_WORK_ID, entrypoint=entrypoint
             )
-            qu = wl.works(_db, facets)
+            qu = self.works_from_database(_db, facets)
             by_entrypoint[entrypoint.URI] = fast_query_count(qu)
         self.size_by_entrypoint = by_entrypoint
         self.size = by_entrypoint[EverythingEntryPoint.URI]

--- a/lane.py
+++ b/lane.py
@@ -703,8 +703,13 @@ class FeaturedFacets(FacetsWithEntryPoint):
         self.random_seed=random_seed
 
     @classmethod
-    def default(cls, lane, **lwargs):
-        return cls(library.minimum_featured_quality, **kwargs)
+    def default(cls, lane, **kwargs):
+        library = lane.library
+        if lane.library:
+            quality = Configuration.DEFAULT_MINIMUM_FEATURED_QUALITY
+        else:
+            quality = library.minimum_featured_quality
+        return cls(quality, **kwargs)
 
     def navigate(self, minimum_featured_quality=None, entrypoint=None):
         """Create a slightly different FeaturedFacets object based on this

--- a/lane.py
+++ b/lane.py
@@ -1973,6 +1973,7 @@ class DatabaseBackedWorkList(WorkList):
 
 
 class SpecificWorkList(DatabaseBackedWorkList):
+    """A WorkList that only finds specific works, identified by ID."""
     def __init__(self, work_ids):
         super(SpecificWorkList, self).__init__()
         self.work_ids = work_ids

--- a/lane.py
+++ b/lane.py
@@ -1797,7 +1797,6 @@ class DatabaseBackedWorkList(WorkList):
         qu = self._defer_unused_fields(qu)
         return qu
 
-
     def bibliographic_filter_clause(self, _db, qu):
         """Create a SQLAlchemy filter that excludes books whose bibliographic
         metadata doesn't match what we're looking for.
@@ -1817,7 +1816,7 @@ class DatabaseBackedWorkList(WorkList):
             clauses.append(Edition.medium.in_(self.media))
         if self.genre_ids:
             wg = aliased(WorkGenre)
-            qu = qu.join(wg, wg.work_id==Work.work_id)
+            qu = qu.join(wg, wg.work_id==Work.id)
             field = wg.genre_id
             clauses.append(field.in_(self.genre_ids))
 

--- a/lane.py
+++ b/lane.py
@@ -304,12 +304,12 @@ class FacetsWithEntryPoint(BaseFacets):
             self.entrypoint.modify_search_filter(filter)
         return filter
 
-    def modify_database_query(self, qu):
+    def modify_database_query(self, _db, qu):
         """Modify the given database query so that it reflects this set of
         facets.
         """
         if self.entrypoint:
-            qu = self.entrypoint.modify_database_query(filter)
+            qu = self.entrypoint.modify_database_query(_db, filter)
         return qu
 
 class Facets(FacetsWithEntryPoint):
@@ -638,7 +638,7 @@ class DatabaseBackedFacets(Facets):
         ordered appropriately.
         """
         if self.entrypoint:
-            qu = self.entrypoint.modify_database_query(qu)
+            qu = self.entrypoint.modify_database_query(_db, qu)
 
         if self.availability == self.AVAILABLE_NOW:
             availability_clause = or_(
@@ -1536,7 +1536,6 @@ class WorkList(object):
         """
         library = self.get_library(_db)
         target_size = library.featured_lane_size
-        facets = facets or self.default_featured_facets(_db)
 
         # We ask for a few extra works for each lane, to reduce the
         # risk that we'll end up reusing a book in two different
@@ -1623,7 +1622,7 @@ class WorkList(object):
                 for x in lane.groups(
                     _db, include_sublanes=False, facets=facets,
                 ):
-                    yield x
+                    yield x, lane
 
     def _featured_works_with_lanes(
         self, _db, lanes, facets, pagination, search_engine, debug=False

--- a/marc.py
+++ b/marc.py
@@ -665,7 +665,7 @@ class MARCExporter(object):
             this_batch_size = 0
             while pagination is not None:
                 # Retrieve one 'page' of works from the search index.
-                works = lane.works_from_search_index(
+                works = lane.works(
                     self._db, pagination=pagination, facets=facets,
                     search_engine=search_engine
                 )

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     Table,
+    text,
 )
 from sqlalchemy.exc import (
     IntegrityError,

--- a/opds.py
+++ b/opds.py
@@ -52,6 +52,7 @@ from model import (
 from lane import (
     Facets,
     FacetsWithEntryPoint,
+    FeaturedFacets,
     Lane,
     Pagination,
     SearchFacets,
@@ -607,7 +608,7 @@ class AcquisitionFeed(OPDSFeed):
                 annotator = annotator()
             cached = None
             use_cache = cache_type != cls.NO_CACHE
-            facets = facets or lane.default_featured_facets(_db)
+            facets = facets or FeaturedFacets.default(lane)
             if use_cache:
                 cache_type = cache_type or CachedFeed.GROUPS_TYPE
                 cached, usable = CachedFeed.fetch(
@@ -798,8 +799,10 @@ class AcquisitionFeed(OPDSFeed):
     def from_query(cls, query, _db, feed_name, url, pagination, url_fn, annotator):
         """Build  a feed representing one page of a given list. Currently used for
         creating an OPDS feed for a custom list and not cached.
+
+        # TODO: Can this be removed?
         """
-        page_of_works = pagination.apply(query)
+        page_of_works = pagination.modify_database_query(query)
         pagination.total_size = int(query.count())
 
         feed = cls(_db, feed_name, url, page_of_works, annotator)
@@ -1706,7 +1709,7 @@ class NavigationFeed(OPDSFeed):
             annotator = annotator()
         cached = None
         use_cache = cache_type != cls.NO_CACHE
-        facets = facets or lane.default_featured_facets(_db)
+        facets = facets or FeaturedFacets.default(lane)
         if use_cache:
             cache_type = cache_type or CachedFeed.NAVIGATION_TYPE
             cached, usable = CachedFeed.fetch(

--- a/opds.py
+++ b/opds.py
@@ -802,7 +802,7 @@ class AcquisitionFeed(OPDSFeed):
 
         # TODO: Can this be removed?
         """
-        page_of_works = pagination.modify_database_query(query)
+        page_of_works = pagination.modify_database_query(_db, query)
         pagination.total_size = int(query.count())
 
         feed = cls(_db, feed_name, url, page_of_works, annotator)

--- a/opds.py
+++ b/opds.py
@@ -800,7 +800,9 @@ class AcquisitionFeed(OPDSFeed):
         """Build  a feed representing one page of a given list. Currently used for
         creating an OPDS feed for a custom list and not cached.
 
-        # TODO: Can this be removed?
+        TODO: This is used by the circulation manager admin interface.
+        Investigating replacing the code that uses this so that it uses
+        the search index.
         """
         page_of_works = pagination.modify_database_query(_db, query)
         pagination.total_size = int(query.count())

--- a/testing.py
+++ b/testing.py
@@ -404,7 +404,7 @@ class DatabaseTest(object):
 
     def _lane(self, display_name=None, library=None,
               parent=None, genres=None, languages=None,
-              fiction=None
+              fiction=None, inherit_parent_restrictions=True
     ):
         display_name = display_name or self._str
         library = library or self._default_library
@@ -412,7 +412,8 @@ class DatabaseTest(object):
             self._db, Lane,
             library=library,
             parent=parent, display_name=display_name,
-            fiction=fiction
+            fiction=fiction,
+            inherit_parent_restrictions=inherit_parent_restrictions
         )
         if is_new and parent:
             lane.priority = len(parent.sublanes)-1

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -40,7 +40,7 @@ class TestEntryPoint(DatabaseTest):
     def test_no_changes(self):
         # EntryPoint doesn't modify queries or search filters.
         qu = self._db.query(Edition)
-        eq_(qu, EntryPoint.apply(qu))
+        eq_(qu, EntryPoint.modify_database_query(self._db, qu))
         args = dict(arg="value")
 
         filter = object()
@@ -98,7 +98,7 @@ class TestEverythingEntryPoint(DatabaseTest):
         eq_("All", EverythingEntryPoint.INTERNAL_NAME)
 
         qu = self._db.query(Edition)
-        eq_(qu, EntryPoint.apply(qu))
+        eq_(qu, EntryPoint.modify_database_query(self._db, qu))
         args = dict(arg="value")
 
         filter = object()
@@ -107,7 +107,7 @@ class TestEverythingEntryPoint(DatabaseTest):
 
 class TestMediumEntryPoint(DatabaseTest):
 
-    def test_apply(self):
+    def test_modify_database_query(self):
         # Create a video, and a entry point that contains videos.
         work = self._work(with_license_pool=True)
         work.license_pools[0].presentation_edition.medium = Edition.VIDEO_MEDIUM
@@ -121,11 +121,11 @@ class TestMediumEntryPoint(DatabaseTest):
 
         # The default entry points filter out the video.
         for entrypoint in EbooksEntryPoint, AudiobooksEntryPoint:
-            modified = entrypoint.apply(qu)
+            modified = entrypoint.modify_database_query(self._db, qu)
             eq_([], modified.all())
 
         # But the video entry point includes it.
-        videos = Videos.apply(qu)
+        videos = Videos.modify_database_query(self._db, qu)
         eq_([work.id], [x.works_id for x in videos])
 
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -2751,9 +2751,9 @@ class TestFilter(DatabaseTest):
         parent.target_age = NumericRange(10, 11, '[]')
         parent.genres = [self.horror, self.fantasy]
         parent.customlists = [self.best_sellers]
-        parent.license_datasource_id = DataSource.lookup(
+        parent.license_datasource = DataSource.lookup(
             self._db, DataSource.GUTENBERG
-        ).id
+        )
 
         # This lane inherits most of its configuration from its parent.
         inherits = self._lane(

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -798,6 +798,16 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
             "president", age_8_10, ordered=False
         )
 
+        # Filters on license source.
+        gutenberg = DataSource.lookup(self._db, DataSource.GUTENBERG)
+        gutenberg_only = Filter(license_datasource=gutenberg)
+        expect([self.moby_dick, self.moby_duck], "moby", gutenberg_only,
+               ordered=False)
+
+        overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
+        overdrive_only = Filter(license_datasource=overdrive)
+        expect([], "moby", overdrive_only, ordered=False)
+
         # Filters on last modified time.
 
         # Obviously this query string matches "Moby-Dick", but it's
@@ -876,7 +886,7 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
         expect([self.moby_dick], "moby duck", f)
 
         # Finally, let's do some end-to-end tests of
-        # WorkList.works_from_search_index.
+        # WorkList.works()
         #
         # That's a simple method that puts together a few pieces
         # which are tested separately, so we don't need to go all-out.
@@ -890,7 +900,7 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
             )
             pages = []
             while pagination:
-                pages.append(worklist.works_from_search_index(
+                pages.append(worklist.works(
                     self._db, facets, pagination, self.search
                 ))
                 pagination = pagination.next_page
@@ -1653,7 +1663,7 @@ class TestFeaturedFacets(EndToEndSearchTest):
         def assert_featured(description, worklist, facets, expect):
             # Generate a list of featured works for the given `worklist`
             # and compare that list against `expect`.
-            actual = worklist.works_from_search_index(
+            actual = worklist.works(
                 self._db, facets, None, self.search, debug=True
             )
             self._assert_works(description, expect, actual)

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -2694,6 +2694,14 @@ class TestFilter(DatabaseTest):
             Filter(customlist_restriction_sets=[[]]).customlist_restriction_sets
         )
 
+        # Test the license_datasource argument
+        overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
+        overdrive_only = Filter(license_datasource=overdrive)
+        eq_([overdrive.id], overdrive_only.license_datasources)
+
+        overdrive_only = Filter(license_datasource=overdrive.id)
+        eq_([overdrive.id], overdrive_only.license_datasources)
+
         # If you pass in a Facets object, its modify_search_filter()
         # and scoring_functions() methods are called.
         class Mock(object):
@@ -2743,6 +2751,9 @@ class TestFilter(DatabaseTest):
         parent.target_age = NumericRange(10, 11, '[]')
         parent.genres = [self.horror, self.fantasy]
         parent.customlists = [self.best_sellers]
+        parent.license_datasource_id = DataSource.lookup(
+            self._db, DataSource.GUTENBERG
+        ).id
 
         # This lane inherits most of its configuration from its parent.
         inherits = self._lane(
@@ -2764,6 +2775,7 @@ class TestFilter(DatabaseTest):
         eq_(parent.languages, filter.languages)
         eq_(parent.fiction, filter.fiction)
         eq_(parent.audiences, filter.audiences)
+        eq_([parent.license_datasource_id], filter.license_datasources)
         eq_((parent.target_age.lower, parent.target_age.upper),
             filter.target_age)
         eq_(True, filter.allow_holds)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -705,10 +705,10 @@ class TestDatabaseBackedFacets(DatabaseTest):
         pass
 
     def test_order_by(self):
-        from ..model import MaterializedWorkWithGenre as m
-
+        E = Edition
+        W = Work
         def order(facet, ascending=None):
-            f = Facets(
+            f = DatabaseBackedFacets(
                 self._default_library,
                 collection=Facets.COLLECTION_FULL,
                 availability=Facets.AVAILABLE_ALL,
@@ -722,30 +722,33 @@ class TestDatabaseBackedFacets(DatabaseTest):
             for i in range(0, len(a)):
                 assert(a[i].compare(b[i]))
 
-        expect = [m.sort_author.asc(), m.sort_title.asc(), m.works_id.asc()]
+        expect = [E.sort_author.asc(), E.sort_title.asc(), W.id.asc()]
         actual = order(Facets.ORDER_AUTHOR, True)
         compare(expect, actual)
 
-        expect = [m.sort_author.desc(), m.sort_title.asc(), m.works_id.asc()]
+        expect = [E.sort_author.desc(), E.sort_title.asc(), W.id.asc()]
         actual = order(Facets.ORDER_AUTHOR, False)
         compare(expect, actual)
 
-        expect = [m.sort_title.asc(), m.sort_author.asc(), m.works_id.asc()]
+        expect = [E.sort_title.asc(), E.sort_author.asc(), W.id.asc()]
         actual = order(Facets.ORDER_TITLE, True)
         compare(expect, actual)
 
-        expect = [m.last_update_time.asc(), m.sort_author.asc(), m.sort_title.asc(), m.works_id.asc()]
+        expect = [W.last_update_time.asc(), E.sort_author.asc(), 
+                  E.sort_title.asc(), W.id.asc()]
         actual = order(Facets.ORDER_LAST_UPDATE, True)
         compare(expect, actual)
 
-        expect = [m.random.asc(), m.sort_author.asc(), m.sort_title.asc(),
-                  m.works_id.asc()]
+        expect = [W.random.asc(), E.sort_author.asc(), E.sort_title.asc(),
+                  W.id.asc()]
         actual = order(Facets.ORDER_RANDOM, True)
         compare(expect, actual)
 
-        expect = [m.availability_time.desc(), m.sort_author.asc(), m.sort_title.asc(), m.works_id.asc()]
-        actual = order(Facets.ORDER_ADDED_TO_COLLECTION, None)
+        # Unsupported sort order -> default (author, title, work ID)
+        expect = [E.sort_author.asc(), E.sort_title.asc(), W.id.asc()]
+        actual = order(Facets.ORDER_ADDED_TO_COLLECTION, True)
         compare(expect, actual)
+
 
     def test_modify_database_query(self):
         # Set up works that are matched by different types of collections.

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -89,14 +89,14 @@ class TestFacetsWithEntryPoint(DatabaseTest):
     def test_modify_database_query(self):
         class MockEntryPoint(object):
             def modify_database_query(self, _db, qu):
-                self.called_with = qu
+                self.called_with = (_db, qu)
 
         ep = MockEntryPoint()
         f = FacetsWithEntryPoint(ep)
         _db = object()
         qu = object()
         f.modify_database_query(_db, qu)
-        eq_(qu, ep.called_with)
+        eq_((_db, qu), ep.called_with)
 
     def test_navigate(self):
         # navigate creates a new FacetsWithEntryPoint.
@@ -1561,7 +1561,8 @@ class TestWorkList(DatabaseTest):
                 self.visible = True
 
             def groups(self, *args, **kwargs):
-                return self._works
+                for i in self._works:
+                    yield i, self
 
         # This WorkList has one featured work.
         child1 = MockWorkList([w1])
@@ -1609,9 +1610,8 @@ class TestWorkList(DatabaseTest):
         eq_(facets, mock.featured_called_with)
 
     def test_works(self):
-        """Test the method that uses the search index to fetch a list of
-        results appropriate for a given WorkList.
-        """
+        # Test the method that uses the search index to fetch a list of
+        # results appropriate for a given WorkList.
 
         class MockSearchClient(object):
             """Respond to search requests with some fake work IDs."""
@@ -1640,7 +1640,7 @@ class TestWorkList(DatabaseTest):
 
         # Ask the WorkList for a page of works, using the search index
         # to drive the query instead of the database.
-        result = wl.works_from_search_index(
+        result = wl.works(
             self._db, facets, mock_pagination, search_client, mock_debug
         )
 
@@ -1670,9 +1670,8 @@ class TestWorkList(DatabaseTest):
             wl.called_with
         )
 
-        # And the fake return value of works_for_hits() was
-        # used as the return value of works_from_search_index(), the
-        # method we're testing.
+        # And the fake return value of works_for_hits() was used as
+        # the return value of works(), the method we're testing.
         eq_(wl.fake_work_list, result)
 
     def test_works_for_hits(self):

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -943,6 +943,335 @@ class TestDatabaseBackedFacets(DatabaseTest):
             [x.name for x in unsupported_order._distinct],
         )
 
+    def test_bibliographic_filter_clause(self):
+        called = dict()
+
+        class MockWorkList(WorkList):
+            """Mock WorkList that simply verifies that
+            bibliographic_filter_clause() calls various hook methods.
+            """
+
+            def __init__(self, languages=None, genre_ids=None, media=None,
+                         customlists=[], list_datasource=None,
+                         list_seen_in_previous_days=None):
+                self.languages = languages
+                self.genre_ids = genre_ids
+                self.media = media
+                self._customlist_ids=[x.id for x in customlists]
+                if list_datasource:
+                    self.list_datasource_id = list_datasource.id
+                else:
+                    self.list_datasource_id = None
+                self.list_seen_in_previous_days = list_seen_in_previous_days
+
+            def audience_filter_clauses(self, _db, qu):
+                called['apply_audience_filter'] = (_db, qu)
+                return []
+
+            def customlist_filter_clauses(self, *args, **kwargs):
+                called['customlist_filter_clauses'] = (args, kwargs)
+                return super(MockWorkList, self).customlist_filter_clauses(
+                    *args, **kwargs
+                )
+
+        wl = MockWorkList()
+        from ..model import MaterializedWorkWithGenre as wg
+        original_qu = self._db.query(wg)
+
+        # If no languages or genre IDs are specified, and the hook
+        # methods do nothing, then bibliographic_filter_clause() has
+        # no effect.
+        featured_object = object()
+        final_qu, bibliographic_filter = wl.bibliographic_filter_clause(
+            self._db, original_qu, featured_object
+        )
+        eq_(original_qu, final_qu)
+        eq_(None, bibliographic_filter)
+
+        # But at least the apply_audience_filter was called with the correct
+        # arguments.
+        _db, qu = called['apply_audience_filter']
+        eq_(self._db, _db)
+        eq_(original_qu, qu)
+
+        # customlist_filter_clauses was not called because the WorkList
+        # doesn't do anything relating to custom lists.
+        assert 'customlist_filter_clauses' not in called
+
+        # If languages, media, and genre IDs are specified, then they are
+        # incorporated into the query.
+        #
+        english_sf = self._work(language="eng", with_license_pool=True)
+        english_sf.presentation_edition.medium = Edition.BOOK_MEDIUM
+        sf, ignore = Genre.lookup(self._db, "Science Fiction")
+        romance, ignore = Genre.lookup(self._db, "Romance")
+        english_sf.genres.append(sf)
+        self.add_to_materialized_view(english_sf)
+
+        # Create a WorkList that will find the MaterializedWorkWithGenre
+        # for the English SF book.
+        def worklist_has_books(
+                expect_books, featured=False, outer_join=False,
+                **worklist_constructor_args
+        ):
+            """Apply bibliographic filters to a query and verify
+            that it finds only the given books.
+            """
+            worklist = MockWorkList(**worklist_constructor_args)
+            qu, clause = worklist.bibliographic_filter_clause(
+                self._db, original_qu, featured=featured,
+                outer_join=outer_join
+            )
+            qu = qu.filter(clause)
+            expect_titles = sorted([x.sort_title for x in expect_books])
+            actual_titles = sorted([x.sort_title for x in qu])
+            eq_(expect_titles, actual_titles)
+
+        worklist_has_books(
+            [english_sf],
+            languages=["eng"], genre_ids=[sf.id], media=[Edition.BOOK_MEDIUM]
+        )
+
+        # WorkLists that do not match by language, medium, or genre will not
+        # find the English SF book.
+        worklist_has_books([], languages=["spa"], genre_ids=[sf.id])
+        worklist_has_books([], languages=["eng"], genre_ids=[romance.id])
+        worklist_has_books(
+            [],
+            languages=["eng"], genre_ids=[sf.id], media=[Edition.AUDIO_MEDIUM]
+        )
+
+        # If the WorkList has custom list IDs, then works will only show up if
+        # they're on one of the matching CustomLists.
+
+        sf_list, ignore = self._customlist(num_entries=0)
+        sf_list.add_entry(english_sf)
+        empty_list, ignore = self._customlist(num_entries=0)
+        self.add_to_materialized_view(english_sf)
+
+        worklist_has_books([], featured="featured value",
+                           outer_join="outer_join value",
+                           customlists=[empty_list])
+        # There were no results, but customlist_filter_clauses was
+        # called, with the arguments we passed in for `featured`
+        # and `outer_join` (plus an intermediary query that we can't
+        # really test).
+        args, kwargs= called['customlist_filter_clauses']
+        untestable, featured, outer_join = args
+        eq_(outer_join, "outer_join value")
+        eq_(featured, "featured value")
+
+        worklist_has_books([english_sf], customlists=[sf_list])
+
+    def test_customlist_filter_clauses(self):
+        """Standalone test of customlist_filter_clauses
+        """
+
+        # If a lane has nothing to do with CustomLists,
+        # apply_customlist_filter does nothing.
+        no_lists = self._lane()
+        qu = self._db.query(Work)
+        new_qu, clauses = no_lists.customlist_filter_clauses(qu)
+        eq_(qu, new_qu)
+        eq_([], clauses)
+
+        # Now set up a Work and a CustomList that contains the work.
+        work = self._work(with_license_pool=True)
+        gutenberg = DataSource.lookup(self._db, DataSource.GUTENBERG)
+        eq_(gutenberg, work.license_pools[0].data_source)
+        gutenberg_list, ignore = self._customlist(num_entries=0)
+        gutenberg_list.data_source = gutenberg
+        gutenberg_list_entry, ignore = gutenberg_list.add_entry(work)
+
+        # This WorkList gets every work on a specific list.
+        works_on_list = WorkList()
+        works_on_list.initialize(
+            self._default_library, customlists=[gutenberg_list]
+        )
+
+        # This lane gets every work on every list associated with Project
+        # Gutenberg.
+        works_on_gutenberg_lists = WorkList()
+        works_on_gutenberg_lists.initialize(
+            self._default_library, list_datasource=gutenberg
+        )
+        self.add_to_materialized_view([work])
+
+        def _run(qu, clauses):
+            # Run a query with certain clauses and pick out the
+            # work IDs returned.
+            modified = qu.filter(and_(*clauses))
+            return [x.works_id for x in modified]
+
+        def results(wl=works_on_gutenberg_lists, must_be_featured=False):
+            qu = self._db.query(work_model)
+            new_qu, clauses = wl.customlist_filter_clauses(
+                qu, must_be_featured=must_be_featured
+            )
+
+            if must_be_featured or wl.list_seen_in_previous_days:
+                # The query comes out different than it goes in -- there's a
+                # new join against CustomListEntry.
+                assert new_qu != qu
+            return _run(new_qu, clauses)
+
+        # Both lanes contain the work.
+        eq_([work.id], results(works_on_list))
+        eq_([work.id], results(works_on_gutenberg_lists))
+
+        # If there's another list with the same work on it, the
+        # work only shows up once.
+        gutenberg_list_2, ignore = self._customlist(num_entries=0)
+        gutenberg_list_2_entry, ignore = gutenberg_list_2.add_entry(work)
+        works_on_list._customlist_ids.append(gutenberg_list.id)
+        eq_([work.id], results(works_on_list))
+
+        # This WorkList gets every work on a list associated with Overdrive.
+        # There are no such lists, so the lane is empty.
+        overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
+        works_on_overdrive_lists = WorkList()
+        works_on_overdrive_lists.initialize(
+            self._default_library, list_datasource=overdrive
+        )
+        eq_([], results(works_on_overdrive_lists))
+
+        # It's possible to restrict a WorkList so that only works that
+        # are _featured_ on a list show up. The work isn't featured,
+        # so it doesn't show up.
+        eq_([], results(must_be_featured=True))
+
+        # Now it's featured, and it shows up.
+        gutenberg_list_entry.featured = True
+        eq_([work.id], results(must_be_featured=True))
+
+        # It's possible to restrict a WorkList to works that were seen on
+        # a certain list recently.
+        now = datetime.datetime.utcnow()
+        two_days_ago = now - datetime.timedelta(days=2)
+        gutenberg_list_entry.most_recent_appearance = two_days_ago
+
+        # The lane will only show works that were seen within the last
+        # day. There are no such works.
+        works_on_gutenberg_lists.list_seen_in_previous_days = 1
+        eq_([], results())
+
+        # Now it's been loosened to three days, and the work shows up.
+        works_on_gutenberg_lists.list_seen_in_previous_days = 3
+        eq_([work.id], results())
+
+        # Now let's test what happens when we chain calls to this
+        # method.
+        gutenberg_list_2_wl = WorkList()
+        gutenberg_list_2_wl.initialize(
+            self._default_library, customlists = [gutenberg_list_2]
+        )
+
+        # These two lines won't work, because these are WorkLists, not
+        # Lanes, but they show the scenario in which this would
+        # actually happen. When determining which works belong in the
+        # child lane, Lane.customlist_filter_clauses() will be called
+        # on the parent lane and then on the child. In this case, only
+        # want books that are on _both_ works_on_list and
+        # gutenberg_list_2.
+        #
+        # gutenberg_list_2_wl.parent = works_on_list
+        # gutenberg_list_2_wl.inherit_parent_restrictions = True
+
+        qu = self._db.query(work_model)
+        list_1_qu, list_1_clauses = works_on_list.customlist_filter_clauses(qu)
+
+        # The query has been modified to indicate that we are filtering
+        # on the materialized view's customlist_id field.
+        eq_(True, list_1_qu.customlist_id_filtered)
+        eq_([work.id], [x.works_id for x in list_1_qu])
+
+        # Now call customlist_filter_clauses again so that the query
+        # must only match books on _both_ lists. This simulates
+        # what happens when the second lane is a child of the first,
+        # and inherits its restrictions.
+        both_lists_qu, list_2_clauses = gutenberg_list_2_wl.customlist_filter_clauses(
+            list_1_qu,
+        )
+        both_lists_clauses = list_1_clauses + list_2_clauses
+
+        # The combined query matches the work that shows up on
+        # both lists.
+        eq_([work.id], _run(both_lists_qu, both_lists_clauses))
+
+        # If we remove `work` from either list, the combined query
+        # matches nothing. This works even though the materialized
+        # view has not been refreshed.
+        for l in [gutenberg_list, gutenberg_list_2]:
+            l.remove_entry(work)
+            eq_([], _run(both_lists_qu, both_lists_clauses))
+            l.add_entry(work)
+
+    def test_audience_filter_clauses(self):
+
+        # Create two childrens' books (one from Gutenberg, one not)
+        # and one book for adults.
+
+        gutenberg_children = self._work(
+            title="Beloved Treasury of Racist Nursery Rhymes",
+            with_license_pool=True,
+            with_open_access_download=True,
+        )
+        eq_(DataSource.GUTENBERG,
+            gutenberg_children.license_pools[0].data_source.name)
+
+        # _work() will not create a test Gutenberg book for children
+        # to avoid exactly the problem we're trying to test, so
+        # we need to set it manually.
+        gutenberg_children.audience=Classifier.AUDIENCE_CHILDREN
+
+        gutenberg_adult = self._work(
+            title="Diseases of the Horse",
+            with_license_pool=True, with_open_access_download=True,
+            audience=Classifier.AUDIENCE_ADULT
+        )
+
+        edition, lp = self._edition(
+            title="Wholesome Nursery Rhymes For All Children",
+            data_source_name=DataSource.OVERDRIVE,
+            with_license_pool=True
+        )
+        non_gutenberg_children = self._work(
+            presentation_edition=edition, audience=Classifier.AUDIENCE_CHILDREN
+        )
+        self.add_to_materialized_view(
+            [gutenberg_children, non_gutenberg_children, gutenberg_adult]
+        )
+
+        def for_audiences(*audiences):
+            """Invoke WorkList.apply_audience_clauses using the given
+            `audiences`, and return all the matching Work objects.
+            """
+            wl = WorkList()
+            wl.audiences = audiences
+            qu = self._db.query(work_model).join(work_model.license_pool)
+            clauses = wl.audience_filter_clauses(self._db, qu)
+            if clauses:
+                qu = qu.filter(and_(*clauses))
+            return [x.works_id for x in qu.all()]
+
+        eq_([gutenberg_adult.id], for_audiences(Classifier.AUDIENCE_ADULT))
+
+        # The Gutenberg "children's" book is filtered out because it we have
+        # no guarantee it is actually suitable for children.
+        eq_([non_gutenberg_children.id],
+            for_audiences(Classifier.AUDIENCE_CHILDREN))
+
+        # This can sometimes lead to unexpected results, but the whole
+        # thing is a hack and needs to be improved anyway.
+        eq_([non_gutenberg_children.id],
+            for_audiences(Classifier.AUDIENCE_ADULT,
+                          Classifier.AUDIENCE_CHILDREN))
+
+        # If no particular audiences are specified, no books are filtered.
+        eq_(set([gutenberg_adult.id, gutenberg_children.id,
+                 non_gutenberg_children.id]),
+            set(for_audiences()))
+
 
 class TestFeaturedFacets(DatabaseTest):
 
@@ -1908,405 +2237,6 @@ class TestWorkList(DatabaseTest):
         wl.initialize(self._default_library)
         qu = self._db.query(work_model)
         eq_(None, wl.apply_filters(self._db, qu, None, None))
-
-    def test_bibliographic_filter_clause(self):
-        called = dict()
-
-        class MockWorkList(WorkList):
-            """Mock WorkList that simply verifies that
-            bibliographic_filter_clause() calls various hook methods.
-            """
-
-            def __init__(self, languages=None, genre_ids=None, media=None,
-                         customlists=[], list_datasource=None,
-                         list_seen_in_previous_days=None):
-                self.languages = languages
-                self.genre_ids = genre_ids
-                self.media = media
-                self._customlist_ids=[x.id for x in customlists]
-                if list_datasource:
-                    self.list_datasource_id = list_datasource.id
-                else:
-                    self.list_datasource_id = None
-                self.list_seen_in_previous_days = list_seen_in_previous_days
-
-            def audience_filter_clauses(self, _db, qu):
-                called['apply_audience_filter'] = (_db, qu)
-                return []
-
-            def customlist_filter_clauses(self, *args, **kwargs):
-                called['customlist_filter_clauses'] = (args, kwargs)
-                return super(MockWorkList, self).customlist_filter_clauses(
-                    *args, **kwargs
-                )
-
-        wl = MockWorkList()
-        from ..model import MaterializedWorkWithGenre as wg
-        original_qu = self._db.query(wg)
-
-        # If no languages or genre IDs are specified, and the hook
-        # methods do nothing, then bibliographic_filter_clause() has
-        # no effect.
-        featured_object = object()
-        final_qu, bibliographic_filter = wl.bibliographic_filter_clause(
-            self._db, original_qu, featured_object
-        )
-        eq_(original_qu, final_qu)
-        eq_(None, bibliographic_filter)
-
-        # But at least the apply_audience_filter was called with the correct
-        # arguments.
-        _db, qu = called['apply_audience_filter']
-        eq_(self._db, _db)
-        eq_(original_qu, qu)
-
-        # customlist_filter_clauses was not called because the WorkList
-        # doesn't do anything relating to custom lists.
-        assert 'customlist_filter_clauses' not in called
-
-        # If languages, media, and genre IDs are specified, then they are
-        # incorporated into the query.
-        #
-        english_sf = self._work(language="eng", with_license_pool=True)
-        english_sf.presentation_edition.medium = Edition.BOOK_MEDIUM
-        sf, ignore = Genre.lookup(self._db, "Science Fiction")
-        romance, ignore = Genre.lookup(self._db, "Romance")
-        english_sf.genres.append(sf)
-        self.add_to_materialized_view(english_sf)
-
-        # Create a WorkList that will find the MaterializedWorkWithGenre
-        # for the English SF book.
-        def worklist_has_books(
-                expect_books, featured=False, outer_join=False,
-                **worklist_constructor_args
-        ):
-            """Apply bibliographic filters to a query and verify
-            that it finds only the given books.
-            """
-            worklist = MockWorkList(**worklist_constructor_args)
-            qu, clause = worklist.bibliographic_filter_clause(
-                self._db, original_qu, featured=featured,
-                outer_join=outer_join
-            )
-            qu = qu.filter(clause)
-            expect_titles = sorted([x.sort_title for x in expect_books])
-            actual_titles = sorted([x.sort_title for x in qu])
-            eq_(expect_titles, actual_titles)
-
-        worklist_has_books(
-            [english_sf],
-            languages=["eng"], genre_ids=[sf.id], media=[Edition.BOOK_MEDIUM]
-        )
-
-        # WorkLists that do not match by language, medium, or genre will not
-        # find the English SF book.
-        worklist_has_books([], languages=["spa"], genre_ids=[sf.id])
-        worklist_has_books([], languages=["eng"], genre_ids=[romance.id])
-        worklist_has_books(
-            [],
-            languages=["eng"], genre_ids=[sf.id], media=[Edition.AUDIO_MEDIUM]
-        )
-
-        # If the WorkList has custom list IDs, then works will only show up if
-        # they're on one of the matching CustomLists.
-
-        sf_list, ignore = self._customlist(num_entries=0)
-        sf_list.add_entry(english_sf)
-        empty_list, ignore = self._customlist(num_entries=0)
-        self.add_to_materialized_view(english_sf)
-
-        worklist_has_books([], featured="featured value",
-                           outer_join="outer_join value",
-                           customlists=[empty_list])
-        # There were no results, but customlist_filter_clauses was
-        # called, with the arguments we passed in for `featured`
-        # and `outer_join` (plus an intermediary query that we can't
-        # really test).
-        args, kwargs= called['customlist_filter_clauses']
-        untestable, featured, outer_join = args
-        eq_(outer_join, "outer_join value")
-        eq_(featured, "featured value")
-
-        worklist_has_books([english_sf], customlists=[sf_list])
-
-
-    def test_audience_filter_clauses(self):
-
-        # Create two childrens' books (one from Gutenberg, one not)
-        # and one book for adults.
-
-        gutenberg_children = self._work(
-            title="Beloved Treasury of Racist Nursery Rhymes",
-            with_license_pool=True,
-            with_open_access_download=True,
-        )
-        eq_(DataSource.GUTENBERG,
-            gutenberg_children.license_pools[0].data_source.name)
-
-        # _work() will not create a test Gutenberg book for children
-        # to avoid exactly the problem we're trying to test, so
-        # we need to set it manually.
-        gutenberg_children.audience=Classifier.AUDIENCE_CHILDREN
-
-        gutenberg_adult = self._work(
-            title="Diseases of the Horse",
-            with_license_pool=True, with_open_access_download=True,
-            audience=Classifier.AUDIENCE_ADULT
-        )
-
-        edition, lp = self._edition(
-            title="Wholesome Nursery Rhymes For All Children",
-            data_source_name=DataSource.OVERDRIVE,
-            with_license_pool=True
-        )
-        non_gutenberg_children = self._work(
-            presentation_edition=edition, audience=Classifier.AUDIENCE_CHILDREN
-        )
-        self.add_to_materialized_view(
-            [gutenberg_children, non_gutenberg_children, gutenberg_adult]
-        )
-
-        def for_audiences(*audiences):
-            """Invoke WorkList.apply_audience_clauses using the given
-            `audiences`, and return all the matching Work objects.
-            """
-            wl = WorkList()
-            wl.audiences = audiences
-            qu = self._db.query(work_model).join(work_model.license_pool)
-            clauses = wl.audience_filter_clauses(self._db, qu)
-            if clauses:
-                qu = qu.filter(and_(*clauses))
-            return [x.works_id for x in qu.all()]
-
-        eq_([gutenberg_adult.id], for_audiences(Classifier.AUDIENCE_ADULT))
-
-        # The Gutenberg "children's" book is filtered out because it we have
-        # no guarantee it is actually suitable for children.
-        eq_([non_gutenberg_children.id],
-            for_audiences(Classifier.AUDIENCE_CHILDREN))
-
-        # This can sometimes lead to unexpected results, but the whole
-        # thing is a hack and needs to be improved anyway.
-        eq_([non_gutenberg_children.id],
-            for_audiences(Classifier.AUDIENCE_ADULT,
-                          Classifier.AUDIENCE_CHILDREN))
-
-        # If no particular audiences are specified, no books are filtered.
-        eq_(set([gutenberg_adult.id, gutenberg_children.id,
-                 non_gutenberg_children.id]),
-            set(for_audiences()))
-
-    def test_customlist_filter_clauses(self):
-        """Standalone test of customlist_filter_clauses
-
-        Some of this code is also tested by test_apply_custom_filters.
-        """
-
-        # If a lane has nothing to do with CustomLists,
-        # apply_customlist_filter does nothing.
-        no_lists = self._lane()
-        qu = self._db.query(Work)
-        new_qu, clauses = no_lists.customlist_filter_clauses(qu)
-        eq_(qu, new_qu)
-        eq_([], clauses)
-
-        # Now set up a Work and a CustomList that contains the work.
-        work = self._work(with_license_pool=True)
-        gutenberg = DataSource.lookup(self._db, DataSource.GUTENBERG)
-        eq_(gutenberg, work.license_pools[0].data_source)
-        gutenberg_list, ignore = self._customlist(num_entries=0)
-        gutenberg_list.data_source = gutenberg
-        gutenberg_list_entry, ignore = gutenberg_list.add_entry(work)
-
-        # This WorkList gets every work on a specific list.
-        works_on_list = WorkList()
-        works_on_list.initialize(
-            self._default_library, customlists=[gutenberg_list]
-        )
-
-        # This lane gets every work on every list associated with Project
-        # Gutenberg.
-        works_on_gutenberg_lists = WorkList()
-        works_on_gutenberg_lists.initialize(
-            self._default_library, list_datasource=gutenberg
-        )
-        self.add_to_materialized_view([work])
-
-        def _run(qu, clauses):
-            # Run a query with certain clauses and pick out the
-            # work IDs returned.
-            modified = qu.filter(and_(*clauses))
-            return [x.works_id for x in modified]
-
-        def results(wl=works_on_gutenberg_lists, must_be_featured=False):
-            qu = self._db.query(work_model)
-            new_qu, clauses = wl.customlist_filter_clauses(
-                qu, must_be_featured=must_be_featured
-            )
-
-            if must_be_featured or wl.list_seen_in_previous_days:
-                # The query comes out different than it goes in -- there's a
-                # new join against CustomListEntry.
-                assert new_qu != qu
-            return _run(new_qu, clauses)
-
-        # Both lanes contain the work.
-        eq_([work.id], results(works_on_list))
-        eq_([work.id], results(works_on_gutenberg_lists))
-
-        # If there's another list with the same work on it, the
-        # work only shows up once.
-        gutenberg_list_2, ignore = self._customlist(num_entries=0)
-        gutenberg_list_2_entry, ignore = gutenberg_list_2.add_entry(work)
-        works_on_list._customlist_ids.append(gutenberg_list.id)
-        eq_([work.id], results(works_on_list))
-
-        # This WorkList gets every work on a list associated with Overdrive.
-        # There are no such lists, so the lane is empty.
-        overdrive = DataSource.lookup(self._db, DataSource.OVERDRIVE)
-        works_on_overdrive_lists = WorkList()
-        works_on_overdrive_lists.initialize(
-            self._default_library, list_datasource=overdrive
-        )
-        eq_([], results(works_on_overdrive_lists))
-
-        # It's possible to restrict a WorkList so that only works that
-        # are _featured_ on a list show up. The work isn't featured,
-        # so it doesn't show up.
-        eq_([], results(must_be_featured=True))
-
-        # Now it's featured, and it shows up.
-        gutenberg_list_entry.featured = True
-        eq_([work.id], results(must_be_featured=True))
-
-        # It's possible to restrict a WorkList to works that were seen on
-        # a certain list recently.
-        now = datetime.datetime.utcnow()
-        two_days_ago = now - datetime.timedelta(days=2)
-        gutenberg_list_entry.most_recent_appearance = two_days_ago
-
-        # The lane will only show works that were seen within the last
-        # day. There are no such works.
-        works_on_gutenberg_lists.list_seen_in_previous_days = 1
-        eq_([], results())
-
-        # Now it's been loosened to three days, and the work shows up.
-        works_on_gutenberg_lists.list_seen_in_previous_days = 3
-        eq_([work.id], results())
-
-        # Now let's test what happens when we chain calls to this
-        # method.
-        gutenberg_list_2_wl = WorkList()
-        gutenberg_list_2_wl.initialize(
-            self._default_library, customlists = [gutenberg_list_2]
-        )
-
-        # These two lines won't work, because these are WorkLists, not
-        # Lanes, but they show the scenario in which this would
-        # actually happen. When determining which works belong in the
-        # child lane, Lane.customlist_filter_clauses() will be called
-        # on the parent lane and then on the child. In this case, only
-        # want books that are on _both_ works_on_list and
-        # gutenberg_list_2.
-        #
-        # gutenberg_list_2_wl.parent = works_on_list
-        # gutenberg_list_2_wl.inherit_parent_restrictions = True
-
-        qu = self._db.query(work_model)
-        list_1_qu, list_1_clauses = works_on_list.customlist_filter_clauses(qu)
-
-        # The query has been modified to indicate that we are filtering
-        # on the materialized view's customlist_id field.
-        eq_(True, list_1_qu.customlist_id_filtered)
-        eq_([work.id], [x.works_id for x in list_1_qu])
-
-        # Now call customlist_filter_clauses again so that the query
-        # must only match books on _both_ lists. This simulates
-        # what happens when the second lane is a child of the first,
-        # and inherits its restrictions.
-        both_lists_qu, list_2_clauses = gutenberg_list_2_wl.customlist_filter_clauses(
-            list_1_qu,
-        )
-        both_lists_clauses = list_1_clauses + list_2_clauses
-
-        # The combined query matches the work that shows up on
-        # both lists.
-        eq_([work.id], _run(both_lists_qu, both_lists_clauses))
-
-        # If we remove `work` from either list, the combined query
-        # matches nothing. This works even though the materialized
-        # view has not been refreshed.
-        for l in [gutenberg_list, gutenberg_list_2]:
-            l.remove_entry(work)
-            eq_([], _run(both_lists_qu, both_lists_clauses))
-            l.add_entry(work)
-
-    def test_random_sample(self):
-        # This lets me test which items are chosen in a random sample,
-        # but for some reason the shuffled lists still come out in an
-        # unpredictable order.
-        random.seed(42)
-
-        # It doesn't matter what type of model object the query
-        # returns, so query something that's faster to create than
-        # Works.
-        i1 = self._identifier()
-        i2 = self._identifier()
-        i3 = self._identifier()
-        i4 = self._identifier()
-        i5 = self._identifier()
-        i6 = self._identifier()
-        i7 = self._identifier()
-        i8 = self._identifier()
-        i9 = self._identifier()
-        i10 = self._identifier()
-        qu = self._db.query(Identifier).order_by(Identifier.id)
-
-        # If the random sample is smaller than the population, a
-        # randomly located slice is chosen, and the slice is
-        # shuffled. (It's presumed that the query sorts items by some
-        # randomly generated number such as Work.random, so that choosing
-        # a slice gets you a random sample -- that's not the case here.)
-        sample = WorkList.random_sample(qu, 2, quality_coefficient=1)
-        eq_([i6, i7], sorted(sample, key=lambda x: x.id))
-
-        # If the random sample is larger than the sample population,
-        # the population is shuffled.
-        sample = WorkList.random_sample(qu, 11)
-        eq_(set([i1, i2, i3, i4, i5, i6, i7, i8, i9, i10]),
-            set(sample))
-
-        # We weight the random sample towards the front of the list.
-        # By default we only choose from the first 10% of the list.
-        #
-        # This means if we sample one item from this ten-item
-        # population, we will always get the first value.
-        for i in range(0, 10):
-            eq_([i1], WorkList.random_sample(qu, 1))
-
-        # If we sample two items, we will always get the first and
-        # second values.
-        for i in range(0, 10):
-            eq_(set([i1, i2]), set(WorkList.random_sample(qu, 2)))
-
-        # If we set the quality coefficient to sample from the first
-        # half of the list, we will never get an item from the second
-        # half.
-        samples = [WorkList.random_sample(qu, 2, 0.5) for x in range(5)]
-        eq_(
-            [set([i4, i3]),
-             set([i1, i2]),
-             set([i3, i2]),
-             set([i1, i2]),
-             set([i3, i4])],
-            [set(x) for x in samples]
-        )
-
-        # This works even if the quality coefficient appears to limit
-        # selection to a fractional number of works.
-        sample = WorkList.random_sample(qu, 2, quality_coefficient=0.23109)
-        eq_([i1, i2], sorted(sample, key=lambda x: x.id))
-
 
     def test_search_target(self):
         # A WorkList can be searched - it is its own search target.

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -2012,7 +2012,7 @@ class TestDatabaseBackedWorkList(DatabaseTest):
         # bibliographic_filter_clauses() returned two clauses which were
         # combined with and_().
         bibliographic_filter_clauses = result.clauses.pop(0)
-        eq_(str(and_('clause 1', 'clause 2')),
+        eq_(str(and_(text('clause 1'), text('clause 2'))),
             str(bibliographic_filter_clauses))
 
         # The rest of the calls are easy to trac.

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -16,6 +16,7 @@ from sqlalchemy.sql.elements import Case
 from sqlalchemy import (
     and_,
     func,
+    text,
 )
 
 from elasticsearch_dsl.function import (
@@ -943,7 +944,6 @@ class TestFeaturedFacets(DatabaseTest):
         # Verify that FeaturedFacets sets appropriate scoring functions
         # for ElasticSearch queries.
         f = FeaturedFacets(minimum_featured_quality=0.55, random_seed=42)
-        from core.external_search import Filter
         filter = Filter()
 
         # In most cases, there are three things that can boost a work's score.
@@ -1923,7 +1923,7 @@ class TestDatabaseBackedWorkList(DatabaseTest):
                 self.stages.append(new_query)
                 return (
                     new_query,
-                    ["clause 1", "clause 2"]
+                    [text("clause 1"), text("clause 2")]
                 )
 
         # The simplest case: no facets or pagination,

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -944,12 +944,10 @@ class TestFeaturedFacets(DatabaseTest):
     def test_constructor(self):
         # Verify that constructor arguments are stored.
         entrypoint = object()
-        facets = FeaturedFacets(1, True, entrypoint, entrypoint_is_default=True)
+        facets = FeaturedFacets(1, entrypoint, entrypoint_is_default=True)
         eq_(1, facets.minimum_featured_quality)
-        eq_(True, facets.uses_customlists)
         eq_(entrypoint, facets.entrypoint)
         eq_(True, facets.entrypoint_is_default)
-
 
     def test_navigate(self):
         """Test the ability of navigate() to move between slight
@@ -960,19 +958,13 @@ class TestFeaturedFacets(DatabaseTest):
 
         different_entrypoint = f.navigate(entrypoint=AudiobooksEntryPoint)
         eq_(1, different_entrypoint.minimum_featured_quality)
-        eq_(True, different_entrypoint.uses_customlists)
         eq_(AudiobooksEntryPoint, different_entrypoint.entrypoint)
+        eq_(False, different_entrypoint.entrypoint_is_default)
 
         different_quality = f.navigate(minimum_featured_quality=2)
         eq_(2, different_quality.minimum_featured_quality)
-        eq_(True, different_quality.uses_customlists)
         eq_(entrypoint, different_quality.entrypoint)
-
-        not_a_list = f.navigate(uses_customlists=False)
-        eq_(1, not_a_list.minimum_featured_quality)
-        eq_(False, not_a_list.uses_customlists)
-        eq_(entrypoint, not_a_list.entrypoint)
-
+        eq_(True, different_entrypoint.entrypoint_is_default)
 
     def test_quality_calculation(self):
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -86,16 +86,16 @@ class TestFacetsWithEntryPoint(DatabaseTest):
         eq_([expect_items], list(f.items()))
         eq_("%s=%s" % expect_items, f.query_string)
 
-    def test_apply(self):
+    def test_modify_database_query(self):
         class MockEntryPoint(object):
-            def apply(self, qu):
+            def modify_database_query(self, qu):
                 self.called_with = qu
 
         ep = MockEntryPoint()
         f = FacetsWithEntryPoint(ep)
         _db = object()
         qu = object()
-        f.apply(_db, qu)
+        f.modify_database_query(_db, qu)
         eq_(qu, ep.called_with)
 
     def test_navigate(self):
@@ -1212,7 +1212,7 @@ class TestPagination(DatabaseTest):
 
         # When total_size is not set, Pagination assumes there is a
         # next page.
-        pagination.apply(query)
+        pagination.modify_database_query(query)
         eq_(True, pagination.has_next_page)
 
         # Here, there is one more item on the next page.
@@ -1249,7 +1249,7 @@ class TestPagination(DatabaseTest):
 
         # When this_page_size is not set, Pagination assumes there is a
         # next page.
-        pagination.apply(query)
+        pagination.modify_database_query(query)
         eq_(True, pagination.has_next_page)
 
         # Here, there is nothing on the current page. There is no next page.

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -3355,9 +3355,25 @@ class TestWorkListGroupsEndToEnd(EndToEndSearchTest):
         )
         discredited_nonfiction.inherit_parent_restrictions = False
 
+        # Since we have a bunch of lanes and works, plus an
+        # Elasticsearch index, let's take this opportunity to verify that
+        # WorkList.works and DatabaseBackedWorkList.works_from_database
+        # give the same results.
+        facets = DatabaseBackedFacets(
+            self._default_library,
+            collection=Facets.COLLECTION_FULL,
+            availability=Facets.AVAILABLE_ALL,
+            order=Facets.ORDER_TITLE
+        )
+        for lane in [fiction, best_sellers, staff_picks, sf_lane, romance_lane,
+                     discredited_nonfiction]:
+            t1 = [x.id for x in lane.works(self._db, facets)]
+            t2 = [x.id for x in lane.works_from_database(self._db, facets)]
+            eq_(t1, t2)
+
         def assert_contents(g, expect):
             """Assert that a generator yields the expected
-            (MaterializedWorkWithGenre, lane) 2-tuples.
+            (Work, lane) 2-tuples.
             """
             results = list(g)
             expect = [


### PR DESCRIPTION
This branch completes https://jira.nypl.org/browse/SIMPLY-2076. It's primarily a refactoring branch and should not change user-visible functionality.

This branch takes all of the code in lane.py that deals with the database (as opposed to the search engine) and either removes it, or puts it in new classes: `DatabaseBackedFacets` and `DatabaseBackedWorkList`. It may be easier to review these classes as though they were new, rather than trying to make sense of those parts of the diffs.

The new facets class is necessary because only a subset of the 'standard' sort orders can be implemented inside the database without using the materialized view.

Speaking of which, all of the lane code to do with the materialized view is gone. All of the database-specific code relating to building a list of featured works is gone. But a lot of code I was hoping to remove is still here. It would be nice to get rid of  `DatabaseBackedWorkList` altogether, and here's what's currently blocking that:

* `WorkList.works()` (the search index method) does its search index thing and calls `works_for_hits`, which creates a `SpecificWorkList`, a subclass of `DatabaseBackedWorkList`. That object does a database lookup to find Works for specific work IDs. This allowed me to eliminate some duplicate code around setting up a basic database query suitable for use in an OPDS feed.
* `Lane` subclasses `DatabaseBackedWorkList`, and we call `works_from_database` to count the total size of a lane. This requires that `DatabaseBackedWorkList` be able to handle every feature of a 'normal' lane, e.g. multiple sets of custom list restrictions. We could probably use the search index instead.
* The `DatabaseBackedWorkList` is the basis for the `RecommendationLane`, which finds works associated with specific ISBNs -- a feature that would be very difficult to reliably add to the search index. Like all WorkLists associated with a specific Work, RecommendationLane has language and audience filters that need to be taken into account. But it doesn't need the super-complicated stuff.
* The database code is already tested and it would be nice to have it around for future requirements. The flip side of this is that if we add a new feature to the `lanes` table we have to implement the filter twice -- once as a search engine filter in `WorkList` and once as a database filter in `DatabaseBackedWorkList`.

This branch also defines two hook methods that a subclass of `WorkList` or `DatabaseBackedWorkList` can implement to hard-code a modification to an outgoing search or database query. This should let me get rid of the awkward code in circulation where every special lane in `api/lanes.py` needs to have its own faceting class, because that's the only way to modify the `Filter` object.