### PR TITLE
Corrected typo in migration script.

### DIFF
--- a/migration/20190926-reweight-classifications.sql
+++ b/migration/20190926-reweight-classifications.sql
@@ -21,7 +21,7 @@ update classifications set weight=1 where id in (select c.id from classification
 
 -- Clear out the audience of all DDC and LCC subjects where were were
 -- deriving audience=Adult from a lack of explicit information.
-update subjects set audience=None where type in ('DDC', 'LCC') and audience='Adult';
+update subjects set audience=NULL where type in ('DDC', 'LCC') and audience='Adult';
 
 -- Delete the 'classify' coverage record for every work on the site,
 -- effectively forcing all works to be reclassified.


### PR DESCRIPTION
I found this error just now when deploying a recent revision to NYPL QA.