### PR TITLE
Add IntegrationClient.enabled

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -98,14 +98,14 @@ class ReplacementPolicy(object):
         )
 
     @classmethod
-    def from_license_source(self, _db, **args):
+    def from_license_source(cls, _db, **args):
         """When gathering data from the license source, overwrite all old data
         from this source with new data from the same source. Also
         overwrite an old rights status with an updated status and update
         the list of available formats. Log availability changes to the
         configured analytics services.
         """
-        return ReplacementPolicy(
+        return cls(
             identifiers=True,
             subjects=True,
             contributions=True,
@@ -117,13 +117,13 @@ class ReplacementPolicy(object):
         )
 
     @classmethod
-    def from_metadata_source(self, **args):
+    def from_metadata_source(cls, **args):
         """When gathering data from a metadata source, overwrite all old data
         from this source, but do not overwrite the rights status or
         the available formats. License sources are the authority on rights
         and formats, and metadata sources have no say in the matter.
         """
-        return ReplacementPolicy(
+        return cls(
             identifiers=True,
             subjects=True,
             contributions=True,
@@ -134,12 +134,12 @@ class ReplacementPolicy(object):
         )
 
     @classmethod
-    def append_only(self, **args):
+    def append_only(cls, **args):
         """Don't overwrite any information, just append it.
 
         This should probably never be used.
         """
-        return ReplacementPolicy(
+        return cls(
             identifiers=False,
             subjects=False,
             contributions=False,

--- a/migration/20191119-integrationclient-enabled.sql
+++ b/migration/20191119-integrationclient-enabled.sql
@@ -1,0 +1,10 @@
+DO $$
+ BEGIN
+  -- Add the 'enabled' column
+  BEGIN
+   ALTER TABLE integrationclients ADD COLUMN enabled boolean default true;
+  EXCEPTION
+   WHEN duplicate_column THEN RAISE NOTICE 'column integrationclients.enabled already exists, not creating it.';
+  END;
+ END;
+$$;

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -506,6 +506,7 @@ from collection import (
 from configuration import (
     ConfigurationSetting,
     ExternalIntegration,
+    ExternalIntegrationLink,
 )
 from complaint import Complaint
 from contributor import (

--- a/model/integrationclient.py
+++ b/model/integrationclient.py
@@ -12,6 +12,7 @@ import datetime
 import os
 import re
 from sqlalchemy import (
+    Boolean,
     Column,
     DateTime,
     Integer,

--- a/model/integrationclient.py
+++ b/model/integrationclient.py
@@ -41,6 +41,10 @@ class IntegrationClient(Base):
     # Shared secret
     shared_secret = Column(Unicode, unique=True, index=True)
 
+    # It may be necessary to disable an integration client until it
+    # upgrades to fix a known bug.
+    enabled = Column(Boolean, default=True)
+
     created = Column(DateTime)
     last_accessed = Column(DateTime)
 


### PR DESCRIPTION
This branch is the core portion of https://github.com/NYPL-Simplified/metadata_wrangler/pull/202, for https://jira.nypl.org/browse/SIMPLY-2418. It adds a new database field to `integrationclients` so we can keep track of which clients are enabled.