### PR TITLE
Extract add time for each title from Overdrive JSON data

### DIFF
--- a/overdrive.py
+++ b/overdrive.py
@@ -355,8 +355,11 @@ class OverdriveAPI(object):
     def _get_book_list_page(self, link, rel_to_follow='next'):
         """Process a page of inventory whose circulation we need to check.
 
-        Returns a list of (title, id, availability_link) 3-tuples,
-        plus a link to the next page of results.
+        Returns a 2-tuple: (availability_info, next_link).
+        `availability_info` is a list of dictionaries, each containing
+           basic availability and bibliographic information about
+           one book.
+        `next_link` is a link to the next page of results.
         """
         # We don't cache this because it changes constantly.
         status_code, headers, content = self.get(link, {})
@@ -371,7 +374,8 @@ class OverdriveAPI(object):
         # Prepare to get availability information for all the books on
         # this page.
         availability_queue = (
-            OverdriveRepresentationExtractor.availability_link_list(content))
+            OverdriveRepresentationExtractor.availability_link_list(content)
+        )
         return availability_queue, next_link
 
 
@@ -562,10 +566,12 @@ class OverdriveRepresentationExtractor(object):
                 cls.log.warn("No ID found in %r", product)
                 continue
             book_id = product['id']
-            data = dict(id=book_id,
-                        title=product.get('title'),
-                        author_name=None)
-
+            data = dict(
+                id=book_id,
+                title=product.get('title'),
+                author_name=None,
+                date_added=product.get('dateAdded')
+            )
             if 'primaryCreator' in product:
                 creator = product['primaryCreator']
                 if creator.get('role') == 'Author':

--- a/tests/files/overdrive/overdrive_book_list_missing_data.json
+++ b/tests/files/overdrive/overdrive_book_list_missing_data.json
@@ -18,10 +18,10 @@
     "offset": 0,
     "products": [
         {
-	    "title": "id is missing"
+	    "title": "i only have a title"
         },
         {
-	    "id": "title is missing"
+	    "id": "i only have an id"
         }
     ]
 }

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -263,21 +263,35 @@ class TestOverdriveRepresentationExtractor(OverdriveTestWithAPI):
         data, raw = self.sample_json("overdrive_book_list.json")
         availability = OverdriveRepresentationExtractor.availability_link_list(
             raw)
+        # Every item in the list has a few important values.
         for item in availability:
-            for key in 'availability_link', 'id', 'title':
+            for key in 'availability_link', 'author_name', 'id', 'title', 'date_added':
                 assert key in item
 
+        # Also run a spot check on the actual values.
+        spot = availability[0]
+        eq_('210bdcad-29b7-445f-8d05-cdbb40abc03a', spot['id'])
+        eq_('King and Maxwell', spot['title'])
+        eq_('David Baldacci', spot['author_name'])
+        eq_('2013-11-12T14:13:00-05:00', spot['date_added'])
+
     def test_availability_info_missing_data(self):
+        # overdrive_book_list_missing_data.json has two products. One
+        # only has a title, the other only has an ID.
         data, raw = self.sample_json("overdrive_book_list_missing_data.json")
         [item] = OverdriveRepresentationExtractor.availability_link_list(
             raw)
 
-        # We got a data structure for the item that has an ID but no title.
-        # We did not get a data structure for the item that has a title
-        # but no ID.
-        eq_('title is missing', item['id'])
+        # We got a data structure -- full of missing data -- for the
+        # item that has an ID.
+        eq_('i only have an id', item['id'])
         eq_(None, item['title'])
+        eq_(None, item['author_name'])
+        eq_(None, item['date_added'])
 
+        # We did not get a data structure for the item that only has a
+        # title, because an ID is required -- otherwise we don't know
+        # what book we're talking about.
 
     def test_link(self):
         data, raw = self.sample_json("overdrive_book_list.json")


### PR DESCRIPTION
This is a support branch for https://jira.nypl.org/browse/SIMPLY-2121. It surfaces one extra piece of information from Overdrive -- the time at which a book was added to Overdrive's collection -- which is necessary for the implementation of `NewTitlesOverdriveCollectionMonitor.should_stop`.