### PR TITLE
Corrected a docstring so we can build the help docs again.

### DIFF
--- a/util/accept_language.py
+++ b/util/accept_language.py
@@ -1,12 +1,16 @@
-"""A package to parce Accept-Language headers.
+"""A package to parse Accept-Language headers.
 
 This is based on accept_language.py. Here is the original licensing
 information for accept_language.py:
+
 Copyright [2017] [Chatbot Developers]
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+You may obtain a copy of the License at:
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
This reformats a new docstring for readability and fixes an indentation problem that was breaking `make html` in circulation/docs/.