### PR TITLE
Add 'library' and 'location' to CirculationEvent

### DIFF
--- a/local_analytics_provider.py
+++ b/local_analytics_provider.py
@@ -28,6 +28,8 @@ class LocalAnalyticsProvider(object):
             return
 
         CirculationEvent.log(
-          _db, license_pool, event_type, old_value, new_value, start=time)
+            _db, license_pool, event_type, old_value, new_value, start=time,
+            library=library
+        )
 
 Provider = LocalAnalyticsProvider

--- a/migration/20190907-circulation-event-migration.sql
+++ b/migration/20190907-circulation-event-migration.sql
@@ -1,0 +1,49 @@
+DO $$ 
+ BEGIN
+  -- Add the 'location' column
+  BEGIN
+   ALTER TABLE circulationevents ADD COLUMN location varchar;
+  EXCEPTION
+   WHEN duplicate_column THEN RAISE NOTICE 'column circulationevents.location already exists, not creating it.';
+  END;
+
+  -- Add the 'library_id' column
+  BEGIN
+   ALTER TABLE circulationevents ADD COLUMN library_id int;
+  EXCEPTION
+   WHEN duplicate_column THEN RAISE NOTICE 'column circulationevents.library_id already exists, not creating it.';
+  END;
+
+  -- Make the 'library_id' column a foreign key reference to libraries.id.
+  BEGIN
+   ALTER TABLE circulationevents ADD CONSTRAINT circulationevents_library_id_fkey FOREIGN KEY (library_id) REFERENCES libraries(id);
+  EXCEPTION
+   when duplicate_object THEN RAISE NOTICE 'column circulationevents.library_id is already a foreign key; leaving it alone.';
+  END;
+
+  -- Remove the unique constraint that involves the 'foreign_patron_id' field.
+  alter table circulationevents drop constraint if exists circulationevents_license_pool_id_type_start_foreign_patron_key;
+
+  -- Drop the 'foreign_patron_id' field itself.
+  alter table circulationevents drop column if exists foreign_patron_id;
+
+  -- Create some indexes to enforce uniqueness constraints.
+
+  -- If there is no library ID, then licence pool + type + start
+  -- must be unique.
+  BEGIN
+   CREATE UNIQUE index ix_circulationevents_license_pool_type_start on circulationevents (license_pool_id, type, start) where library_id is null;
+  EXCEPTION
+   WHEN duplicate_table THEN RAISE NOTICE 'unique index ix_circulationevents_license_pool_type_start already exists; leaving it alone.';
+  END;
+
+  -- If there is a library ID, then license pool + library +
+  -- type + start must be unique.
+  BEGIN
+   CREATE UNIQUE index ix_circulationevents_license_pool_library_type_start on circulationevents (license_pool_id, library_id, type, start);
+  EXCEPTION
+   WHEN duplicate_table THEN RAISE NOTICE 'unique index ix_circulationevents_license_pool_library_type_start already exists; leaving it alone.';
+  END;
+
+ END;
+$$;

--- a/model/circulationevent.py
+++ b/model/circulationevent.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
-    UniqueConstraint,
+    Unicode,
 )
 
 class CirculationEvent(Base):
@@ -42,12 +42,54 @@ class CirculationEvent(Base):
     old_value = Column(Integer)
     delta = Column(Integer)
     new_value = Column(Integer)
-    foreign_patron_id = Column(String)
 
-    # A given license pool can only have one event of a given type for
-    # a given patron at a given time.
-    __table_args__ = (UniqueConstraint('license_pool_id', 'type', 'start',
-                                       'foreign_patron_id'),)
+    # The Library associated with the event, if it happened in the
+    # context of a particular Library and we know which one.
+    library_id = Column(
+        Integer, ForeignKey('libraries.id'),
+        index=True, nullable=True
+    )
+
+    # The geographic location associated with the event. This string
+    # may mean different things for different libraries. It might be a
+    # measurement of latitude and longitude, or it might be taken from
+    # a controlled vocabulary -- a list of library branch codes, for
+    # instance.
+    location = Column(Unicode, index=True)
+
+    __table_args__ = (
+        # Make it easy to list circulation events in descending
+        # order. This is used in the admin interface to show recent
+        # events.
+        #
+        # TODO: Maybe there should also be an index that takes
+        # library_id into account, for per-library event lists.
+        Index(
+            "ix_circulationevents_start_desc_nullslast",
+            start.desc().nullslast()
+        ),
+
+        # License pool ID + library ID + type + start must be unique.
+        Index(
+            "ix_circulationevents_license_pool_library_type_start",
+            license_pool_id,
+            library_id,
+            type,
+            start,
+            unique=True
+        ),
+
+        # However, library_id may be null. If this is so, then license pool ID
+        # + type + start must be unique.
+        Index(
+            "ix_circulationevents_license_pool_type_start",
+            license_pool_id,
+            type,
+            start,
+            unique=True,
+            postgresql_where=(library_id==None)
+        ),
+    )
 
     # Constants for use in logging circulation events to JSON
     SOURCE = u"source"
@@ -89,7 +131,7 @@ class CirculationEvent(Base):
 
     @classmethod
     def log(cls, _db, license_pool, event_name, old_value, new_value,
-            start=None, end=None, foreign_patron_id=None):
+            start=None, end=None, library=None):
         if new_value is None or old_value is None:
             delta = None
         else:
@@ -101,7 +143,7 @@ class CirculationEvent(Base):
         logging.info("EVENT %s %s=>%s", event_name, old_value, new_value)
         event, was_new = get_one_or_create(
             _db, CirculationEvent, license_pool=license_pool,
-            type=event_name, start=start, foreign_patron_id=foreign_patron_id,
+            type=event_name, start=start, library=library,
             create_method_kwargs=dict(
                 old_value=old_value,
                 new_value=new_value,
@@ -109,6 +151,3 @@ class CirculationEvent(Base):
                 end=end)
             )
         return event, was_new
-
-
-Index("ix_circulationevents_start_desc_nullslast", CirculationEvent.start.desc().nullslast())

--- a/model/circulationevent.py
+++ b/model/circulationevent.py
@@ -131,7 +131,7 @@ class CirculationEvent(Base):
 
     @classmethod
     def log(cls, _db, license_pool, event_name, old_value, new_value,
-            start=None, end=None, library=None):
+            start=None, end=None, library=None, location=None):
         if new_value is None or old_value is None:
             delta = None
         else:
@@ -148,6 +148,8 @@ class CirculationEvent(Base):
                 old_value=old_value,
                 new_value=new_value,
                 delta=delta,
-                end=end)
+                end=end,
+                location=location
             )
+        )
         return event, was_new

--- a/model/circulationevent.py
+++ b/model/circulationevent.py
@@ -132,6 +132,9 @@ class CirculationEvent(Base):
     @classmethod
     def log(cls, _db, license_pool, event_name, old_value, new_value,
             start=None, end=None, library=None, location=None):
+        """Log a CirculationEvent to the database, assuming it
+        hasn't already been recorded.
+        """
         if new_value is None or old_value is None:
             delta = None
         else:
@@ -140,7 +143,6 @@ class CirculationEvent(Base):
             start = datetime.datetime.utcnow()
         if not end:
             end = start
-        logging.info("EVENT %s %s=>%s", event_name, old_value, new_value)
         event, was_new = get_one_or_create(
             _db, CirculationEvent, license_pool=license_pool,
             type=event_name, start=start, library=library,
@@ -152,4 +154,6 @@ class CirculationEvent(Base):
                 location=location
             )
         )
+        if was_new:
+            logging.info("EVENT %s %s=>%s", event_name, old_value, new_value)
         return event, was_new

--- a/model/library.py
+++ b/model/library.py
@@ -7,6 +7,7 @@ from . import (
     get_one,
 )
 from ..config import Configuration
+from circulationevent import CirculationEvent
 from edition import Edition
 from ..entrypoint import EntryPoint
 from ..facets import FacetConstants
@@ -105,6 +106,12 @@ class Library(Base, HasFullTableCache):
     settings = relationship(
         "ConfigurationSetting", backref="library",
         lazy="joined", cascade="all, delete-orphan",
+    )
+
+    # A Library may have many CirculationEvents
+    circulation_events = relationship(
+        "CirculationEvent", backref="library",
+        cascade='all, delete-orphan'
     )
 
     _cache = HasFullTableCache.RESET

--- a/tests/models/test_circulationevent.py
+++ b/tests/models/test_circulationevent.py
@@ -111,6 +111,68 @@ class TestCirculationEvent(DatabaseTest):
         # updating the dataset.
         eq_(0, event.license_pool.licenses_owned)
 
+    def test_log(self):
+        # Basic test of CirculationEvent.log.
+
+        pool = self._licensepool(edition=None)
+        library = self._default_library
+        event_name = CirculationEvent.DISTRIBUTOR_CHECKOUT
+        old_value = 10
+        new_value = 8
+        start = datetime.datetime(2019, 1, 1)
+        end = datetime.datetime(2019, 1, 2)
+        location = "Westgate Branch"
+
+        m = CirculationEvent.log
+        event, is_new = m(
+            self._db, license_pool=pool, event_name=event_name,
+            library=library, old_value=old_value, new_value=new_value,
+            start=start, end=end, location=location
+        )
+        eq_(True, is_new)
+        eq_(pool, event.license_pool)
+        eq_(library, event.library)
+        eq_(-2, event.delta)  # calculated from old_value and new_value
+        eq_(start, event.start)
+        eq_(end, event.end)
+        eq_(location, location)
+
+        # If log finds another event with the same license pool,
+        # library, event name, and start date, that event is returned
+        # unchanged.
+        event, is_new = m(
+            self._db, license_pool=pool, event_name=event_name,
+            library=library, start=start,
+
+            # These values will be ignored.
+            old_value=500, new_value=200,
+            end=datetime.datetime.utcnow(),
+            location="another location"
+        )
+        eq_(False, is_new)
+        eq_(pool, event.license_pool)
+        eq_(library, event.library)
+        eq_(-2, event.delta)
+        eq_(start, event.start)
+        eq_(end, event.end)
+        eq_(location, location)
+
+        # If no timestamp is provided, the current time is used. This
+        # is the most common case, so basically a new event will be
+        # created each time you call log().
+        event, is_new = m(
+            self._db, license_pool=pool, event_name=event_name,
+            library=library, old_value=old_value, new_value=new_value,
+            end=end, location=location
+        )
+        assert (datetime.datetime.utcnow() - event.start).total_seconds() < 2
+        eq_(True, is_new)
+        eq_(pool, event.license_pool)
+        eq_(library, event.library)
+        eq_(-2, event.delta)
+        eq_(end, event.end)
+        eq_(location, location)
+
     def test_uniqueness_constraints_no_library(self):
         # If library is null, then license_pool + type + start must be
         # unique.

--- a/tests/models/test_circulationevent.py
+++ b/tests/models/test_circulationevent.py
@@ -1,11 +1,16 @@
 # encoding: utf-8
 from nose.tools import (
+    assert_raises,
     eq_,
     set_trace,
 )
 import datetime
+from sqlalchemy.exc import IntegrityError
 from .. import DatabaseTest
-from ...model import get_one_or_create
+from ...model import (
+    create,
+    get_one_or_create
+)
 from ...model.circulationevent import CirculationEvent
 from ...model.datasource import DataSource
 from ...model.identifier import Identifier
@@ -64,10 +69,9 @@ class TestCirculationEvent(DatabaseTest):
         old_value = self._get_int(data, 'old_value')
         new_value = self._get_int(data, 'new_value')
         delta = self._get_int(data, 'delta')
-        foreign_patron_id = data.get("foreign_patron_id")
         event, was_new = get_one_or_create(
             _db, CirculationEvent, license_pool=license_pool,
-            type=type, start=start, foreign_patron_id=foreign_patron_id,
+            type=type, start=start,
             create_method_kwargs=dict(
                 old_value=old_value,
                 new_value=new_value,
@@ -106,3 +110,51 @@ class TestCirculationEvent(DatabaseTest):
         # The creator of a circulation event is responsible for also
         # updating the dataset.
         eq_(0, event.license_pool.licenses_owned)
+
+    def test_uniqueness_constraints_no_library(self):
+        # If library is null, then license_pool + type + start must be
+        # unique.
+        pool = self._licensepool(edition=None)
+        now = datetime.datetime.utcnow()
+        kwargs = dict(
+            license_pool=pool, type=CirculationEvent.DISTRIBUTOR_TITLE_ADD,
+        )
+        event = create(self._db, CirculationEvent, start=now, **kwargs)
+
+        # Different timestamp -- no problem.
+        now2 = datetime.datetime.utcnow()
+        event2 = create(self._db, CirculationEvent, start=now2, **kwargs)
+        assert event != event2
+
+        # Reuse the timestamp and you get an IntegrityError which ruins the
+        # entire transaction.
+        assert_raises(
+            IntegrityError, create, self._db, CirculationEvent, start=now,
+            **kwargs
+        )
+        self._db.rollback()
+
+    def test_uniqueness_constraints_with_library(self):
+        # If library is provided, then license_pool + library + type +
+        # start must be unique.
+        pool = self._licensepool(edition=None)
+        now = datetime.datetime.utcnow()
+        kwargs = dict(
+            license_pool=pool,
+            library=self._default_library,
+            type=CirculationEvent.DISTRIBUTOR_TITLE_ADD,
+        )
+        event = create(self._db, CirculationEvent, start=now, **kwargs)
+
+        # Different timestamp -- no problem.
+        now2 = datetime.datetime.utcnow()
+        event2 = create(self._db, CirculationEvent, start=now2, **kwargs)
+        assert event != event2
+
+        # Reuse the timestamp and you get an IntegrityError which ruins the
+        # entire transaction.
+        assert_raises(
+            IntegrityError, create, self._db, CirculationEvent, start=now,
+            **kwargs
+        )
+        self._db.rollback()

--- a/tests/models/test_circulationevent.py
+++ b/tests/models/test_circulationevent.py
@@ -135,7 +135,7 @@ class TestCirculationEvent(DatabaseTest):
         eq_(-2, event.delta)  # calculated from old_value and new_value
         eq_(start, event.start)
         eq_(end, event.end)
-        eq_(location, location)
+        eq_(location, event.location)
 
         # If log finds another event with the same license pool,
         # library, event name, and start date, that event is returned
@@ -155,7 +155,7 @@ class TestCirculationEvent(DatabaseTest):
         eq_(-2, event.delta)
         eq_(start, event.start)
         eq_(end, event.end)
-        eq_(location, location)
+        eq_(location, event.location)
 
         # If no timestamp is provided, the current time is used. This
         # is the most common case, so basically a new event will be
@@ -171,7 +171,7 @@ class TestCirculationEvent(DatabaseTest):
         eq_(library, event.library)
         eq_(-2, event.delta)
         eq_(end, event.end)
-        eq_(location, location)
+        eq_(location, event.location)
 
     def test_uniqueness_constraints_no_library(self):
         # If library is null, then license_pool + type + start must be

--- a/tests/test_local_analytics_provider.py
+++ b/tests/test_local_analytics_provider.py
@@ -44,6 +44,7 @@ class TestLocalAnalyticsProvider(DatabaseTest):
         [event] = qu.all()
 
         eq_(lp, event.license_pool)
+        eq_(self._default_library, event.library)
         eq_(CirculationEvent.DISTRIBUTOR_CHECKIN, event.type)
         eq_(now, event.start)
 


### PR DESCRIPTION
This is support work for https://jira.nypl.org/browse/SIMPLY-2185. It adds two fields to CirculationEvent -- `library_id` (a foreign key reference to Library.id) and `location` (a string that may only have meaning within a particular library system). It removes one field, `foreign_patron_identifier`, which hasn't been used for several years and could cause privacy problems, especially when combined with `location`.

Previously we had a unique constraint on (license_pool_id, event, start, foreign_patron_identifier). This constraint didn't actually constrain anything, because the constraint doesn't apply when one of the fields is null, and foreign_patron_identifier is always null. I redid this as two different unique indexes -- one on (license_pool_id, library_id, event, start) and one on (license_pool_id, event, start) for cases where library_id is null.

However, I don't think this is going to help in real situations, because in almost all situations we don't know the start date of the event, so we use the current time. AFAIK the only events for which we know the start date are events from the Bibliotheca API. It might be better for performance to remove these indexes.