### PR TITLE
Main collection is everything

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -2379,15 +2379,7 @@ class Filter(SearchBase):
             # Only open-access books should be displayed.
             nested_filters['licensepools'].append(open_access)
 
-        if self.subcollection==FacetConstants.COLLECTION_MAIN:
-            # Exclude open-access books with a quality of less than
-            # 0.3.
-            not_open_access = Term(**{'licensepools.open_access' : False})
-            decent_quality = self._match_range('licensepools.quality', 'gte', 0.3)
-            nested_filters['licensepools'].append(
-                Bool(should=[not_open_access, decent_quality])
-            )
-        elif self.subcollection==FacetConstants.COLLECTION_FEATURED:
+        if self.subcollection==FacetConstants.COLLECTION_FEATURED:
             # Exclude books with a quality of less than the library's
             # minimum featured quality.
             range_query = self._match_range(

--- a/facets.py
+++ b/facets.py
@@ -125,7 +125,7 @@ class FacetConstants(object):
     }
 
 
-class FacetConfig(object):
+class FacetConfig(FacetConstants):
     """A class that implements the facet-related methods of
     Library, and allows modifications to the enabled
     and default facets. For use when a controller needs to

--- a/facets.py
+++ b/facets.py
@@ -11,11 +11,9 @@ class FacetConstants(object):
     # Subset the collection, roughly, by quality.
     COLLECTION_FACET_GROUP_NAME = 'collection'
     COLLECTION_FULL = "full"
-    COLLECTION_MAIN = "main"
     COLLECTION_FEATURED = "featured"
     COLLECTION_FACETS = [
         COLLECTION_FULL,
-        COLLECTION_MAIN,
         COLLECTION_FEATURED,
     ]
 
@@ -91,7 +89,6 @@ class FacetConstants(object):
         AVAILABLE_OPEN_ACCESS : _("Yours to keep"),
 
         COLLECTION_FULL : _("Everything"),
-        COLLECTION_MAIN : _("Main Collection"),
         COLLECTION_FEATURED : _("Popular Books"),
     }
 
@@ -105,7 +102,7 @@ class FacetConstants(object):
             AVAILABLE_ALL, AVAILABLE_NOW, AVAILABLE_OPEN_ACCESS
         ],
         COLLECTION_FACET_GROUP_NAME : [
-            COLLECTION_FULL, COLLECTION_MAIN, COLLECTION_FEATURED
+            COLLECTION_FULL, COLLECTION_FEATURED
         ]
     }
 
@@ -114,7 +111,7 @@ class FacetConstants(object):
     DEFAULT_FACET = {
         ORDER_FACET_GROUP_NAME : ORDER_AUTHOR,
         AVAILABILITY_FACET_GROUP_NAME : AVAILABLE_ALL,
-        COLLECTION_FACET_GROUP_NAME : COLLECTION_MAIN,
+        COLLECTION_FACET_GROUP_NAME : COLLECTION_FULL,
     }
 
     SORT_ORDER_TO_ELASTICSEARCH_FIELD_NAME = {

--- a/lane.py
+++ b/lane.py
@@ -691,14 +691,6 @@ class DatabaseBackedFacets(Facets):
         if self.collection == self.COLLECTION_FULL:
             # Include everything.
             pass
-        elif self.collection == self.COLLECTION_MAIN:
-            # Exclude open-access books with a quality of less than
-            # 0.3.
-            or_clause = or_(
-                LicensePool.open_access==False,
-                Work.quality >= 0.3
-            )
-            qu = qu.filter(or_clause)
         elif self.collection == self.COLLECTION_FEATURED:
             # Exclude books with a quality of less than the library's
             # minimum featured quality.

--- a/migration/20190916-remove-main-collection-facet.sql
+++ b/migration/20190916-remove-main-collection-facet.sql
@@ -8,7 +8,7 @@
 update configurationsettings set value = replace(value, '"main",', '') where key='facets_enabled_collection';
 
 -- Remove ', "main"' for cases where "main" is the last item in the JSON list.
-update configurationsettings set value = replace(value, ', "main"', '') where key='facets_enabled_collection';
+update configurationsettings set value = replace(value, ', "main"]', ']') where key='facets_enabled_collection';
 
 -- If 'main' was the default collection, change it.
 update configurationsettings set value='full' where key='facets_default_collection' and value='main';

--- a/migration/20190916-remove-main-collection-facet.sql
+++ b/migration/20190916-remove-main-collection-facet.sql
@@ -1,0 +1,14 @@
+-- 'main' is no longer a recognized facet in the 'collection' facet
+-- group.
+
+-- This migration script removes it from the list of enabled facets,
+-- if it's present, and changes the default if 'main' is the default.
+
+-- Remove '"main",' for cases where "main" is not the last item in the JSON list.
+update configurationsettings set value = replace(value, '"main",', '') where key='facets_enabled_collection';
+
+-- Remove ', "main"' for cases where "main" is the last item in the JSON list.
+update configurationsettings set value = replace(value, ', "main"', '') where key='facets_enabled_collection';
+
+-- If 'main' was the default collection, change it.
+update configurationsettings set value='full' where key='facets_default_collection' and value='main';

--- a/migration/20190916-remove-main-collection-facet.sql
+++ b/migration/20190916-remove-main-collection-facet.sql
@@ -10,5 +10,8 @@ update configurationsettings set value = replace(value, '"main",', '') where key
 -- Remove ', "main"' for cases where "main" is the last item in the JSON list.
 update configurationsettings set value = replace(value, ', "main"]', ']') where key='facets_enabled_collection';
 
+-- If 'main' is the *only* enabled collection facet, use 'full' instead.
+update configurationsettings set value = '["full"]' where key='facets_enabled_collection' and value='["main"]';
+
 -- If 'main' was the default collection, change it.
 update configurationsettings set value='full' where key='facets_default_collection' and value='main';

--- a/opds.py
+++ b/opds.py
@@ -1028,13 +1028,20 @@ class AcquisitionFeed(OPDSFeed):
         circumstances apply. You need to decide whether to call
         add_entrypoint_links in addition to calling this method.
         """
-        for group, value, new_facets, selected, in facets.facet_groups:
+        for group, value, new_facets, selected in facets.facet_groups:
             url = annotator.facet_url(new_facets)
             if not url:
                 continue
-            group_title = str(Facets.GROUP_DISPLAY_TITLES[group])
-            facet_title = str(Facets.FACET_DISPLAY_TITLES[value])
-            yield cls.facet_link(url, facet_title, group_title, selected)
+            group_title = Facets.GROUP_DISPLAY_TITLES.get(group)
+            facet_title = Facets.FACET_DISPLAY_TITLES.get(value)
+            if not (group_title and facet_title):
+                # This facet group or facet, is not recognized by the
+                # system. It may be left over from an earlier version,
+                # or just weird junk data.
+                continue
+            yield cls.facet_link(
+                url, unicode(facet_title), unicode(group_title), selected
+            )
 
     def __init__(self, _db, title, url, works, annotator=None,
                  precomposed_entries=[]):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1018,10 +1018,6 @@ class TestFacetFilters(EndToEndSearchTest):
         expect(Facets.COLLECTION_FEATURED, Facets.AVAILABLE_ALL,
                [self.becoming, self.moby])
 
-        # Eliminate low-quality open-access works.
-        expect(Facets.COLLECTION_MAIN, Facets.AVAILABLE_ALL,
-               [self.becoming, self.moby, self.duck])
-
 
 class TestSearchOrder(EndToEndSearchTest):
 
@@ -2189,23 +2185,6 @@ class TestQuery(DatabaseTest):
 
             # Return the rest to be verified in a test-specific way.
             return built
-
-        # When using the 'main' collection...
-        built = from_facets(Facets.COLLECTION_MAIN, None, None)
-
-        # An additional nested filter is applied.
-        [exclude_lq_open_access] = built.nested_filter_calls
-        eq_('nested', exclude_lq_open_access['name_or_query'])
-        eq_('licensepools', exclude_lq_open_access['path'])
-
-        # It excludes open-access books known to be of low quality.
-        nested_filter = exclude_lq_open_access['query']
-        not_open_access = {'term': {'licensepools.open_access': False}}
-        decent_quality = Filter._match_range('licensepools.quality', 'gte', 0.3)
-        eq_(
-            nested_filter.to_dict(),
-            {'bool': {'filter': [{'bool': {'should': [not_open_access, decent_quality]}}]}}
-        )
 
         # When using the 'featured' collection...
         built = from_facets(Facets.COLLECTION_FEATURED, None, None)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -937,7 +937,7 @@ class TestDatabaseBackedFacets(DatabaseTest):
         assert licensed_high not in open_access
         assert licensed_low not in open_access
 
-        # If we restrict to the featured collection we lose both
+        # If we restrict to the featured collection we lose the two
         # low-quality books.
         featured_collection = facetify(collection=Facets.COLLECTION_FEATURED)
         eq_(2, featured_collection.count())

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -302,14 +302,15 @@ class TestFacets(DatabaseTest):
         )
         all_groups = list(facets.facet_groups)
 
-        # By default, there are a 9 facet transitions: three groups of three.
-        eq_(9, len(all_groups))
+        # By default, there are 8 facet transitions: two groups of three
+        # and one group of two.
+        eq_(8, len(all_groups))
 
-        # available=all, collection=main, and order=title are the selected
+        # available=all, collection=full, and order=title are the selected
         # facets.
         selected = sorted([x[:2] for x in all_groups if x[-1] == True])
         eq_(
-            [('available', 'all'), ('collection', 'main'), ('order', 'title')],
+            [('available', 'all'), ('collection', 'full'), ('order', 'title')],
             selected
         )
 
@@ -317,12 +318,12 @@ class TestFacets(DatabaseTest):
                 Facets.ORDER_FACET_GROUP_NAME : [
                     Facets.ORDER_WORK_ID, Facets.ORDER_TITLE
                 ],
-                Facets.COLLECTION_FACET_GROUP_NAME : [Facets.COLLECTION_FULL],
+                Facets.COLLECTION_FACET_GROUP_NAME : [Facets.COLLECTION_FEATURED],
                 Facets.AVAILABILITY_FACET_GROUP_NAME : [Facets.AVAILABLE_ALL],
         }
         test_default_facets = {
             Facets.ORDER_FACET_GROUP_NAME : Facets.ORDER_TITLE,
-            Facets.COLLECTION_FACET_GROUP_NAME : Facets.COLLECTION_FULL,
+            Facets.COLLECTION_FACET_GROUP_NAME : Facets.COLLECTION_FEATURED,
             Facets.AVAILABILITY_FACET_GROUP_NAME : Facets.AVAILABLE_ALL,
         }
         library = self._default_library

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -298,7 +298,7 @@ class TestFacets(DatabaseTest):
 
         facets = Facets(
             self._default_library,
-            Facets.COLLECTION_MAIN, Facets.AVAILABLE_ALL, Facets.ORDER_TITLE
+            Facets.COLLECTION_FULL, Facets.AVAILABLE_ALL, Facets.ORDER_TITLE
         )
         all_groups = list(facets.facet_groups)
 
@@ -395,7 +395,7 @@ class TestFacets(DatabaseTest):
             Facets.ORDER_FACET_GROUP_NAME : [
                 Facets.ORDER_TITLE, Facets.ORDER_AUTHOR,
             ],
-            Facets.COLLECTION_FACET_GROUP_NAME : [Facets.COLLECTION_MAIN],
+            Facets.COLLECTION_FACET_GROUP_NAME : [Facets.COLLECTION_FULL],
             Facets.AVAILABILITY_FACET_GROUP_NAME : [Facets.AVAILABLE_OPEN_ACCESS]
         }
         library = self._default_library
@@ -405,7 +405,7 @@ class TestFacets(DatabaseTest):
         # no matter the Configuration.
         facets = Facets(
             self._default_library,
-            Facets.COLLECTION_MAIN, Facets.AVAILABLE_OPEN_ACCESS,
+            Facets.COLLECTION_FULL, Facets.AVAILABLE_OPEN_ACCESS,
             Facets.ORDER_TITLE, enabled_facets=enabled_facets
         )
         all_groups = list(facets.facet_groups)
@@ -417,13 +417,13 @@ class TestFacets(DatabaseTest):
             Facets.ORDER_FACET_GROUP_NAME : [
                 Facets.ORDER_TITLE, Facets.ORDER_AUTHOR,
             ],
-            Facets.COLLECTION_FACET_GROUP_NAME : [Facets.COLLECTION_MAIN],
+            Facets.COLLECTION_FACET_GROUP_NAME : [Facets.COLLECTION_FULL],
             Facets.AVAILABILITY_FACET_GROUP_NAME : [Facets.AVAILABLE_OPEN_ACCESS]
         }
 
         facets = Facets(
             None,
-            Facets.COLLECTION_MAIN, Facets.AVAILABLE_OPEN_ACCESS,
+            Facets.COLLECTION_FULL, Facets.AVAILABLE_OPEN_ACCESS,
             Facets.ORDER_TITLE, enabled_facets=enabled_facets
         )
         all_groups = list(facets.facet_groups)
@@ -436,12 +436,12 @@ class TestFacets(DatabaseTest):
         """
         facets = Facets(
             self._default_library,
-            Facets.COLLECTION_MAIN, Facets.AVAILABLE_ALL, Facets.ORDER_TITLE,
+            Facets.COLLECTION_FULL, Facets.AVAILABLE_ALL, Facets.ORDER_TITLE,
             entrypoint=AudiobooksEntryPoint
         )
         eq_([
             ('available', Facets.AVAILABLE_ALL),
-            ('collection', Facets.COLLECTION_MAIN),
+            ('collection', Facets.COLLECTION_FULL),
             ('entrypoint', AudiobooksEntryPoint.INTERNAL_NAME),
             ('order', Facets.ORDER_TITLE)],
             sorted(facets.items())
@@ -587,7 +587,7 @@ class TestFacets(DatabaseTest):
             # single setting for each facet group.
             mock_enabled = dict(order=[Facets.ORDER_TITLE],
                                 available=[Facets.AVAILABLE_OPEN_ACCESS],
-                                collection=[Facets.COLLECTION_MAIN])
+                                collection=[Facets.COLLECTION_FULL])
 
             @classmethod
             def available_facets(cls, config, facet_group_name):
@@ -625,7 +625,7 @@ class TestFacets(DatabaseTest):
         # The current values came from the defaults provided by default_facet().
         eq_(Facets.ORDER_TITLE, result.order)
         eq_(Facets.AVAILABLE_OPEN_ACCESS, result.availability)
-        eq_(Facets.COLLECTION_MAIN, result.collection)
+        eq_(Facets.COLLECTION_FULL, result.collection)
 
     def test_modify_search_filter(self):
         
@@ -930,17 +930,12 @@ class TestDatabaseBackedFacets(DatabaseTest):
         eq_(3, available_now.count())
         assert licensed_high not in available_now
 
-        # If we restrict to open-access books we lose two books.
+        # If we restrict to open-access books we lose the two licensed
+        # books.
         open_access = facetify(available=Facets.AVAILABLE_OPEN_ACCESS)
         eq_(2, open_access.count())
         assert licensed_high not in open_access
         assert licensed_low not in open_access
-
-        # If we restrict to the main collection we lose the low-quality
-        # open-access book.
-        main_collection = facetify(collection=Facets.COLLECTION_MAIN)
-        eq_(3, main_collection.count())
-        assert open_access_low not in main_collection
 
         # If we restrict to the featured collection we lose both
         # low-quality books.

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1970,9 +1970,10 @@ class TestAcquisitionFeed(DatabaseTest):
         eq_(ep.URI, feed.feed.attrib[feed.CURRENT_ENTRYPOINT_ATTRIBUTE])
 
     def test_facet_links_unrecognized_facets(self):
-        """AcquisitionFeed.facet_links excludes links for any facet groups or
-        facets not known to the current version of the system.
-        """
+        # AcquisitionFeed.facet_links does not produce links for any
+        # facet groups or facets not known to the current version of
+        # the system, because it doesn't know what the links should look
+        # like.
         class MockAnnotator(object):
             def facet_url(self, new_facets):
                 return "url: " + new_facets
@@ -1997,7 +1998,7 @@ class TestAcquisitionFeed(DatabaseTest):
                 yield (
                     Facets.COLLECTION_FACET_GROUP_NAME,
                     "no such facet",
-                    "try a collection that exists instead",
+                    "this facet does not exist",
                     True,
                 )
 
@@ -2005,7 +2006,7 @@ class TestAcquisitionFeed(DatabaseTest):
                 yield (
                     "no such group",
                     Facets.COLLECTION_FULL,
-                    "try a group that exists instead",
+                    "this facet exists but it's in a nonexistent group",
                     True,
                 )
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -2244,7 +2244,7 @@ class TestEntrypointLinkInsertion(DatabaseTest):
         # The make_link function that was passed in calls
         # TestAnnotator.feed_url() when passed an EntryPoint. The
         # Facets object's other facet groups are propagated in this URL.
-        first_page_url = "http://wl/?available=all&collection=main&entrypoint=Book&order=author"
+        first_page_url = "http://wl/?available=all&collection=full&entrypoint=Book&order=author"
         eq_(first_page_url, make_link(EbooksEntryPoint))
 
         # Pagination information is not propagated through entry point links

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1969,6 +1969,79 @@ class TestAcquisitionFeed(DatabaseTest):
         feed.show_current_entrypoint(ep)
         eq_(ep.URI, feed.feed.attrib[feed.CURRENT_ENTRYPOINT_ATTRIBUTE])
 
+    def test_facet_links_unrecognized_facets(self):
+        """AcquisitionFeed.facet_links excludes links for any facet groups or
+        facets not known to the current version of the system.
+        """
+        class MockAnnotator(object):
+            def facet_url(self, new_facets):
+                return "url: " + new_facets
+
+        class MockFacets(object):
+            @property
+            def facet_groups(self):
+                """Yield a facet group+facet 4-tuple that passes the test we're
+                running (which will be turned into a link), and then a
+                bunch that don't (which will be ignored).
+                """
+
+                # Real facet group, real facet
+                yield (
+                    Facets.COLLECTION_FACET_GROUP_NAME,
+                    Facets.COLLECTION_FULL,
+                    "try the featured collection instead",
+                    True,
+                )
+
+                # Real facet group, nonexistent facet
+                yield (
+                    Facets.COLLECTION_FACET_GROUP_NAME,
+                    "no such facet",
+                    "try a collection that exists instead",
+                    True,
+                )
+
+                # Nonexistent facet group, real facet
+                yield (
+                    "no such group",
+                    Facets.COLLECTION_FULL,
+                    "try a group that exists instead",
+                    True,
+                )
+
+                # Nonexistent facet group, nonexistent facet
+                yield (
+                    "no such group",
+                    "no such facet",
+                    "i just don't know",
+                    True,
+                )
+
+        class MockFeed(AcquisitionFeed):
+            links = []
+            @classmethod
+            def facet_link(cls, url, facet_title, group_title, selected):
+                # Return the passed-in objects as is.
+                return (url, facet_title, group_title, selected)
+
+        annotator = MockAnnotator()
+        facets = MockFacets()
+
+        # The only 4-tuple yielded by facet_groups was passed on to us.
+        # The link was run through MockAnnotator.facet_url(),
+        # and the human-readable titles were found using lookups.
+        #
+        # The other three 4-tuples were ignored since we don't know
+        # how to generate human-readable titles for them.
+        [[url, facet, group, selected]] = MockFeed.facet_links(
+            annotator, facets
+        )
+        eq_('url: try the featured collection instead', url)
+        eq_(Facets.FACET_DISPLAY_TITLES[Facets.COLLECTION_FULL], facet)
+        eq_(Facets.GROUP_DISPLAY_TITLES[Facets.COLLECTION_FACET_GROUP_NAME],
+            group)
+        eq_(True, selected)
+
 
 class TestLookupAcquisitionFeed(DatabaseTest):
 


### PR DESCRIPTION
This branch implements https://jira.nypl.org/browse/SIMPLY-2286. It removes one facet -- "main collection" from the "collection" facet group, leaving only "everything" and "popular books".

In addition to a migration script (which is a little complicated) I changed the one piece of the code where an unrecognized facet or facet group could cause a crash: `AcquisitionFeed.facet_links`. This is the code that looks up the human-readable names of facets or facet groups. If there's no human-readable name for a facet or facet group, the code used to crash. Now it just ignores that facet or facet group.