### PR TITLE
Sphinx documentation

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -319,7 +319,8 @@ class URNLookupController(object):
         """Processes a list of URNs for a lookup request.
 
         :return: None or, to override default feed behavior, a ProblemDetail
-        or Response
+            or Response.
+
         """
         identifiers_by_urn, failures = Identifier.parse_urns(self._db, urns)
         self.add_urn_failure_messages(failures)

--- a/config.py
+++ b/config.py
@@ -492,15 +492,16 @@ class Configuration(object):
         this value and reload the configuration if appropriate.
 
         :param known_value: We know when the site configuration was
-        last updated--it's this timestamp. Use it instead of checking
-        with the database.
+            last updated--it's this timestamp. Use it instead of checking
+            with the database.
 
         :param timeout: We will only call out to the database once in
-        this number of seconds. If we are asked again before this
-        number of seconds elapses, we will assume site configuration
-        has not changed.
+            this number of seconds. If we are asked again before this
+            number of seconds elapses, we will assume site configuration
+            has not changed.
 
         :return: a datetime object.
+
         """
         now = datetime.datetime.utcnow()
 

--- a/coverage.py
+++ b/coverage.py
@@ -307,9 +307,10 @@ class BaseCoverageProvider(object):
 
         NOTE: If you override this method, it's very important that
         your implementation eventually do one of the following:
-            * Set progress.finish
-            * Set progress.exception
-            * Raise an exception
+        * Set progress.finish
+        * Set progress.exception
+        * Raise an exception
+
         If you don't do any of these things, run() will assume you still
         have work to do, and will keep calling run_once() forever.
 
@@ -516,8 +517,8 @@ class BaseCoverageProvider(object):
         need coverage.
 
         :param subset: A list of Identifier objects. If present, return
-        only items that need coverage *and* are associated with one
-        of these identifiers.
+            only items that need coverage *and* are associated with one
+            of these identifiers.
 
         Implemented in CoverageProvider and WorkCoverageProvider.
         """
@@ -852,14 +853,14 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
         """Ensure coverage for one specific item.
 
         :param item: This should always be an Identifier, but this
-        code will also work if it's an Edition. (The Edition's
-        .primary_identifier will be covered.)
+            code will also work if it's an Edition. (The Edition's
+            .primary_identifier will be covered.)
         :param force: Run the coverage code even if an existing
-           coverage record for this item was created after
-           `self.cutoff_time`.
+            coverage record for this item was created after `self.cutoff_time`.
         :return: Either a coverage record or a CoverageFailure.
 
         TODO: This could be abstracted and moved to BaseCoverageProvider.
+
         """
         if isinstance(item, Identifier):
             identifier = item
@@ -910,7 +911,7 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
         with the given metadata.
 
         :return: The Identifier (if successful) or an appropriate
-        CoverageFailure (if not).
+            CoverageFailure (if not).
         """
         edition = self.edition(identifier)
         if isinstance(edition, CoverageFailure):
@@ -1101,7 +1102,7 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
         CollectionCoverageProviders will be yielded in a random order.
 
         :param kwargs: Keyword arguments passed into the constructor for
-        CollectionCoverageProvider (or, more likely, one of its subclasses).
+            CollectionCoverageProvider (or, more likely, one of its subclasses).
 
         """
         for collection in cls.collections(_db):
@@ -1130,9 +1131,9 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
         creating one if necessary.
 
         :param data_source: If it's necessary to create a LicensePool,
-        the new LicensePool will have this DataSource. The default is to
-        use the DataSource associated with the CoverageProvider. This
-        should only be needed by the metadata wrangler.
+            the new LicensePool will have this DataSource. The default is to
+            use the DataSource associated with the CoverageProvider. This
+            should only be needed by the metadata wrangler.
         """
         license_pools = [
             p for p in identifier.licensed_through
@@ -1189,7 +1190,7 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
             calculate_work() if and when it is called.
 
         :return: A Work, if possible. Otherwise, a CoverageFailure explaining
-        why no Work could be created.
+            why no Work could be created.
 
         """
         work = identifier.work
@@ -1240,7 +1241,7 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
         all the information is up to date.
 
         :return: The Identifier (if successful) or an appropriate
-        CoverageFailure (if not).
+            CoverageFailure (if not).
         """
 
         if not metadata and not circulationdata:
@@ -1382,7 +1383,7 @@ class WorkCoverageProvider(BaseCoverageProvider):
         on the Metadata Wrangler.
 
         :param force: Set to True to reset an existing CoverageRecord's status
-        "registered", regardless of its current status.
+            "registered", regardless of its current status.
         """
         was_registered = True
         if not force:
@@ -1409,7 +1410,7 @@ class WorkCoverageProvider(BaseCoverageProvider):
         chosen.
 
         :param: Only Works connected with one of the given identifiers
-        are chosen.
+            are chosen.
         """
         qu = Work.missing_coverage_from(
             self._db, operation=self.operation,

--- a/external_search.py
+++ b/external_search.py
@@ -29,7 +29,7 @@ from elasticsearch_dsl.query import (
     Term,
     Terms,
 )
-from spellchecker import SpellChecker
+# from spellchecker import SpellChecker
 
 from flask_babel import lazy_gettext as _
 from config import (
@@ -147,8 +147,8 @@ class ExternalSearchIndex(HasSelfTests):
         """Prefix the given value with the prefix to use when generating index
         and alias names.
 
-        :return: A string "{prefix}-{value}", or None if no prefix is
-        configured.
+        :return: A string "{prefix}-{value}", or None if no prefix is configured.
+
         """
         integration = cls.search_integration(_db)
         if not integration:
@@ -819,8 +819,8 @@ class Mapping(MappingDocument):
     def script_name(cls, base_name):
         """Scope a script name with "simplified" (to avoid confusion with
         other applications on the Elasticsearch server), and the
-        version number (to avoid confusion with other versions _of
-        this application_, which may implement the same script
+        version number (to avoid confusion with other versions *of
+        this application*, which may implement the same script
         differently, on this Elasticsearch server).
         """
         return "simplified.%s.%s" % (base_name, cls.version_name())
@@ -1413,8 +1413,8 @@ class Query(SearchBase):
         """Make an Elasticsearch-DSL Search object out of this query.
 
         :param elasticsearch: An Elasticsearch-DSL Search object. This
-        object is ready to run a search against an Elasticsearch server,
-        but it doesn't represent any particular Elasticsearch query.
+            object is ready to run a search against an Elasticsearch server,
+            but it doesn't represent any particular Elasticsearch query.
 
         :return: An Elasticsearch-DSL Search object that's prepared
             to run this specific query.
@@ -1585,10 +1585,10 @@ class Query(SearchBase):
         a given field.
 
         :param base_field: The name of the field to search,
-        e.g. "title" or "contributors.sort_name".
+            e.g. "title" or "contributors.sort_name".
 
         :param query_string: The query string to use, if different from
-        self.query_string.
+            self.query_string.
 
         :yield: A sequence of (hypothesis, weight) 2-tuples.
         """
@@ -1684,10 +1684,10 @@ class Query(SearchBase):
         which a query string might represent a book's author.
 
         :param query_string: The query string that might be the name
-        of an author.
+            of an author.
 
         :yield: A sequence of Elasticsearch-DSL query objects to be
-        considered as hypotheses.
+            considered as hypotheses.
         """
 
         # Ask Elasticsearch to match what was typed against
@@ -2484,9 +2484,9 @@ class Filter(SearchBase):
         explaining how search results should be ordered.
 
         :return: A list of dictionaries, each dictionary mapping a
-        field name to an explanation of how to sort that
-        field. Usually the explanation is a simple string, either
-        'asc' or 'desc'.
+            field name to an explanation of how to sort that
+            field. Usually the explanation is a simple string, either
+            'asc' or 'desc'.
         """
         if not self.order:
             return []

--- a/external_search.py
+++ b/external_search.py
@@ -29,7 +29,7 @@ from elasticsearch_dsl.query import (
     Term,
     Terms,
 )
-# from spellchecker import SpellChecker
+from spellchecker import SpellChecker
 
 from flask_babel import lazy_gettext as _
 from config import (

--- a/lane.py
+++ b/lane.py
@@ -267,14 +267,14 @@ class FacetsWithEntryPoint(BaseFacets):
         given WorkList.
 
         :param valid_entrypoints: The EntryPoints that might be
-        valid. This is probably not the value of
-        WorkList.selectable_entrypoints, because an EntryPoint
-        selected in a WorkList remains valid (but not selectable) for
-        all of its children.
+            valid. This is probably not the value of
+            WorkList.selectable_entrypoints, because an EntryPoint
+            selected in a WorkList remains valid (but not selectable) for
+            all of its children.
 
         :param default: A class to use as the default EntryPoint if
-        none is specified. If no default is specified, the first
-        enabled EntryPoint will be used.
+            none is specified. If no default is specified, the first
+            enabled EntryPoint will be used.
 
         :return: A 2-tuple (EntryPoint class, is_default).
         """
@@ -1097,53 +1097,53 @@ class WorkList(object):
         initialization code.
 
         :param library: Only Works available in this Library will be
-        included in lists.
+            included in lists.
 
         :param display_name: Name to display for this WorkList in the
-        user interface.
+            user interface.
 
         :param genres: Only Works classified under one of these Genres
-        will be included in lists.
+            will be included in lists.
 
         :param audiences: Only Works classified under one of these audiences
-        will be included in lists.
+            will be included in lists.
 
         :param languages: Only Works in one of these languages will be
-        included in lists.
+            included in lists.
 
         :param media: Only Works in one of these media will be included
-        in lists.
+            in lists.
 
         :param fiction: Only Works with this fiction status will be included
-        in lists.
+            in lists.
 
         :param target_age: Only Works targeted at readers in this age range
-        will be included in lists.
+            will be included in lists.
 
         :param license_datasource: Only Works with a LicensePool from this
-        DataSource will be included in lists.
+            DataSource will be included in lists.
 
         :param customlists: Only Works included on one of these CustomLists
-        will be included in lists.
+            will be included in lists.
 
         :param list_datasource: Only Works included on a CustomList
-        associated with this DataSource will be included in
-        lists. This overrides any specific CustomLists provided in
-        `customlists`.
+            associated with this DataSource will be included in
+            lists. This overrides any specific CustomLists provided in
+            `customlists`.
 
         :param list_seen_in_previous_days: Only Works that were added
-        to a matching CustomList within this number of days will be
-        included in lists.
+            to a matching CustomList within this number of days will be
+            included in lists.
 
         :param children: This WorkList has children, which are also
-        WorkLists.
+            WorkLists.
 
         :param priority: A number indicating where this WorkList should
-        show up in relation to its siblings when it is the child of
-        some other WorkList.
+            show up in relation to its siblings when it is the child of
+            some other WorkList.
 
         :param entrypoints: A list of EntryPoint classes representing
-        different ways of slicing up this WorkList.
+            different ways of slicing up this WorkList.
 
         """
         self.library_id = None
@@ -1381,12 +1381,12 @@ class WorkList(object):
 
         :param facets: A FeaturedFacets object that may restrict the works on view.
         :param search_engine: An ExternalSearchIndex to use when
-           asking for the featured works in a given WorkList.
+            asking for the featured works in a given WorkList.
         :param debug: A debug argument passed into `search_engine` when
-           running the search.
+            running the search.
         :yield: A sequence of (Work, WorkList) 2-tuples, with each
-        WorkList representing the child WorkList in which the Work is
-        found.
+            WorkList representing the child WorkList in which the Work is
+            found.
         """
         if not include_sublanes:
             # We only need to find featured works for this lane,
@@ -1486,7 +1486,7 @@ class WorkList(object):
 
         :param _db: A database connection
         :param hits: A list of Hit objects from ElasticSearch.
-        :return A list of Work or (if the search results include
+        :return: A list of Work or (if the search results include
             script fields), WorkSearchResult objects.
         """
 
@@ -1875,10 +1875,11 @@ class DatabaseBackedWorkList(WorkList):
         """Create a SQLAlchemy filter that excludes books whose bibliographic
         metadata doesn't match what we're looking for.
 
-        :return: A 2-tuple (query, clauses).
-
-        - query is either `qu`, or a new query that has been modified to
+        query is either `qu`, or a new query that has been modified to
         join against additional tables.
+
+        :returns: A 2-tuple (query, clauses).
+
         """
         # Audience language, and genre restrictions are allowed on all
         # WorkLists. (So are collection restrictions, but those are
@@ -2426,7 +2427,7 @@ class Lane(Base, DatabaseBackedWorkList):
         that Genre should be in this Lane.
 
         :return: A list of genre IDs, or None if this Lane does not
-        consider genres at all.
+            consider genres at all.
         """
         if not hasattr(self, '_genre_ids'):
             self._genre_ids = self._gather_genre_ids()

--- a/lane.py
+++ b/lane.py
@@ -1878,7 +1878,7 @@ class DatabaseBackedWorkList(WorkList):
         query is either `qu`, or a new query that has been modified to
         join against additional tables.
 
-        :returns: A 2-tuple (query, clauses).
+        :return: A 2-tuple (query, clauses).
 
         """
         # Audience language, and genre restrictions are allowed on all

--- a/log.py
+++ b/log.py
@@ -393,10 +393,9 @@ class LogConfiguration(object):
         as configured in the database.
 
         :param _db: A database connection. If this is None, the default logging
-        configuration will be used.
+            configuration will be used.
 
-        :param testing: True if unit tests are currently running; otherwise
-        False.
+        :param testing: True if unit tests are currently running; otherwise False.
         """
         log_level, database_log_level, new_handlers, errors = (
             cls.from_configuration(_db, testing)
@@ -442,20 +441,20 @@ class LogConfiguration(object):
         """Return the logging policy as configured in the database.
 
         :param _db: A database connection. If None, the default
-        logging policy will be used.
+            logging policy will be used.
 
         :param testing: A boolean indicating whether a unit test is
-        happening right now. If True, the database configuration will
-        be ignored in favor of a known test-friendly policy. (It's
-        okay to pass in False during a test *of this method*.)
+            happening right now. If True, the database configuration will
+            be ignored in favor of a known test-friendly policy. (It's
+            okay to pass in False during a test *of this method*.)
 
         :return: A 3-tuple (internal_log_level, database_log_level,
-        handlers). `internal_log_level` is the log level to be used
-        for most log messages. `database_log_level` is the log level
-        to be applied to the loggers for the database connector and
-        other verbose third-party libraries. `handlers` is a list of
-        Handler objects that will be associated with the top-level
-        logger.
+            handlers). `internal_log_level` is the log level to be used
+            for most log messages. `database_log_level` is the log level
+            to be applied to the loggers for the database connector and
+            other verbose third-party libraries. `handlers` is a list of
+            Handler objects that will be associated with the top-level
+            logger.
         """
         log_level = cls.DEFAULT_LOG_LEVEL
         database_log_level = cls.DEFAULT_DATABASE_LOG_LEVEL

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -287,7 +287,7 @@ class ContributorData(object):
         ContributorData's information.
 
         :param: destination -- the Contributor or ContributorData object to
-                write this ContributorData object's metadata to.
+            write this ContributorData object's metadata to.
         :param: replace -- Replacement policy (not currently used).
 
         :return: the possibly changed Contributor object and a flag of whether it's been changed.
@@ -1128,10 +1128,11 @@ class CirculationData(MetaToModelUtility):
         """Update the title with this CirculationData's information.
 
         :param collection: A Collection representing actual copies of
-        this title. Availability information (e.g. number of copies)
-        will be associated with a LicensePool in this Collection. If
-        this is not present, only delivery information (e.g. format
-        information and open-access downloads) will be processed.
+            this title. Availability information (e.g. number of copies)
+            will be associated with a LicensePool in this Collection. If
+            this is not present, only delivery information (e.g. format
+            information and open-access downloads) will be processed.
+
         """
         # Immediately raise an exception if there is information that
         # can only be stored in a LicensePool, but we have no
@@ -1652,12 +1653,12 @@ class Metadata(MetaToModelUtility):
         """Apply this metadata to the given edition.
 
         :param mirror: Open-access books and cover images will be mirrored
-        to this MirrorUploader.
+            to this MirrorUploader.
         :return: (edition, made_core_changes), where edition is the newly-updated object, and made_core_changes
-        answers the question: were any edition core fields harmed in the making of this update?
-        So, if title changed, return True.
-        New: If contributors changed, this is now considered a core change,
-        so work.simple_opds_feed refresh can be triggered.
+            answers the question: were any edition core fields harmed in the making of this update?
+            So, if title changed, return True.
+            New: If contributors changed, this is now considered a core change,
+            so work.simple_opds_feed refresh can be triggered.
         """
         _db = Session.object_session(edition)
 

--- a/mirror.py
+++ b/mirror.py
@@ -24,8 +24,8 @@ class MirrorUploader(object):
         :return: A MirrorUploader.
 
         :raise: CannotLoadConfiguration if no integration with
-        goal==STORAGE_GOAL is configured, or if multiple integrations
-        are so configured.
+            goal==STORAGE_GOAL is configured, or if multiple integrations
+            are so configured.
         """
         integration = cls.sitewide_integration(_db)
         return cls.implementation(integration)

--- a/model/classification.py
+++ b/model/classification.py
@@ -245,13 +245,14 @@ class Subject(Base):
     def assign_to_genres(cls, _db, type_restriction=None, force=False,
                          batch_size=1000):
         """Find subjects that have not been checked yet, assign each a
-        genre/audience/fiction status if possible, and mark each as
-        checked.
+        genre/audience/fiction status if possible, and mark each as checked.
+
         :param type_restriction: Only consider subjects of the given type.
         :param force: Assign a genre to all subjects not just the ones that
-                      have been checked.
+            have been checked.
         :param batch_size: Perform a database commit every time this many
-                           subjects have been checked.
+            subjects have been checked.
+
         """
         q = _db.query(Subject).filter(Subject.locked==False)
 

--- a/model/collection.py
+++ b/model/collection.py
@@ -224,7 +224,7 @@ class Collection(Base, HasFullTableCache):
         Collections marked for deletion are not included.
 
         :param protocol: Protocol to use. If this is None, all
-        Collections will be returned except those marked for deletion.
+            Collections will be returned except those marked for deletion.
         """
         qu = _db.query(Collection)
         if protocol:
@@ -346,7 +346,7 @@ class Collection(Base, HasFullTableCache):
         of creating another one.
 
         :param protocol: The protocol known to be in use when getting
-        licenses for this collection.
+            licenses for this collection.
         """
         _db = Session.object_session(self)
         goal = ExternalIntegration.LICENSE_GOAL
@@ -676,13 +676,13 @@ class Collection(Base, HasFullTableCache):
         :param query: The query to restrict.
 
         :param show_suppressed: Include titles that have nothing but
-        suppressed LicensePools.
+            suppressed LicensePools.
 
         :param collection_ids: Only include titles in the given
-        collections.
+            collections.
 
         :param allow_holds: If false, pools with no available copies
-        will be hidden.
+            will be hidden.
         """
 
         # Only find presentation-ready works.

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -266,13 +266,14 @@ class ExternalIntegration(Base, HasFullTableCache):
         made unique by a ConfigurationSetting, such as
         ExternalIntegration.URL, rather than by anything in the
         ExternalIntecation itself.
+
         :param protocol: ExternalIntegrations must have this protocol.
         :param goal: ExternalIntegrations must have this goal.
         :param key: Look only at ExternalIntegrations with
             a ConfigurationSetting for this key.
         :param value: Find ExternalIntegrations whose ConfigurationSetting
             has this value.
-        :return: A Query object.
+        :returns: A Query object.
         """
         return _db.query(
             ExternalIntegration
@@ -367,11 +368,12 @@ class ExternalIntegration(Base, HasFullTableCache):
     def explain(self, library=None, include_secrets=False):
         """Create a series of human-readable strings to explain an
         ExternalIntegration's settings.
+
         :param library: Include additional settings imposed upon this
-           ExternalIntegration by the given Library.
+            ExternalIntegration by the given Library.
         :param include_secrets: For security reasons,
-           sensitive settings such as passwords are not displayed by default.
-        :return: A list of explanatory strings.
+            sensitive settings such as passwords are not displayed by default.
+        :returns: A list of explanatory strings.
         """
         lines = []
         lines.append("ID: %s" % self.id)
@@ -405,17 +407,17 @@ class ConfigurationSetting(Base, HasFullTableCache):
     A ConfigurationSetting may be associated with an
     ExternalIntegration, a Library, both, or neither.
     * The secret used by the circulation manager to sign OAuth bearer
-      tokens is not associated with an ExternalIntegration or with a
-      Library.
+    tokens is not associated with an ExternalIntegration or with a
+    Library.
     * The link to a library's privacy policy is associated with the
-      Library, but not with any particular ExternalIntegration.
+    Library, but not with any particular ExternalIntegration.
     * The "website ID" for an Overdrive collection is associated with
-      an ExternalIntegration (the Overdrive integration), but not with
-      any particular Library (since multiple libraries might share an
-      Overdrive collection).
+    an ExternalIntegration (the Overdrive integration), but not with
+    any particular Library (since multiple libraries might share an
+    Overdrive collection).
     * The "identifier prefix" used to determine which library a patron
-      is a patron of, is associated with both a Library and an
-      ExternalIntegration.
+    is a patron of, is associated with both a Library and an
+    ExternalIntegration.
     """
     __tablename__ = 'configurationsettings'
     id = Column(Integer, primary_key=True)

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -273,7 +273,7 @@ class ExternalIntegration(Base, HasFullTableCache):
             a ConfigurationSetting for this key.
         :param value: Find ExternalIntegrations whose ConfigurationSetting
             has this value.
-        :returns: A Query object.
+        :return: A Query object.
         """
         return _db.query(
             ExternalIntegration
@@ -373,7 +373,7 @@ class ExternalIntegration(Base, HasFullTableCache):
             ExternalIntegration by the given Library.
         :param include_secrets: For security reasons,
             sensitive settings such as passwords are not displayed by default.
-        :returns: A list of explanatory strings.
+        :return: A list of explanatory strings.
         """
         lines = []
         lines.append("ID: %s" % self.id)

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -62,7 +62,7 @@ class BaseCoverageRecord(object):
         :param count_as_not_covered_if_covered_before: If a coverage record
             exists, but is older than the given date, do not count it as
             covered.
-        :returns: A clause that can be passed in to Query.filter().
+        :return: A clause that can be passed in to Query.filter().
         """
         if not count_as_covered:
             count_as_covered = cls.DEFAULT_COUNT_AS_COVERED

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -55,13 +55,14 @@ class BaseCoverageRecord(object):
     def not_covered(cls, count_as_covered=None,
                     count_as_not_covered_if_covered_before=None):
         """Filter a query to find only items without coverage records.
+
         :param count_as_covered: A list of constants that indicate
-           types of coverage records that should count as 'coverage'
-           for purposes of this query.
+            types of coverage records that should count as 'coverage'
+            for purposes of this query.
         :param count_as_not_covered_if_covered_before: If a coverage record
-           exists, but is older than the given date, do not count it as
-           covered.
-        :return: A clause that can be passed in to Query.filter().
+            exists, but is older than the given date, do not count it as
+            covered.
+        :returns: A clause that can be passed in to Query.filter().
         """
         if not count_as_covered:
             count_as_covered = cls.DEFAULT_COUNT_AS_COVERED

--- a/model/credential.py
+++ b/model/credential.py
@@ -204,17 +204,18 @@ class DelegatedPatronIdentifier(Base):
     ):
         """Look up the delegated identifier for the given patron. If there is
         none, create one.
+
         :param library_uri: A URI identifying the patron's library.
         :param patron_identifier: An identifier used by that library to
-         distinguish between this patron and others. This should be
-         an identifier created solely for the purpose of identifying the
-         patron with _this_ library, and not (e.g.) the patron's barcode.
+            distinguish between this patron and others. This should be
+            an identifier created solely for the purpose of identifying the
+            patron with _this_ library, and not (e.g.) the patron's barcode.
         :param identifier_type: The type of the delegated identifier
-         to look up. (probably ADOBE_ACCOUNT_ID)
+            to look up. (probably ADOBE_ACCOUNT_ID)
         :param create_function: If this patron does not have a
-         DelegatedPatronIdentifier, one will be created, and this
-         function will be called to determine the value of
-         DelegatedPatronIdentifier.delegated_identifier.
+            DelegatedPatronIdentifier, one will be created, and this
+            function will be called to determine the value of
+            DelegatedPatronIdentifier.delegated_identifier.
         :return: A 2-tuple (DelegatedPatronIdentifier, is_new)
         """
         identifier, is_new = get_one_or_create(

--- a/model/edition.py
+++ b/model/edition.py
@@ -229,8 +229,7 @@ class Edition(Base, EditionConstants):
                        create_if_not_exists=True):
         """Find the Edition representing the given data source's view of
         the work that it primarily identifies by foreign ID.
-        e.g. for_foreign_id(_db, DataSource.OVERDRIVE,
-                            Identifier.OVERDRIVE_ID, uuid)
+        e.g. for_foreign_id(_db, DataSource.OVERDRIVE, Identifier.OVERDRIVE_ID, uuid)
         finds the Edition for Overdrive's view of a book identified
         by Overdrive UUID.
         This:
@@ -238,6 +237,7 @@ class Edition(Base, EditionConstants):
         will probably return nothing, because although Overdrive knows
         that books have ISBNs, it doesn't use ISBN as a primary
         identifier.
+
         """
         # Look up the data source if necessary.
         if isinstance(data_source, basestring):
@@ -305,10 +305,11 @@ class Edition(Base, EditionConstants):
         """Find Editions from `edition_data_source` whose primary
         identifiers have no CoverageRecord from
         `coverage_data_source`.
-        e.g.
-         gutenberg = DataSource.lookup(_db, DataSource.GUTENBERG)
-         oclc_classify = DataSource.lookup(_db, DataSource.OCLC)
-         missing_coverage_from(_db, gutenberg, oclc_classify)
+        e.g.::
+        gutenberg = DataSource.lookup(_db, DataSource.GUTENBERG)
+        oclc_classify = DataSource.lookup(_db, DataSource.OCLC)
+        missing_coverage_from(_db, gutenberg, oclc_classify)
+        
         will find Editions that came from Project Gutenberg and
         have never been used as input to the OCLC Classify web
         service.

--- a/model/identifier.py
+++ b/model/identifier.py
@@ -278,16 +278,17 @@ class Identifier(Base, IdentifierConstants):
     def parse_urns(cls, _db, identifier_strings, autocreate=True,
                    allowed_types=None):
         """Converts a batch of URNs into Identifier objects.
+
         :param _db: A database connection
         :param identifier_strings: A list of strings, each a URN
-           identifying some identifier.
+            identifying some identifier.
         :param autocreate: Create an Identifier for a URN if none
             presently exists.
         :param allowed_types: If this is a list of Identifier
             types, only identifiers of those types may be looked
             up. All other identifier types will be treated as though
             they did not exist.
-        :return: A 2-tuple (identifiers, failures). `identifiers` is a
+        :returns: A 2-tuple (identifiers, failures). `identifiers` is a
             list of Identifiers. `failures` is a list of URNs that
             did not become Identifiers.
         """
@@ -557,14 +558,15 @@ class Identifier(Base, IdentifierConstants):
     def classify(self, data_source, subject_type, subject_identifier,
                  subject_name=None, weight=1):
         """Classify this Identifier under a Subject.
+
         :param type: Classification scheme; one of the constants from Subject.
         :param subject_identifier: Internal ID of the subject according to that classification scheme.
-        ``value``: Human-readable description of the subject, if different
-                   from the ID.
-        ``weight``: How confident the data source is in classifying a
-                    book under this subject. The meaning of this
-                    number depends entirely on the source of the
-                    information.
+        :param value: Human-readable description of the subject, if different
+            from the ID.
+        :param weight: How confident the data source is in classifying a
+            book under this subject. The meaning of this
+            number depends entirely on the source of the
+            information.
         """
         _db = Session.object_session(self)
         # Turn the subject type and identifier into a Subject.

--- a/model/identifier.py
+++ b/model/identifier.py
@@ -288,7 +288,7 @@ class Identifier(Base, IdentifierConstants):
             types, only identifiers of those types may be looked
             up. All other identifier types will be treated as though
             they did not exist.
-        :returns: A 2-tuple (identifiers, failures). `identifiers` is a
+        :return: A 2-tuple (identifiers, failures). `identifiers` is a
             list of Identifiers. `failures` is a list of URNs that
             did not become Identifiers.
         """

--- a/model/integrationclient.py
+++ b/model/integrationclient.py
@@ -50,9 +50,9 @@ class IntegrationClient(Base):
     def for_url(cls, _db, url):
         """Finds the IntegrationClient for the given server URL.
 
-        :return: an IntegrationClient. If it didn't already exist,
-        it will be created. If it didn't already have a secret, no
-        secret will be set.
+        :returns: an IntegrationClient. If it didn't already exist,
+            it will be created. If it didn't already have a secret, no
+            secret will be set.
         """
         url = cls.normalize_url(url)
         now = datetime.datetime.utcnow()

--- a/model/integrationclient.py
+++ b/model/integrationclient.py
@@ -50,7 +50,7 @@ class IntegrationClient(Base):
     def for_url(cls, _db, url):
         """Finds the IntegrationClient for the given server URL.
 
-        :returns: an IntegrationClient. If it didn't already exist,
+        :return: an IntegrationClient. If it didn't already exist,
             it will be created. If it didn't already have a secret, no
             secret will be set.
         """

--- a/model/library.py
+++ b/model/library.py
@@ -344,7 +344,7 @@ class Library(Base, HasFullTableCache):
 
         :param include_secrets: For security reasons, secrets are not
             displayed by default.
-        :returns: A list of explanatory strings.
+        :return: A list of explanatory strings.
         """
         lines = []
         if self.uuid:

--- a/model/library.py
+++ b/model/library.py
@@ -341,9 +341,10 @@ class Library(Base, HasFullTableCache):
     def explain(self, include_secrets=False):
         """Create a series of human-readable strings to explain a library's
         settings.
+
         :param include_secrets: For security reasons, secrets are not
             displayed by default.
-        :return: A list of explanatory strings.
+        :returns: A list of explanatory strings.
         """
         lines = []
         if self.uuid:

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -487,21 +487,22 @@ class LicensePool(Base):
                  original_resource=None, transformation_settings=None,
                  ):
         """Add a link between this LicensePool and a Resource.
+
         :param rel: The relationship between this LicensePool and the resource
-               on the other end of the link.
+            on the other end of the link.
         :param href: The URI of the resource on the other end of the link.
         :param media_type: Media type of the representation associated
-               with the resource.
+            with the resource.
         :param content: Content of the representation associated with the
-               resource.
+            resource.
         :param content_path: Path (relative to DATA_DIRECTORY) of the
-               representation associated with the resource.
+            representation associated with the resource.
         :param rights_status_uri: The URI of the RightsStatus for this resource.
         :param rights_explanation: A free text explanation of why the RightsStatus
-               applies.
+            applies.
         :param original_resource: Another resource that this resource was derived from.
         :param transformation_settings: The settings used to transform the original
-               resource into this resource.
+            resource into this resource.
         """
         return self.identifier.add_link(
             rel, href, data_source, media_type, content, content_path,
@@ -1222,6 +1223,7 @@ class LicensePoolDeliveryMechanism(Base):
             resource=None, autocommit=True):
         """Register the fact that a distributor makes a title available in a
         certain format.
+
         :param data_source: A DataSource identifying the distributor.
         :param identifier: An Identifier identifying the title.
         :param content_type: The title is available in this media type.
@@ -1281,6 +1283,7 @@ class LicensePoolDeliveryMechanism(Base):
     def compatible_with(self, other):
         """Can a single loan be fulfilled with both this
         LicensePoolDeliveryMechanism and the given one?
+
         :param other: A LicensePoolDeliveryMechanism.
         """
         if not isinstance(other, LicensePoolDeliveryMechanism):
@@ -1524,6 +1527,7 @@ class DeliveryMechanism(Base, HasFullTableCache):
     def compatible_with(self, other, open_access_rules=False):
         """Can a single loan be fulfilled with both this delivery mechanism
         and the given one?
+
         :param other: A DeliveryMechanism
         :param open_access: If this is True, the rules for open-access
             fulfillment will be applied. If not, the stricted rules

--- a/model/listeners.py
+++ b/model/listeners.py
@@ -41,11 +41,11 @@ def site_configuration_has_changed(_db, timeout=1):
     of what you consider "site configuration", just to be safe.
 
     :param _db: Either a Session or (to save time in a common case) an
-    ORM object that can turned into a Session.
+        ORM object that can turned into a Session.
 
     :param timeout: Nothing will happen if it's been fewer than this
-    number of seconds since the last site configuration change was
-    recorded.
+        number of seconds since the last site configuration change was
+        recorded.
     """
     has_lock = site_configuration_has_changed_lock.acquire(blocking=False)
     if not has_lock:

--- a/model/resource.py
+++ b/model/resource.py
@@ -1056,6 +1056,7 @@ class Representation(Base, MediaTypes):
     ):
         """Determine whether making a GET request to a given URL is likely to
         have a useful result.
+
         :param URL: URL under consideration.
         :param headers: Headers that would be sent with the GET request.
         :param do_not_access: Domains to which GET requests are not useful.

--- a/monitor.py
+++ b/monitor.py
@@ -328,7 +328,7 @@ class CollectionMonitor(Monitor):
         yielded before Monitors with newer values.
 
         :param constructor_kwargs: These keyword arguments will be passed
-        into the CollectionMonitor constructor.
+            into the CollectionMonitor constructor.
 
         """
         service_match = or_(Timestamp.service==cls.SERVICE_NAME,
@@ -745,13 +745,13 @@ class ReaperMonitor(Monitor):
 
     A subclass of ReaperMonitor MUST define values for the following
     constants:
-    MODEL_CLASS - The model class this monitor is reaping, e.g. Credential.
-    TIMESTAMP_FIELD - Within the model class, the DateTime field to be
-       used when deciding which rows to deleting,
-       e.g. 'expires'. The reaper will be more efficient if there's
-       an index on this field.
-    MAX_AGE - A datetime.timedelta or number of days representing
-        the time that must pass before an item can be safely deleted.
+    * MODEL_CLASS - The model class this monitor is reaping, e.g. Credential.
+    * TIMESTAMP_FIELD - Within the model class, the DateTime field to be
+    used when deciding which rows to deleting,
+    e.g. 'expires'. The reaper will be more efficient if there's
+    an index on this field.
+    * MAX_AGE - A datetime.timedelta or number of days representing
+    the time that must pass before an item can be safely deleted.
 
     """
     MODEL_CLASS = None

--- a/opds.py
+++ b/opds.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm.session import Session
 
 import requests
 
-from lxml import builder, etree
+from lxml import etree
 
 from cdn import cdnify
 from config import Configuration
@@ -227,7 +227,7 @@ class Annotator(object):
         """Return all relevant classifications of this work.
 
         :return: A dictionary mapping 'scheme' URLs to dictionaries of
-        attribute-value pairs.
+            attribute-value pairs.
 
         Notable attributes: 'term', 'label', 'http://schema.org/ratingValue'
         """
@@ -411,8 +411,8 @@ class Annotator(object):
         which is always the identifier's URN.
 
         :return: A 2-tuple (URL, media type). If a single value is
-        returned, the media type will be presumed to be that of an
-        OPDS entry.
+            returned, the media type will be presumed to be that of an
+            OPDS entry.
         """
         # In the absence of any specific controllers, there is no
         # permalink. This method must be defined in a subclass.
@@ -500,8 +500,8 @@ class VerboseAnnotator(Annotator):
         Subject.uri_lookup.)
 
         :param policy: A PresentationCalculationPolicy to
-           use when deciding how deep to go when finding equivalent
-           identifiers for the work.
+            use when deciding how deep to go when finding equivalent
+            identifiers for the work.
         """
         policy = policy or PresentationCalculationPolicy(
             equivalent_identifier_cutoff=100

--- a/opds_import.py
+++ b/opds_import.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.orm.session import Session
 from flask_babel import lazy_gettext as _
 
-from lxml import builder, etree
+from lxml import etree
 
 from monitor import CollectionMonitor
 from util import LanguageCodes
@@ -283,8 +283,8 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup):
         :param identifier: an ISBN-type Identifier.
 
         :param working_display_name: The display name of the author
-        (i.e. the name format human being used as opposed to the name
-        that goes into library records).
+            (i.e. the name format human being used as opposed to the name
+            that goes into library records).
         """
         args = "display_name=%s" % (
             urllib.quote(working_display_name.encode("utf8"))
@@ -923,8 +923,8 @@ class OPDSImporter(object):
         All the stuff that Feedparser can't handle so we have to use lxml.
 
         :return: a dictionary mapping IDs to dictionaries. The inner
-        dictionary can be used as keyword arguments to the Metadata
-        constructor.
+            dictionary can be used as keyword arguments to the Metadata
+            constructor.
         """
         values = {}
         failures = {}
@@ -1423,12 +1423,12 @@ class OPDSImporter(object):
         """Convert a <link> tag into a LinkData object.
 
         :param feed_url: The URL to the enclosing feed, for use in resolving
-        relative links.
+            relative links.
 
         :param entry_rights_uri: A URI describing the rights advertised
-        in the entry. Unless this specific link says otherwise, we
-        will assume that the representation on the other end of the link
-        if made available on these terms.
+            in the entry. Unless this specific link says otherwise, we
+            will assume that the representation on the other end of the link
+            if made available on these terms.
         """
         attr = link_tag.attrib
         rel = attr.get('rel')

--- a/overdrive.py
+++ b/overdrive.py
@@ -553,8 +553,7 @@ class OverdriveRepresentationExtractor(object):
 
     @classmethod
     def availability_link_list(cls, book_list):
-        """:return: A list of dictionaries with keys `id`, `title`,
-        `availability_link`.
+        """:return: A list of dictionaries with keys `id`, `title`, `availability_link`.
         """
         l = []
         if not 'products' in book_list:
@@ -1088,7 +1087,7 @@ class OverdriveAdvantageAccount(object):
         account.
 
         :return: a 2-tuple of Collections (primary Overdrive
-        collection, Overdrive Advantage collection)
+            collection, Overdrive Advantage collection)
         """
         # First find the parent Collection.
         try:

--- a/s3.py
+++ b/s3.py
@@ -223,8 +223,7 @@ class S3Uploader(MirrorUploader):
         """Quote the path portions of an S3 key while leaving the path
         characters themselves alone.
 
-        :param key: Either a key, or a list of parts to be
-        assembled into a key.
+        :param key: Either a key, or a list of parts to be assembled into a key.
 
         :return: A bytestring that can be used as an S3 key.
         """

--- a/scripts.py
+++ b/scripts.py
@@ -813,7 +813,7 @@ class CustomListSweeperScript(LibraryInputScript):
 class SubjectInputScript(Script):
     """A script whose command line filters the set of Subjects.
 
-    :returns: a 2-tuple (subject type, subject filter) that can be
+    :return: a 2-tuple (subject type, subject filter) that can be
         passed into the SubjectSweepMonitor constructor.
 
     """
@@ -2303,7 +2303,7 @@ class DatabaseMigrationScript(Script):
     def fetch_migration_files(self):
         """Pulls migration files from the expected locations
 
-        :returns: a tuple with a list of migration filenames and a dictionary of
+        :return: a tuple with a list of migration filenames and a dictionary of
             those files separated by their absolute directory location.
         """
         migrations = list()

--- a/scripts.py
+++ b/scripts.py
@@ -298,7 +298,6 @@ class RunMultipleMonitorsScript(Script):
         raise NotImplementedError()
 
     def do_run(self):
-        """Run all appropriate monitors."""
         for monitor in self.monitors(**self.kwargs):
             try:
                 monitor.run()
@@ -356,10 +355,6 @@ class RunCoverageProvidersScript(Script):
             self.providers.append(i)
 
     def do_run(self):
-        """
-        :return: A CoverageProviderProgress for every CoverageProvider
-        that completed successfully.
-        """
         providers = list(self.providers)
         if not providers:
             self.log.info('No CoverageProviders to run.')
@@ -426,7 +421,7 @@ class RunThreadedCollectionCoverageProviderScript(Script):
         updates the timestamp accordingly.
 
         :param pool: A DatabasePool (or other) object for use in testing
-        environments.
+            environments.
         """
         collections = self.provider_class.collections(self._db)
         if not collections:
@@ -818,8 +813,9 @@ class CustomListSweeperScript(LibraryInputScript):
 class SubjectInputScript(Script):
     """A script whose command line filters the set of Subjects.
 
-    :return: a 2-tuple (subject type, subject filter) that can be
-    passed into the SubjectSweepMonitor constructor.
+    :returns: a 2-tuple (subject type, subject filter) that can be
+        passed into the SubjectSweepMonitor constructor.
+
     """
 
     @classmethod
@@ -1918,7 +1914,8 @@ class MirrorResourcesScript(CollectionInputScript):
         been mirrored.
 
         :param unmirrored: A replacement for Hyperlink.unmirrored,
-        for use in tests.
+            for use in tests.
+
         """
         unmirrored = unmirrored or Hyperlink.unmirrored
         for link in unmirrored(collection):
@@ -2306,8 +2303,8 @@ class DatabaseMigrationScript(Script):
     def fetch_migration_files(self):
         """Pulls migration files from the expected locations
 
-        :return: a tuple with a list of migration filenames and a dictionary of
-        those files separated by their absolute directory location.
+        :returns: a tuple with a list of migration filenames and a dictionary of
+            those files separated by their absolute directory location.
         """
         migrations = list()
         migrations_by_dir = defaultdict(list)
@@ -3206,8 +3203,6 @@ class SearchIndexCoverageRemover(TimestampScript, RemovesSearchCoverage):
     fresh coverage for every Work the next time it runs.
     """
     def do_run(self):
-        """Delete all WorkCoverageRecords for the UPDATE_SEARCH_INDEX_OPERATION.
-        """
         count = self.remove_search_coverage_records()
         return TimestampData(
             achievements="Coverage records deleted: %(deleted)d" % dict(

--- a/selftest.py
+++ b/selftest.py
@@ -110,20 +110,21 @@ class HasSelfTests(object):
     def run_self_tests(cls, _db, constructor_method=None, *args, **kwargs):
         """Instantiate this class and call _run_self_tests on it.
 
-        :param _db: A database connection. Will be passed into
-        _run_self_tests. This connection may need to be used again
-        in *args, if the constructor needs it.
+        :param _db: A database connection. Will be passed into `_run_self_tests`.
+            This connection may need to be used again
+            in args, if the constructor needs it.
 
         :param constructor_method: Method to use to instantiate the
-        class, if different from the default constructor.
+            class, if different from the default constructor.
 
         :param args: Positional arguments to pass into the constructor.
         :param kwargs: Keyword arguments to pass into the constructor.
 
-        :return: A 2-tuple (results_dict, results_list) `results_dict`
-        is a JSON-serializable dictionary describing the results of
-        the self-test. `results_list` is a list of SelfTestResult
-        objects.
+        :returns: A 2-tuple (results_dict, results_list) `results_dict`
+            is a JSON-serializable dictionary describing the results of
+            the self-test. `results_list` is a list of SelfTestResult
+            objects.
+
         """
         from external_search import ExternalSearchIndex
 

--- a/selftest.py
+++ b/selftest.py
@@ -120,7 +120,7 @@ class HasSelfTests(object):
         :param args: Positional arguments to pass into the constructor.
         :param kwargs: Keyword arguments to pass into the constructor.
 
-        :returns: A 2-tuple (results_dict, results_list) `results_dict`
+        :return: A 2-tuple (results_dict, results_list) `results_dict`
             is a JSON-serializable dictionary describing the results of
             the self-test. `results_list` is a list of SelfTestResult
             objects.

--- a/testing.py
+++ b/testing.py
@@ -720,15 +720,17 @@ class DatabaseTest(object):
         Calls the class method that examines the current state of the database model
         (whether it's been committed or not).
 
-        NOTE:  If you set_trace, and hit "continue", you'll start seeing console output right
+        NOTE: If you set_trace, and hit "continue", you'll start seeing console output right
         away, without waiting for the whole test to run and the standard output section to display.
         You can also use nosetest --nocapture.
-        I use:
-        def test_name(self):
-            [code...]
-            set_trace()
-            self.print_database_instance()  # TODO: remove before prod
-            [code...]
+
+        I use::
+
+            def test_name(self):
+                [code...]
+                set_trace()
+                self.print_database_instance()  # TODO: remove before prod
+                [code...]
         """
         if not 'TESTING' in os.environ:
             # we are on production, abort, abort!
@@ -754,13 +756,16 @@ class DatabaseTest(object):
         Be careful of leaving it in code and potentially outputting
         vast tracts of data into your output stream on production.
 
-        Call like this:
-        set_trace()
-        from testing import (
-            DatabaseTest,
-        )
-        _db = Session.object_session(self)
-        DatabaseTest.print_database_class(_db)  # TODO: remove before prod
+        Call like this::
+
+            set_trace()
+            from testing import (l=
+                DatabaseTest,
+            )
+            _db = Session.object_session(self)
+            DatabaseTest.print_database_class(_db)
+            
+            TODO: remove before prod
         """
         if not 'TESTING' in os.environ:
             # we are on production, abort, abort!

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -2,7 +2,6 @@ import os
 import datetime
 import urllib
 from StringIO import StringIO
-from lxml import builder
 from nose.tools import (
     set_trace,
     eq_,

--- a/util/epub.py
+++ b/util/epub.py
@@ -23,7 +23,7 @@ class EpubAccessor(object):
             the absence of the `content` parameter
         :param content: A string representing the compressed EPUB
 
-        :returns: A tuple containing a ZipFile of the EPUB and the path to its
+        :return: A tuple containing a ZipFile of the EPUB and the path to its
             package
         """
         if not (url or content):

--- a/util/epub.py
+++ b/util/epub.py
@@ -23,8 +23,8 @@ class EpubAccessor(object):
             the absence of the `content` parameter
         :param content: A string representing the compressed EPUB
 
-        :return: A tuple containing a ZipFile of the EPUB and the path to its
-        package
+        :return : A tuple containing a ZipFile of the EPUB and the path to its
+            package
         """
         if not (url or content):
             raise ValueError("Cannot open epub without url or content")

--- a/util/epub.py
+++ b/util/epub.py
@@ -23,7 +23,7 @@ class EpubAccessor(object):
             the absence of the `content` parameter
         :param content: A string representing the compressed EPUB
 
-        :return : A tuple containing a ZipFile of the EPUB and the path to its
+        :returns: A tuple containing a ZipFile of the EPUB and the path to its
             package
         """
         if not (url or content):

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -5,6 +5,16 @@ import logging
 from lxml import builder, etree
 from nose.tools import set_trace
 
+class ElementMaker(builder.ElementMaker):
+    """A helper object for creating etree elements."""
+
+    def __dict__(self):
+        # Remove default_typemap from the dictionary -- it contains functions
+        # that can't be pickled.
+        return dict(
+            (k, v) for k, v in super(ElementMaker, self).__dict__
+            if k != 'default_typemap'
+        )
 
 class AtomFeed(object):
 
@@ -41,9 +51,9 @@ class AtomFeed(object):
     }
 
     default_typemap = {datetime: lambda e, v: _strftime(v)}
-    E = builder.ElementMaker(typemap=default_typemap, nsmap=nsmap)
-    SIMPLIFIED = builder.ElementMaker(typemap=default_typemap, nsmap=nsmap, namespace=SIMPLIFIED_NS)
-    SCHEMA = builder.ElementMaker(typemap=default_typemap, nsmap=nsmap, namespace=SCHEMA_NS)
+    E = ElementMaker(typemap=default_typemap, nsmap=nsmap)
+    SIMPLIFIED = ElementMaker(typemap=default_typemap, nsmap=nsmap, namespace=SIMPLIFIED_NS)
+    SCHEMA = ElementMaker(typemap=default_typemap, nsmap=nsmap, namespace=SCHEMA_NS)
 
     @classmethod
     def _strftime(self, date):

--- a/util/personal_names.py
+++ b/util/personal_names.py
@@ -172,13 +172,14 @@ def display_name_to_sort_name(display_name):
 
 def name_tidy(name):
     """
-    - Converts to NFKD unicode.
-    - Strips excessive whitespace and trailing punctuation.
-    - Normalizes PhD/MD suffixes.
-    - Does not perform any potentially name-altering business logic, such as
-    running HumanName parser or any other name part reorganization.
-    - Does not perform any cleaning that would later need to be reversed,
-    such as lowercasing.
+    * Converts to NFKD unicode.
+    * Strips excessive whitespace and trailing punctuation.
+    * Normalizes PhD/MD suffixes.
+    * Does not perform any potentially name-altering business logic, such as
+        running HumanName parser or any other name part reorganization.
+    * Does not perform any cleaning that would later need to be reversed,
+        such as lowercasing.
+
     """
     name = unicodedata.normalize("NFKD", unicode(name))
     name = WorkIDCalculator.consecutiveCharacterStrip.sub(" ", name)


### PR DESCRIPTION
Helps resolve [SIMPLY-2161](https://jira.nypl.org/browse/SIMPLY-2161).

The [documentation on readthedocs](https://circulation.readthedocs.io/en/sphinx-documentation/index.html) could use an introduction and better navigation, but for this first step the goal was to generate the docs and deploy it.

I'll explain more in the PR for `circulation`. For this repo, it's mostly updating the docstrings (in [rst - reStructuredText](http://docutils.sourceforge.net/rst.html)) so that [sphinx](https://www.sphinx-doc.org/en/master/) can parse them correctly. @leonardr also helped fixed a pickle issue in /utils/opds_writer with the lxml package.