### PR TITLE
Count the size of lanes using Elasticsearch code

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -516,10 +516,9 @@ return champion;
     def count_works(self, filter):
         """Instead of retrieving works that match `filter`, count the total."""
         qu = self.create_search_doc(
-            query_string=query_string, filter=filter, pagination=None,
-            debug=False
+            query_string=None, filter=filter, pagination=None, debug=False
         )
-        return qu.count()
+        return qu.count(filter)
 
     def bulk_update(self, works, retry_on_batch_failure=True):
         """Upload a batch of works to the search index at once."""

--- a/external_search.py
+++ b/external_search.py
@@ -518,7 +518,7 @@ return champion;
         qu = self.create_search_doc(
             query_string=None, filter=filter, pagination=None, debug=False
         )
-        return qu.count(filter)
+        return qu.count()
 
     def bulk_update(self, works, retry_on_batch_failure=True):
         """Upload a batch of works to the search index at once."""
@@ -2463,6 +2463,8 @@ class MockExternalSearchIndex(ExternalSearchIndex):
             pagination.page_loaded(results)
         return results
 
+    def count_works(self, filter):
+        return len(self.docs)
 
     def bulk(self, docs, **kwargs):
         for doc in docs:

--- a/external_search.py
+++ b/external_search.py
@@ -513,6 +513,14 @@ return champion;
 
         return results
 
+    def count_works(self, filter):
+        """Instead of retrieving works that match `filter`, count them."""
+        qu = search_engine.create_search_doc(
+            query_string=None, filter=filter, pagination=None,
+            debug=False
+        )
+        return qu.count()
+
     def bulk_update(self, works, retry_on_batch_failure=True):
         """Upload a batch of works to the search index at once."""
 

--- a/external_search.py
+++ b/external_search.py
@@ -514,9 +514,9 @@ return champion;
         return results
 
     def count_works(self, filter):
-        """Instead of retrieving works that match `filter`, count them."""
-        qu = search_engine.create_search_doc(
-            query_string=None, filter=filter, pagination=None,
+        """Instead of retrieving works that match `filter`, count the total."""
+        qu = self.create_search_doc(
+            query_string=query_string, filter=filter, pagination=None,
             debug=False
         )
         return qu.count()

--- a/lane.py
+++ b/lane.py
@@ -1620,7 +1620,7 @@ class WorkList(object):
                 offset=0, size=Pagination.DEFAULT_SEARCH_SIZE
             )
 
-        filter = self.filter(_db, self, facets)
+        filter = self.filter(_db, facets)
         try:
             hits = search_client.query_works(
                 query, filter, pagination, debug
@@ -2456,6 +2456,7 @@ class Lane(Base, DatabaseBackedWorkList):
     def update_size(self, _db, search_engine=None):
         """Update the stored estimate of the number of Works in this Lane."""
         library = self.get_library(_db)
+        from external_search import ExternalSearchIndex
         search_engine = search_engine or ExternalSearchIndex.load(_db)
 
         # Do the estimate for every known entry point.
@@ -2467,11 +2468,7 @@ class Lane(Base, DatabaseBackedWorkList):
                 order=FacetConstants.ORDER_WORK_ID, entrypoint=entrypoint
             )
             filter = self.filter(_db, facets)
-            qu = search_engine.create_search_doc(
-                query_string=None, filter=filter, pagination=None,
-                debug=False
-            )
-            by_entrypoint[entrypoint.URI] = qu.count()
+            by_entrypoint[entrypoint.URI] = search_engine.count_works(filter)
         self.size_by_entrypoint = by_entrypoint
         self.size = by_entrypoint[EverythingEntryPoint.URI]
 

--- a/lane.py
+++ b/lane.py
@@ -1521,6 +1521,11 @@ class WorkList(object):
         return self.works_for_hits(_db, hits)
 
     def filter(self, _db, facets):
+        """Helper method to instantiate a Filter object for this WorkList.
+
+        Using this ensures that modify_search_filter_hook() is always
+        called.
+        """
         from external_search import Filter
         filter = Filter.from_worklist(_db, self, facets)
         return self.modify_search_filter_hook(filter)


### PR DESCRIPTION
This branch completes https://jira.nypl.org/browse/SIMPLY-2088, though I expect it'll cause some test failures in circulation that I'll have to deal with.

This branch introduces `ExternalSearchIndex.count_works(filter)`, which asks ElasticSearch how many total works match the filter. This is used as a substitute for a database query in `Lane.update_size`.

Rather than having a separate end-to-end test, `count_works` is tested every time a test calls `EndToEndSearchTest._expect_results` with arguments that are compatible with `count_works`. First we test that `query()` gets the correct works, then we call `count_works` with the same `Filter` and verify that it gets the right _number_ of works.

I tested this on a real site and got good performance and correct-looking results.