### PR TITLE
Allow filter modification hook to modify in place

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -1465,7 +1465,13 @@ class WorkList(object):
         """
         from external_search import Filter
         filter = Filter.from_worklist(_db, self, facets)
-        return self.modify_search_filter_hook(filter)
+        modified = self.modify_search_filter_hook(filter)
+        if modified is None:
+            # This doesn't make sense; there needs to be a Filter
+            # object even if no filtering is being done. Assume
+            # the Filter passed in was modified in place.
+            modified = filter
+        return modified
 
     def modify_search_filter_hook(self, filter):
         """A hook method allowing subclasses to modify a Filter

--- a/lane.py
+++ b/lane.py
@@ -1467,9 +1467,8 @@ class WorkList(object):
         filter = Filter.from_worklist(_db, self, facets)
         modified = self.modify_search_filter_hook(filter)
         if modified is None:
-            # This doesn't make sense; there needs to be a Filter
-            # object even if no filtering is being done. Assume
-            # the Filter passed in was modified in place.
+            # The Filter was modified in place, rather than a new
+            # Filter being returned.
             modified = filter
         return modified
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1629,6 +1629,34 @@ class TestWorkList(DatabaseTest):
         wl.list_datasource_id = object()
         eq_(True, wl.uses_customlists)
 
+    def test_filter(self):
+        # Verify that filter() calls modify_search_filter_hook()
+        # and can handle either a new Filter being returned or a Filter
+        # modified in place.
+
+        class ModifyInPlace(WorkList):
+            # A WorkList that modifies its search filter in place.
+            def modify_search_filter_hook(self, filter):
+                filter.hook_called = True
+
+        wl = ModifyInPlace()
+        wl.initialize(self._default_library)
+        facets = SearchFacets()
+        filter = wl.filter(self._db, facets)
+        assert isinstance(filter, Filter)
+        eq_(True, filter.hook_called)
+
+        class NewFilter(WorkList):
+            # A WorkList that returns a brand new Filter
+            def modify_search_filter_hook(self, filter):
+                return "A brand new Filter"
+
+        wl = NewFilter()
+        wl.initialize(self._default_library)
+        facets = SearchFacets()
+        filter = wl.filter(self._db, facets)
+        eq_("A brand new Filter", filter)
+
     def test_groups(self):
         w1 = MockWork(1)
         w2 = MockWork(2)


### PR DESCRIPTION
This branch stops https://jira.nypl.org/browse/SIMPLY-2410 from happening again by allowing `modify_search_filter_hook` to modify its `Filter` in place rather than returning a new one.

Returning a new one is still supported, and I added a test that tests it both ways.