### PR TITLE
Corrected docstring syntax.

### DIFF
--- a/model/collection.py
+++ b/model/collection.py
@@ -471,7 +471,7 @@ class Collection(Base, HasFullTableCache):
         A circulation manager provides a Collection's metadata
         identifier as part of collection registration. The metadata
         wrangler creates a corresponding Collection on its side,
-        _named after_ the metadata identifier -- regardless of the name
+        *named after* the metadata identifier -- regardless of the name
         of that collection on the circulation manager side.
         """
         account_id = self.unique_account_id


### PR DESCRIPTION
This simple branch fixes a syntax error that was breaking the docstring of a recently changed method. This prevented circulation branches from running the full test suite, since the initial doc build failed.