### PR TITLE
Remove all ES1 code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
 env:
   global:
     - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_core_test"
-    - ES_VERSION="6.3.2" ES_DOWNLOAD="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz" SIMPLIFIED_ELASTICSEARCH_VERSION=6
+    - ES_VERSION="6.3.2" ES_DOWNLOAD="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz"
 
 services:
   - postgresql

--- a/elasticsearch-requirements-1.txt
+++ b/elasticsearch-requirements-1.txt
@@ -1,2 +1,0 @@
-elasticsearch==2.1.0
-elasticsearch-dsl<2.0.0

--- a/elasticsearch-requirements-6.txt
+++ b/elasticsearch-requirements-6.txt
@@ -1,2 +1,0 @@
-elasticsearch>6.0.0,<7.0.0
-elasticsearch-dsl>6.0.0,<7.0.0

--- a/external_search.py
+++ b/external_search.py
@@ -699,7 +699,7 @@ return champion;
 
 class ExternalSearchIndexVersions(object):
 
-    VERSIONS = ['v1']
+    VERSIONS = ['v4']
 
     @classmethod
     def latest(cls):
@@ -752,7 +752,7 @@ class ExternalSearchIndexVersions(object):
             elif type == 'filterable_text':
                 description['type'] = 'text'
                 description['analyzer'] = "en_analyzer"
-                description['fields'] =  cls.V1_FILTERABLE_TEXT_FIELDS
+                description['fields'] =  cls.V4_FILTERABLE_TEXT_FIELDS
             mapping = cls.map_fields(
                 fields=fields,
                 mapping=mapping,
@@ -763,8 +763,8 @@ class ExternalSearchIndexVersions(object):
     # Use regular expressions to normalized values in sortable fields.
     # These regexes are applied in order; that way "H. G. Wells"
     # becomes "H G Wells" becomes "HG Wells".
-    V1_CHAR_FILTERS = {}
-    V1_AUTHOR_CHAR_FILTER_NAMES = []
+    V4_CHAR_FILTERS = {}
+    V4_AUTHOR_CHAR_FILTER_NAMES = []
     for name, pattern, replacement in [
         # The special author name "[Unknown]" should sort after everything
         # else. REPLACEMENT CHARACTER is the final valid Unicode character.
@@ -788,13 +788,13 @@ class ExternalSearchIndexVersions(object):
         normalizer = dict(type="pattern_replace",
                           pattern=pattern,
                           replacement=replacement)
-        V1_CHAR_FILTERS[name] = normalizer
-        V1_AUTHOR_CHAR_FILTER_NAMES.append(name)
+        V4_CHAR_FILTERS[name] = normalizer
+        V4_AUTHOR_CHAR_FILTER_NAMES.append(name)
 
     # We want to index most text fields twice: once using the standard
     # analyzer and once using a minimal analyzer for near-exact
     # matches.
-    V1_BASIC_STRING_FIELDS = {
+    V4_BASIC_STRING_FIELDS = {
         "minimal": {
             "type": "text",
             "analyzer": "en_minimal_analyzer"},
@@ -808,8 +808,8 @@ class ExternalSearchIndexVersions(object):
     # index as text fields (for use in searching) _and_ as keyword
     # fields (for use in filtering). For the keyword field, only
     # the most basic normalization is applied.
-    V1_FILTERABLE_TEXT_FIELDS = dict(V1_BASIC_STRING_FIELDS)
-    V1_FILTERABLE_TEXT_FIELDS["keyword"] = {
+    V4_FILTERABLE_TEXT_FIELDS = dict(V4_BASIC_STRING_FIELDS)
+    V4_FILTERABLE_TEXT_FIELDS["keyword"] = {
         "type": "keyword",
         "index": True,
         "store": False,
@@ -817,7 +817,7 @@ class ExternalSearchIndexVersions(object):
     }
 
     @classmethod
-    def v1_body(cls):
+    def v4_body(cls):
         """The first search body designed for ElasticSearch 6.
 
         This body has bibliographic information in the core document,
@@ -853,7 +853,7 @@ class ExternalSearchIndexVersions(object):
                         "country": "US"
                     }
                 },
-                "char_filter" : cls.V1_CHAR_FILTERS,
+                "char_filter" : cls.V4_CHAR_FILTERS,
 
                 # This normalizer is used on freeform strings that
                 # will be used as tokens in filters. This way we can,
@@ -890,7 +890,7 @@ class ExternalSearchIndexVersions(object):
                     # normalizing names.
                     "en_sort_author_analyzer": {
                         "tokenizer": "keyword",
-                        "char_filter": cls.V1_AUTHOR_CHAR_FILTER_NAMES,
+                        "char_filter": cls.V4_AUTHOR_CHAR_FILTER_NAMES,
                         "filter": [ "en_sortable_filter" ],
                     }
                 }
@@ -905,7 +905,7 @@ class ExternalSearchIndexVersions(object):
             field_description={
                 "type": "text",
                 "analyzer": "en_analyzer",
-                "fields": cls.V1_BASIC_STRING_FIELDS
+                "fields": cls.V4_BASIC_STRING_FIELDS
             }
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,8 @@ isbnlib
 textblob
 rdflib
 
--r elasticsearch-requirements-${SIMPLIFIED_ELASTICSEARCH_VERSION}.txt
+elasticsearch>6.0.0,<7.0.0
+elasticsearch-dsl>6.0.0,<7.0.0
 
 python-dateutil
 uwsgi

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -133,7 +133,7 @@ class TestExternalSearch(ExternalSearchTest):
         """
         if not self.search:
             return
-        eq_("test_index-v1", self.search.works_index_name(self._db))
+        eq_("test_index-v4", self.search.works_index_name(self._db))
 
     def test_setup_index_creates_new_index(self):
         if not self.search:
@@ -329,8 +329,8 @@ class TestExternalSearchIndexVersions(object):
         for searching.
         """
         filters = []
-        for filter_name in ExternalSearchIndexVersions.V1_AUTHOR_CHAR_FILTER_NAMES:
-            configuration = ExternalSearchIndexVersions.V1_CHAR_FILTERS[filter_name]
+        for filter_name in ExternalSearchIndexVersions.V4_AUTHOR_CHAR_FILTER_NAMES:
+            configuration = ExternalSearchIndexVersions.V4_CHAR_FILTERS[filter_name]
             find = re.compile(configuration['pattern'])
             replace = configuration['replacement']
             # Hack to (imperfectly) convert Java regex format to Python format.


### PR DESCRIPTION
Completes https://jira.nypl.org/browse/SIMPLY-2094. ElasticSearch 1 is no longer supported and we are restarting the search document versioning to `v1`.

The biggest change here is that in ES6, query objects are used in both query and filter context, so elasticsearch_dsl no longer has separate `Q` and `F` objects. Previously we imported the `Q` class under two different names so that the same code could work on ES1 and ES6. Now we input the class once and use it consistently.