### PR TITLE
Body refactoring

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -948,13 +948,13 @@ class CurrentMapping(Mapping):
         common_text_analyzer = dict(
             type="custom", char_filter=["html_strip"], tokenizer="standard",
         )
-        common_filter = ["lowercase", "asciifolding"]
+        common_filter = ["lowercase", "asciifolding", "en_stop_filter"]
 
         # Our default analyzer uses a standard English stemmer.
         self.filters['en_stem_filter'] = dict(type="stemmer", name="english")
         self.analyzers['en_analyzer'] = dict(common_text_analyzer)
         self.analyzers['en_analyzer']['filter'] = (
-            common_filter + ['en_stop_filter', 'en_stem_filter']
+            common_filter + ['en_stem_filter']
         )
 
         # Whereas the 'minimal' analyzer uses a less aggressive English
@@ -964,7 +964,7 @@ class CurrentMapping(Mapping):
         )
         self.analyzers['en_minimal_analyzer'] = dict(common_text_analyzer)
         self.analyzers['en_minimal_analyzer']['filter'] = (
-            common_filter + ['en_stop_filter', 'en_stem_minimal_filter']
+            common_filter + ['en_stem_minimal_filter']
         )
 
         # Here's a special filter used only by the analyzer for the
@@ -983,7 +983,7 @@ class CurrentMapping(Mapping):
         # fields can't specify char_filter.
         self.analyzers['en_sort_author_analyzer'] = dict(
             tokenizer="keyword",
-            filter = common_filter + ["en_sortable_filter"],
+            filter = ["en_sortable_filter"],
             char_filter = self.AUTHOR_CHAR_FILTER_NAMES,
         )
 

--- a/external_search.py
+++ b/external_search.py
@@ -983,7 +983,7 @@ class CurrentMapping(Mapping):
         # fields can't specify char_filter.
         self.analyzers['en_sort_author_analyzer'] = dict(
             tokenizer="keyword",
-            filter=common_filter + ["en_sortable_filter"],
+            filter = common_filter + ["en_sortable_filter"],
             char_filter = self.AUTHOR_CHAR_FILTER_NAMES,
         )
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1356,9 +1356,9 @@ class TestAuthorFilter(EndToEndSearchTest):
             lc="n2013008575"
         )
         self.display_name = Contributor(
-            sort_name=Edition.UNKNOWN_AUTHOR, display_name='Ann Leckie'
+            sort_name=Edition.UNKNOWN_AUTHOR, display_name='ann leckie'
         )
-        self.sort_name = Contributor(sort_name='Leckie, Ann')
+        self.sort_name = Contributor(sort_name='LECKIE, ANN')
         self.viaf = Contributor(
             sort_name=Edition.UNKNOWN_AUTHOR, viaf="73520345"
         )

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1754,8 +1754,7 @@ class TestFeaturedFacets(EndToEndSearchTest):
             "Works permuted by a random seed",
             worklist, random_facets,
             [self.hq_available_2, self.hq_available,
-             self.not_featured_on_list,
-             self.hq_not_available,
+             self.not_featured_on_list, self.hq_not_available,
              self.featured_on_list],
         )
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1753,8 +1753,8 @@ class TestFeaturedFacets(EndToEndSearchTest):
         assert_featured(
             "Works permuted by a random seed",
             worklist, random_facets,
-            [self.not_featured_on_list, self.hq_available_2,
-             self.hq_available,
+            [self.hq_available_2, self.hq_available,
+             self.not_featured_on_list,
              self.hq_not_available,
              self.featured_on_list],
         )

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -3444,7 +3444,7 @@ class TestWorkListGroupsEndToEnd(EndToEndSearchTest):
 
             # Most of the time, we want a simple deterministic query.
             facets = facets or FeaturedFacets(
-                1, random_seed=FeaturedFacets.DETERMINISTIC
+                1, random_seed=Filter.DETERMINISTIC
             )
 
             return lane.groups(

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -3595,7 +3595,7 @@ class TestWorkListGroupsEndToEnd(EndToEndSearchTest):
                 filter.languages = ['lan']
         facets = FeaturedFacets(
             1, entrypoint=LQRomanceEntryPoint,
-            random_seed=FeaturedFacets.DETERMINISTIC
+            random_seed=Filter.DETERMINISTIC
         )
         assert_contents(
             make_groups(fiction, facets=facets),


### PR DESCRIPTION
This is hopefully the last branch before I merge elasticsearch-paginated-lists into master. It makes more miscellaneous changes to external_search.py to make the search system easier to explain.

The main changes:

* Instead of a bunch of generic query objects, we now import specific classes like `Term` and `DisMax` from `elasticsearch_dsl.query`. This makes it easier to talk about pieces of queries.
* I replaced the `icu_collation_property_hook` method with `sort_author_keyword_property_hook`. The `icu_collation_property_hook` was designed for an `icu_collation_property` that also needs a normalizer, but the only such field is `sort_author`, and we were adding a bunch of stuff onto `sort_author` after defining it as a custom type. It's simpler to define a custom data type that's just for `sort_author`, and let `sort_title` be a standard `icu_collation_property`.
* I moved the code that makes scoring functions for "featurability" out of lane.py and into `Filter`. Conceptually it belongs in `FeaturedFacets`, but this keeps all of the Elasticsearch code in `external_search.py`, which I think makes it easier to wrap your head around the whole system. Instead of doing this, I could move `FeaturedFacets` itself into `external_search.py`.
