### PR TITLE
Make it easy to load different types of Pagination objects from requests, as with Facets

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -128,7 +128,7 @@ def load_pagination_from_request(
 ):
     """Figure out which Pagination object this request is asking for.
 
-    :param base_class: The Pagination subclass to use.
+    :param base_class: A subclass of Pagination to instantiate.
     :param base_class_constructor_kwargs: Extra keyword arguments to use
         when instantiating the Pagination subclass.
     :param default_size: The default page size.
@@ -137,7 +137,6 @@ def load_pagination_from_request(
     kwargs = base_class_constructor_kwargs or dict()
 
     get_arg = flask.request.args.get
-    get_header = flask.request.headers.get
     default_size = default_size or base_class.DEFAULT_SIZE
     return base_class.from_request(get_arg, default_size, **kwargs)
         

--- a/app_server.py
+++ b/app_server.py
@@ -122,6 +122,7 @@ def load_facets_from_request(
         default_entrypoint, **kwargs
     )
 
+
 def load_pagination_from_request(
     base_class=Pagination, base_class_constructor_kwargs=None,
     default_size=None
@@ -137,9 +138,8 @@ def load_pagination_from_request(
     kwargs = base_class_constructor_kwargs or dict()
 
     get_arg = flask.request.args.get
-    default_size = default_size or base_class.DEFAULT_SIZE
     return base_class.from_request(get_arg, default_size, **kwargs)
-        
+
 
 def returns_problem_detail(f):
     @wraps(f)

--- a/app_server.py
+++ b/app_server.py
@@ -122,26 +122,25 @@ def load_facets_from_request(
         default_entrypoint, **kwargs
     )
 
-def load_pagination_from_request(default_size=Pagination.DEFAULT_SIZE):
-    """Figure out which Pagination object this request is asking for."""
-    arg = flask.request.args.get
-    size = arg('size', default_size)
-    offset = arg('after', 0)
-    return load_pagination(size, offset)
+def load_pagination_from_request(
+    base_class=Pagination, base_class_constructor_kwargs=None,
+    default_size=None
+):
+    """Figure out which Pagination object this request is asking for.
 
-def load_pagination(size, offset):
-    """Turn user input into a Pagination object."""
-    try:
-        size = int(size)
-    except ValueError:
-        return INVALID_INPUT.detailed(_("Invalid page size: %(size)s", size=size))
-    size = min(size, 100)
-    if offset:
-        try:
-            offset = int(offset)
-        except ValueError:
-            return INVALID_INPUT.detailed(_("Invalid offset: %(offset)s", offset=offset))
-    return Pagination(offset, size)
+    :param base_class: The Pagination subclass to use.
+    :param base_class_constructor_kwargs: Extra keyword arguments to use
+        when instantiating the Pagination subclass.
+    :param default_size: The default page size.
+    :return: An instance of `base_class`.
+    """
+    kwargs = base_class_constructor_kwargs or dict()
+
+    get_arg = flask.request.args.get
+    get_header = flask.request.headers.get
+    default_size = default_size or base_class.DEFAULT_SIZE
+    return base_class.from_request(get_arg, default_size, **kwargs)
+        
 
 def returns_problem_detail(f):
     @wraps(f)

--- a/external_search.py
+++ b/external_search.py
@@ -2387,7 +2387,7 @@ class SortKeyPagination(Pagination):
         pagination_key = get_arg('key', None)
         if pagination_key:
             try:
-                pagination_key = cls.parse_pagination_key(pagination_key)
+                pagination_key = json.loads(pagination_key)
             except ValueError, e:
                 return INVALID_INPUT.detailed(
                     _("Invalid page key: %(key)s", key=pagination_key)
@@ -2395,7 +2395,9 @@ class SortKeyPagination(Pagination):
         return cls(pagination_key, size)
 
     def items(self):
-        """Yield the URL arguments necessary to convey the current page."""
+        """Yield the URL arguments necessary to convey the current page
+        state.
+        """
         pagination_key = self.pagination_key
         if pagination_key:
             yield("key", self.pagination_key)
@@ -2403,16 +2405,10 @@ class SortKeyPagination(Pagination):
 
     @property
     def pagination_key(self):
-        """Create the pagination key for this page.
-
-        """
+        """Create the pagination key for this page."""
         if not self.last_item_on_previous_page:
             return None
         return json.dumps(self.last_item_on_previous_page)
-
-    @classmethod
-    def parse_pagination_key(self, value):
-        return json.loads(value)
 
     @property
     def offset(self):

--- a/external_search.py
+++ b/external_search.py
@@ -58,6 +58,8 @@ from selftest import (
     HasSelfTests,
     SelfTestResult,
 )
+from util.problem_detail import ProblemDetail
+
 import os
 import logging
 import re
@@ -2363,6 +2365,7 @@ class SortKeyPagination(Pagination):
     previous page left off, rather than using a numeric index into the
     list.
     """
+
     def __init__(self, last_item_on_previous_page=None,
                  size=Pagination.DEFAULT_SIZE):
         self.size = size
@@ -2370,8 +2373,40 @@ class SortKeyPagination(Pagination):
 
         # These variables are set by page_loaded(), after the query
         # is run.
+        self.page_has_loaded = False
         self.last_item_on_this_page = None
         self.this_page_size = None
+
+    @classmethod
+    def from_request(cls, get_arg, default_size):
+        """Instantiate a Pagination object from a Flask request."""
+        size = cls.size_from_request(get_arg, default_size)
+        if isinstance(size, ProblemDetail):
+            return size
+        pagination_key = get_arg('key', None)
+        if pagination_key:
+            pagination_key = cls.parse_pagination_key(pagination_key)
+        return cls(pagination_key, size)
+
+    def items(self):
+        """Yield the URL arguments necessary to convey the current page."""
+        pagination_key = self.pagination_key
+        if pagination_key:
+            yield("key", self.pagination_key)
+        yield("size", self.size)
+
+    @property
+    def pagination_key(self):
+        """Create the pagination key for this page.
+
+        """
+        if not self.last_item_on_previous_page:
+            return None
+        return json.dumps(self.last_item_on_previous_page)
+
+    @classmethod
+    def parse_pagination_key(self, value):
+        return json.loads(value)
 
     @property
     def offset(self):
@@ -2387,7 +2422,7 @@ class SortKeyPagination(Pagination):
         # in pagination, so act like we don't.
         return None
 
-    def apply(self, qu):
+    def modify_database_query(self, qu):
         raise NotImplementedError(
             "SortKeyPagination does not work with database queries."
         )

--- a/external_search.py
+++ b/external_search.py
@@ -54,6 +54,7 @@ from coverage import (
     CoverageFailure,
     WorkPresentationProvider,
 )
+from problem_details import INVALID_INPUT
 from selftest import (
     HasSelfTests,
     SelfTestResult,
@@ -2378,14 +2379,19 @@ class SortKeyPagination(Pagination):
         self.this_page_size = None
 
     @classmethod
-    def from_request(cls, get_arg, default_size):
-        """Instantiate a Pagination object from a Flask request."""
+    def from_request(cls, get_arg, default_size=None):
+        """Instantiate a SortKeyPagination object from a Flask request."""
         size = cls.size_from_request(get_arg, default_size)
         if isinstance(size, ProblemDetail):
             return size
         pagination_key = get_arg('key', None)
         if pagination_key:
-            pagination_key = cls.parse_pagination_key(pagination_key)
+            try:
+                pagination_key = cls.parse_pagination_key(pagination_key)
+            except ValueError, e:
+                return INVALID_INPUT.detailed(
+                    _("Invalid page key: %(key)s", key=pagination_key)
+                )
         return cls(pagination_key, size)
 
     def items(self):

--- a/lane.py
+++ b/lane.py
@@ -962,7 +962,7 @@ class Pagination(object):
 
     @classmethod
     def _int_from_request(cls, key, get_arg, make_detail, default):
-        """Helper method to get and parse an integer value from 
+        """Helper method to get and parse an integer value from
         a URL query argument in a Flask request.
 
         :param key: Name of the argument.

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -341,9 +341,9 @@ class TestLoadMethods(DatabaseTest):
         eq_('some value', facets.called_with['some_arg'])
 
     def test_load_pagination_from_request(self):
-        # Verify that load_pagination_from_request insantiates a 
-        # class 
-
+        # Verify that load_pagination_from_request insantiates a
+        # pagination object of the specified class (Pagination, by
+        # default.)
         class Mock(object):
             DEFAULT_SIZE = 22
 

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -364,11 +364,11 @@ class TestLoadMethods(DatabaseTest):
             eq_((flask.request.args.get, 44, extra_kwargs),
                 Mock.called_with)
 
-        # If no default size is specified, the class DEFAULT_SIZE is
-        # used.
+        # If no default size is specified, we trust from_request to
+        # use the class default.
         with self.app.test_request_context('/'):
             pagination = load_pagination_from_request(base_class=Mock)
-            eq_((flask.request.args.get, 22, {}),
+            eq_((flask.request.args.get, None, {}),
                 Mock.called_with)
 
         # Now try a real case using the default pagination class,

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -76,6 +76,8 @@ from ..external_search import (
 
 from ..classifier import Classifier
 
+from ..problem_details import INVALID_INPUT
+
 from ..testing import (
     ExternalSearchTest,
     EndToEndSearchTest,
@@ -3520,6 +3522,51 @@ class TestSortKeyPagination(DatabaseTest):
     pagination by tracking the last item on the previous page,
     rather than by tracking the number of items seen so far.
     """
+    def test_from_request(self):
+        # No arguments -> Class defaults.
+        pagination = SortKeyPagination.from_request({}.get, None)
+        assert isinstance(pagination, SortKeyPagination)
+        eq_(SortKeyPagination.DEFAULT_SIZE, pagination.size)
+        eq_(None, pagination.pagination_key)
+
+        # Override the default page size.
+        pagination = SortKeyPagination.from_request({}.get, 100)
+        assert isinstance(pagination, SortKeyPagination)
+        eq_(100, pagination.size)
+        eq_(None, pagination.pagination_key)
+
+        # The most common usages.
+        pagination = SortKeyPagination.from_request(dict(size="4").get)
+        assert isinstance(pagination, SortKeyPagination)
+        eq_(4, pagination.size)
+        eq_(None, pagination.pagination_key)
+
+        pagination_key = json.dumps(["field 1", 2])
+
+        pagination = SortKeyPagination.from_request(
+            dict(key=pagination_key).get
+        )
+        assert isinstance(pagination, SortKeyPagination)
+        eq_(SortKeyPagination.DEFAULT_SIZE, pagination.size)
+        eq_(pagination_key, pagination.pagination_key)
+
+        # Invalid size -> problem detail
+        error = SortKeyPagination.from_request(dict(size="string").get)
+        eq_(INVALID_INPUT.uri, error.uri)
+        eq_("Invalid page size: string", str(error.detail))
+
+        # Invalid pagination key -> problem detail
+        error = SortKeyPagination.from_request(dict(key="not json").get)
+        eq_(INVALID_INPUT.uri, error.uri)
+        eq_("Invalid page key: not json", str(error.detail))
+
+        # Size too large -> cut down to MAX_SIZE
+        pagination = SortKeyPagination.from_request(dict(size="10000").get)
+        assert isinstance(pagination, SortKeyPagination)
+        eq_(SortKeyPagination.MAX_SIZE, pagination.size)
+        eq_(None, pagination.pagination_key)
+
+
     def test_unimplemented_features(self):
         # Check certain features of a normal Pagination object that
         # are not implemented in SortKeyPagination.
@@ -3544,7 +3591,7 @@ class TestSortKeyPagination(DatabaseTest):
         assert_raises_regexp(
             NotImplementedError,
             "SortKeyPagination does not work with database queries.",
-            pagination.apply, object()
+            pagination.modify_database_query, object()
         )
 
     def test_modify_search_query(self):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -3566,6 +3566,14 @@ class TestSortKeyPagination(DatabaseTest):
         eq_(SortKeyPagination.MAX_SIZE, pagination.size)
         eq_(None, pagination.pagination_key)
 
+    def test_items(self):
+        pagination = SortKeyPagination(size=20)
+        eq_(("size", 20), list(pagination.items()))
+        pagination.pagination_key = "some kind of key"
+        eq_(
+            [("key", "some kind of key"), ("size", 20)],
+            list(pagination.items())
+        )
 
     def test_unimplemented_features(self):
         # Check certain features of a normal Pagination object that

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1341,18 +1341,6 @@ class TestPagination(DatabaseTest):
         eq_(Pagination.MAX_SIZE, pagination.size)
         eq_(0, pagination.offset)
 
-    def test_load_pagination_from_request_default_size(self):
-        with self.app.test_request_context('/?size=50&after=10'):
-            pagination = load_pagination_from_request(default_size=10)
-            eq_(50, pagination.size)
-            eq_(10, pagination.offset)
-
-        with self.app.test_request_context('/'):
-            pagination = load_pagination_from_request(default_size=10)
-            eq_(10, pagination.size)
-            eq_(0, pagination.offset)
-
-
     def test_has_next_page_total_size(self):
         """Test the ability of Pagination.total_size to control whether there is a next page."""
         query = self._db.query(Work)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1321,6 +1321,11 @@ class TestPagination(DatabaseTest):
         eq_(Pagination.DEFAULT_SIZE, pagination.size)
         eq_(6, pagination.offset)
 
+        pagination = Pagination.from_request(dict(size=4, after=6).get)
+        assert isinstance(pagination, Pagination)
+        eq_(4, pagination.size)
+        eq_(6, pagination.offset)
+
         # Invalid size or offset -> problem detail
         error = Pagination.from_request(dict(size="string").get)
         eq_(INVALID_INPUT.uri, error.uri)


### PR DESCRIPTION
This is a support branch for https://jira.nypl.org/browse/SIMPLY-2087. It changes `load_pagination_from_request` from something hard-coded to create `Pagination` objects, to something more like `load_facets_from_request`. Most of the work is delegated to either `Pagination` or one of its subclasses, such as `SortKeyPagination`.

This branch implements `from_request` for both `Pagination` and `SortPagination`. It also implements some missing functionality that would have prevented a `SortPagination` object from modifying an outgoing URL.

Elasticsearch's `search_after` functionality, is stateless, so it works fine across HTTP requests, but it isn't really designed for that.  The information necessary to preserve state for the queries we run (which are generally ordered by at least three different fields, two of which are text fields) is really long and ugly -- it's based on hashes and looks like:

```
["ᖘ䭊⨩匐⋊ᕄዒ㼿ȡ䱔昩いউ䔼ࢂ㄁က眯箘෌໦୰਀", "➛児┩偠⇹䒤渂ခ湟省怀", 328233]
```

That results in super-long URLs that look like [this](http://localhost:6500/QANYPL/feed/355?available=now&last_item_on_previous_page=%5B%22%5Cu1598%5Cu4b4a%5Cu2a29%5Cu5310%5Cu22ca%5Cu1544%5Cu12d2%5Cu3f3f%5Cu0221%5Cu4c54%5Cu6629%5Cu3044%5Cu0989%5Cu453c%5Cu0882%5Cu3101%5Cu1000%5Cu772f%5Cu7b98%5Cu0dcc%5Cu0ee6%5Cu0b70%5Cu0a00%5Cu0001%22%2C+%22%5Cu279b%5Cu5150%5Cu2529%5Cu5060%5Cu21f9%5Cu44a4%5Cu6e02%5Cu1001%5Cu6e5f%5Cu7701%5Cu6000%5Cu0001%22%2C+328233%5D&collection=full&entrypoint=Book&order=title&size=50).

I think we could use the actual values instead of hashes -- that would make things more readable but the URLs would be even longer.

I couldn't find an example of anyone with a better solution for `search_after` -- the usages I saw sort on a single field, or calculate (in advance) sort keys for every page, so that asking for "page 2000" gives you the right page.