### PR TITLE
Incorporate pagination instructions into the Elasticsearch query itself.

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -997,9 +997,12 @@ class Pagination(object):
         return qu.offset(self.offset).limit(self.size)
 
     def modify_search_query(self, search):
-        # Do nothing -- all necessary pagination information is kept in
-        # offset and size, which external_search knows how to apply.
-        return search
+        """Modify a Search object so that it retrieves only a single 'page'
+        of results.
+
+        :return: A Search object.
+        """
+        return search[self.offset:self.offset+self.size]
 
     def page_loaded(self, page):
         """An actual page of results has been fetched. Keep any internal state

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1347,10 +1347,11 @@ class TestPagination(DatabaseTest):
         eq_(True, pagination.page_has_loaded)
 
     def test_modify_search_query(self):
-        # The default implementation of modify_search_query is a no-op.
-        pagination = Pagination()
-        o = object()
-        eq_(o, pagination.modify_search_query(o))
+        # The default implementation of modify_search_query is to slice
+        # a set of search results like a list.
+        pagination = Pagination(offset=2, size=3)
+        o = [1,2,3,4,5,6]
+        eq_(o[2:2+3], pagination.modify_search_query(o))
 
 
 class MockWork(object):


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-2409 by consistently moving the point at which lists are paginated from outside `query_works_multi` to inside `query_works_multi`. In some cases, we were doing pagination twice -- once in the Elasticsearch server and once in Python code afterwards -- which led to empty result sets.

Imagine two lists of 50 books each. We want to issue a single Elasticsearch query that gets items 1-10 in list A, and items 31-40 in list B. That part was working just fine -- `query_works_multi` would return two lists of ten books each.

But then we ran some _additional_ code that selected items [0:10] from list A and items [30:40] from list B. List A is fine -- there are ten items in the list and we want the first ten. List B would end up empty: we're asking for items 31-40 but there are only ten items in the list (representing items 31-40 in the underlying resultset). 

Our existing tests didn't catch this problem because we didn't have a test against a real search index for regular `Pagination` -- only for `SortKeyPagination`.