### PR TITLE
Remove apostrophes from posessives rather than stemming the whole posessive

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -898,7 +898,12 @@ class CurrentMapping(Mapping):
     # Use regular expressions to normalized values in sortable fields.
     # These regexes are applied in order; that way "H. G. Wells"
     # becomes "H G Wells" becomes "HG Wells".
-    CHAR_FILTERS = {}
+    CHAR_FILTERS = {
+        "remove_apostrophes": dict(
+            type="pattern_replace", pattern="'",
+            replacement="",
+        )
+    }
     AUTHOR_CHAR_FILTER_NAMES = []
     for name, pattern, replacement in [
         # The special author name "[Unknown]" should sort after everything
@@ -994,17 +999,18 @@ class CurrentMapping(Mapping):
         #
         # * keyword_marker -- Exempt certain keywords from stemming
         # * synonym -- Introduce synonyms for words
+        #   (but probably better to use synonym_graph during the search
+        #    -- it's more flexible).
 
         # Here's the common analyzer configuration. The comment NEW
         # means this is something we added on top of Elasticsearch's
         # default configuration for the English analyzer.
         common_text_analyzer = dict(
             type="custom",
-            char_filter=["html_strip"],              # NEW
+            char_filter=["html_strip", "remove_apostrophes"], # NEW
             tokenizer="standard",
         )
         common_filter = [
-            "english_posessive_stemmer",
             "lowercase",
             "asciifolding",                          # NEW
         ]


### PR DESCRIPTION
This branch represents a better way to address https://jira.nypl.org/browse/SIMPLY-575, which takes into account the way people search on phones. Rather than turning "washington's war" into "washington war", we now turn it into "washingtons war". Depending on the analyzer, it may then be stemmed to "washington war", or it may be left as "washingtons war". Since people on phones tend to type the _s_ part of a posessive without the _'_ part, it can be important to keep track of whether the _s_ was there originally.

The tests for this are integration tests in https://github.com/NYPL-Simplified/circulation/pull/1285