### PR TITLE
Add a reaper for works with no license pools

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -830,6 +830,20 @@ class PatronRecordReaper(ReaperMonitor):
 ReaperMonitor.REGISTRY.append(PatronRecordReaper)
 
 
+class WorkReaper(ReaperMonitor):
+    """Remove Works that have no associated LicensePools.
+
+    Unlike other reapers, no timestamp is relevant. As soon as a Work
+    loses its last LicensePool it can be removed.
+    """
+    MODEL_CLASS = Work
+
+    def query(self):
+        return self._db.query(Work).outerjoin(Work.license_pools).filter(
+            LicensePool.id==None
+        )
+
+
 class CollectionReaper(ReaperMonitor):
     """Remove collections that have been marked for deletion."""
     MODEL_CLASS = Collection


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-2061.

Amy, I'm asking you to do this review as a way of giving one more piece of thought to whether there might be bad side effects to removing Works with no LicensePools. I'm almost positive it'll be fine, both from thinking about it and because a running circ manager recently had to manually delete a ton of Works with no LicensePools.