### PR TITLE
Add uniqueness constraints on Credentials

### DIFF
--- a/migration/20191022-unique-credentials.sql
+++ b/migration/20191022-unique-credentials.sql
@@ -1,0 +1,52 @@
+-- Delete all duplicate credentials before creating unique indexes.
+delete from credentials where id in (select c1.id from credentials c1 join credentials c2 on c1.data_source_id = c2.data_source_id and c1.patron_id=c2.patron_id and c1.type = c2.type and c1.collection_id = c2.collection_id and c1.id < c2.id);
+
+DO $$ 
+ BEGIN
+  -- Remove the unique index on (data_source_id, type, credential).
+  -- We'll recreate a better version of it immediately afterwards.
+  drop index if exists ix_credentials_data_source_id_type_token;
+
+  -- If both patron_id and collection_id are null, then (data_source_id,
+  -- type, credential) must be unique.
+  BEGIN
+   CREATE UNIQUE index ix_credentials_data_source_id_type_credential on credentials (data_source_id, type, credential) where patron_id is null and collection_id is null;
+  EXCEPTION
+   WHEN duplicate_table THEN RAISE NOTICE 'Index ix_credentials_data_source_id_type_credential already exists, leaving it alone.';
+  END;
+
+  -- If patron_id is null, then (data_source_id, type, collection_id)
+  -- must be unique.
+  BEGIN
+   CREATE UNIQUE index ix_credentials_data_source_id_type_collection_id on credentials (data_source_id, type, collection_id) where patron_id is null;
+  EXCEPTION
+   WHEN duplicate_table THEN RAISE NOTICE 'Index ix_credentials_data_source_id_type_collection_id already exists, leaving it alone.';
+  END;
+
+  -- If collection_id is null but patron_id is not, then
+  -- (data_source_id, type, patron_id) must be unique.
+  BEGIN
+   CREATE UNIQUE index ix_credentials_data_source_id_type_patron_id on credentials (data_source_id, type, patron_id) where collection_id is null;
+  EXCEPTION
+   WHEN duplicate_table THEN RAISE NOTICE 'Index ix_credentials_data_source_id_type_patron_id already exists, leaving it alone.';
+  END;
+
+  -- If patron_id is null but collection_id is not, then
+  -- (data_source_id, type, collection_id) must be unique.
+  -- (At the moment this never happens.)
+  BEGIN
+   CREATE UNIQUE index ix_credentials_data_source_id_type_collection_id on credentials (data_source_id, type, collection_id) where patron_id is null;
+  EXCEPTION
+   WHEN duplicate_table THEN RAISE NOTICE 'Index ix_credentials_data_source_id_type_collection_id already exists, leaving it alone.';
+  END;
+
+  -- If both patron_id and collection_id have values, then
+  -- (data_source_id, type, patron_id, collection_id) must be unique.
+  BEGIN
+   CREATE UNIQUE index ix_credentials_data_source_id_type_patron_id_collection_id on credentials (data_source_id, type, patron_id, collection_id);
+  EXCEPTION
+   WHEN duplicate_table THEN RAISE NOTICE 'Index ix_credentials_data_source_id_type_patron_id_collection_id already exists, leaving it alone.';
+  END;
+
+ END;
+$$;

--- a/migration/20191022-unique-credentials.sql
+++ b/migration/20191022-unique-credentials.sql
@@ -1,5 +1,5 @@
 -- Delete all duplicate credentials before creating unique indexes.
-delete from credentials where id in (select c1.id from credentials c1 join credentials c2 on c1.data_source_id = c2.data_source_id and c1.patron_id=c2.patron_id and c1.type = c2.type and c1.collection_id = c2.collection_id and c1.id < c2.id);
+delete from credentials where id in (select c1.id from credentials c1 join credentials c2 on c1.data_source_id = c2.data_source_id and c1.patron_id=c2.patron_id and c1.type = c2.type and (c1.collection_id = c2.collection_id or (c1.collection_id is null and c2.collection_id is null)) and c1.id < c2.id);
 
 DO $$ 
  BEGIN

--- a/model/credential.py
+++ b/model/credential.py
@@ -72,11 +72,11 @@ class Credential(Base):
         ),
 
         # If neither collection_id nor patron_id is null, then
-        # (data_source, type, collection_id, patron_id)
+        # (data_source, type, patron_id, collection_id)
         # must be unique.
         Index(
-            "ix_credentials_data_source_id_type_collection_id_patron_id",
-            data_source_id, type, collection_id, patron_id,
+            "ix_credentials_data_source_id_type_patron_id_collection_id",
+            data_source_id, type, patron_id, collection_id,
             unique=True,
         ),
     )

--- a/model/credential.py
+++ b/model/credential.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import (
     relationship,
 )
 from sqlalchemy.orm.session import Session
+from sqlalchemy.sql.expression import and_
 import uuid
 
 class Credential(Base):
@@ -50,13 +51,13 @@ class Credential(Base):
         Index(
             "ix_credentials_data_source_id_type_token",
             data_source_id, type, credential, unique=True,
-            postgresql_where=(patron_id==None, collection_id==None)
+            postgresql_where=and_(patron_id==None, collection_id==None)
         ),
 
         # If patron_id is null but collection_id is not, then
         # (data_source, type, collection_id) must be unique.
         Index(
-            "ix_credentials_data_source_id_type_token",
+            "ix_credentials_data_source_id_type_collection_id",
             data_source_id, type, collection_id,
             unique=True, postgresql_where=(patron_id==None)
         ),
@@ -65,7 +66,7 @@ class Credential(Base):
         # (data_source, type, patron_id) must be unique.
         # (At the moment this never happens.)
         Index(
-            "ix_credentials_data_source_id_type_token",
+            "ix_credentials_data_source_id_type_patron_id",
             data_source_id, type, patron_id,
             unique=True, postgresql_where=(collection_id==None)
         ),
@@ -74,7 +75,7 @@ class Credential(Base):
         # (data_source, type, collection_id, patron_id)
         # must be unique.
         Index(
-            "ix_credentials_data_source_id_type_token",
+            "ix_credentials_data_source_id_type_collection_id_patron_id",
             data_source_id, type, collection_id, patron_id,
             unique=True,
         ),


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-2353 by implementing uniqueness constraints on the `credentials` table. Requests that previously would have triggered a race condition will now fail _without_ screwing up the database.

I've tested this with a fresh database and with an old database migrated using the migration script.