### PR TITLE
Filtered out superceded license pools when getting works for a lane.

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -1796,6 +1796,8 @@ class DatabaseBackedWorkList(WorkList):
             Work.license_pools
         ).join(
             Work.presentation_edition
+        ).filter(
+            LicensePool.superceded==False
         )
 
         # Apply optimizations.

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -3297,6 +3297,17 @@ class TestLane(DatabaseTest):
         eq_(facets, lane.called_with)
         Lane._groups_for_lanes = old_value
 
+    def test_works_from_database_with_superceded_pool(self):
+        work = self._work(with_license_pool=True)
+        work.license_pools[0].superceded = True
+        ignore, pool = self._edition(with_license_pool=True)
+        pool.work = work
+
+        lane = self._lane()
+        [w] = lane.works_from_database(self._db).all()
+        # Only one pool is loaded, and it's the non-superceded one.
+        eq_([pool], w.license_pools)
+
 
 class TestWorkListGroupsEndToEnd(EndToEndSearchTest):
     # A comprehensive end-to-end test of WorkList.groups()


### PR DESCRIPTION
This fixes a bug I ran into where the wrong license pool was being loaded for a work, and the OPDS feed incorrectly said the work had no active license pool.

The problem was that making the query distinct chooses one license pool, but the query also has an optimization to prevent loading the other pools. We need to make sure the query gets a non-superceded pool.