### PR TITLE
Improve Collection.for_metadata_identifier

### DIFF
--- a/model/collection.py
+++ b/model/collection.py
@@ -468,8 +468,11 @@ class Collection(Base, HasFullTableCache):
         this Collection on the metadata wrangler. This identifier is
         composed of the Collection protocol and account identifier.
 
-        In the metadata wrangler, this identifier is used as the unique
-        name of the collection.
+        A circulation manager provides a Collection's metadata
+        identifier as part of collection registration. The metadata
+        wrangler creates a corresponding Collection on its side,
+        _named after_ the metadata identifier -- regardless of the name
+        of that collection on the circulation manager side.
         """
         account_id = self.unique_account_id
         if self.protocol == ExternalIntegration.OPDS_IMPORT:

--- a/model/collection.py
+++ b/model/collection.py
@@ -531,6 +531,10 @@ class Collection(Base, HasFullTableCache):
             # For OPDS Import collections only, we store the URL to
             # the OPDS feed (the "account ID") and the data source.
             collection.external_account_id = account_id
+            if data_source and not isinstance(data_source, DataSource):
+                data_source = DataSource.lookup(
+                    _db, data_source, autocreate=True
+                )
             collection.data_source = data_source
 
         return collection, is_new

--- a/model/collection.py
+++ b/model/collection.py
@@ -486,35 +486,51 @@ class Collection(Base, HasFullTableCache):
         return encode(metadata_identifier)
 
     @classmethod
-    def from_metadata_identifier(cls, _db, metadata_identifier, data_source=None):
-        """Finds or creates a Collection on the metadata wrangler, based
-        on its unique metadata_identifier
-        """
-        collection = get_one(_db, Collection, name=metadata_identifier)
-        is_new = False
-
-        opds_collection_without_url = (
-            collection and collection.protocol==ExternalIntegration.OPDS_IMPORT
-            and not collection.external_account_id
-        )
-
-        if not collection or opds_collection_without_url:
+    def _decode_metadata_identifier(cls, metadata_identifier):
+        """Invert the metadata_identifier property."""
+        try:
             decode = base64.urlsafe_b64decode
             details = decode(metadata_identifier)
             encoded_details  = details.split(':', 1)
             [protocol, account_id] = [decode(d) for d in encoded_details]
-
-            if not collection:
-                collection, is_new = create(
-                    _db, Collection, name=metadata_identifier
+        except (TypeError, ValueError) as e:
+            raise ValueError(
+                u"Metadata identifier '%s' is invalid: %s" % (
+                    metadata_identifier, unicode(e)
                 )
-                collection.create_external_integration(protocol)
+            )
+        return protocol, account_id
 
-            if protocol == ExternalIntegration.OPDS_IMPORT:
-                # Share the feed URL so the Metadata Wrangler can find it.
-                collection.external_account_id = account_id
+    @classmethod
+    def from_metadata_identifier(cls, _db, metadata_identifier, data_source=None):
+        """Finds or creates a Collection on the metadata wrangler, based
+        on its unique metadata_identifier.
+        """
 
-        if data_source:
+        # Decode the metadata identifier into a protocol and an
+        # account ID. If the metadata identifier is invalid, this
+        # will raise an exception.
+        protocol, account_id = cls._decode_metadata_identifier(metadata_identifier)
+
+        # Now that we know the metadata identifier is valid, try to
+        # look up a collection named after it.
+        collection = get_one(_db, Collection, name=metadata_identifier)
+        is_new = False
+
+        if not collection:
+            # Create a collection named after the metadata
+            # identifier. Give it an ExternalIntegration with the
+            # corresponding protocol, and set its data source and
+            # external_account_id.
+            collection, is_new = create(
+                _db, Collection, name=metadata_identifier
+            )
+            collection.create_external_integration(protocol)
+
+        if protocol == ExternalIntegration.OPDS_IMPORT:
+            # For OPDS Import collections only, we store the URL to
+            # the OPDS feed (the "account ID") and the data source.
+            collection.external_account_id = account_id
             collection.data_source = data_source
 
         return collection, is_new

--- a/model/collection.py
+++ b/model/collection.py
@@ -488,6 +488,8 @@ class Collection(Base, HasFullTableCache):
     @classmethod
     def _decode_metadata_identifier(cls, metadata_identifier):
         """Invert the metadata_identifier property."""
+        if not metadata_identifier:
+            raise ValueError("No metadata identifier provided.")
         try:
             decode = base64.urlsafe_b64decode
             details = decode(metadata_identifier)

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -441,6 +441,15 @@ class TestCollection(DatabaseTest):
         eq_(expected, opds.metadata_identifier)
 
     def test_from_metadata_identifier(self):
+        # A ValueError results if we try to look up using an invalid
+        # identifier.
+        assert_raises_regexp(
+            ValueError,
+            "Metadata identifier 'not a real identifier' is invalid: Incorrect padding",
+            Collection.from_metadata_identifier,
+            self._db, "not a real identifier"
+        )
+
         # If a mirrored collection doesn't exist, it is created.
         self.collection.external_account_id = 'id'
         mirror_collection, is_new = Collection.from_metadata_identifier(
@@ -460,6 +469,9 @@ class TestCollection(DatabaseTest):
         )[0]
         mirror_collection.create_external_integration(collection.protocol)
         # Confirm that there's no external_account_id and no DataSource.
+
+        # TODO I don't understand why we don't store this information,
+        # even if only to keep it in an easy-to-read form.
         eq_(None, mirror_collection.external_account_id)
         eq_(None, mirror_collection.data_source)
 

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -453,6 +453,14 @@ class TestCollection(DatabaseTest):
             self._db, "not a real identifier", data_source=data_source
         )
 
+        # Of if we pass in the empty string.
+        assert_raises_regexp(
+            ValueError,
+            "No metadata identifier provided",
+            Collection.from_metadata_identifier,
+            self._db, "", data_source=data_source
+        )
+
         # No new data source was created.
         def new_data_source():
             return DataSource.lookup(self._db, data_source)

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -441,48 +441,67 @@ class TestCollection(DatabaseTest):
         eq_(expected, opds.metadata_identifier)
 
     def test_from_metadata_identifier(self):
+
+        data_source = "New data source"
+
         # A ValueError results if we try to look up using an invalid
         # identifier.
         assert_raises_regexp(
             ValueError,
             "Metadata identifier 'not a real identifier' is invalid: Incorrect padding",
             Collection.from_metadata_identifier,
-            self._db, "not a real identifier"
+            self._db, "not a real identifier", data_source=data_source
         )
+
+        # No new data source was created.
+        def new_data_source():
+            return DataSource.lookup(self._db, data_source)
+        eq_(None, new_data_source())
 
         # If a mirrored collection doesn't exist, it is created.
         self.collection.external_account_id = 'id'
         mirror_collection, is_new = Collection.from_metadata_identifier(
-            self._db, self.collection.metadata_identifier
+            self._db, self.collection.metadata_identifier,
+            data_source=data_source
         )
         eq_(True, is_new)
         eq_(self.collection.metadata_identifier, mirror_collection.name)
         eq_(self.collection.protocol, mirror_collection.protocol)
-        # Because this isn't an OPDS collection, no account details are held.
+
+        # Because this isn't an OPDS collection, the external account
+        # ID is not stored, the data source is the default source for
+        # the protocol, and no new data source was created.
         eq_(None, mirror_collection.external_account_id)
+        eq_(DataSource.OVERDRIVE, mirror_collection.data_source.name)
+        eq_(None, new_data_source())
 
         # If the mirrored collection already exists, it is returned.
         collection = self._collection(external_account_id=self._url)
         mirror_collection = create(
             self._db, Collection,
-            name=collection.metadata_identifier,
+            name=collection.metadata_identifier
         )[0]
         mirror_collection.create_external_integration(collection.protocol)
-        # Confirm that there's no external_account_id and no DataSource.
 
+        # Confirm that there's no external_account_id and no DataSource.
         # TODO I don't understand why we don't store this information,
         # even if only to keep it in an easy-to-read form.
         eq_(None, mirror_collection.external_account_id)
         eq_(None, mirror_collection.data_source)
+        eq_(None, new_data_source())
 
-        source = DataSource.lookup(self._db, DataSource.OA_CONTENT_SERVER)
+        # Now try a lookup of an OPDS Import-type collection.
         result, is_new = Collection.from_metadata_identifier(
-            self._db, collection.metadata_identifier, data_source=source
+            self._db, collection.metadata_identifier, data_source=data_source
         )
         eq_(False, is_new)
         eq_(mirror_collection, result)
         # The external_account_id and data_source have been set now.
         eq_(collection.external_account_id, mirror_collection.external_account_id)
+
+        # A new DataSource object has been created.
+        source = new_data_source()
+        eq_("New data source", source.name)
         eq_(source, mirror_collection.data_source)
 
     def test_catalog_identifier(self):


### PR DESCRIPTION
This branch makes some improvements to the code that turns a metadata identifier into a Collection.
In particular, invalid or missing metadata identifiers result in distinct ValueErrors, not random base64 errors.

This is core work for https://github.com/NYPL-Simplified/metadata_wrangler/pull/199. Only the metadata wrangler uses Collection.for_metadata_identifier, so this is effectively metadata wrangler code.

