### PR TITLE
Make it easy to modify a filter so that it returns nothing

### DIFF
--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1796,7 +1796,6 @@ class TestQuery(DatabaseTest):
         query = Query("query string", filter)
         eq_("query string", query.query_string)
         eq_(filter, query.filter)
-        eq_(False, query.match_nothing)
 
     def test_build(self):
         # Verify that the build() method combines the 'query' part of

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -857,6 +857,11 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
             f = Filter(identifiers=identifiers)
             expect(results, None, f, ordered=False)
 
+        # Setting .match_nothing on a Filter makes it always return nothing,
+        # even if it would otherwise return works.
+        nothing = Filter(fiction=True, match_nothing=True)
+        expect([], None, nothing)
+
         # Filters that come from site or library settings.
 
         # The source for the 'Pride and Prejudice' audiobook has been
@@ -1787,9 +1792,11 @@ class TestQuery(DatabaseTest):
     def test_constructor(self):
         # Verify that the Query constructor sets members with
         # no processing.
-        query = Query("query string", "filter")
+        filter = Filter()
+        query = Query("query string", filter)
         eq_("query string", query.query_string)
-        eq_("filter", query.filter)
+        eq_(filter, query.filter)
+        eq_(False, query.match_nothing)
 
     def test_build(self):
         # Verify that the build() method combines the 'query' part of
@@ -2639,19 +2646,22 @@ class TestFilter(DatabaseTest):
         fiction = object()
         audiences = object()
         author = object()
+        match_nothing = object()
 
         # Test the easy stuff -- these arguments just get stored on
         # the Filter object. If necessary, they'll be cleaned up
         # later, during build().
         filter = Filter(
             media=media, languages=languages,
-            fiction=fiction, audiences=audiences, author=author
+            fiction=fiction, audiences=audiences, author=author,
+            match_nothing=match_nothing
         )
         eq_(media, filter.media)
         eq_(languages, filter.languages)
         eq_(fiction, filter.fiction)
         eq_(audiences, filter.audiences)
         eq_(author, filter.author)
+        eq_(match_nothing, filter.match_nothing)
 
         # Test the `collections` argument.
 


### PR DESCRIPTION
More core work for https://jira.nypl.org/browse/SIMPLY-2110.
If there are no recommendations for a work, we don't even want to run the Elasticsearch query. Previously we were modifying a database query so that it contained a contradiction, but there's no way for lane code to make random modifications to an Elasticsearch query -- it can only modify the `Filter` object and let the code in `external_search` sort out what it means in Elasticsearch terms.