### PR TITLE
Refactor the code that generated the Elasticsearch index mapping.

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -774,7 +774,7 @@ class MappingV4(Mapping):
             elif type == 'filterable_text':
                 description['type'] = 'text'
                 description['analyzer'] = "en_analyzer"
-                description['fields'] =  cls.V4_FILTERABLE_TEXT_FIELDS
+                description['fields'] =  cls.FILTERABLE_TEXT_FIELDS
             mapping = cls.map_fields(
                 fields=fields,
                 mapping=mapping,
@@ -785,8 +785,8 @@ class MappingV4(Mapping):
     # Use regular expressions to normalized values in sortable fields.
     # These regexes are applied in order; that way "H. G. Wells"
     # becomes "H G Wells" becomes "HG Wells".
-    V4_CHAR_FILTERS = {}
-    V4_AUTHOR_CHAR_FILTER_NAMES = []
+    CHAR_FILTERS = {}
+    AUTHOR_CHAR_FILTER_NAMES = []
     for name, pattern, replacement in [
         # The special author name "[Unknown]" should sort after everything
         # else. REPLACEMENT CHARACTER is the final valid Unicode character.
@@ -810,13 +810,13 @@ class MappingV4(Mapping):
         normalizer = dict(type="pattern_replace",
                           pattern=pattern,
                           replacement=replacement)
-        V4_CHAR_FILTERS[name] = normalizer
-        V4_AUTHOR_CHAR_FILTER_NAMES.append(name)
+        CHAR_FILTERS[name] = normalizer
+        AUTHOR_CHAR_FILTER_NAMES.append(name)
 
     # We want to index most text fields twice: once using the standard
     # analyzer and once using a minimal analyzer for near-exact
     # matches.
-    V4_BASIC_STRING_FIELDS = {
+    BASIC_STRING_FIELDS = {
         "minimal": {
             "type": "text",
             "analyzer": "en_minimal_analyzer"},
@@ -830,8 +830,8 @@ class MappingV4(Mapping):
     # index as text fields (for use in searching) _and_ as keyword
     # fields (for use in filtering). For the keyword field, only
     # the most basic normalization is applied.
-    V4_FILTERABLE_TEXT_FIELDS = dict(V4_BASIC_STRING_FIELDS)
-    V4_FILTERABLE_TEXT_FIELDS["keyword"] = {
+    FILTERABLE_TEXT_FIELDS = dict(BASIC_STRING_FIELDS)
+    FILTERABLE_TEXT_FIELDS["keyword"] = {
         "type": "keyword",
         "index": True,
         "store": False,
@@ -875,7 +875,7 @@ class MappingV4(Mapping):
                         "country": "US"
                     }
                 },
-                "char_filter" : cls.V4_CHAR_FILTERS,
+                "char_filter" : cls.CHAR_FILTERS,
 
                 # This normalizer is used on freeform strings that
                 # will be used as tokens in filters. This way we can,
@@ -912,7 +912,7 @@ class MappingV4(Mapping):
                     # normalizing names.
                     "en_sort_author_analyzer": {
                         "tokenizer": "keyword",
-                        "char_filter": cls.V4_AUTHOR_CHAR_FILTER_NAMES,
+                        "char_filter": cls.AUTHOR_CHAR_FILTER_NAMES,
                         "filter": [ "en_sortable_filter" ],
                     }
                 }
@@ -927,7 +927,7 @@ class MappingV4(Mapping):
             field_description={
                 "type": "text",
                 "analyzer": "en_analyzer",
-                "fields": cls.V4_BASIC_STRING_FIELDS
+                "fields": cls.BASIC_STRING_FIELDS
             }
         )
 

--- a/external_search.py
+++ b/external_search.py
@@ -1115,8 +1115,8 @@ class Query(SearchBase):
     # something in exactly as is.
     #
     # TODO: If we're really serious about 'minimal stemming', we
-    # should use title and series instead of .minimal. Using .minimal
-    # gets rid of plurals and stop words.
+    # should use a version that doesn't stem plurals or remove stop
+    # words.
     MINIMAL_STEMMING_QUERY_FIELDS = [
         'title.minimal', 'author', 'series.minimal'
     ]

--- a/external_search.py
+++ b/external_search.py
@@ -141,7 +141,8 @@ class ExternalSearchIndex(HasSelfTests):
         prefix = setting.value_or_default(cls.DEFAULT_WORKS_INDEX_PREFIX)
         return prefix + '-' + value
 
-    def works_index_name(self, _db):
+    @classmethod
+    def works_index_name(cls, _db):
         """Look up the name of the search index.
 
         It's possible, but unlikely, that the search index alias will
@@ -149,7 +150,7 @@ class ExternalSearchIndex(HasSelfTests):
         new one needed to be created, this would be the name of that
         index.
         """
-        return self.works_prefixed(_db, self.mapping.version_name())
+        return cls.works_prefixed(_db, CurrentMapping.version_name())
 
     @classmethod
     def works_alias_name(cls, _db):
@@ -1116,9 +1117,9 @@ class Query(SearchBase):
     # author), because we're handling the case where the user typed
     # something in exactly as is.
     #
-    # TODO: If we're really serious about 'minimal stemming',
-    # we should use title.standard and series.standard instead of
-    # .minimal. Using .minimal gets rid of plurals and stop words.
+    # TODO: If we're really serious about 'minimal stemming', we
+    # should use title and series instead of .minimal. Using .minimal
+    # gets rid of plurals and stop words.
     MINIMAL_STEMMING_QUERY_FIELDS = [
         'title.minimal', 'author', 'series.minimal'
     ]

--- a/external_search.py
+++ b/external_search.py
@@ -981,7 +981,8 @@ class MappingV4(Mapping):
             tokenizer="keyword", filter=["en_sortable_filter"],
         )
 
-        # Now, the main event. Set up the field properties.
+        # Now, the main event. Set up the field properties for the
+        # base document.
         fields_by_type = {
             "basic_text": ['title', 'subtitle', 'summary',
                            'classifications.term'],
@@ -994,15 +995,16 @@ class MappingV4(Mapping):
         }
         self.add_properties(fields_by_type)
 
-        # Sort author gets a different analyzer designed especially
-        # to normalize author names.
+        # Sort author is special -- it gets a different analyzer
+        # designed especially to normalize author names.
 
         # It's based on the standard analyzer for sortable fields.
         self.analyzers['en_sort_author_analyzer'] = dict(
             self.analyzers['en_sortable_analyzer']
         )
-        # But it has some extra character filters -- regexes that
-        # normalize names like "J. R. R. Tolkein".
+
+        # But it has some extra character filters -- regexes that do
+        # things like convert "J. R. R. Tolkien" to "J.R.R. Tolkien".
         self.analyzers['en_sort_author_analyzer']['char_filter'] = (
             self.AUTHOR_CHAR_FILTER_NAMES
         )
@@ -1013,28 +1015,28 @@ class MappingV4(Mapping):
 
         # Set up subdocuments.
         contributors = self.subdocument("contributors")
-        contributor_fields_by_type = {
+        contributor_fields = {
             'filterable_text' : ['sort_name', 'display_name', 'family_name'],
             'keyword': ['role', 'lc', 'viaf'],
         }
-        contributors.add_properties(contributor_fields_by_type)
+        contributors.add_properties(contributor_fields)
 
         licensepools = self.subdocument("licensepools")
-        licensepool_fields_by_type = {
+        licensepool_fields = {
             'integer': ['collection_id', 'data_source_id'],
             'long': ['availability_time'],
             'boolean': ['available', 'open_access', 'suppressed', 'licensed'],
             'keyword': ['medium'],
         }
-        licensepools.add_properties(licensepool_fields_by_type)
+        licensepools.add_properties(licensepool_fields)
 
         customlists = self.subdocument("customlists")
-        customlist_fields_by_type = {
+        customlist_fields = {
             'integer': ['list_id'],
             'long':  ['first_appearance'],
             'boolean': ['featured'],
         }
-        customlists.add_properties(customlist_fields_by_type)
+        customlists.add_properties(customlist_fields)
 
     @classmethod
     def stored_scripts(cls):

--- a/external_search.py
+++ b/external_search.py
@@ -736,10 +736,11 @@ class MappingDocument(object):
         property type.
 
         This type does not exist in Elasticsearch. It's our name for a
-        text field that is indexed three times: once using the English
-        analyzer ("title"), once using Elasticsearch's standard
-        analyzer ("title.standard"), and once using a minimal analyzer
-        ("title.minimal") for near-exact matches.
+        text field that is indexed three times: once using our default
+        English analyzer ("title"), once using Elasticsearch's
+        standard analyzer ("title.standard"), and once using a minimal
+        analyzer ("title.minimal") for near-exact matches.
+
         """
         description['type'] = 'text'
         description['analyzer'] = 'en_analyzer'
@@ -934,11 +935,14 @@ class CurrentMapping(Mapping):
         # Set up analyzers.
         #
 
-        # The first two analyzers are used for the 'default' and
-        # 'minimal' views of most text fields. They're identical
-        # except for the last filter in the chain.
+        # The first two analyzers are used for the default and
+        # 'minimal' views of most text fields (for the 'standard'
+        # view, we use Elasticsearch's default analyzer). The two
+        # analyzers are identical except for the last filter in the
+        # chain.
 
-        # Both analyzers filter out stopwords.
+        # Both analyzers filter out stopwords, convert to lowercase,
+        # and fold to ASCII when possible.
         self.filters['en_stop_filter'] = dict(
             type="stop", stopwords=["_english_"]
         )
@@ -947,14 +951,14 @@ class CurrentMapping(Mapping):
         )
         common_filter = ["lowercase", "asciifolding", "en_stop_filter"]
 
-        # The 'default' analyzer uses a standard English stemmer.
+        # Our default analyzer uses a standard English stemmer.
         self.filters['en_stem_filter'] = dict(type="stemmer", name="english")
         self.analyzers['en_analyzer'] = dict(common_text_analyzer)
         self.analyzers['en_analyzer']['filter'] = (
             common_filter + ['en_stem_filter']
         )
 
-        # The 'minimal' analyzer uses a less aggressive English
+        # Whereas the 'minimal' analyzer uses a less aggressive English
         # stemmer.
         self.filters['en_stem_minimal_filter'] = dict(
             type="stemmer", name="minimal_english"
@@ -964,7 +968,8 @@ class CurrentMapping(Mapping):
             common_filter + ['en_stem_minimal_filter']
         )
 
-        # An analyzer for textual fields we intend to sort on rather than query.
+        # Here's an analyzer for textual fields we intend to sort on
+        # rather than query.
         self.filters['en_sortable_filter'] = dict(
             type="icu_collation", language="en", country="US"
         )

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -329,8 +329,8 @@ class TestMappingV4(object):
         # Elasticsearch to use when normalizing fields that will be used
         # for searching.
         filters = []
-        for filter_name in MappingV4.V4_AUTHOR_CHAR_FILTER_NAMES:
-            configuration = MappingV4.V4_CHAR_FILTERS[filter_name]
+        for filter_name in MappingV4.AUTHOR_CHAR_FILTER_NAMES:
+            configuration = MappingV4.CHAR_FILTERS[filter_name]
             find = re.compile(configuration['pattern'])
             replace = configuration['replacement']
             # Hack to (imperfectly) convert Java regex format to Python format.

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -3189,7 +3189,8 @@ class TestFilter(DatabaseTest):
         eq_({}, sort)
 
         # The script is the 'simplified.work_last_update' stored script.
-        eq_('simplified.work_last_update', script.pop('stored'))
+        version = Mapping.latest_version_name()
+        eq_('simplified.work_last_update.%s' % version, script.pop('stored'))
 
         # Two parameters are passed into the script -- the IDs of the
         # collections and the lists relevant to the query. This is so

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -51,10 +51,10 @@ from ..model import (
     get_one_or_create,
 )
 from ..external_search import (
+    CurrentMapping,
     ExternalSearchIndex,
     Filter,
     Mapping,
-    MappingV4,
     MockExternalSearchIndex,
     MockSearchResult,
     Query,
@@ -167,7 +167,7 @@ class TestExternalSearch(ExternalSearchTest):
         self.integration.set_setting(ExternalSearchIndex.WORKS_INDEX_PREFIX_KEY, u'banana')
         self.search.set_works_index_and_alias(self._db)
 
-        expected_index = 'banana-' + Mapping.latest().version_name()
+        expected_index = 'banana-' + CurrentMapping.version_name()
         expected_alias = 'banana-' + self.search.CURRENT_ALIAS_SUFFIX
         eq_(expected_index, self.search.works_index)
         eq_(expected_alias, self.search.works_alias)
@@ -183,7 +183,7 @@ class TestExternalSearch(ExternalSearchTest):
             return
 
         # The index was generated from the string in configuration.
-        version = Mapping.latest().version_name()
+        version = CurrentMapping.version_name()
         index_name = 'test_index-' + version
         eq_(index_name, self.search.works_index)
         eq_(True, self.search.indices.exists(index_name))
@@ -322,15 +322,15 @@ class TestExternalSearch(ExternalSearchTest):
         eq_({collection.name: 1}, result)
 
 
-class TestMappingV4(object):
+class TestCurrentMapping(object):
 
     def test_character_filters(self):
         # Verify the functionality of the regular expressions we tell
         # Elasticsearch to use when normalizing fields that will be used
         # for searching.
         filters = []
-        for filter_name in MappingV4.AUTHOR_CHAR_FILTER_NAMES:
-            configuration = MappingV4.CHAR_FILTERS[filter_name]
+        for filter_name in CurrentMapping.AUTHOR_CHAR_FILTER_NAMES:
+            configuration = CurrentMapping.CHAR_FILTERS[filter_name]
             find = re.compile(configuration['pattern'])
             replace = configuration['replacement']
             # Hack to (imperfectly) convert Java regex format to Python format.
@@ -3189,7 +3189,7 @@ class TestFilter(DatabaseTest):
         eq_({}, sort)
 
         # The script is the 'simplified.work_last_update' stored script.
-        version = Mapping.latest_version_name()
+        version = CurrentMapping.version_name()
         eq_('simplified.work_last_update.%s' % version, script.pop('stored'))
 
         # Two parameters are passed into the script -- the IDs of the

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1561,10 +1561,6 @@ class TestExactMatches(EndToEndSearchTest):
             "aziz ansari"
         )
 
-        # The next two cases have slightly different outcomes in
-        # Elasticsearch 1 and Elasticsearch 6, so we're only testing
-        # the invariants between versions.
-
         # 'peter graves' is a string that has exact matches in both
         # title and author.
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -3189,8 +3189,8 @@ class TestFilter(DatabaseTest):
         eq_({}, sort)
 
         # The script is the 'simplified.work_last_update' stored script.
-        version = CurrentMapping.version_name()
-        eq_('simplified.work_last_update.%s' % version, script.pop('stored'))
+        eq_(CurrentMapping.script_name("work_last_update"),
+            script.pop('stored'))
 
         # Two parameters are passed into the script -- the IDs of the
         # collections and the lists relevant to the query. This is so

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -52,8 +52,9 @@ from ..model import (
 )
 from ..external_search import (
     ExternalSearchIndex,
-    ExternalSearchIndexVersions,
     Filter,
+    Mapping,
+    MappingV4,
     MockExternalSearchIndex,
     MockSearchResult,
     Query,
@@ -166,7 +167,7 @@ class TestExternalSearch(ExternalSearchTest):
         self.integration.set_setting(ExternalSearchIndex.WORKS_INDEX_PREFIX_KEY, u'banana')
         self.search.set_works_index_and_alias(self._db)
 
-        expected_index = 'banana-' + ExternalSearchIndexVersions.latest()
+        expected_index = 'banana-' + Mapping.latest().version_name()
         expected_alias = 'banana-' + self.search.CURRENT_ALIAS_SUFFIX
         eq_(expected_index, self.search.works_index)
         eq_(expected_alias, self.search.works_alias)
@@ -182,7 +183,7 @@ class TestExternalSearch(ExternalSearchTest):
             return
 
         # The index was generated from the string in configuration.
-        version = ExternalSearchIndexVersions.VERSIONS[-1]
+        version = Mapping.latest().version_name()
         index_name = 'test_index-' + version
         eq_(index_name, self.search.works_index)
         eq_(True, self.search.indices.exists(index_name))
@@ -321,16 +322,15 @@ class TestExternalSearch(ExternalSearchTest):
         eq_({collection.name: 1}, result)
 
 
-class TestExternalSearchIndexVersions(object):
+class TestMappingV4(object):
 
     def test_character_filters(self):
-        """Verify the functionality of the regular expressions we tell
-        Elasticsearch to use when normalizing fields that will be used
-        for searching.
-        """
+        # Verify the functionality of the regular expressions we tell
+        # Elasticsearch to use when normalizing fields that will be used
+        # for searching.
         filters = []
-        for filter_name in ExternalSearchIndexVersions.V4_AUTHOR_CHAR_FILTER_NAMES:
-            configuration = ExternalSearchIndexVersions.V4_CHAR_FILTERS[filter_name]
+        for filter_name in MappingV4.V4_AUTHOR_CHAR_FILTER_NAMES:
+            configuration = MappingV4.V4_CHAR_FILTERS[filter_name]
             find = re.compile(configuration['pattern'])
             replace = configuration['replacement']
             # Hack to (imperfectly) convert Java regex format to Python format.


### PR DESCRIPTION
This is almost entirely a refactoring branch to make it easier for me to write documentation explaining how the body of the mapping document is generated.

The `CurrentMapping` class contains only the information that makes this mapping distinct from past and future versions. The dirty work of generating the mapping document done by `MappingDocument` and the work of interacting with the Elasticsearch index is kept in the superclass, `Mapping`. `CurrentMapping` is still really complicated -- we have to make analyzers, character filters, a normalizer, etc. -- but all of the complexity is directly related to some feature of our particular index.

There are a few minor changes to the mapping document:

For 'basic text' fields (the ones that have a default field, a 'minimal' field, and a 'standard' field), the default fields now have index=True, store=False, just like the 'minimal' and 'standard' field. I don't think this makes a difference, since these are the default values, but it's more explicit.

More seriously, I discovered and fixed a bug: 'en_stem_minimal_filter' was using the 'english' stemmer rather than the 'minimal_english' stemmer. So the 'minimal_english' stemmer wasn't being used and normal matches were being boosted the same as near-exact matches. Apparently `TestExactMatches` wasn't able to find this bug because an exact match was getting the boost -- it's just that a less exact match would have also gotten the boost. I'm not sure what to do about this. 

I'll attach 'before' and 'after' JSON files which you can compare with jsondiff.com.