### PR TITLE
If a neighborhood is passed into LocalAnalyticsProvider.collect_event, it's used as CirculationEvent.location.

### DIFF
--- a/local_analytics_provider.py
+++ b/local_analytics_provider.py
@@ -27,9 +27,11 @@ class LocalAnalyticsProvider(object):
         if library and self.library_id and library.id != self.library_id:
             return
 
-        CirculationEvent.log(
+        neighborhood = kwargs.pop("neighborhood", None)
+
+        return CirculationEvent.log(
             _db, license_pool, event_type, old_value, new_value, start=time,
-            library=library
+            library=library, location=neighborhood
         )
 
 Provider = LocalAnalyticsProvider

--- a/tests/test_local_analytics_provider.py
+++ b/tests/test_local_analytics_provider.py
@@ -89,15 +89,34 @@ class TestLocalAnalyticsProvider(DatabaseTest):
         # If a 'neighborhood' argument is provided, its value
         # is used as CirculationEvent.location.
 
+        # The default LocalAnalytics object doesn't have a location
+        # gathering policy, and the default is to ignore location.
         event, is_new = self.la.collect_event(
             self._default_library, None, "event", datetime.datetime.utcnow(),
-            neighborhood="Vacant Lot"
+            neighborhood="Gormenghast"
         )
         eq_(True, is_new)
-        eq_("Vacant Lot", event.location)
+        eq_(None, event.location)
 
-        # No neighborhood == no location.
-        event2, is_new = self.la.collect_event(
+        # Create another LocalAnalytics object that uses the patron
+        # neighborhood as the event location.
+
+        p = LocalAnalyticsProvider
+        self.integration.setting(p.LOCATION_SOURCE).value = (
+            p.LOCATION_SOURCE_NEIGHBORHOOD
+        )
+        la = p(self.integration, self._default_library)
+
+        event, is_new = la.collect_event(
+            self._default_library, None, "event", datetime.datetime.utcnow(),
+            neighborhood="Gormenghast"
+        )
+        eq_(True, is_new)
+        eq_("Gormenghast", event.location)
+
+        # If no neighborhood is available, the event ends up with no location
+        # anyway.
+        event2, is_new = la.collect_event(
             self._default_library, None, "event", datetime.datetime.utcnow(),
         )
         assert event2 != event

--- a/tests/test_local_analytics_provider.py
+++ b/tests/test_local_analytics_provider.py
@@ -84,3 +84,22 @@ class TestLocalAnalyticsProvider(DatabaseTest):
             "Either library or license_pool must be provided.",
             self.la.collect_event, None, None, "event", now
         )
+
+    def test_neighborhood_is_location(self):
+        # If a 'neighborhood' argument is provided, its value
+        # is used as CirculationEvent.location.
+
+        event, is_new = self.la.collect_event(
+            self._default_library, None, "event", datetime.datetime.utcnow(),
+            neighborhood="Vacant Lot"
+        )
+        eq_(True, is_new)
+        eq_("Vacant Lot", event.location)
+
+        # No neighborhood == no location.
+        event2, is_new = self.la.collect_event(
+            self._default_library, None, "event", datetime.datetime.utcnow(),
+        )
+        assert event2 != event
+        eq_(True, is_new)
+        eq_(None, event2.location)


### PR DESCRIPTION
This is work for https://jira.nypl.org/browse/SIMPLY-2271. The local analytics provider looks for an incoming 'neighborhood' and if there is one, it's added to `CirculationEvent.location`.

I also added a basic configuration UI that allows the admin to turn this feature on and off. I used a dropdown instead of a checkbox because eventually there will be a third option: gather approximate location through IP geolocation.