### PR TITLE
Allow the 'location' of a new CirculationEvent to be a callable function

### DIFF
--- a/model/circulationevent.py
+++ b/model/circulationevent.py
@@ -135,6 +135,12 @@ class CirculationEvent(Base):
         """Log a CirculationEvent to the database, assuming it
         hasn't already been recorded.
         """
+        if callable(location):
+            # The event location is a deferred function, probably
+            # because obtaining it is expensive. There's no way around
+            # it -- we have to do the expensive thing.
+            location = location()
+
         if new_value is None or old_value is None:
             delta = None
         else:

--- a/tests/models/test_circulationevent.py
+++ b/tests/models/test_circulationevent.py
@@ -157,6 +157,12 @@ class TestCirculationEvent(DatabaseTest):
         eq_(end, event.end)
         eq_(location, event.location)
 
+        # location may be a callable rather than a string; this lets
+        # the creator of the event defer a potentially expensive
+        # lookup until it's absolutely clear that the lookup needs to
+        # happen.
+        location = lambda : "Eastgate Branch"
+
         # If no timestamp is provided, the current time is used. This
         # is the most common case, so basically a new event will be
         # created each time you call log().
@@ -171,7 +177,7 @@ class TestCirculationEvent(DatabaseTest):
         eq_(library, event.library)
         eq_(-2, event.delta)
         eq_(end, event.end)
-        eq_(location, event.location)
+        eq_("Eastgate Branch", event.location)
 
     def test_uniqueness_constraints_no_library(self):
         # If library is null, then license_pool + type + start must be


### PR DESCRIPTION
In situations where it's expensive to determine the 'location' of a CirculationEvent, we want to wait until the last possible minute to get that information. After all, it might turn out not to be necessary. But by the time we're sure we need that information, we may not have the execution context necessary to get that information.

To name a concrete example: determining the location of a CirculationEvent for a library that uses Millenium to authenticate patrons will probably require doing a patron data lookup for the request's active patron. But by the time we're 100% sure a CirculationEvent is actually going to happen, we don't have a Patron object or the MilleniumPatronAPI object, and we don't even know whether this particular request was authenticated using Millenium.

This branch makes it possible for the code that _does_ have this information to specify `location` as a callable function rather than a specific value. The callable function carries around its execution context with it, and if it's ever needed, calling the function will perform the expensive operation and return a usable value.

This is similar to the strategy used in[APIAwareFulfillmentInfo](https://github.com/NYPL-Simplified/circulation/blob/master/api/circulation.py#L217), where we want to defer an expensive API call that probably won't be necessary.