### PR TITLE
Update the list of media types fulfillable by the default client

### DIFF
--- a/model/licensing.py
+++ b/model/licensing.py
@@ -1421,13 +1421,30 @@ class DeliveryMechanism(Base, HasFullTableCache):
 
     # These are the media type/DRM scheme combos known to be supported
     # by the default Library Simplified client.
+    #
+    # This is primarily used when deciding which books can be imported
+    # from an OPDS For Distributors collection.
     default_client_can_fulfill_lookup = set([
+        # EPUB books
         (MediaTypes.EPUB_MEDIA_TYPE, NO_DRM),
         (MediaTypes.EPUB_MEDIA_TYPE, ADOBE_DRM),
-        (MediaTypes.EPUB_MEDIA_TYPE, BEARER_TOKEN),
+
+        # PDF books
+        (MediaTypes.PDF_MEDIA_TYPE, NO_DRM),
+
+        # Various audiobook formats
         (None, FINDAWAY_DRM),
-        (MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE, None),
+        (MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE, NO_DRM),
     ])
+
+    # If the default client supports a given media type with no DRM,
+    # we can infer that the client _also_ supports that media type via
+    # bearer token exchange.
+    for media_type, drm in list(default_client_can_fulfill_lookup):
+        if drm == NO_DRM:
+            default_client_can_fulfill_lookup.add(
+                (media_type, BEARER_TOKEN)
+            )
 
     license_pool_delivery_mechanisms = relationship(
         "LicensePoolDeliveryMechanism",

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -1441,7 +1441,7 @@ class DeliveryMechanism(Base, HasFullTableCache):
     # we can infer that the client _also_ supports that media type via
     # bearer token exchange.
     for media_type, drm in list(default_client_can_fulfill_lookup):
-        if drm == NO_DRM:
+        if media_type is not None and drm == NO_DRM:
             default_client_can_fulfill_lookup.add(
                 (media_type, BEARER_TOKEN)
             )


### PR DESCRIPTION
This branch is one of a couple I'm writing to address https://jira.nypl.org/browse/SIMPLY-2370.

The circulation manager keeps a list of media type/DRM scheme combos that SimplyE can render. Since SimplyE gains capabilities over time, it's possible for a circulation manager to have an old copy of this list, and for this reason we haven't used it for very much and haven't put much work into keeping it up to date.

However, SIMPLY-2370 presents a good argument for keeping it up to date, so this branch does the work of bringing it up to date.
