### PR TITLE
Weight keyword matches for publisher and imprint much lower than keyw…

### DIFF
--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -418,7 +418,7 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
         self.subtitle_match.presentation_edition.subtitle = "Match"
 
         self.summary_match = _work(title="SummaryM")
-        self.summary_match.summary_text = "It's a Match!"
+        self.summary_match.summary_text = "It's a Match! The story of a work whose summary contained an important keyword."
 
         self.publisher_match = _work(title="PublisherM")
         self.publisher_match.presentation_edition.publisher = "Match"
@@ -595,12 +595,12 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
         # Search in publisher name.
         expect(self.moby_dick, "gutenberg")
 
-        # Title > subtitle > publisher > word found in summary
+        # Title > subtitle > word found in summary > publisher
         order = [
             self.title_match,
             self.subtitle_match,
-            self.publisher_match,
             self.summary_match,
+            self.publisher_match,
         ]
         expect(order, "match")
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -418,7 +418,7 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
         self.subtitle_match.presentation_edition.subtitle = "Match"
 
         self.summary_match = _work(title="SummaryM")
-        self.summary_match.summary_text = "Match"
+        self.summary_match.summary_text = "It's a Match!"
 
         self.publisher_match = _work(title="PublisherM")
         self.publisher_match.presentation_edition.publisher = "Match"


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-2203.
Most of the tests are integration tests, which I've added to https://github.com/NYPL-Simplified/circulation/pull/1296

This solution isn't ideal, but without intelligence about whether a string is likely to be a publisher search, I don't see a better option.