### PR TITLE
Delete circulation events before creating unique indexes.

### DIFF
--- a/log.py
+++ b/log.py
@@ -33,7 +33,17 @@ class JSONFormatter(logging.Formatter):
 
         if record.args:
             record_args = tuple([no_bytestring(arg) for arg in record.args])
-            message = message % record_args
+            try:
+                message = message % record_args
+            except Exception, e:
+                # There was a problem formatting the log message,
+                # which points to a bug. A problem with the logging
+                # code shouldn't break the code that actually does the
+                # work, but we can't just let this slide -- we need to
+                # report the problem so it can be fixed.
+                message = "Log message could not be formatted. Exception: %r. Original message: message=%r args=%r" % (
+                    e, message, record_args
+                )
         data = dict(
             host=self.hostname,
             app=self.app_name,

--- a/migration/20190907-circulation-event-migration.sql
+++ b/migration/20190907-circulation-event-migration.sql
@@ -1,3 +1,6 @@
+-- Delete all duplicate circulation events before creating unique indexes.
+delete from circulationevents where id in (select ce1.id from circulationevents ce1 join circulationevents as ce2 on ce1.license_pool_id = ce2.license_pool_id and ce1.type = ce2.type and ce1.start = ce2.start and ce1.id < ce2.id);
+
 DO $$ 
  BEGIN
   -- Add the 'location' column


### PR DESCRIPTION
This branch changes the 20190907-circulation-event-migration.sql migration so that it deletes all  circulation events that would prevent the creation of a unique index.

There's also an unrelated change regarding a crash I saw because of a logging bug in an external dependency.