### PR TITLE
Create a default Local Analytics service if one already does not exist.

### DIFF
--- a/local_analytics_provider.py
+++ b/local_analytics_provider.py
@@ -1,5 +1,11 @@
 from flask_babel import lazy_gettext as _
-from model import Session, CirculationEvent
+from model import (
+    Session,
+    CirculationEvent,
+    ExternalIntegration,
+    get_one,
+    create
+)
 
 class LocalAnalyticsProvider(object):
     NAME = _("Local Analytics")
@@ -62,5 +68,29 @@ class LocalAnalyticsProvider(object):
             _db, license_pool, event_type, old_value, new_value, start=time,
             library=library, location=neighborhood
         )
+    
+    @classmethod
+    def initialize(cls, _db):
+        """Find or create a local analytics service.
+        """
+
+        # If a local analytics service already exists, return it.
+        local_analytics = get_one(
+            _db, ExternalIntegration,
+            protocol=cls.__module__,
+            goal=ExternalIntegration.ANALYTICS_GOAL
+        )
+
+        # If a local analytics service already exists, don't create a
+        # default one. Otherwise, create it with default name of
+        # "Local Analytics".
+        if not local_analytics:
+            local_analytics, ignore = create(
+                _db, ExternalIntegration,
+                protocol=cls.__module__,
+                goal=ExternalIntegration.ANALYTICS_GOAL,
+                name=str(cls.NAME)
+            )
+        return local_analytics
 
 Provider = LocalAnalyticsProvider

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -188,8 +188,6 @@ class TestAnalytics(DatabaseTest):
         assert isinstance(local_analytics, ExternalIntegration)
         eq_(local_analytics.name, LocalAnalyticsProvider.NAME)
 
-        self._db.delete(local_analytics)
-
         # When an analytics provider is initialized, retrieving a
         # local analytics service should return the same one.
         local_analytics = LocalAnalyticsProvider.initialize(self._db)

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -15,6 +15,7 @@ from ..model import (
     ExternalIntegration,
     Library,
     create,
+    get_one
 )
 import json
 
@@ -168,3 +169,36 @@ class TestAnalytics(DatabaseTest):
         # It's counted as a sitewide event, but not as a library event.
         eq_(3, sitewide_provider.count)
         eq_(1, library_provider.count)
+
+    def test_initialize(self):
+
+        local_analytics = get_one(
+            self._db, ExternalIntegration,
+            protocol=LocalAnalyticsProvider.__module__,
+            goal=ExternalIntegration.ANALYTICS_GOAL
+        )
+
+        # There shouldn't exist a local analytics service.
+        eq_(None, local_analytics)
+
+        # So when the Local Analytics provider is initialized, it will
+        # create one with the default name of "Local Analytics".
+        local_analytics = LocalAnalyticsProvider.initialize(self._db)
+
+        assert isinstance(local_analytics, ExternalIntegration)
+        eq_(local_analytics.name, LocalAnalyticsProvider.NAME)
+
+        self._db.delete(local_analytics)
+
+        # When an analytics provider is initialized, retrieving a
+        # local analytics service should return the same one.
+        local_analytics = LocalAnalyticsProvider.initialize(self._db)
+
+        local_analytics_2 = get_one(
+            self._db, ExternalIntegration,
+            protocol=LocalAnalyticsProvider.__module__,
+            goal=ExternalIntegration.ANALYTICS_GOAL
+        )
+
+        eq_(local_analytics_2.id, local_analytics.id)
+        eq_(local_analytics_2.name, local_analytics.name)


### PR DESCRIPTION
Resolves [SIMPLY-2346](https://jira.nypl.org/browse/SIMPLY-2346). Adding a function to LocalAnalyticsProvider to get or create a local analytics integration. It'll be used when the app starts so there will be a default service if none exists.