### PR TITLE
Optimize feed generation

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -419,7 +419,6 @@ class ExternalSearchIndex(HasSelfTests):
                           debug):
 
         query = Query(query_string, filter)
-        query_without_filter = Query(query_string)
         search = query.build(self.search, pagination)
         if debug:
             search = search.extra(explain=True)

--- a/external_search.py
+++ b/external_search.py
@@ -1468,8 +1468,8 @@ class Query(SearchBase):
                 self.fuzzy_coefficient = 0.5
         else:
             # Since this query does not contain any words, there is no
-            # risk that a word might misspell. Do not create or run
-            # the 'fuzzy' hypotheses at all.
+            # risk that a word might be misspelled. Do not create or
+            # run the 'fuzzy' hypotheses at all.
             self.fuzzy_coefficient = 0
 
     def build(self, elasticsearch, pagination=None):

--- a/external_search.py
+++ b/external_search.py
@@ -441,7 +441,6 @@ class ExternalSearchIndex(HasSelfTests):
         # we're asking for.
         if fields:
             search = search.source(fields)
-
         return search
 
     def query_works(self, query_string, filter=None, pagination=None,
@@ -1408,6 +1407,10 @@ class Query(SearchBase):
     # in a query string are _important_.
     STOPWORD_FIELDS = ['title', 'subtitle', 'series']
 
+    # SpellChecker is expensive to initialize, so keep around
+    # a class-level instance.
+    SPELLCHECKER = SpellChecker()
+
     def __init__(self, query_string, filter=None, use_query_parser=True):
         """Store a query string and filter.
 
@@ -1449,22 +1452,25 @@ class Query(SearchBase):
         #
         # Depending on the query, the stregnth of a fuzzy hypothesis
         # may be reduced even further -- that's determined here.
-        #
-        # NOTE: if you ever have reason to set fuzzy_coefficient to
-        # zero, fuzzy hypotheses will not be considered at all.
-        if SpellChecker().unknown(self.words):
-            # Spell check failed. This is the default behavior, if
-            # only because peoples' names will generally fail spell
-            # check. Fuzzy queries will be given their full weight.
-            self.fuzzy_coefficient = 1.0
+        if self.words:
+            if self.SPELLCHECKER.unknown(self.words):
+                # Spell check failed. This is the default behavior, if
+                # only because peoples' names will generally fail spell
+                # check. Fuzzy queries will be given their full weight.
+                self.fuzzy_coefficient = 1.0
+            else:
+                # Everything seems to be spelled correctly. But sometimes
+                # a word can be misspelled as another word, e.g. "came" ->
+                # "cane", or a name may be misspelled as a word. We'll
+                # still check the fuzzy hypotheses, but we can improve
+                # results overall by giving them only half their normal
+                # strength.
+                self.fuzzy_coefficient = 0.5
         else:
-            # Everything seems to be spelled correctly. But sometimes
-            # a word can be misspelled as another word, e.g. "came" ->
-            # "cane", or a name may be misspelled as a word. We'll
-            # still check the fuzzy hypotheses, but we can improve
-            # results overall by giving them only half their normal
-            # strength.
-            self.fuzzy_coefficient = 0.5
+            # Since this query does not contain any words, there is no
+            # risk that a word might misspell. Do not create or run
+            # the 'fuzzy' hypotheses at all.
+            self.fuzzy_coefficient = 0
 
     def build(self, elasticsearch, pagination=None):
         """Make an Elasticsearch-DSL Search object out of this query.

--- a/lane.py
+++ b/lane.py
@@ -1869,6 +1869,10 @@ class DatabaseBackedWorkList(WorkList):
             joinedload(license_pool_name, "delivery_mechanisms"),
             joinedload(license_pool_name, "delivery_mechanisms", "delivery_mechanism"),
 
+
+            joinedload(license_pool_name, "presentation_edition"),
+            joinedload(license_pool_name, "presentation_edition", "primary_identifier"),
+
             # These speed up the process of generating the open-access link
             # for open-access works.
             joinedload(license_pool_name, "delivery_mechanisms", "resource"),

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -2024,6 +2024,13 @@ class TestQuery(DatabaseTest):
         eq_(True, query.contains_stopwords)
         eq_(1, query.fuzzy_coefficient)
 
+        # Try again with a query that contains no query string.
+        # The fuzzy hypotheses will not be run at all.
+        query = Query(None)
+        eq_(None, query.contains_stopwords)
+        eq_(0, query.fuzzy_coefficient)
+
+
     def test_build(self):
         # Verify that the build() method combines the 'query' part of
         # a Query and the 'filter' part to create a single


### PR DESCRIPTION
This branch makes a couple small changes to stop certain bits of expensive code from running while we're generating OPDS feeds. I've got a circulation branch that adopts this code and adds one more optimization.

From most to least effective, the changes I made are:

* Instantiating a single `SpellChecker` rather than making a new one every time a `Query` is initialized.
* Stop instantiating a whole other `Query` object on every search that never gets used.
* Preload work.license_pools.presentation_edition.primary_identifier to avoid an extra database request to find the primary identifier of the active license pool for each work. I'm not 100% sure about this one because it makes the database query heavier, but I'm pretty sure we do need it every time we make an OPDS feed.
* Generating and running the fuzzy hypotheses for a query that has no query string and so can't have any misspellings. This one isn't very bad at all -- presumably Elasticsearch ignores those hypotheses -- but it makes the code more readable.