### PR TITLE
Make the mock query_works a little more realistic.

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -2544,7 +2544,15 @@ class MockExternalSearchIndex(ExternalSearchIndex):
         self.queries.append((query_string, filter, pagination, debug))
         # During a test we always sort works by the order in which the
         # work was created.
-        docs = sorted(self.docs.values(), key=lambda x: x['_id'])
+
+        def sort_key(x):
+            # This needs to work with either a MockSearchResult or a
+            # dictionary representing a raw search result.
+            if isinstance(x, MockSearchResult):
+                return x.work_id
+            else:
+                return x['_id']
+        docs = sorted(self.docs.values(), key=sort_key)
         if pagination:
             start_at = 0
             if isinstance(pagination, SortKeyPagination):

--- a/external_search.py
+++ b/external_search.py
@@ -2542,7 +2542,9 @@ class MockExternalSearchIndex(ExternalSearchIndex):
 
     def query_works(self, query_string, filter, pagination, debug=False, search=None):
         self.queries.append((query_string, filter, pagination, debug))
-        docs = self.docs.values()
+        # During a test we always sort works by the order in which the
+        # work was created.
+        docs = sorted(self.docs.values(), key=lambda x: x['_id'])
         if pagination:
             start_at = 0
             if isinstance(pagination, SortKeyPagination):
@@ -2565,7 +2567,7 @@ class MockExternalSearchIndex(ExternalSearchIndex):
                 results.append(x)
             else:
                 results.append(
-                    MockSearchResult("title", "author", {}, x['_id'])
+                    MockSearchResult(x["title"], x["author"], {}, x['_id'])
                 )
 
         if pagination:


### PR DESCRIPTION
A small support branch for https://github.com/NYPL-Simplified/circulation/pull/1262.

When TestFeedController.test_feed makes a real OPDS feed and looks in the URL for the "next" link, this lets us check for a realistic value of the `key` query variable.

The various ways we have of mocking searches are getting messy.