### PR TITLE
Add the WorkReaper to the registry so it actually gets run.

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -842,6 +842,7 @@ class WorkReaper(ReaperMonitor):
         return self._db.query(Work).outerjoin(Work.license_pools).filter(
             LicensePool.id==None
         )
+ReaperMonitor.REGISTRY.append(WorkReaper)
 
 
 class CollectionReaper(ReaperMonitor):


### PR DESCRIPTION
This fixes a bug I found while QAing https://jira.nypl.org/browse/SIMPLY-2061. The reaper for abandoned works works fine, but since I didn't add it to the registry, the database_reaper script doesn't run it.,