### PR TITLE
Index almost all text fields as keywords to make exact-match searches possible

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -994,9 +994,10 @@ class CurrentMapping(Mapping):
         # Now, the main event. Set up the field properties for the
         # base document.
         fields_by_type = {
-            "basic_text": ['title', 'subtitle', 'summary',
-                           'classifications.term'],
-            'filterable_text': ['series'],
+            "basic_text": ['summary'],
+            'filterable_text': [
+                'title', 'subtitle', 'series', 'classifications.term'
+            ],
             'boolean': ['presentation_ready'],
             'icu_collation_keyword': ['sort_title'],
             'sort_author_keyword' : ['sort_author'],

--- a/external_search.py
+++ b/external_search.py
@@ -2661,7 +2661,7 @@ class MockExternalSearchIndex(ExternalSearchIndex):
     def create_search_doc(self, query_string, filter=None, pagination=None, debug=False):
         return self.docs.values()
 
-    def query_works(self, query_string, filter, pagination, debug=False, search=None):
+    def query_works(self, query_string, filter, pagination, debug=False):
         self.queries.append((query_string, filter, pagination, debug))
         # During a test we always sort works by the order in which the
         # work was created.


### PR DESCRIPTION
This branch makes almost all of the text fields associated with a work into `filterable_text` (indexed four times including once as a keyword) rather than `basic_text` (indexed three times, no keyword). The only exception is `summary`, which is a huge chunk of text no one is going to try to match.

This will give me a testbed to improve our search techniques. We try really hard to promote close matches, but without indexing title (in particular) as a keyword, we have no way of promoting an _exact_ title match, which is a very common scenario.

Once it's all done, I hope to be able to get rid of one or two of the ways that a `filterable_text` is indexed, but I can't be sure yet.