### PR TITLE
MARC Record Generator Unicode Issue

### DIFF
--- a/marc.py
+++ b/marc.py
@@ -588,7 +588,7 @@ class MARCExporter(object):
         record = None
         existing_record = getattr(work, annotator.marc_cache_field)
         if existing_record and not force_create:
-            record = Record(data=existing_record, force_utf8=True)
+            record = Record(data=existing_record.encode("utf8"), force_utf8=True)
 
         if not record:
             record = Record(leader=annotator.leader(work), force_utf8=True)

--- a/marc.py
+++ b/marc.py
@@ -609,7 +609,7 @@ class MARCExporter(object):
             annotator.add_ebooks_subject(record)
 
             data = record.as_marc()
-            setattr(work, annotator.marc_cache_field, data)
+            setattr(work, annotator.marc_cache_field, data.decode("utf8"))
 
         # Add additional fields that should not be cached.
         annotator.annotate_work_record(work, pool, edition, identifier, record, integration)

--- a/marc.py
+++ b/marc.py
@@ -588,9 +588,7 @@ class MARCExporter(object):
         record = None
         existing_record = getattr(work, annotator.marc_cache_field)
         if existing_record and not force_create:
-            if isinstance(existing_record, unicode):
-                existing_record = existing_record.encode("utf8")
-            record = Record(data=existing_record, force_utf8=True)
+            record = Record(data=existing_record.encode("utf8"), force_utf8=True)
 
         if not record:
             record = Record(leader=annotator.leader(work), force_utf8=True)
@@ -611,7 +609,7 @@ class MARCExporter(object):
             annotator.add_ebooks_subject(record)
 
             data = record.as_marc()
-            setattr(work, annotator.marc_cache_field, data)
+            setattr(work, annotator.marc_cache_field, data.decode("utf8"))
 
         # Add additional fields that should not be cached.
         annotator.annotate_work_record(work, pool, edition, identifier, record, integration)

--- a/marc.py
+++ b/marc.py
@@ -588,7 +588,9 @@ class MARCExporter(object):
         record = None
         existing_record = getattr(work, annotator.marc_cache_field)
         if existing_record and not force_create:
-            record = Record(data=existing_record.encode("utf8"), force_utf8=True)
+            if isinstance(existing_record, unicode):
+                existing_record = existing_record.encode("utf8")
+            record = Record(data=existing_record, force_utf8=True)
 
         if not record:
             record = Record(leader=annotator.leader(work), force_utf8=True)
@@ -609,7 +611,7 @@ class MARCExporter(object):
             annotator.add_ebooks_subject(record)
 
             data = record.as_marc()
-            setattr(work, annotator.marc_cache_field, data.decode("utf8"))
+            setattr(work, annotator.marc_cache_field, data)
 
         # Add additional fields that should not be cached.
         annotator.annotate_work_record(work, pool, edition, identifier, record, integration)

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -484,12 +484,13 @@ class TestMARCExporter(DatabaseTest):
           with_license_pool=True
         )
         record = MARCExporter.create_record(work, annotator)
+        loaded_record = MARCExporter.create_record(work, annotator)
+        eq_(record.as_marc(), loaded_record.as_marc())
 
         # Loads a existing record from the DB
         db = Session(self.connection)
         new_work = get_one(db, Work, id=work.id)
         new_record = MARCExporter.create_record(new_work, annotator)
-
         eq_(record.as_marc(), new_record.as_marc())
 
     def test_records(self):


### PR DESCRIPTION
## Issue

In my logs for `cache_marc_files.log` I'm seeing this:

```
{"host": "8caf88a7885e", "name": "root", "level": "ERROR", "timestamp": "2019-10-24T01:01:21.495675", "app": "simplified", "traceback": "Traceback (most recent call last):\n  File \"/var/www/circulation/core/s3.py\", line 369, in multipart_upload\n    yield upload\n  File \"/var/www/circulation/core/marc.py\", line 657, in records\n    work, annotator, force_refresh, self.integration\n  File \"/var/www/circulation/core/marc.py\", line 570, in create_record\n    record = Record(data=existing_record, force_utf8=True)\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/pymarc/record.py\", line 75, in __init__\n    encoding=file_encoding)\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/pymarc/record.py\", line 310, in decode_marc\n    data = data.decode('utf-8', utf8_handling)\n  File \"/var/www/circulation/env/lib/python2.7/encodings/utf_8.py\", line 16, in decode\n    return codecs.utf_8_decode(input, errors, True)\nUnicodeEncodeError: 'ascii' codec can't encode character u'\\xf6' in position 12: ordinal not in range(128)", "message": "Multipart upload of https://s3.amazonaws.com/marc-clp/clp/2019-10-24+01%3A01%3A16.360374/Children+and+Middle+Grade.mrc failed: UnicodeEncodeError('ascii', u'Selma Lagerl\\xf6f\\x1e', 12, 13, 'ordinal not in range(128)')", "filename": "s3.py"}
{"host": "8caf88a7885e", "name": "root", "level": "INFO", "timestamp": "2019-10-24T01:01:21.496211", "app": "simplified", "message": "Aborting upload of clp/2019-10-24 01:01:16.360374/Children and Middle Grade.mrc", "filename": "s3.py"}
{"host": "8caf88a7885e", "name": "root", "level": "INFO", "timestamp": "2019-10-24T01:01:25.776586", "app": "simplified", "message": "Obtained 500xWork in 1.80sec", "filename": "lane.py"}
{"host": "8caf88a7885e", "name": "root", "level": "ERROR", "timestamp": "2019-10-24T01:01:25.841154", "app": "simplified", "traceback": "Traceback (most recent call last):\n  File \"/var/www/circulation/core/s3.py\", line 369, in multipart_upload\n    yield upload\n  File \"/var/www/circulation/core/marc.py\", line 657, in records\n    work, annotator, force_refresh, self.integration\n  File \"/var/www/circulation/core/marc.py\", line 570, in create_record\n    record = Record(data=existing_record, force_utf8=True)\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/pymarc/record.py\", line 75, in __init__\n    encoding=file_encoding)\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/pymarc/record.py\", line 310, in decode_marc\n    data = data.decode('utf-8', utf8_handling)\n  File \"/var/www/circulation/env/lib/python2.7/encodings/utf_8.py\", line 16, in decode\n    return codecs.utf_8_decode(input, errors, True)\nUnicodeEncodeError: 'ascii' codec can't encode character u'\\u2019' in position 11: ordinal not in range(128)", "message": "Multipart upload of https://s3.amazonaws.com/marc-clp/clp/2019-08-14+01%3A52%3A23.148977-2019-10-24+01%3A01%3A21.657478/Children+and+Middle+Grade.mrc failed: UnicodeEncodeError('ascii', u'Little Mimi\\u2019s First Counting Lesson', 11, 12, 'ordinal not in range(128)')", "filename": "s3.py"}
{"host": "8caf88a7885e", "name": "root", "level": "INFO", "timestamp": "2019-10-24T01:01:25.841773", "app": "simplified", "message": "Aborting upload of clp/2019-08-14 01:52:23.148977-2019-10-24 01:01:21.657478/Children and Middle Grade.mrc", "filename": "s3.py"}
```

## Interested
@aslagle @leonardr