### PR TITLE
Generate grouped feeds with a single multisearch query

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -3128,6 +3128,14 @@ class MockExternalSearchIndex(ExternalSearchIndex):
             pagination.page_loaded(results)
         return results
 
+    def query_works_multi(self, queries, debug=False):
+        # Implement query_works_multi by calling query_works several
+        # times. This is the opposite of what happens in the
+        # non-mocked ExternalSearchIndex, because it's easier to mock
+        # the simple case and performance isn't an issue.
+        for (query_string, filter, pagination) in queries:
+            yield self.query_works(query_string, filter, pagination, debug)
+
     def count_works(self, filter):
         return len(self.docs)
 

--- a/lane.py
+++ b/lane.py
@@ -1484,7 +1484,7 @@ class WorkList(object):
             script fields), WorkSearchResult objects.
         """
 
-        [results] = self.works_for_resultsets(self, _db, [hits])
+        [results] = self.works_for_resultsets(_db, [hits])
         return results
 
     def works_for_resultsets(self, _db, resultsets):
@@ -1516,7 +1516,8 @@ class WorkList(object):
         # DatabaseBackedWorkList that fetches those specific Works
         # while applying the general availability filters.
         #
-        # TODO: There's a lot of room for improvement here.
+        # TODO: There's a lot of room for improvement here, but
+        # performance isn't a big concern -- it's just ugly.
         wl = SpecificWorkList(work_ids)
         wl.initialize(self.get_library(_db))
         qu = wl.works_from_database(_db)
@@ -1732,16 +1733,6 @@ class WorkList(object):
         # need to pick out unusable WorkLists, make a recursive call
         # to WorkList.works() for each one, and fold them into the
         # results we got from the big multi-query.
-
-        searchable = []
-        not_searchable = []
-        for lane in lanes:
-            if isinstance(lane, Lane):
-                l = searchable
-            else:
-                l = not_searchable
-            l.append(lane)
-
         queries = []
         for lane in lanes:
             overview_facets = lane.overview_facets(_db, facets)

--- a/lane.py
+++ b/lane.py
@@ -1730,9 +1730,11 @@ class WorkList(object):
         # generated using an Elasticsearch query. That is, there are
         # no subclasses of the DatabaseExclusiveWorkList class defined
         # in circulation/api/lanes.py. If that ever changes, we'll
-        # need to pick out unusable WorkLists, make a recursive call
-        # to WorkList.works() for each one, and fold them into the
-        # results we got from the big multi-query.
+        # need to change this code.
+        #
+        # The simplest change would probably be to return a dictionary
+        # mapping WorkList to Works and let the caller figure out the
+        # ordering. In fact, we could start doing that now.
         queries = []
         for lane in lanes:
             overview_facets = lane.overview_facets(_db, facets)

--- a/lane.py
+++ b/lane.py
@@ -1517,9 +1517,6 @@ class WorkList(object):
             # be safe.
             has_script_fields = False
 
-        # Check the first search result see if any script fields were
-        # included.
-
         # The simplest way to turn Hits into Works is to create a
         # DatabaseBackedWorkList that fetches those specific Works
         # while applying the general availability filters.

--- a/lane.py
+++ b/lane.py
@@ -1475,16 +1475,45 @@ class WorkList(object):
     def works_for_hits(self, _db, hits):
         """Convert a list of search results into Work objects.
 
+        This works by calling works_for_resultsets() on a list
+        containing a single list of search results.
+
         :param _db: A database connection
         :param hits: A list of Hit objects from ElasticSearch.
         :return: A list of Work or (if the search results include
             script fields), WorkSearchResult objects.
         """
 
-        work_ids = [x.work_id for x in hits]
+        [results] = self.works_for_resultsets(self, _db, [hits])
+        return results
 
-        # The simplest way to do this is to create a
-        # DatabaseBackedWorkList that fetches those specific works
+    def works_for_resultsets(self, _db, resultsets):
+        """Convert a list of lists of Hit objects into a list
+        of lists of Work objects.
+        """
+        from external_search import (
+            Filter,
+            WorkSearchResult,
+        )
+
+        test_case = None
+        work_ids = set()
+        for resultset in resultsets:
+            for result in resultset:
+                work_ids.add(result.work_id)
+                if not test_case:
+                    test_case = result
+
+        # Check the first search result see if any script fields were
+        # included.
+        has_script_fields = (
+            test_case is not None and any(
+                x in test_case for x in Filter.KNOWN_SCRIPT_FIELDS
+            )
+        )
+
+        # The simplest way to turn Hits into Works is to create a
+        # DatabaseBackedWorkList that fetches those specific Works
         # while applying the general availability filters.
         #
         # TODO: There's a lot of room for improvement here.
@@ -1492,44 +1521,32 @@ class WorkList(object):
         wl.initialize(self.get_library(_db))
         qu = wl.works_from_database(_db)
         a = time.time()
-        works = qu.all()
+        all_works = qu.all()
 
-        # Put the results in the same order as the work_ids were.
+        # Create a list of lists with the same membership as the original
+        # `resultsets`, but with Hit objects replaced with Work objects.
         work_by_id = dict()
-        for w in works:
+        for w in all_works:
             work_by_id[w.id] = w
 
-        from external_search import (
-            Filter,
-            WorkSearchResult,
-        )
-
-        # Check the first search result see if any script fields were
-        # included.
-        test_case = None
-        if hits:
-            test_case = hits[0]
-        has_script_fields = (
-            test_case is not None and any(
-                x in test_case for x in Filter.KNOWN_SCRIPT_FIELDS
-            )
-        )
-
-        results = []
-        for hit in hits:
-            if hit.work_id in work_by_id:
-                work = work_by_id[hit.work_id]
-                if has_script_fields:
-                    # Wrap the Work objects in WorkSearchResult so the
-                    # data from script fields isn't lost.
-                    work = WorkSearchResult(work, hit)
-                results.append(work)
+        work_lists = []
+        for resultset in resultsets:
+            works = []
+            work_lists.append(works)
+            for hit in resultset:
+                if hit.work_id in work_by_id:
+                    work = work_by_id[hit.work_id]
+                    if has_script_fields:
+                        # Wrap the Work objects in WorkSearchResult so the
+                        # data from script fields isn't lost.
+                        work = WorkSearchResult(work, hit)
+                    works.append(work)
 
         b = time.time()
         logging.info(
-            u"Obtained %sxWork in %.2fsec", len(results), b-a
+            u"Obtained %sxWork in %.2fsec", len(all_works), b-a
         )
-        return results
+        return work_lists
 
     @property
     def search_target(self):
@@ -1707,12 +1724,36 @@ class WorkList(object):
             return
 
         # Ask the search engine for works from every lane we're given.
+
+        # NOTE: At the moment, every WorkList in the system can be
+        # generated using an Elasticsearch query. That is, there are
+        # no subclasses of the DatabaseExclusiveWorkList class defined
+        # in circulation/api/lanes.py. If that ever changes, we'll
+        # need to pick out unusable WorkLists, make a recursive call
+        # to WorkList.works() for each one, and fold them into the
+        # results we got from the big multi-query.
+
+        searchable = []
+        not_searchable = []
         for lane in lanes:
-            adapted = lane.overview_facets(_db, facets)
-            for work in lane.works(
-                _db, adapted, pagination, search_engine=search_engine,
-                debug=debug
-            ):
+            if isinstance(lane, Lane):
+                l = searchable
+            else:
+                l = not_searchable
+            l.append(lane)
+
+        queries = []
+        for lane in lanes:
+            overview_facets = lane.overview_facets(_db, facets)
+            from external_search import Filter
+            filter = Filter.from_worklist(_db, lane, overview_facets)
+            queries.append((None, filter, pagination))
+        resultsets = list(search_engine.query_works_multi(queries))
+        works = self.works_for_resultsets(_db, resultsets)
+
+        for i, lane in enumerate(lanes):
+            results = works[i]
+            for work in results:
                 yield work, lane
 
 

--- a/lane.py
+++ b/lane.py
@@ -1496,21 +1496,29 @@ class WorkList(object):
             WorkSearchResult,
         )
 
-        test_case = None
+        has_script_fields = None
         work_ids = set()
         for resultset in resultsets:
             for result in resultset:
                 work_ids.add(result.work_id)
-                if not test_case:
-                    test_case = result
+                if has_script_fields is None:
+                    # We don't know whether any script fields were
+                    # included, and now we're in a position to find
+                    # out.
+                    has_script_fields = (
+                        any(
+                            x in result for x in Filter.KNOWN_SCRIPT_FIELDS
+                        )
+                    )
+
+        if has_script_fields is None:
+            # This can only happen when there are no results. The code
+            # will work even if has_script_fields is None, but just to
+            # be safe.
+            has_script_fields = False
 
         # Check the first search result see if any script fields were
         # included.
-        has_script_fields = (
-            test_case is not None and any(
-                x in test_case for x in Filter.KNOWN_SCRIPT_FIELDS
-            )
-        )
 
         # The simplest way to turn Hits into Works is to create a
         # DatabaseBackedWorkList that fetches those specific Works

--- a/testing.py
+++ b/testing.py
@@ -1126,7 +1126,7 @@ class EndToEndSearchTest(ExternalSearchTest):
         )
 
     def _expect_results(self, expect, query_string=None, filter=None, pagination=None, **kwargs):
-        """Helper function to call query() and verify that it
+        """Helper function to call query_works() and verify that it
         returns certain work IDs.
 
         :param ordered: If this is True (the default), then the
@@ -1148,6 +1148,19 @@ class EndToEndSearchTest(ExternalSearchTest):
         )
 
     def _expect_results_multi(self, expect, queries, **kwargs):
+        """Helper function to call query_works_multi() and verify that it
+        returns certain work IDs.
+
+        :param expect: A list of lists of Works that you expect
+            to get back from each query in `queries`.
+        :param queries: A list of (query string, Filter, Pagination)
+            3-tuples.
+        :param ordered: If this is True (the default), then the
+           assertion will only succeed if the search results come in
+           in the exact order specified in `works`. If this is False,
+           then those exact results must come up, but their order is
+           not what's being tested.
+        """
         should_be_ordered = kwargs.pop('ordered', True)
         resultset = list(
             self.search.query_works_multi(


### PR DESCRIPTION
This branch completes https://jira.nypl.org/browse/SIMPLY-2015. It changes the query used to generated grouped OPDS feeds so that it uses a single Elasticsearch query and a single database query to get all the books that will be used in the feed, in the proper order.

As I mentioned in the ticket, the speedup is 20-30% -- nothing to sneeze at, but less than I was hoping for.

Rather than calling `lane.works()` on every `Lane` it's given, `WorkList._featured_works_for_lanes()` now builds a query for each `Lane` and runs all the queries using a single `ExternalSearchIndex.query_works_multi()` call.

The result is a list of lists of Hit objects. These are transformed into Work objects using a single call to `WorkList.works_for_resultsets`. This new method contains code from the old `works_for_hits` method (which turned a single list of Hits into a list of WorkList). It now goes through a list of lists, building a list of work IDs, makes a single database query to fetch all the corresponding Works, and then builds a list of list of Works corresponding to the list of list of Hits.

The old `works_for_hits` method now wraps its argument in an extra list, calls `works_for_resultsets`, and unwraps the result. This is analogous to how my previous branch changed `query_works` to wrap its single query in a list, call `query_works_multi`, and unwrap the results.