### PR TITLE
Copied the slice_timespan method in from circulation and added a test for it.

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -286,6 +286,27 @@ class TimelineMonitor(Monitor):
         """
         raise NotImplementedError()
 
+    @classmethod
+    def slice_timespan(cls, start, cutoff, increment):
+        """Slice a span of time into segements no large than [increment].
+
+        This lets you divide up a task like "gather the entire
+        circulation history for a collection" into chunks of one day.
+
+        :param start: A datetime.
+        :param cutoff: A datetime.
+        :param increment: A timedelta.
+        """
+        slice_start = start
+        while slice_start < cutoff:
+            full_slice = True
+            slice_cutoff = slice_start + increment
+            if slice_cutoff > cutoff:
+                slice_cutoff = cutoff
+                full_slice = False
+            yield slice_start, slice_cutoff, full_slice
+            slice_start = slice_start + increment
+
 
 class CollectionMonitor(Monitor):
     """A Monitor that does something for all Collections that come

--- a/monitor.py
+++ b/monitor.py
@@ -288,7 +288,7 @@ class TimelineMonitor(Monitor):
 
     @classmethod
     def slice_timespan(cls, start, cutoff, increment):
-        """Slice a span of time into segements no large than [increment].
+        """Slice a span of time into segments no large than [increment].
 
         This lets you divide up a task like "gather the entire
         circulation history for a collection" into chunks of one day.

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1347,10 +1347,11 @@ class TestPagination(DatabaseTest):
         eq_(True, pagination.page_has_loaded)
 
     def test_modify_search_query(self):
-        # The default implementation of modify_search_query is a no-op.
-        pagination = Pagination()
-        o = object()
-        eq_(o, pagination.modify_search_query(o))
+        # The default implementation of modify_search_query is to slice
+        # a set of search results like a list.
+        pagination = Pagination(offset=2, size=3)
+        o = [1,2,3,4,5,6]
+        eq_(o[2:2+3], pagination.modify_search_query(o))
 
 
 class MockWork(object):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -425,6 +425,32 @@ class TestTimelineMonitor(DatabaseTest):
         eq_(m.DEFAULT_START_TIME, progress.start)
         eq_(None, progress.finish)
 
+    def test_slice_timespan(self):
+        # Test the slice_timespan utility method.
+
+        # Slicing up the time between 121 minutes ago and now in increments
+        # of one hour will yield three slices:
+        #
+        # 121 minutes ago -> 61 minutes ago
+        # 61 minutes ago -> 1 minute ago
+        # 1 minute ago -> now
+        now = datetime.datetime.utcnow()
+        one_hour = datetime.timedelta(minutes=60)
+        ago_1 = now - datetime.timedelta(minutes=1)
+        ago_61 = ago_1 - one_hour
+        ago_121 = ago_61 - one_hour
+
+        slice1, slice2, slice3 = list(
+            TimelineMonitor.slice_timespan(ago_121, now, one_hour)
+        )
+        eq_(slice1, (ago_121, ago_61, True))
+        eq_(slice2, (ago_61, ago_1, True))
+        eq_(slice3, (ago_1, now, False))
+
+        # The True/True/False indicates that the first two slices are
+        # complete -- they cover a span of an entire hour. The final
+        # slice is incomplete -- it covers only one minute.
+
 
 class MockSweepMonitor(SweepMonitor):
     """A SweepMonitor that does nothing."""


### PR DESCRIPTION
A tiny support branch for https://jira.nypl.org/browse/SIMPLY-1221. The Bibliotheca monitor has a helper method that slices a span of time into chunks, so that you can make API requests for small periods of time that won't overwhelm the API. 1221 is about bringing this same functionality to the Enki monitor, so I moved the helper method to `TimelineMonitor`, the common superclass of the Bibliotheca and Enki monitors.

The code is the same as what's currently in circulation/api/bibliotheca.py, except I made it a class method. The test is new; this previously didn't have a standalone test.