### PR TITLE
Reindex a work whenever its last_update_time changes

### DIFF
--- a/model/listeners.py
+++ b/model/listeners.py
@@ -276,25 +276,6 @@ def licensepool_collection_change(target, value, oldvalue, initiator):
         return
     work.external_index_needs_updating()
 
-
-@event.listens_for(LicensePool.licenses_owned, 'set')
-def licenses_owned_change(target, value, oldvalue, initiator):
-    """A Work may need to have its search document re-indexed if one of
-    its LicensePools changes the number of licenses_owned to or from zero.
-    """
-    work = target.work
-    if not work:
-        return
-    if target.open_access:
-        # For open-access works, the licenses_owned value doesn't
-        # matter.
-        return
-    if (value == oldvalue) or (value > 0 and oldvalue > 0):
-        # The availability of this LicensePool has not changed. No need
-        # to reindex anything.
-        return
-    work.external_index_needs_updating()
-
 @event.listens_for(LicensePool.open_access, 'set')
 def licensepool_open_access_change(target, value, oldvalue, initiator):
     """A Work may need to have its search document re-indexed if one of
@@ -308,3 +289,13 @@ def licensepool_open_access_change(target, value, oldvalue, initiator):
     if value == oldvalue:
         return
     work.external_index_needs_updating()
+
+@event.listens_for(Work.last_update_time, 'set')
+def last_update_time_change(target, value, oldvalue, initator):
+    """A Work needs to have its search document re-indexed whenever its
+    last_update_time changes.
+
+    Among other things, this happens whenever the LicensePool's availability
+    information changes.
+    """
+    target.external_index_needs_updating()

--- a/tests/models/test_listeners.py
+++ b/tests/models/test_listeners.py
@@ -183,55 +183,7 @@ class TestSiteConfigurationHasChanged(DatabaseTest):
         self._db.commit()
         self.mock.assert_was_not_called()
 
-class TestWorkReindexing(DatabaseTest):
-    """Test the circumstances under which a database change
-    requires that a Work's entry in the search index be recreated.
-    """
-
-    def _assert_work_needs_update(self, work):
-        [update_search] = work.coverage_records
-        eq_(WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION,
-            update_search.operation)
-        eq_(WorkCoverageRecord.REGISTERED, update_search.status)
-
-    def test_open_access_change(self):
-        work = self._work(with_license_pool=True)
-        work.coverage_records = []
-        [pool] = work.license_pools
-        pool.open_access = True
-        self._assert_work_needs_update(work)
-
-    def test_last_update_time_change(self):
-        work = self._work()
-        work.coverage_records = []
-        work.last_update_time = datetime.datetime.utcnow()
-        self._assert_work_needs_update(work)
-
-    def test_collection_change(self):
-        work = self._work(with_license_pool=True)
-        work.coverage_records = []
-        collection2 = self._collection()
-        [pool] = work.license_pools
-        pool.collection_id = collection2.id
-        self._assert_work_needs_update(work)
-
-    def test_licensepool_deleted(self):
-        work = self._work(with_license_pool=True)
-        work.coverage_records = []
-        [pool] = work.license_pools
-        self._db.delete(pool)
-        self._db.commit()
-        self._assert_work_needs_update(work)
-
-    def test_work_gains_licensepool(self):
-        work = self._work()
-        work.coverage_records = []
-        pool = self._licensepool(None)
-        work.license_pools.append(pool)
-        self._assert_work_needs_update(work)
-
-    def test_work_loses_licensepool(self):
-        work = self._work(with_license_pool=True)
-        work.coverage_records = []
-        work.license_pools = []
-        self._assert_work_needs_update(work)
+        # NOTE: test_work.py:TestWork.test_reindex_on_availability_change
+        # tests the circumstances under which a database change
+        # requires that a Work's entry in the search index be
+        # recreated.

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -1124,34 +1124,12 @@ class TestWork(DatabaseTest):
         record = find_record(work)
         eq_(registered, record.status)
 
-        # Set it back to non-open-access so that licenses_owned
-        # becomes relevant.
-        pool.open_access = False
-
-        # If its licenses_owned goes from zero to nonzero, it needs to
-        # be reindexed.
+        # If its last_update_time is changed, it needs to be
+        # reindexed. (This happens whenever
+        # LicensePool.update_availability is called, meaning that
+        # patron transactions always trigger a reindex).
         record.status = success
-        pool.licenses_owned = 10
-        pool.licenses_available = 10
-        eq_(registered, record.status)
-
-        # If its licenses_owned changes, but not to zero, nothing happens.
-        record.status = success
-        pool.licenses_owned = 1
-        eq_(success, record.status)
-
-        # If its licenses_available changes, nothing happens
-        pool.licenses_available = 0
-        eq_(success, record.status)
-
-        # If its licenses_owned goes from nonzero to zero, it needs to
-        # be reindexed.
-        pool.licenses_owned = 0
-        eq_(registered, record.status)
-
-        # If it becomes open-access again, it needs to be reindexed.
-        record.status = success
-        pool.open_access = True
+        work.last_update_time = datetime.datetime.utcnow()
         eq_(registered, record.status)
 
         # If its collection changes (which shouldn't happen), it needs


### PR DESCRIPTION
This ensures that we reindex whenever LicensePool.update_availability is called. 

Ticket: https://jira.nypl.org/browse/SIMPLY-2122