### PR TITLE
DPLA Audiobook support

### DIFF
--- a/log.py
+++ b/log.py
@@ -27,7 +27,7 @@ class JSONFormatter(logging.Formatter):
     def format(self, record):
         message = unicode(record.msg)
         def no_bytestring(s):
-            if isinstance(s, str):
+            if isinstance(s, bytes):
                 s = unicode(s)
             return s
 

--- a/log.py
+++ b/log.py
@@ -26,14 +26,14 @@ class JSONFormatter(logging.Formatter):
 
     def format(self, record):
         message = unicode(record.msg)
+        def no_bytestring(s):
+            if isinstance(s, str):
+                s = unicode(s)
+            return s
 
         if record.args:
-            recordArgs = ()
-            for a in record.args:
-                if isinstance(a, str):
-                    a = unicode(a)
-                recordArgs = recordArgs + (a,)
-            message = message % recordArgs
+            record_args = tuple([no_bytestring(arg) for arg in record.args])
+            message = message % record_args
         data = dict(
             host=self.hostname,
             app=self.app_name,

--- a/log.py
+++ b/log.py
@@ -25,9 +25,15 @@ class JSONFormatter(logging.Formatter):
         self.app_name = app_name or LogConfiguration.DEFAULT_APP_NAME
 
     def format(self, record):
-        message = record.msg
+        message = unicode(record.msg)
+
         if record.args:
-            message = record.msg % record.args
+            recordArgs = ()
+            for a in record.args:
+                if isinstance(a, str):
+                    a = unicode(a)
+                recordArgs = recordArgs + (a,)
+            message = message % recordArgs
         data = dict(
             host=self.hostname,
             app=self.app_name,

--- a/model/constants.py
+++ b/model/constants.py
@@ -248,8 +248,12 @@ class MediaTypes(object):
         SVG_MEDIA_TYPE,
     ]
 
+    # If an open access book is imported and not any of these media types,
+    # then it won't show up in an OPDS feed.
     SUPPORTED_BOOK_MEDIA_TYPES = [
-        EPUB_MEDIA_TYPE
+        EPUB_MEDIA_TYPE,
+        PDF_MEDIA_TYPE,
+        AUDIOBOOK_MANIFEST_MEDIA_TYPE
     ]
 
     # Most of the time, if you believe a resource to be media type A,

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -1402,6 +1402,7 @@ class DeliveryMechanism(Base, HasFullTableCache):
     STREAMING_DRM = u"Streaming"
     OVERDRIVE_DRM = u"Overdrive DRM"
     BEARER_TOKEN = u"application/vnd.librarysimplified.bearer-token+json"
+    AUDIOBOOK_NO_DRM = u"http://www.feedbooks.com/audiobooks/access-restriction"
 
     STREAMING_PROFILE = ';profile="http://librarysimplified.org/terms/profiles/streaming-media"'
     MEDIA_TYPES_FOR_STREAMING = {

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -1402,7 +1402,7 @@ class DeliveryMechanism(Base, HasFullTableCache):
     STREAMING_DRM = u"Streaming"
     OVERDRIVE_DRM = u"Overdrive DRM"
     BEARER_TOKEN = u"application/vnd.librarysimplified.bearer-token+json"
-    AUDIOBOOK_NO_DRM = u"http://www.feedbooks.com/audiobooks/access-restriction"
+    AUDIOBOOK_DRM = u"http://www.feedbooks.com/audiobooks/access-restriction"
 
     STREAMING_PROFILE = ';profile="http://librarysimplified.org/terms/profiles/streaming-media"'
     MEDIA_TYPES_FOR_STREAMING = {

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -1402,8 +1402,9 @@ class DeliveryMechanism(Base, HasFullTableCache):
     STREAMING_DRM = u"Streaming"
     OVERDRIVE_DRM = u"Overdrive DRM"
     BEARER_TOKEN = u"application/vnd.librarysimplified.bearer-token+json"
-    AUDIOBOOK_DRM = u"http://www.feedbooks.com/audiobooks/access-restriction"
+    FEEDBOOKS_AUDIOBOOK_DRM = u"http://www.feedbooks.com/audiobooks/access-restriction"
 
+    FEEDBOOKS_AUDIOBOOK_PROFILE = ';profile="%s"' % FEEDBOOKS_AUDIOBOOK_DRM
     STREAMING_PROFILE = ';profile="http://librarysimplified.org/terms/profiles/streaming-media"'
     MEDIA_TYPES_FOR_STREAMING = {
         STREAMING_TEXT_CONTENT_TYPE: MediaTypes.TEXT_HTML_MEDIA_TYPE
@@ -1517,6 +1518,8 @@ class DeliveryMechanism(Base, HasFullTableCache):
         content type, assuming it's represented as a media type.
         """
         if self.is_media_type(self.content_type):
+            if self.drm_scheme == self.FEEDBOOKS_AUDIOBOOK_DRM:
+                return self.content_type + self.FEEDBOOKS_AUDIOBOOK_PROFILE
             return self.content_type
 
         media_type_for_streaming = self.MEDIA_TYPES_FOR_STREAMING.get(self.content_type)

--- a/opds.py
+++ b/opds.py
@@ -1162,7 +1162,7 @@ class AcquisitionFeed(OPDSFeed):
         """
         xml = None
         field = self.annotator.opds_cache_field
-        # set_trace()
+
         if field and work and not force_create and use_cache:
             xml = getattr(work, field)
 

--- a/opds.py
+++ b/opds.py
@@ -38,6 +38,7 @@ from model import (
     CustomList,
     CustomListEntry,
     DataSource,
+    DeliveryMechanism,
     Hyperlink,
     PresentationCalculationPolicy,
     Resource,
@@ -1597,7 +1598,10 @@ class AcquisitionFeed(OPDSFeed):
         # Finally, you get the goodies.
         media = delivery_mechanism.content_type_media_type
         if media:
+            if delivery_mechanism.drm_scheme == DeliveryMechanism.AUDIOBOOK_DRM:
+                media += ';profile=' + delivery_mechanism.drm_scheme
             types.append(media)
+
         return types
 
 

--- a/opds.py
+++ b/opds.py
@@ -1598,8 +1598,6 @@ class AcquisitionFeed(OPDSFeed):
         # Finally, you get the goodies.
         media = delivery_mechanism.content_type_media_type
         if media:
-            if delivery_mechanism.drm_scheme == DeliveryMechanism.AUDIOBOOK_DRM:
-                media += ';profile=' + delivery_mechanism.drm_scheme
             types.append(media)
 
         return types

--- a/opds.py
+++ b/opds.py
@@ -1161,6 +1161,7 @@ class AcquisitionFeed(OPDSFeed):
         """
         xml = None
         field = self.annotator.opds_cache_field
+        # set_trace()
         if field and work and not force_create and use_cache:
             xml = getattr(work, field)
 

--- a/opds_import.py
+++ b/opds_import.py
@@ -56,7 +56,7 @@ from model import (
     Subject,
     get_one,
 )
-
+from model.constants import MediaTypes
 from coverage import CoverageFailure
 from util.http import (
     BadResponseException,
@@ -562,7 +562,6 @@ class OPDSImporter(object):
         # If parsing the overall feed throws an exception, we should address that before
         # moving on. Let the exception propagate.
         metadata_objs, failures = self.extract_feed_data(feed, feed_url)
-
         # make editions.  if have problem, make sure associated pool and work aren't created.
         for key, metadata in metadata_objs.iteritems():
             # key is identifier.urn here
@@ -1295,8 +1294,6 @@ class OPDSImporter(object):
                 alternate_identifiers.append(v)
         data['identifiers'] = alternate_identifiers
 
-        data['medium'] = cls.extract_medium(entry_tag)
-
         data['contributors'] = []
         for author_tag in parser._xpath(entry_tag, 'atom:author'):
             contributor = cls.extract_contributor(parser, author_tag)
@@ -1321,6 +1318,9 @@ class OPDSImporter(object):
             for link_tag in parser._xpath(entry_tag, 'atom:link')
         ])
 
+        derived_medium = cls.get_medium_from_links(data['links'])
+        data['medium'] = cls.extract_medium(entry_tag, derived_medium)
+
         series_tag = parser._xpath(entry_tag, 'schema:Series')
         if series_tag:
             data['series'], data['series_position'] = cls.extract_series(series_tag[0])
@@ -1340,6 +1340,17 @@ class OPDSImporter(object):
         return data
 
     @classmethod
+    def get_medium_from_links(cls, links):
+        """Get medium type if found in the links."""
+        links = [l for l in links if 'http://opds-spec.org/acquisition/' in l.rel]
+        derived_medium = None
+        for link in links:
+            if link.media_type == MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE:
+                derived_medium = Edition.AUDIO_MEDIUM
+        
+        return derived_medium
+
+    @classmethod
     def extract_identifier(cls, identifier_tag):
         """Turn a <dcterms:identifier> tag into an IdentifierData object."""
         try:
@@ -1349,7 +1360,7 @@ class OPDSImporter(object):
             return None
 
     @classmethod
-    def extract_medium(cls, entry_tag):
+    def extract_medium(cls, entry_tag, derived_medium):
         """Derive a value for Edition.medium from <atom:entry
         schema:additionalType>.
         """
@@ -1357,7 +1368,7 @@ class OPDSImporter(object):
         # If no additionalType is given, assume we're talking about an
         # ebook.
         default_additional_type = Edition.medium_to_additional_type[
-            Edition.BOOK_MEDIUM
+            derived_medium or Edition.BOOK_MEDIUM
         ]
         additional_type = entry_tag.get('{http://schema.org/}additionalType',
                                         default_additional_type)

--- a/opds_import.py
+++ b/opds_import.py
@@ -1347,6 +1347,10 @@ class OPDSImporter(object):
         for link in links:
             if link.media_type == MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE:
                 derived_medium = Edition.AUDIO_MEDIUM
+                break
+            elif link.media_type == MediaTypes.EPUB_MEDIA_TYPE:
+                derived_medium = Edition.BOOK_MEDIUM
+                break
         
         return derived_medium
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Requirements for core
-accept_types
+accept_types==0.3.0
 boto3
 feedparser
 pillow

--- a/tests/files/opds/audiobooks.opds
+++ b/tests/files/opds/audiobooks.opds
@@ -4,34 +4,10 @@
 <updated>2019-08-19T00:00:00Z</updated>
 <link rel="self" href="https://s3.amazonaws.com/open.minitex.org/librevox"/>
 <entry>
-  <id>urn:uuid:f6ea5431-bc4d-437d-8de5-a3bde04a5c43</id>
-  <title>Everglades Wildguide</title>
-  <bibframe:distribution bibframe:ProviderName="LibriVox"/>
-  <author>
-  <name>Jean Craighead George</name>
-  <simplified:sort_name>George, Jean Craighead</simplified:sort_name>
-  </author>
-  <summary type="html">
-  LibriVox recording of Everglades Wildguide by Jean Craighead George Read in English by VfkaBT This is a United States National Parks guidebook written by a popular young people's nature writer, Jean Craighead George. It covers the Everglades in detail, from its mangrove swamps to its sawgrass prairies. (Summary by Matt Pierard) For further information, including links to online text, reader information, RSS feeds, CD cover or other formats (if available), please go to the LibriVox catalog page for this recording. For more free audio books or to become a volunteer reader, visit LibriVox.org . M4B Audiobook (57MB)
-  </summary>
-  <updated>2017-07-01T19:36:25Z</updated>
-  <link href="https://archive.org/services/img/evergladeswildguide_1707_librivox" type="image/jpeg" rel="http://opds-spec.org/image"/>
-  <link href="https://archive.org/services/img/evergladeswildguide_1707_librivox" type="image/jpeg" rel="http://opds-spec.org/image/thumbnail"/>
-  <dcterms:issued>2017</dcterms:issued>
-  <link href="https://dp.la/exchange/audiobook" type="application/audiobook+json;profile=http://www.feedbooks.com/audiobooks/access-restriction" rel="http://opds-spec.org/acquisition" />
-  <category term="librivox" label="librivox"/>
-  <category term="audiobooks" label="audiobooks"/>
-  <category term="nature" label="nature"/>
-  <category term="ecology" label="ecology"/>
-  <category term="florida everglades" label="florida everglades"/>
-  <category term="united states department of the interior" label="united states department of the interior"/>
-</entry>
-<entry>
   <title>Zhitiia Sviatykh, v. 12 - August</title>
   <id>urn:uuid:836f559f-3bfd-4b33-96f7-0bd1878a5dab</id>
   <updated>2008-11-24T13:27:00Z</updated>
   <link href="https://api.archivelab.org/books/kniga_zitij_svjatyh_na_mesjac_avgust_eu_0811_librivox/opds_audio_manifest" type="application/audiobook+json" rel="http://opds-spec.org/acquisition/open-access"/>
-  <link href="https://archive.org/details/kniga_zitij_svjatyh_na_mesjac_avgust_eu_0811_librivox" type="text/html" rel="http://opds-spec.org/acquisition/open-access" dcterms:rights="https://creativecommons.org/licenses/by-nc-nd/4.0/"/>
   <link href="https://archive.org/services/img/kniga_zitij_svjatyh_na_mesjac_avgust_eu_0811_librivox" type="image/jpeg" rel="http://opds-spec.org/image"/>
   <link href="https://archive.org/services/img/kniga_zitij_svjatyh_na_mesjac_avgust_eu_0811_librivox" type="image/jpeg" rel="http://opds-spec.org/image/thumbnail"/>
   <dcterms:issued>2008</dcterms:issued>

--- a/tests/files/opds/audiobooks.opds
+++ b/tests/files/opds/audiobooks.opds
@@ -1,0 +1,58 @@
+<feed xmlns:app="http://www.w3.org/2007/app" xmlns:bibframe="http://bibframe.org/vocab/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:drm="http://librarysimplified.org/terms/drm" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/" xmlns:simplified="http://librarysimplified.org/terms/" xmlns="http://www.w3.org/2005/Atom">
+<id>https://s3.amazonaws.com/open.minitex.org/librevox</id>
+<title>Librivox Audiobooks</title>
+<updated>2019-08-19T00:00:00Z</updated>
+<link rel="self" href="https://s3.amazonaws.com/open.minitex.org/librevox"/>
+<entry>
+  <id>urn:uuid:f6ea5431-bc4d-437d-8de5-a3bde04a5c43</id>
+  <title>Everglades Wildguide</title>
+  <bibframe:distribution bibframe:ProviderName="LibriVox"/>
+  <author>
+  <name>Jean Craighead George</name>
+  <simplified:sort_name>George, Jean Craighead</simplified:sort_name>
+  </author>
+  <summary type="html">
+  LibriVox recording of Everglades Wildguide by Jean Craighead George Read in English by VfkaBT This is a United States National Parks guidebook written by a popular young people's nature writer, Jean Craighead George. It covers the Everglades in detail, from its mangrove swamps to its sawgrass prairies. (Summary by Matt Pierard) For further information, including links to online text, reader information, RSS feeds, CD cover or other formats (if available), please go to the LibriVox catalog page for this recording. For more free audio books or to become a volunteer reader, visit LibriVox.org . M4B Audiobook (57MB)
+  </summary>
+  <updated>2017-07-01T19:36:25Z</updated>
+  <link href="https://archive.org/services/img/evergladeswildguide_1707_librivox" type="image/jpeg" rel="http://opds-spec.org/image"/>
+  <link href="https://archive.org/services/img/evergladeswildguide_1707_librivox" type="image/jpeg" rel="http://opds-spec.org/image/thumbnail"/>
+  <dcterms:issued>2017</dcterms:issued>
+  <link href="https://dp.la/exchange/audiobook" type="application/audiobook+json;profile=http://www.feedbooks.com/audiobooks/access-restriction" rel="http://opds-spec.org/acquisition" />
+  <category term="librivox" label="librivox"/>
+  <category term="audiobooks" label="audiobooks"/>
+  <category term="nature" label="nature"/>
+  <category term="ecology" label="ecology"/>
+  <category term="florida everglades" label="florida everglades"/>
+  <category term="united states department of the interior" label="united states department of the interior"/>
+</entry>
+<entry>
+  <title>Zhitiia Sviatykh, v. 12 - August</title>
+  <id>urn:uuid:836f559f-3bfd-4b33-96f7-0bd1878a5dab</id>
+  <updated>2008-11-24T13:27:00Z</updated>
+  <link href="https://api.archivelab.org/books/kniga_zitij_svjatyh_na_mesjac_avgust_eu_0811_librivox/opds_audio_manifest" type="application/audiobook+json" rel="http://opds-spec.org/acquisition/open-access"/>
+  <link href="https://archive.org/details/kniga_zitij_svjatyh_na_mesjac_avgust_eu_0811_librivox" type="text/html" rel="http://opds-spec.org/acquisition/open-access" dcterms:rights="https://creativecommons.org/licenses/by-nc-nd/4.0/"/>
+  <link href="https://archive.org/services/img/kniga_zitij_svjatyh_na_mesjac_avgust_eu_0811_librivox" type="image/jpeg" rel="http://opds-spec.org/image"/>
+  <link href="https://archive.org/services/img/kniga_zitij_svjatyh_na_mesjac_avgust_eu_0811_librivox" type="image/jpeg" rel="http://opds-spec.org/image/thumbnail"/>
+  <dcterms:issued>2008</dcterms:issued>
+  <published>2008-11-24T00:00:00Z</published>
+  <author>
+  <name>Dimitrij, Saint Metropolitan of Rostov</name>
+  </author>
+  <category term="librivox" label="librivox"/>
+  <category term="literature" label="literature"/>
+  <category term="audiobook" label="audiobook"/>
+  <category term="Книга житій святыхъ на мѣсяцъ август" label="Книга житій святыхъ на мѣсяцъ август"/>
+  <category term="Dimitriĭ" label="Dimitriĭ"/>
+  <category term="Saint Metropolitan of Rostov" label="Saint Metropolitan of Rostov"/>
+  <category term="Святитель Димитрій Ростовскій" label="Святитель Димитрій Ростовскій"/>
+  <category term="religion" label="religion"/>
+  <category term="orthodox" label="orthodox"/>
+  <category term="saints" label="saints"/>
+  <category term="Church Slavonic" label="Church Slavonic"/>
+  <dcterms:publisher>LibriVox</dcterms:publisher>
+  <summary type="html">
+  Librivox recording of Жития Святых, т. 12 - август , Zhitiia Sviatykh, v. 12 - August (“The Book of Lives of the Saints for the Month of August”) by Dimitriĭ, Saint Metropolitan of Rostov. Read by Euthymius . Жития и похвалы святых подобятся светлостию звездам: якоже бо звезды положением на небеси утвержденны суть, всю же поднебесную просвещают, тыяжде и от Индиан зрятся, ни сокрываются от скифов, землю озаряют, и морю светят, и плавающих корабли управляют: ихже имен аще и не вемы множества ради, обаче светлей доброте их чудимся. Сице и светлость святых, аще и затворены суть мощи их во гробех, но силы их в поднебесней земными пределы не суть определенны: чудимся тех житию, и удивляемся славе, еюже Бог угодившыя Ему прославляет. [St. Symeon Metaphrastes on the Lives of the Saints, 10th century A. D. ENGLISH TRANSLATION: The lives and the eulogies of the Saints resemble, by their luminosity, the stars: for as the stars, firmly studded in the firmament as they are, illume the entire universe, and the same stars are beheld by the Indians, and are not hid from the Scythians, and shed their radiance over the earth and the seas, and show the way to the ships: and even if we know not their names for their multitude’s sake, we as yet admire their brilliant loveliness. So, too, doeth the brilliance of the Saints, even when their relics are shut under a tombstone, yet their miracles in the entire universe are not bound by earthly confines: we admire their lives and wonder at the glory wherewith God glorifieth those who have pleased Him. This succinct description is found as introduction to each of the 12 volumes of the Church Slavonic Lives.] For further information, including links to M4B audio book, online text, reader information, RSS feeds, CD cover or other formats (if available), please go to the LibriVox catalog page for this recording. For more free audiobooks, or to become a volunteer reader, please visit librivox.org . M4B audio book, part 1 (153MB) M4B audio book, part 2 (154MB) M4B audio book, part 3 (134MB)
+  </summary>
+</entry>
+</feed>

--- a/tests/models/test_licensing.py
+++ b/tests/models/test_licensing.py
@@ -41,6 +41,10 @@ class TestDeliveryMechanism(DatabaseTest):
             self._db, Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM)
         self.overdrive_streaming_text, ignore = DeliveryMechanism.lookup(
             self._db, DeliveryMechanism.STREAMING_TEXT_CONTENT_TYPE, DeliveryMechanism.OVERDRIVE_DRM)
+        self.audiobook_drm_scheme, ignore = DeliveryMechanism.lookup(
+            self._db, Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
+            DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM
+        )
 
     def test_implicit_medium(self):
         eq_(Edition.BOOK_MEDIUM, self.epub_no_drm.implicit_medium)
@@ -68,6 +72,8 @@ class TestDeliveryMechanism(DatabaseTest):
         eq_(Representation.EPUB_MEDIA_TYPE, self.epub_adobe_drm.content_type_media_type)
         eq_(Representation.TEXT_HTML_MEDIA_TYPE + DeliveryMechanism.STREAMING_PROFILE,
             self.overdrive_streaming_text.content_type_media_type)
+        eq_(Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE + DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_PROFILE,
+            self.audiobook_drm_scheme.content_type_media_type)
 
     def test_default_fulfillable(self):
         mechanism, is_new = DeliveryMechanism.lookup(

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -466,6 +466,7 @@ class TestOPDS(DatabaseTest):
         # TODO PYTHON3 order of attrs is different
         eq_(etree.tounicode(b), '<link href="%s" rel="http://opds-spec.org/acquisition/borrow" type="application/epub"/>' % href)
 
+        # A direct acquisition link to a document with embedded access restriction rules.
         c = m(rel, href, ['application/audiobook+json;profile=http://www.feedbooks.com/audiobooks/access-restriction'])
         eq_(etree.tounicode(c), '<link href="%s" rel="http://opds-spec.org/acquisition/borrow" type="application/audiobook+json;profile=http://www.feedbooks.com/audiobooks/access-restriction"/>' % href)
 
@@ -1797,11 +1798,11 @@ class TestAcquisitionFeed(DatabaseTest):
 
         audiobook_drm, ignore = DeliveryMechanism.lookup(
             self._db, Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
-            DeliveryMechanism.AUDIOBOOK_DRM
+            DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM
         )
 
         eq_(
-            [Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE + ';profile=' + DeliveryMechanism.AUDIOBOOK_DRM],
+            [Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE + DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_PROFILE],
             m(audiobook_drm)
         )
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -33,6 +33,7 @@ from ..model import (
     CustomListEntry,
     DataSource,
     DeliveryMechanism,
+    Edition,
     ExternalIntegration,
     Genre,
     Measurement,
@@ -464,6 +465,9 @@ class TestOPDS(DatabaseTest):
         b = m(rel, href, ["application/epub"])
         # TODO PYTHON3 order of attrs is different
         eq_(etree.tounicode(b), '<link href="%s" rel="http://opds-spec.org/acquisition/borrow" type="application/epub"/>' % href)
+
+        c = m(rel, href, ['application/audiobook+json;profile=http://www.feedbooks.com/audiobooks/access-restriction'])
+        eq_(etree.tounicode(c), '<link href="%s" rel="http://opds-spec.org/acquisition/borrow" type="application/audiobook+json;profile=http://www.feedbooks.com/audiobooks/access-restriction"/>' % href)
 
     def test_group_uri(self):
         work = self._work(with_open_access_download=True, authors="Alice")
@@ -1789,6 +1793,16 @@ class TestAcquisitionFeed(DatabaseTest):
             [OPDSFeed.ENTRY_TYPE,
              Representation.TEXT_HTML_MEDIA_TYPE + DeliveryMechanism.STREAMING_PROFILE],
             m(overdrive_streaming_text)
+        )
+
+        audiobook_drm, ignore = DeliveryMechanism.lookup(
+            self._db, Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
+            DeliveryMechanism.AUDIOBOOK_DRM
+        )
+
+        eq_(
+            [Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE + ';profile=' + DeliveryMechanism.AUDIOBOOK_DRM],
+            m(audiobook_drm)
         )
 
         # Test a case where there is a DRM scheme but no underlying

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -316,6 +316,21 @@ class TestOPDSImporter(OPDSImporterTest):
         link = OPDSImporter.extract_link(relative, "http://server")
         eq_("http://server/foo/bar", link.href)
 
+    def test_get_medium_from_links(self):
+        audio_links = [
+            LinkData(href="url", rel="http://opds-spec.org/acquisition/", media_type="application/audiobook+json"),
+            LinkData(href="url", rel="http://opds-spec.org/image"),
+        ]
+        book_links = [
+            LinkData(href="url", rel="http://opds-spec.org/image"),
+            LinkData(href="url", rel="http://opds-spec.org/acquisition/", media_type="application/epub+zip"),
+        ]
+
+        m = OPDSImporter.get_medium_from_links
+
+        eq_(m(audio_links), "Audio")
+        eq_(m(book_links), "Book")
+
     def test_extract_link_rights_uri(self):
 
         # Most of the time, a link's rights URI is inherited from the entry.


### PR DESCRIPTION
Helps resolve [SIMPLY2234](https://jira.nypl.org/browse/SIMPLY-2234) and [SIMPLY-2236](https://jira.nypl.org/browse/SIMPLY-2236).
Open access Audiobooks will be imported as media type "Audio". For audiobooks with drm, the entry in an OPDS feed will have a link tag with the media type as well as its drm scheme appended at the end.