### PR TITLE
Allow WorkLists to modify an incoming FeaturedFacets object to a faceting object that works for them

### DIFF
--- a/config.py
+++ b/config.py
@@ -119,11 +119,6 @@ class Configuration(object):
     # ConfigurationSetting key for a CDN's mirror domain
     CDN_MIRRORED_DOMAIN_KEY = u'mirrored_domain'
 
-    # The names of the site-wide configuration settings that determine
-    # feed cache time.
-    NONGROUPED_MAX_AGE_POLICY = "default_nongrouped_feed_max_age"
-    GROUPED_MAX_AGE_POLICY = "default_grouped_feed_max_age"
-
     # The name of the per-library configuration policy that controls whether
     # books may be put on hold.
     ALLOW_HOLDS = "allow_holds"
@@ -173,18 +168,6 @@ class Configuration(object):
     EXCLUDED_AUDIO_DATA_SOURCES = 'excluded_audio_data_sources'
 
     SITEWIDE_SETTINGS = [
-        {
-            "key": NONGROUPED_MAX_AGE_POLICY,
-            "label": _("Cache time for paginated OPDS feeds (in seconds)"),
-            "required": True,
-            "type": "number",
-        },
-        {
-            "key": GROUPED_MAX_AGE_POLICY,
-            "label": _("Cache time for grouped OPDS feeds (in seconds)"),
-            "required": True,
-            "type": "number",
-        },
         {
             "key": BASE_URL_KEY,
             "label": _("Base url of the application"),

--- a/external_search.py
+++ b/external_search.py
@@ -522,6 +522,11 @@ return champion;
     def bulk_update(self, works, retry_on_batch_failure=True):
         """Upload a batch of works to the search index at once."""
 
+        if not works:
+            # There's nothing to do. Don't bother making any requests
+            # to the search index.
+            return [], []
+
         time1 = time.time()
         needs_add = []
         successes = []

--- a/lane.py
+++ b/lane.py
@@ -320,8 +320,10 @@ class Facets(FacetsWithEntryPoint):
     feeds that list all the works in some WorkList.
     """
     @classmethod
-    def default(cls, library):
-        return cls(library, collection=None, availability=None, order=None)
+    def default(cls, library, collection=None, availability=None, order=None,
+                entrypoint=None):
+        return cls(library, collection=collection, availability=availability,
+                   order=availability, entrypoint=entrypoint)
 
     @classmethod
     def available_facets(cls, config, facet_group_name):

--- a/lane.py
+++ b/lane.py
@@ -1036,6 +1036,11 @@ class WorkList(object):
     # default. Most WorkList subclasses will override this.
     MAX_CACHE_AGE = 14*24*60*60
 
+    # In your subclass, set MAX_CACHE_AGE to this value to guarantee
+    # that cached feeds never expire -- they must be explicitly
+    # regenerated.
+    CACHE_FOREVER = 'forever'
+
     # By default, a WorkList is always visible.
     visible = True
 

--- a/lane.py
+++ b/lane.py
@@ -1413,8 +1413,9 @@ class WorkList(object):
                 continue
 
             if isinstance(child, Lane):
-                # Children that turn out to be Lanes go into relevant_lanes.
-                # Their Works will all be filled in with a single query.
+                # Children that turn out to be Lanes go into
+                # relevant_lanes. Their Works will be obtained from
+                # the search index.
                 relevant_lanes.append(child)
             # Both Lanes and WorkLists go into relevant_children.
             # This controls the yield order for Works.

--- a/lane.py
+++ b/lane.py
@@ -323,7 +323,7 @@ class Facets(FacetsWithEntryPoint):
     def default(cls, library, collection=None, availability=None, order=None,
                 entrypoint=None):
         return cls(library, collection=collection, availability=availability,
-                   order=availability, entrypoint=entrypoint)
+                   order=order, entrypoint=entrypoint)
 
     @classmethod
     def available_facets(cls, config, facet_group_name):

--- a/lane.py
+++ b/lane.py
@@ -1032,8 +1032,8 @@ class WorkList(object):
     By default, these Work objects come from a search index.
     """
 
-    # Unless a sitewide setting intervenes, the set of Works in a
-    # WorkList is cacheable for two weeks by default.
+    # The set of Works in a WorkList is cacheable for two weeks by
+    # default. Most WorkList subclasses will override this.
     MAX_CACHE_AGE = 14*24*60*60
 
     # By default, a WorkList is always visible.
@@ -2082,8 +2082,9 @@ class Lane(Base, DatabaseBackedWorkList):
     books.
     """
 
-    # Unless a sitewide setting intervenes, the set of Works in a
-    # Lane is cacheable for twenty minutes by default.
+    # The set of Works in a standard Lane is cacheable for twenty
+    # minutes. Note that this only applies to paginated feeds --
+    # grouped feeds are cached indefinitely.
     MAX_CACHE_AGE = 20*60
 
     __tablename__ = 'lanes'

--- a/lane.py
+++ b/lane.py
@@ -562,6 +562,24 @@ class DefaultSortOrderFacets(Facets):
     """
 
     @classmethod
+    def available_facets(cls, config, facet_group_name):
+        """Make sure the default sort order is the first item
+        in the list of available sort orders.
+        """
+        if facet_group_name != cls.ORDER_FACET_GROUP_NAME:
+            return super(SeriesFacets, cls).available_facets(
+                config, facet_group_name
+            )
+        default = config.enabled_facets(facet_group_name)
+
+        # Promote the default sort order to the front of the list,
+        # adding it if necessary.
+        order = cls.DEFAULT_SORT_ORDER
+        if order in default:
+            default = filter(lambda x: x==order, default)
+        return [order] + default
+
+    @classmethod
     def default_facet(cls, config, facet_group_name):
         if facet_group_name == cls.ORDER_FACET_GROUP_NAME:
             return cls.DEFAULT_SORT_ORDER

--- a/lane.py
+++ b/lane.py
@@ -555,6 +555,21 @@ class Facets(FacetsWithEntryPoint):
                 logging.error("Unrecognized sort order: %s", self.order)
 
 
+class DefaultSortOrderFacets(Facets):
+    """A faceting object that changes the default sort order.
+
+    Subclasses must set DEFAULT_SORT_ORDER
+    """
+
+    @classmethod
+    def default_facet(cls, config, facet_group_name):
+        if facet_group_name == cls.ORDER_FACET_GROUP_NAME:
+            return cls.DEFAULT_SORT_ORDER
+        return super(DefaultSortOrderFacets, cls).default_facet(
+            config, facet_group_name
+        )
+
+
 class DatabaseBackedFacets(Facets):
     """A generic faceting object designed for managing queries against the
     database. (Other faceting objects are designed for managing

--- a/migration/20190629-remove-sitewide-cache-time-settings.sql
+++ b/migration/20190629-remove-sitewide-cache-time-settings.sql
@@ -1,0 +1,2 @@
+-- These site-wide configuration settings are no longer used.
+delete from configurationsettings where library_id is null and external_integration_id is null and key in ('default_nongrouped_feed_max_age', 'default_grouped_feed_max_age');

--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -73,9 +73,6 @@ class CachedFeed(Base):
     SERIES_TYPE = u'series'
     CONTRIBUTOR_TYPE = u'contributor'
 
-    # A constant indicating that, once generated, a feed should never expire.
-    CACHE_FOREVER = 'forever'
-
     log = logging.getLogger("CachedFeed")
 
     @classmethod
@@ -137,7 +134,7 @@ class CachedFeed(Base):
             # cached feed as stale.
             return feed, False
 
-        if max_age is self.CACHE_FOREVER:
+        if max_age is lane.CACHE_FOREVER:
             # This feed is so expensive to generate that it must be cached
             # forever (unless force_refresh is True).
             if not is_new and feed.content:
@@ -185,8 +182,8 @@ class CachedFeed(Base):
             # It's too expensive to generate grouped feeds for
             # Lanes on the fly. To generate these you will
             # need to pass in force_refresh=True
-            return cls.CACHE_FOREVER
-        return cls.MAX_CACHE_AGE
+            return lane.CACHE_FOREVER
+        return lane.MAX_CACHE_AGE
 
     def update(self, _db, content):
         self.content = content

--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -183,6 +183,9 @@ class CachedFeed(Base):
             # Lanes on the fly. To generate these you will
             # need to pass in force_refresh=True
             return lane.CACHE_FOREVER
+        if lane.MAX_CACHE_AGE is None:
+            # Assume the feed should not be cached at all.
+            return 0
         return lane.MAX_CACHE_AGE
 
     def update(self, _db, content):

--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -66,6 +66,7 @@ class CachedFeed(Base):
     GROUPS_TYPE = u'groups'
     PAGE_TYPE = u'page'
     NAVIGATION_TYPE = u'navigation'
+    RELATED_TYPE = u'related'
     RECOMMENDATIONS_TYPE = u'recommendations'
     SERIES_TYPE = u'series'
     CONTRIBUTOR_TYPE = u'contributor'
@@ -78,12 +79,12 @@ class CachedFeed(Base):
         from ..opds import AcquisitionFeed
         from ..lane import Lane, WorkList
         if max_age is None:
-            if type == cls.GROUPS_TYPE:
+            if hasattr(lane, 'MAX_CACHE_AGE'):
+                max_age = lane.MAX_CACHE_AGE
+            elif type == cls.GROUPS_TYPE:
                 max_age = AcquisitionFeed.grouped_max_age(_db)
             elif type == cls.PAGE_TYPE:
                 max_age = AcquisitionFeed.nongrouped_max_age(_db)
-            elif hasattr(lane, 'MAX_CACHE_AGE'):
-                max_age = lane.MAX_CACHE_AGE
             else:
                 max_age = 0
         if isinstance(max_age, int):

--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -66,6 +66,7 @@ class CachedFeed(Base):
     GROUPS_TYPE = u'groups'
     PAGE_TYPE = u'page'
     NAVIGATION_TYPE = u'navigation'
+    CRAWLABLE_TYPE = u'crawlable'
     RELATED_TYPE = u'related'
     RECOMMENDATIONS_TYPE = u'recommendations'
     SERIES_TYPE = u'series'

--- a/opds.py
+++ b/opds.py
@@ -1041,37 +1041,6 @@ class AcquisitionFeed(OPDSFeed):
             facet_title = str(Facets.FACET_DISPLAY_TITLES[value])
             yield cls.facet_link(url, facet_title, group_title, selected)
 
-    CACHE_FOREVER = 'forever'
-
-    NONGROUPED_MAX_AGE_POLICY = Configuration.NONGROUPED_MAX_AGE_POLICY
-    DEFAULT_NONGROUPED_MAX_AGE = 1200
-
-    GROUPED_MAX_AGE_POLICY = Configuration.GROUPED_MAX_AGE_POLICY
-    DEFAULT_GROUPED_MAX_AGE = CACHE_FOREVER
-
-    @classmethod
-    def grouped_max_age(cls, _db):
-        "The maximum cache time for a grouped acquisition feed."
-        value = ConfigurationSetting.sitewide(
-            _db, cls.GROUPED_MAX_AGE_POLICY).int_value
-        if value is None:
-            value = cls.DEFAULT_GROUPED_MAX_AGE
-        return value
-
-    @classmethod
-    def nongrouped_max_age(cls, _db):
-        "The maximum cache time for a non-grouped acquisition feed."
-        value = ConfigurationSetting.sitewide(
-            _db, cls.NONGROUPED_MAX_AGE_POLICY).int_value
-        if value is cls.CACHE_FOREVER:
-            logging.error(
-                "Non-grouped acquisition feed cannot be cached forever."
-            )
-            value = None
-        if value is None:
-            value = cls.DEFAULT_NONGROUPED_MAX_AGE
-        return value
-
     def __init__(self, _db, title, url, works, annotator=None,
                  precomposed_entries=[]):
         """Turn a list of works, messages, and precomposed <opds> entries

--- a/tests/models/test_cachedfeed.py
+++ b/tests/models/test_cachedfeed.py
@@ -159,7 +159,7 @@ class TestCachedFeed(DatabaseTest):
         # When site-wide configuration settings are not set, grouped
         # feeds for lanes are cached forever and other feeds are
         # cached for Lane.MAX_CACHE_AGE.
-        time(lane, groups, AcquisitionFeed.CACHE_FOREVER)
+        time(lane, groups, Lane.CACHE_FOREVER)
         time(lane, page, Lane.MAX_CACHE_AGE)
         time(lane, other, Lane.MAX_CACHE_AGE)
 
@@ -172,35 +172,7 @@ class TestCachedFeed(DatabaseTest):
         for type in (groups, page, other):
             time(has_max_cache_age, type, HasMaxCacheAge.MAX_CACHE_AGE)
 
-        # WorkLists with MAX_CACHE_AGE set to None use values that
-        # come from AcquisitionFeed.
-        time(no_max_cache_age, groups, AcquisitionFeed.DEFAULT_GROUPED_MAX_AGE)
-        time(no_max_cache_age, page, AcquisitionFeed.DEFAULT_NONGROUPED_MAX_AGE)
-
-        # AcquisitionFeed doesn't know what kind of feed this is and
-        # assumes it should not be cached.
-        time(no_max_cache_age, other, 0)
-
-        # Now set the sitewide feed time settings. This will affect
-        # some values but not others.
-        conf = ConfigurationSetting.sitewide
-        conf(self._db, AcquisitionFeed.GROUPED_MAX_AGE_POLICY).value = "10"
-        conf(self._db, AcquisitionFeed.NONGROUPED_MAX_AGE_POLICY).value = "20"
-
-        # Grouped lane feeds are cached forever, no matter what, but
-        # caching time of their paginated feeds is affected.
-        time(lane, groups, AcquisitionFeed.CACHE_FOREVER)
-        time(lane, page, 20)
-        time(lane, other, Lane.MAX_CACHE_AGE)
-
-        # Works with no explicit MAX_CACHE_AGE set are unaffected.
+        # If MAX_CACHE_AGE is set to None, AcquisitionFeed assumes the feed
+        # should not be cached at all.
         for type in (groups, page, other):
-            time(default_max_cache_age, type, WorkList.MAX_CACHE_AGE)
-
-        # Works with explicit MAX_CACHE_AGE set are unaffected.
-        for type in (groups, page, other):
-            time(has_max_cache_age, type, HasMaxCacheAge.MAX_CACHE_AGE)
-
-        # Works with MAX_CACHE_AGE set to None are affected.
-        time(no_max_cache_age, groups, 10)
-        time(no_max_cache_age, page, 20)
+            time(no_max_cache_age, type, 0)

--- a/tests/test_cachedfeed.py
+++ b/tests/test_cachedfeed.py
@@ -134,7 +134,7 @@ class TestCachedFeed(DatabaseTest):
         # If we ask for a group feed that will be cached forever, and it's
         # not around, we'll get a page feed instead.
         feed, fresh = CachedFeed.fetch(
-            *args, max_age=AcquisitionFeed.CACHE_FOREVER
+            *args, max_age=WorkList.CACHE_FOREVER
         )
         eq_(CachedFeed.PAGE_TYPE, feed.type)
 
@@ -145,13 +145,13 @@ class TestCachedFeed(DatabaseTest):
         # Or if we explicitly demand that the feed be created, it will
         # be created.
         feed, fresh = CachedFeed.fetch(
-            *args, force_refresh=True, max_age=AcquisitionFeed.CACHE_FOREVER
+            *args, force_refresh=True, max_age=WorkList.CACHE_FOREVER
         )
         feed.update(self._db, "Cache this forever!")
 
         # Once the feed has content associated with it, we can ask for
         # it in cached-forever mode and no longer get the exception.
         feed, fresh = CachedFeed.fetch(
-            *args, max_age=AcquisitionFeed.CACHE_FOREVER
+            *args, max_age=WorkList.CACHE_FOREVER
         )
         eq_("Cache this forever!", feed.content)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -354,7 +354,8 @@ class TestFacets(DatabaseTest):
                 self.kwargs = kwargs
         facets = Mock.default(self._default_library)
         eq_(self._default_library, facets.library)
-        eq_(dict(collection=None, availability=None, order=None),
+        eq_(dict(collection=None, availability=None, order=None,
+                 entrypoint=None),
             facets.kwargs)
 
     def test_default_availability(self):

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -28,6 +28,8 @@ from elasticsearch.exceptions import ElasticsearchException
 
 from ..classifier import Classifier
 
+from ..config import Configuration
+
 from ..entrypoint import (
     AudiobooksEntryPoint,
     EbooksEntryPoint,
@@ -44,6 +46,7 @@ from ..external_search import (
 from ..lane import (
     DatabaseBackedFacets,
     DatabaseBackedWorkList,
+    DefaultSortOrderFacets,
     FacetConstants,
     Facets,
     FacetsWithEntryPoint,
@@ -668,6 +671,74 @@ class TestFacets(DatabaseTest):
         filter = Filter()
         facets.modify_search_filter(filter)
         eq_(None, filter.order)
+
+
+class TestDefaultSortOrderFacets(DatabaseTest):
+
+    def setup(self):
+        super(TestDefaultSortOrderFacets, self).setup()
+        self.config = self._default_library
+
+    def _check_other_groups_not_changed(self, cls):
+        # Verify that nothing has changed for the collection or
+        # availability facet groups.
+        for group_name in (Facets.COLLECTION_FACET_GROUP_NAME,
+                           Facets.AVAILABILITY_FACET_GROUP_NAME):
+            eq_(Facets.available_facets(self.config, group_name),
+                cls.available_facets(self.config, group_name))
+            eq_(Facets.default_facet(self.config, group_name),
+                cls.default_facet(self.config, group_name))
+
+    def test_sort_order_rearrangement(self):
+        # Test the case where a DefaultSortOrderFacets does nothing but
+        # rearrange the default sort orders.
+
+        class TitleFirst(DefaultSortOrderFacets):
+            DEFAULT_SORT_ORDER = Facets.ORDER_TITLE
+
+        # In general, TitleFirst has the same options and
+        # defaults as a normal Facets object.
+        self._check_other_groups_not_changed(TitleFirst)
+
+        # But the default sort order for TitleFirst is ORDER_TITLE.
+        order = Facets.ORDER_FACET_GROUP_NAME
+        eq_(TitleFirst.DEFAULT_SORT_ORDER,
+            TitleFirst.default_facet(self.config, order))
+        assert Facets.default_facet(
+            self.config, order
+        ) != TitleFirst.DEFAULT_SORT_ORDER
+
+        # TitleFirst has the same sort orders as Facets, but ORDER_TITLE
+        # comes first in the list.
+        default_orders = Facets.available_facets(self.config, order)
+        title_first_orders = TitleFirst.available_facets(self.config, order)
+        eq_(set(default_orders), set(title_first_orders))
+        eq_(Facets.ORDER_TITLE, title_first_orders[0])
+        assert default_orders[0] != Facets.ORDER_TITLE
+
+    def test_new_sort_order(self):
+        # Test the case where DefaultSortOrderFacets adds a sort order
+        # not ordinarily supported.
+        class SeriesFirst(DefaultSortOrderFacets):
+            DEFAULT_SORT_ORDER = Facets.ORDER_SERIES_POSITION
+
+        # In general, SeriesFirst has the same options and
+        # defaults as a normal Facets object.
+        self._check_other_groups_not_changed(SeriesFirst)
+
+        # But its default sort order is ORDER_SERIES.
+        order = Facets.ORDER_FACET_GROUP_NAME
+        eq_(SeriesFirst.DEFAULT_SORT_ORDER,
+            SeriesFirst.default_facet(self.config, order))
+        assert Facets.default_facet(
+            self.config, order
+        ) != SeriesFirst.DEFAULT_SORT_ORDER
+
+        # Its list of sort orders is the same as Facets, except Series
+        # has been added to the front of the list.
+        default = Facets.available_facets(self.config, order)
+        series = SeriesFirst.available_facets(self.config, order)
+        eq_([SeriesFirst.DEFAULT_SORT_ORDER] + default, series)
         
 
 class TestDatabaseBackedFacets(DatabaseTest):
@@ -921,6 +992,29 @@ class TestFeaturedFacets(DatabaseTest):
         eq_(1, facets.minimum_featured_quality)
         eq_(entrypoint, facets.entrypoint)
         eq_(True, facets.entrypoint_is_default)
+
+    def test_default(self):
+        # Check how FeaturedFacets gets its minimum_featured_quality value.
+
+        library1 = self._default_library
+        library1.setting(Configuration.MINIMUM_FEATURED_QUALITY).value = 0.22
+        library2 = self._library()
+        library2.setting(Configuration.MINIMUM_FEATURED_QUALITY).value = 0.99
+        lane = self._lane(library=library2)
+
+        # FeaturedFacets can be instantiated for a library...
+        facets = FeaturedFacets.default(library1)
+        eq_(library1.minimum_featured_quality, facets.minimum_featured_quality)
+
+        # Or for a lane -- in which case it will take on the value for
+        # the library associated with that lane.
+        facets = FeaturedFacets.default(lane)
+        eq_(library2.minimum_featured_quality, facets.minimum_featured_quality)
+
+        # Or with nothing -- in which case the default value is used.
+        facets = FeaturedFacets.default(None)
+        eq_(Configuration.DEFAULT_MINIMUM_FEATURED_QUALITY,
+            facets.minimum_featured_quality)
 
     def test_navigate(self):
         # Test the ability of navigate() to move between slight
@@ -1586,24 +1680,54 @@ class TestWorkList(DatabaseTest):
         """
         class MockWorkList(WorkList):
 
+            overview_facets_called_with = None
+
             def works(self, _db, facets):
-                self.featured_called_with = facets
+                self.works_called_with = facets
                 return []
 
+            def overview_facets(self, _db, facets):
+                self.overview_facets_called_with = facets
+                return "A new faceting object"
+
             def _groups_for_lanes(
-                self, _db, relevant_children, relevant_lanes, facets, search_engine=None, debug=False
+                self, _db, relevant_children, relevant_lanes, facets, **kwargs
             ):
-                self.groups_called_with = facets
+                self._groups_for_lanes_called_with = facets
                 return []
 
         mock = MockWorkList()
         mock.initialize(library=self._default_library)
         facets = object()
-        [x for x in mock.groups(self._db, facets=facets)]
-        eq_(facets, mock.groups_called_with)
 
+        # First, try the situation where we're trying to make a grouped feed
+        # out of the (imaginary) sublanes of this lane.
+        [x for x in mock.groups(self._db, facets=facets)]
+
+        # overview_facets() was not called.
+        eq_(None, mock.overview_facets_called_with)
+
+        # The _groups_for_lanes() method was called with the
+        # (imaginary) list of sublanes and the original faceting
+        # object.  The _groups_for_lanes() implementation is
+        # responsible for giving each sublane a chance to adapt that
+        # faceting object to its own needs.
+        eq_(facets, mock._groups_for_lanes_called_with)
+        mock._groups_for_lanes_called_with = None
+
+        # Now try the situation where we're just trying to get _part_ of
+        # a grouped feed -- the part for which this lane is responsible.
         [x for x in mock.groups(self._db, facets=facets, include_sublanes=False)]
-        eq_(facets, mock.featured_called_with)
+        # Now, the original faceting object was passed into
+        # overview_facets().
+        eq_(facets, mock.overview_facets_called_with)
+
+        # And the return value of overview_facets() was passed into
+        # works()
+        eq_("A new faceting object", mock.works_called_with)
+
+        # _groups_for_lanes was not called.
+        eq_(None, mock._groups_for_lanes_called_with)
 
     def test_works(self):
         # Test the method that uses the search index to fetch a list of
@@ -3533,17 +3657,73 @@ class TestWorkListGroups(DatabaseTest):
         # same way every time.
         random.seed(42)
 
-    def test_groups_for_lanes_propagates_facets(self):
-        class Mock(WorkList):
-            def _featured_works_with_lanes(self, *args, **kwargs):
-                self.featured_called_with = kwargs['facets']
-                return []
+    def test_groups_for_lanes_adapts_facets(self):
+        # Verify that _groups_for_lanes gives each of a WorkList's
+        # non-queryable children the opportunity to adapt the incoming
+        # FeaturedFacets objects to its own needs.
 
-        wl = Mock()
-        wl.initialize(library=self._default_library)
+        class MockParent(WorkList):
+
+            def _featured_works_with_lanes(
+                    self, _db, lanes, facets, *args, **kwargs
+            ):
+                self._featured_works_with_lanes_called_with = (lanes, facets)
+                return super(MockParent, self)._featured_works_with_lanes(
+                    _db, lanes, facets, *args, **kwargs
+                )
+
+        class MockChild(WorkList):
+            def __init__(self, work):
+                self.work = work
+                self.id = work.title
+                super(MockChild, self).__init__()
+
+            def overview_facets(self, _db, facets):
+                self.overview_facets_called_with = (_db, facets)
+                return "Custom facets for %s." % self.id
+
+            def works(self, _db, facets, *args, **kwargs):
+                self.works_called_with = facets
+                return [self.work]
+
+        parent = MockParent()
+        child1 = MockChild(self._work(title="Lane 1"))
+        child2 = MockChild(self._work(title="Lane 2"))
+        children = [child1, child2]
+
+        for wl in children:
+            wl.initialize(library=self._default_library)
+        parent.initialize(library=self._default_library,
+                         children=[child1, child2])
+
+        # We're going to make a grouped feed in which both children
+        # are relevant, but neither one is queryable.
+        relevant = parent.children
+        queryable = []
         facets = FeaturedFacets(0)
-        groups = list(wl._groups_for_lanes(self._db, [], [], facets))
-        eq_(facets, wl.featured_called_with)
+        groups = list(
+            parent._groups_for_lanes(self._db, relevant, queryable, facets)
+        )
+
+        # Each sublane was asked in turn to provide works for the feed.
+        eq_([(child1.work, child1), (child2.work, child2)], groups)
+
+        # But we're more interested in what happened to the faceting objects.
+
+        # The original faceting object was passed into
+        # _featured_works_with_lanes, but none of the lanes were
+        # queryable, so it ended up doing nothing.
+        eq_(([], facets), parent._featured_works_with_lanes_called_with)
+
+        # Each non-queryable sublane was given a chance to adapt that
+        # faceting object to its own needs.
+        for wl in children:
+            eq_(wl.overview_facets_called_with, (self._db, facets))
+
+        # Each lane's adapted faceting object was then passed into
+        # works().
+        eq_("Custom facets for Lane 1.", child1.works_called_with)
+        eq_("Custom facets for Lane 2.", child2.works_called_with)
 
     def test_featured_works_with_lanes(self):
         # _featured_works_with_lanes calls works_from_search_index

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1337,11 +1337,6 @@ class TestOPDS(DatabaseTest):
                 pagination=Pagination.default(), search_engine=search_engine
             )
 
-        af = AcquisitionFeed
-        policy = ConfigurationSetting.sitewide(
-            self._db, af.NONGROUPED_MAX_AGE_POLICY)
-        policy.value = "10"
-
         feed1 = make_page()
         assert work1.title in feed1
         cached = get_one(self._db, CachedFeed, lane=fantasy_lane)
@@ -1359,10 +1354,9 @@ class TestOPDS(DatabaseTest):
         assert work2.title not in feed2
         assert cached.timestamp == old_timestamp
 
-        # Change the policy to disable caching, and we get
-        # a brand new page with the new work.
-        policy.value = "0"
-
+        # Change the WorkList's MAX_CACHE_AGE to disable caching, and
+        # we get a brand new page with the new work.
+        fantasy_lane.MAX_CACHE_AGE = 0
         feed3 = make_page()
         assert cached.timestamp > old_timestamp
         assert work2.title in feed3


### PR DESCRIPTION
This is a support branch for https://jira.nypl.org/browse/SIMPLY-1981. It changes the way grouped feeds are generated.

For normal Lanes, the behavior is unaffected -- a FeaturedFacets object means that the ElasticSearch scoring function is changed to make a random sample of high-quality works show up at the top (rather than e.g. works showing up in alphabetical order).

For other types of WorkLists, FeaturedFacets isn't very useful -- it just says "show some featured stuff". This branch introduces the `WorkList.overview_facets` method, which takes a FeaturedFacets object and returns some other object appropriate for _that WorkList_ to use when "showing some featured stuff".

This branch also brings in some generally useful code from circulation -- a faceting object that works just like `Facets` except it changes the default sort order, possibly to a field not normally enabled in `Facets`.