### PR TITLE
Fix classification weights

### DIFF
--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -89,12 +89,6 @@ class Classifier(object):
     SIMPLIFIED_GENRE = "http://librarysimplified.org/terms/genres/Simplified/"
     SIMPLIFIED_FICTION_STATUS = "http://librarysimplified.org/terms/fiction/"
 
-    # If we hear about a classification from a distributor (and we
-    # trust the distributor to have accurate classifications), we
-    # should give it this weight. This lets us keep the weights
-    # consistent across distributors.
-    TRUSTED_DISTRIBUTOR_WEIGHT = 100.0
-
     classifiers = dict()
 
     @classmethod

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -89,6 +89,12 @@ class Classifier(object):
     SIMPLIFIED_GENRE = "http://librarysimplified.org/terms/genres/Simplified/"
     SIMPLIFIED_FICTION_STATUS = "http://librarysimplified.org/terms/fiction/"
 
+    # If we hear about a classification from a distributor (and we
+    # trust the distributor to have accurate classifications), we
+    # should give it this weight. This lets us keep the weights
+    # consistent across distributors.
+    TRUSTED_DISTRIBUTOR_WEIGHT = 100.0
+
     classifiers = dict()
 
     @classmethod

--- a/classifier/ddc.py
+++ b/classifier/ddc.py
@@ -161,7 +161,10 @@ class DeweyDecimalClassifier(Classifier):
         if isinstance(identifier, basestring) and identifier=='FIC':
             # FIC is used for all types of fiction.
             return None
-        return cls.AUDIENCE_ADULT
+
+        # Everything else is _supposedly_ for adults, but we don't
+        # trust that assumption.
+        return None
 
     @classmethod
     def genre(cls, identifier, name, fiction=None, audience=None):

--- a/classifier/lcc.py
+++ b/classifier/lcc.py
@@ -111,7 +111,9 @@ class LCCClassifier(Classifier):
     def audience(cls, identifier, name):
         if identifier.startswith("PZ"):
             return cls.AUDIENCE_CHILDREN
-        # Everything else is implicitly for adults.
-        return cls.AUDIENCE_ADULT
+
+        # Everything else is _supposedly_ for adults, but we don't
+        # trust that assumption.
+        return None
 
 Classifier.classifiers[Classifier.LCC] = LCCClassifier

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -23,6 +23,7 @@ import re
 
 from pymarc import MARCReader
 
+from classifier import Classifier
 from util import LanguageCodes
 from util.http import RemoteIntegrationException
 from util.personal_names import name_tidy

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -27,11 +27,11 @@ from util import LanguageCodes
 from util.http import RemoteIntegrationException
 from util.personal_names import name_tidy
 from util.median import median
-from classifier import Classifier
 from model import (
     get_one,
     get_one_or_create,
     CirculationEvent,
+    Classification,
     Collection,
     Contributor,
     CoverageRecord,
@@ -2115,10 +2115,10 @@ class CSVMetadataImporter(object):
     # When classifications are imported from a CSV file, we treat 
     # them as though they came from a trusted distributor.
     DEFAULT_SUBJECT_FIELD_NAMES = {
-        'tags': (Subject.TAG, Classifier.TRUSTED_DISTRIBUTOR_WEIGHT),
-        'age' : (Subject.AGE_RANGE, Classifier.TRUSTED_DISTRIBUTOR_WEIGHT),
+        'tags': (Subject.TAG, Classification.TRUSTED_DISTRIBUTOR_WEIGHT),
+        'age' : (Subject.AGE_RANGE, Classification.TRUSTED_DISTRIBUTOR_WEIGHT),
         'audience' : (Subject.FREEFORM_AUDIENCE,
-                      Classifier.TRUSTED_DISTRIBUTOR_WEIGHT),
+                      Classification.TRUSTED_DISTRIBUTOR_WEIGHT),
     }
 
     def __init__(

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -2112,10 +2112,13 @@ class CSVMetadataImporter(object):
         Identifier.ISBN : ("isbn", 0.75),
     }
 
+    # When classifications are imported from a CSV file, we treat 
+    # them as though they came from a trusted distributor.
     DEFAULT_SUBJECT_FIELD_NAMES = {
-        'tags': (Subject.TAG, 100),
-        'age' : (Subject.AGE_RANGE, 100),
-        'audience' : (Subject.FREEFORM_AUDIENCE, 100),
+        'tags': (Subject.TAG, Classifier.TRUSTED_DISTRIBUTOR_WEIGHT),
+        'age' : (Subject.AGE_RANGE, Classifier.TRUSTED_DISTRIBUTOR_WEIGHT),
+        'audience' : (Subject.FREEFORM_AUDIENCE,
+                      Classifier.TRUSTED_DISTRIBUTOR_WEIGHT),
     }
 
     def __init__(

--- a/migration/20190926-reweight-classifications.sql
+++ b/migration/20190926-reweight-classifications.sql
@@ -6,8 +6,11 @@
 -- we see from other commercial distributors.
 update classifications set weight=100 where id in (select c.id from classifications c join datasources ds on ds.id=c.data_source_id where ds.name='Axis 360' and weight=1);
 
--- Weight any Bibliotheca BISAC classifiers similarly.
-update classifications set weight=100 where s.id in (select c.id from classifications c join subjects s on s.id=c.subject_id join datasources ds on ds.id=c.data_source_id where ds.name='Bibliotheca' and s.type='BISAC' and c.weight=15);
+-- Weight any Bibliotheca BISAC classifications similarly.
+update classifications set weight=100 where id in (select c.id from classifications c join subjects s on s.id=c.subject_id join datasources ds on ds.id=c.data_source_id where ds.name='Bibliotheca' and s.type='BISAC' and c.weight=15);
+
+-- Same for ENKI tags.
+update classifications set weight=100 where id in (select c.id from classifications c join subjects s on s.id=c.subject_id join datasources ds on ds.id=c.data_source_id where ds.name='Enki' and s.type='tag' and c.weight=1);
 
 -- Give a weight of 1 to any schema:audience and schema:targetAge
 -- classifications that came from the metadata wrangler.

--- a/migration/20190926-reweight-classifications.sql
+++ b/migration/20190926-reweight-classifications.sql
@@ -1,0 +1,71 @@
+-- This reweights some classifications and marks some works as needing their 
+-- classifications redone using the new weights.
+
+-- First, delete the 'classify' coverage records for certain works,
+-- effectively forcing them to be reclassified. Unfortunately this will
+-- probably cover most of the works on the site.
+--
+-- TODO: In fact, it would be simpler to delete all of the 'classify'
+-- coverage records. This script would run much faster and there would
+-- be no question about whether there are problems with this (rather
+-- complex) query. The downside is some records would be incorrectly
+-- deleted -- basically Overdrive books where we never asked the
+-- metadata wrangler about them -- and there would be wasted effort on
+-- the backend. But that's not a lot of books.
+delete from workcoveragerecords where operation='classify' and work_id in (
+
+ -- Which works? It's something about the primary identifier of their
+ -- presentation edition.
+ select w.id from works w join editions e on w.presentation_edition_id=e.id where e.primary_identifier_id in (
+
+  -- What is it about that identifier? It has to be within a certain
+  -- distance of an identifier that was handled incorrectly under
+  -- the old system.
+
+  select fn_recursive_equivalents(c.identifier_id, 3, 0.5) from classifications c join subjects s on s.id=c.subject_id join datasources ds on c.data_source_id=ds.id
+  
+  -- So what was wrong with the old system?
+
+  -- We used to overweight schema:audience and schema:targetAge
+  -- weights that came in from OPDS import (basically, the metadata
+  -- wrangler).
+  where (
+   (s.type in ('schema:audience', 'schema:targetAge') and c.weight=100
+    and ds.name='Library Simplified metadata wrangler'
+   )
+
+   -- We used to underweight classifications of all kinds that
+   -- came from Axis 360.
+   OR (ds.name='Axis 360' and c.weight=1)
+
+   -- We used to underweight BISAC classifications that
+   -- came from Bibliotheca.
+   OR (ds.name='Bibliotheca' and s.type='BISAC' and c.weight=15)
+
+   -- We used to assume that certain DDC or LCC classifications had
+   -- audience=Adult, based on implicit assumptions that are often
+   -- violated.
+   OR (s.type in ('DDC', 'LCC') and s.audience='Adult')
+  )
+ )
+
+);
+
+-- Now that we've deleted the appropriate coverage records (which
+-- required the old system to be in place), change the weights of
+-- certain classifications to reflect the new system.
+
+-- Give any Axis 360 classifications weights that are more like what
+-- we see from other commercial distributors.
+update classifications set weight=100 where id in (select c.id from classifications c join datasources ds on ds.id=c.data_source_id where ds.name='Axis 360' and weight=1);
+
+-- Weight any Bibliotheca BISAC classifiers similarly.
+update classifications set weight=100 where s.id in (select c.id from classifications c join subjects s on s.id=c.subject_id join datasources ds on ds.id=c.data_source_id where ds.name='Bibliotheca' and s.type='BISAC' and c.weight=15);
+
+-- Give a weight of 1 to any schema:audience and schema:targetAge
+-- classifications that came from the metadata wrangler.
+update classifications set weight=1 where id in (select c.id from classifications c join datasources ds on ds.id=c.data_source_id join subjects s on s.id=c.subject_id where ds.name='Library Simplified metadata wrangler' and s.type in ('schema:audience', 'schema:targetAge') and c.weight=100);
+
+-- Clear out the audience of all DDC and LCC subjects where were were
+-- deriving audience=Adult from a lack of explicit information.
+update subjects set audience=None where type in ('DDC', 'LCC') and audience='Adult';

--- a/migration/20190926-reweight-classifications.sql
+++ b/migration/20190926-reweight-classifications.sql
@@ -12,8 +12,8 @@ update classifications set weight=100 where id in (select c.id from classificati
 -- Same for ENKI tags.
 update classifications set weight=100 where id in (select c.id from classifications c join subjects s on s.id=c.subject_id join datasources ds on ds.id=c.data_source_id where ds.name='Enki' and s.type='tag' and c.weight=1);
 
--- Same for all classifications from RBdigital, regardless of type.
-update classifications set weight=100 where id in (select c.id from classifications c join subjects s on s.id=c.subject_id join datasources ds on ds.id=c.data_source_id where ds.name='RBdigital');
+-- Same for all classifications from RBdigital or Odilo, regardless of type.
+update classifications set weight=100 where id in (select c.id from classifications c join subjects s on s.id=c.subject_id join datasources ds on ds.id=c.data_source_id where ds.name in ('RBdigital', 'Odilo'));
 
 -- Give a weight of 1 to any schema:audience and schema:targetAge
 -- classifications that came from the metadata wrangler.

--- a/migration/20190926-reweight-classifications.sql
+++ b/migration/20190926-reweight-classifications.sql
@@ -1,59 +1,6 @@
--- This reweights some classifications and marks some works as needing their 
--- classifications redone using the new weights.
-
--- First, delete the 'classify' coverage records for certain works,
--- effectively forcing them to be reclassified. Unfortunately this will
--- probably cover most of the works on the site.
---
--- TODO: In fact, it would be simpler to delete all of the 'classify'
--- coverage records. This script would run much faster and there would
--- be no question about whether there are problems with this (rather
--- complex) query. The downside is some records would be incorrectly
--- deleted -- basically Overdrive books where we never asked the
--- metadata wrangler about them -- and there would be wasted effort on
--- the backend. But that's not a lot of books.
-delete from workcoveragerecords where operation='classify' and work_id in (
-
- -- Which works? It's something about the primary identifier of their
- -- presentation edition.
- select w.id from works w join editions e on w.presentation_edition_id=e.id where e.primary_identifier_id in (
-
-  -- What is it about that identifier? It has to be within a certain
-  -- distance of an identifier that was handled incorrectly under
-  -- the old system.
-
-  select fn_recursive_equivalents(c.identifier_id, 3, 0.5) from classifications c join subjects s on s.id=c.subject_id join datasources ds on c.data_source_id=ds.id
-  
-  -- So what was wrong with the old system?
-
-  -- We used to overweight schema:audience and schema:targetAge
-  -- weights that came in from OPDS import (basically, the metadata
-  -- wrangler).
-  where (
-   (s.type in ('schema:audience', 'schema:targetAge') and c.weight=100
-    and ds.name='Library Simplified metadata wrangler'
-   )
-
-   -- We used to underweight classifications of all kinds that
-   -- came from Axis 360.
-   OR (ds.name='Axis 360' and c.weight=1)
-
-   -- We used to underweight BISAC classifications that
-   -- came from Bibliotheca.
-   OR (ds.name='Bibliotheca' and s.type='BISAC' and c.weight=15)
-
-   -- We used to assume that certain DDC or LCC classifications had
-   -- audience=Adult, based on implicit assumptions that are often
-   -- violated.
-   OR (s.type in ('DDC', 'LCC') and s.audience='Adult')
-  )
- )
-
-);
-
--- Now that we've deleted the appropriate coverage records (which
--- required the old system to be in place), change the weights of
--- certain classifications to reflect the new system.
+-- This reweights some classifications to reflect changes in the way
+-- we weight data from different sources and the fact that we no longer
+-- infer audience from Dewey and LCC classifications.
 
 -- Give any Axis 360 classifications weights that are more like what
 -- we see from other commercial distributors.
@@ -69,3 +16,12 @@ update classifications set weight=1 where id in (select c.id from classification
 -- Clear out the audience of all DDC and LCC subjects where were were
 -- deriving audience=Adult from a lack of explicit information.
 update subjects set audience=None where type in ('DDC', 'LCC') and audience='Adult';
+
+-- Delete the 'classify' coverage record for every work on the site,
+-- effectively forcing all works to be reclassified.
+--
+-- We don't technically need to delete every single 'classify' record,
+-- but on a normal site we will effectively end up deleting all of
+-- them, and the query to pinpoint only the ones that need to be
+-- deleted takes a really long time to run.
+delete from workcoveragerecords where operation='classify';

--- a/migration/20190926-reweight-classifications.sql
+++ b/migration/20190926-reweight-classifications.sql
@@ -12,6 +12,9 @@ update classifications set weight=100 where id in (select c.id from classificati
 -- Same for ENKI tags.
 update classifications set weight=100 where id in (select c.id from classifications c join subjects s on s.id=c.subject_id join datasources ds on ds.id=c.data_source_id where ds.name='Enki' and s.type='tag' and c.weight=1);
 
+-- Same for all classifications from RBdigital, regardless of type.
+update classifications set weight=100 where id in (select c.id from classifications c join subjects s on s.id=c.subject_id join datasources ds on ds.id=c.data_source_id where ds.name='RBdigital');
+
 -- Give a weight of 1 to any schema:audience and schema:targetAge
 -- classifications that came from the metadata wrangler.
 update classifications set weight=1 where id in (select c.id from classifications c join datasources ds on ds.id=c.data_source_id join subjects s on s.id=c.subject_id where ds.name='Library Simplified metadata wrangler' and s.type in ('schema:audience', 'schema:targetAge') and c.weight=100);

--- a/model/classification.py
+++ b/model/classification.py
@@ -344,6 +344,12 @@ class Classification(Base):
     # How much weight the data source gives to this classification.
     weight = Column(Integer)
 
+    # If we hear about a classification from a distributor (and we
+    # trust the distributor to have accurate classifications), we
+    # should give it this weight. This lets us keep the weights
+    # consistent across distributors.
+    TRUSTED_DISTRIBUTOR_WEIGHT = 100.0
+
     @property
     def scaled_weight(self):
         weight = self.weight

--- a/opds_import.py
+++ b/opds_import.py
@@ -1424,16 +1424,12 @@ class OPDSImporter(object):
         term = attr.get('term')
         name = attr.get('label')
         default_weight = 1
-        if subject_type in (
-                Subject.FREEFORM_AUDIENCE, Subject.AGE_RANGE
-        ):
-            default_weight = 100
 
         weight = attr.get('{http://schema.org/}ratingValue', default_weight)
         try:
             weight = int(weight)
         except ValueError, e:
-            weight = 1
+            weight = default_weight
 
         return SubjectData(
             type=subject_type,

--- a/overdrive.py
+++ b/overdrive.py
@@ -23,6 +23,7 @@ from config import (
 from model import (
     get_one,
     get_one_or_create,
+    Classification,
     Collection,
     ConfigurationSetting,
     Contributor,
@@ -781,7 +782,7 @@ class OverdriveRepresentationExtractor(object):
 
         # If we trust classification data, we'll give it this weight.
         # Otherwise we'll probably give it a fraction of this weight.
-        trusted_weight = Classifier.TRUSTED_DISTRIBUTOR_WEIGHT
+        trusted_weight = Classification.TRUSTED_DISTRIBUTOR_WEIGHT
 
         if include_bibliographic:
             title = book.get('title', None)

--- a/overdrive.py
+++ b/overdrive.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm.exc import (
 )
 from sqlalchemy.orm.session import Session
 
+from classifier import Classifier
 from config import (
     temp_config,
     CannotLoadConfiguration,
@@ -778,6 +779,10 @@ class OverdriveRepresentationExtractor(object):
             Identifier.OVERDRIVE_ID, overdrive_id
         )
 
+        # If we trust classification data, we'll give it this weight.
+        # Otherwise we'll probably give it a fraction of this weight.
+        trusted_weight = Classifier.TRUSTED_DISTRIBUTOR_WEIGHT
+
         if include_bibliographic:
             title = book.get('title', None)
             sort_title = book.get('sortTitle')
@@ -814,13 +819,17 @@ class OverdriveRepresentationExtractor(object):
             for sub in book.get('subjects', []):
                 subject = SubjectData(
                     type=Subject.OVERDRIVE, identifier=sub['value'],
-                    weight=100
+                    weight=trusted_weight,
                 )
                 subjects.append(subject)
 
             for sub in book.get('keywords', []):
                 subject = SubjectData(
                     type=Subject.TAG, identifier=sub['value'],
+                    # We don't use TRUSTED_DISTRIBUTOR_WEIGHT because
+                    # we don't know where the tags come from --
+                    # probably Overdrive users -- and they're
+                    # frequently wrong.
                     weight=1
                 )
                 subjects.append(subject)
@@ -830,12 +839,12 @@ class OverdriveRepresentationExtractor(object):
                 # n.b. Grade levels are measurements of reading level, not
                 # age appropriateness. We can use them as a measure of age
                 # appropriateness in a pinch, but we weight them less
-                # heavily than other information from Overdrive.
+                # heavily than TRUSTED_DISTRIBUTOR_WEIGHT.
                 for i in book['grade_levels']:
                     subject = SubjectData(
                         type=Subject.GRADE_LEVEL,
                         identifier=i['value'],
-                        weight=10
+                        weight=trusted_weight / 10
                     )
                     subjects.append(subject)
 
@@ -868,7 +877,7 @@ class OverdriveRepresentationExtractor(object):
                 identifier = str(book[name])
                 subjects.append(
                     SubjectData(type=subject_type, identifier=identifier,
-                                weight=100
+                                weight=trusted_weight
                             )
                 )
 
@@ -876,7 +885,7 @@ class OverdriveRepresentationExtractor(object):
                 grade_level = grade_level_info.get('value')
                 subjects.append(
                     SubjectData(type=Subject.GRADE_LEVEL, identifier=grade_level,
-                                weight=100)
+                                weight=trusted_weight)
                 )
 
             identifiers = []

--- a/tests/classifiers/test_lcc.py
+++ b/tests/classifiers/test_lcc.py
@@ -25,13 +25,18 @@ class TestLCC(object):
         def aud(identifier):
             return LCC.audience(LCC.scrub_identifier(identifier), None)
 
-        eq_(adult, aud("PR"))
-        eq_(adult, aud("P"))
-        eq_(adult, aud("PA"))
-        eq_(adult, aud("J821.8 CARRIKK"))
         eq_(child, aud("PZ"))
         eq_(child, aud("PZ2384 M68 2003"))
         eq_(child, aud("pz2384 m68 2003"))
+
+        # We could derive audience=Adult from this, but we've seen
+        # this go wrong, and it's not terribly important overall, so
+        # we don't.
+        eq_(None, aud("PR"))
+        eq_(None, aud("P"))
+        eq_(None, aud("PA"))
+        eq_(None, aud("J821.8 CARRIKK"))
+
 
     def test_is_fiction(self):
         def fic(lcc):


### PR DESCRIPTION
This branch fixes the part of https://jira.nypl.org/browse/SIMPLY-2320 that can be fixed in core. The circulation PR is https://github.com/NYPL-Simplified/circulation/pull/1332.

I decided to stop deriving implicit "Adult" audience information from LCC and Dewey classifications, even though I don't know how frequently a children's book is classified under a non-juvenile LCC or Dewey classification. It has definitely happened and we don't need to scrape for hints that a book's classification is "Adult". That's the default and that's where we'll go in the absence of information.

I'm pretty confident that the migration script works but as I say in the script, it's  simpler and faster to delete _all_ of the "classify" WorkCoverageRecords. Almost every work on a normal site will need to be reclassified.

Since we're reclassifying everything, I'm very interested in hearing about other problems of this sort, so that we don't have to do this again for a while.