### PR TITLE
Make MetadataWranglerOPDSLookup implement HasSelfTests

### DIFF
--- a/opds_import.py
+++ b/opds_import.py
@@ -198,8 +198,8 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup, HasSelfTests):
                 continue
 
             lookup = lookup_class.from_config(_db, c)
-            results[c] = list(lookup._run_collection_self_tests())
-        return results
+            for i in lookup._run_collection_self_tests():
+                yield i
 
     def _run_collection_self_tests(self):
         """Run the self-test suite on the Collection associated with this
@@ -232,12 +232,12 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup, HasSelfTests):
         ):
             yield self._feed_self_test(title, m, *args)
 
-    @classmethod
-    def _feed_self_test(cls, name, method, *args):
+    def _feed_self_test(self, name, method, *args):
         """Retrieve a feed from the metadata wrangler and 
         turn it into a SelfTestResult.
         """
         result = SelfTestResult(name)
+        result.collection = self.collection
 
         # If the server returns a 500 error we don't want to raise an
         # exception -- we want to record it as part of the test
@@ -245,9 +245,7 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup, HasSelfTests):
         kwargs = dict(allowed_response_codes=['%sxx' % f for f in range(1,6)])
 
         response = method(*args, **kwargs)
-        result.result = "\n".join(
-            cls._summarize_feed_response(response)
-        )
+        result.result = self._summarize_feed_response(response)
 
         # Once we process the OPDS feed we can call this a success.
         result.success = True

--- a/opds_import.py
+++ b/opds_import.py
@@ -71,7 +71,7 @@ from util.string_helpers import base64
 from mirror import MirrorUploader
 from selftest import (
     HasSelfTests,
-    TestResult,
+    SelfTestResult,
 )
 
 
@@ -176,34 +176,48 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup, HasSelfTests):
             collection=collection
         )
 
-    def _run_self_tests(self, _db):
+    def _run_self_tests(self, _db, lookup_class=None):
+        """Run self-tests on every eligible Collection.
+
+        :param _db: A database connection.
+        :param lookup_class: Pass in a mock class to instantiate that
+           class as needed instead of MetadataWranglerOPDSLookup.
+        :return: A dictionary mapping Collection objects to lists of
+           SelfTestResult objects.
+        """
+        lookup_class = lookup_class or MetadataWranglerOPDSLookup
+        results = dict()
+
+        # Find all eligible Collections on the system, instantiate a
+        # _new_ MetadataWranglerOPDSLookup for each, and call
+        # its _run_collection_self_tests method.
+        for c in _db.query(Collection):
+            try:
+                metadata_identifier = c.metadata_identifier
+            except ValueError, e:
+                continue
+
+            lookup = lookup_class.from_config(_db, c)
+            results[c] = list(lookup._run_collection_self_tests())
+        return results
+
+    def _run_collection_self_tests(self):
+        """Run the self-test suite on the Collection associated with this
+        MetadataWranglerOPDSLookup.
+        """
         if not self.collection:
-            # This MetadataWranglerOPDSLookup was instantiated with no
-            # Collection by the run_self_tests class method.
-            #
-            # We want to find all the Collections on the system, instantiate
-            # a _new_ MetadataWranglerOPDSLookup for each, and call
-            # _run_self_tests on each.
-            for c in _db.query(Collection):
-                lookup = MetadataWranglerOPDSLookup.from_config(_db, c)
-                for result in lookup._run_self_tests(_db):
-                    yield result
+            return
+        metadata_identifier = None
+        try:
+            metadata_identifier = self.collection.metadata_identifier
+        except ValueError, e:
+            # This collection has no metadata identifier. It's
+            # probably a "Manual intervention" collection. It cannot
+            # interact with the metadata wrangler and there's no need
+            # to test it.
             return
 
-        # If we've reached this point, we have an associated Collection.
-        # See what the metadata wrangler says about it.
-        
-        # The first "test result" acts as a spacer, since we're
-        # running the same tests for every collection.
-        spacer = TestResult(
-            'Testing collection "%s" (metadata identifier: "%s")' % (
-                self.collection.name, self.collection.metadata_identifiers
-            )
-        )
-        spacer.success = True
-        yield spacer
-
-        # Check various endpoints the yield OPDS feeds.
+        # Check various endpoints that yield OPDS feeds.
         one_day_ago = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         prefix = '"%s" - ' % self.collection.name
         for title, m, args in (
@@ -216,35 +230,64 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup, HasSelfTests):
                 self.metadata_needed, []
             )
         ):
-            yield self._feed_self_test(title, m, args)
+            yield self._feed_self_test(title, m, *args)
 
-    def _feed_self_test(self, title, method, args):
+    @classmethod
+    def _feed_self_test(cls, name, method, *args):
         """Retrieve a feed from the metadata wrangler and 
-        turn it into a TestResult.
+        turn it into a SelfTestResult.
         """
-        result = TestResult(name)
-        response = m(*args)
-        self.annotate_test_result_with_feed_data(result, response)
+        result = SelfTestResult(name)
 
-        # Once we parse the OPDS feed we can call this a success.
+        # If the server returns a 500 error we don't want to raise an
+        # exception -- we want to record it as part of the test
+        # result.
+        kwargs = dict(allowed_response_codes=['%sxx' % f for f in range(1,6)])
+
+        response = method(*args, **kwargs)
+        result.result = "\n".join(
+            cls._summarize_feed_response(response)
+        )
+
+        # Once we process the OPDS feed we can call this a success.
         result.success = True
         result.end = datetime.datetime.utcnow()
         return result
 
-    def annotate_test_result_with_feed_data(self, result, response):
-        """Parse an OPDS feed and annotate a TestResult with information
+    @classmethod
+    def _summarize_feed_response(cls, response):
+        """Parse an OPDS feed and return some information
         about it:
 
-        * The URL that was requested.
+        * How the feed was requested.
+        * What the response code was.
         * The number of items on the first page.
-        * The title of the first item on the page, if any.
+        * The title of each item on the page, if any.
         * The total number of items in the feed, if available.
 
-        :param result: A TestResult for an in-progress test.
         :param response: A requests Response object.
+        :return: A list of strings summarizing the feed.
         """
-        set_trace()
-        pass
+        lines = []
+        lines.append("Request URL: %s" % response.url)
+        lines.append(
+            "Request authorization: %s" %
+            response.request.headers.get('Authorization')
+        )
+        lines.append("Status code: %d" % response.status_code)
+        if response.status_code == 200:
+            feed = feedparser.parse(response.content)
+            total_results = feed['feed'].get('opensearch_totalresults')
+            if total_results is not None:
+                lines.append(
+                    "Total identifiers registered with this collection: %s" % (
+                        total_results
+                    )
+                )
+            lines.append("Entries on this page: %d" % len(feed['entries']))
+            for i in feed['entries']:
+                lines.append(" " + i['title'])
+        return lines
 
     def __init__(self, url, shared_secret=None, collection=None):
         super(MetadataWranglerOPDSLookup, self).__init__(url)
@@ -323,14 +366,14 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup, HasSelfTests):
         add_with_metadata_url = self.get_collection_url(self.ADD_WITH_METADATA_ENDPOINT)
         return self._post(add_with_metadata_url, unicode(feed))
 
-    def metadata_needed(self):
+    def metadata_needed(self, **kwargs):
         """Get a feed of items that need additional metadata to be processed
         by the Metadata Wrangler.
         """
         metadata_needed_url = self.get_collection_url(
             self.METADATA_NEEDED_ENDPOINT
         )
-        return self._get(metadata_needed_url)
+        return self._get(metadata_needed_url, **kwargs)
 
     def remove(self, identifiers):
         """Remove items from an authenticated Metadata Wrangler Collection"""
@@ -340,7 +383,7 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup, HasSelfTests):
         logging.info("Metadata Wrangler Collection Removal URL: %s", url)
         return self._post(url)
 
-    def updates(self, last_update_time):
+    def updates(self, last_update_time, **kwargs):
         """Retrieve updated items from an authenticated Metadata
         Wrangler Collection
 
@@ -352,7 +395,7 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup, HasSelfTests):
             formatted_time = last_update_time.strftime('%Y-%m-%dT%H:%M:%SZ')
             url = self.add_args(url, ('last_update_time='+formatted_time))
         logging.info("Metadata Wrangler Collection Updates URL: %s", url)
-        return self._get(url)
+        return self._get(url, **kwargs)
 
     def canonicalize_author_name(self, identifier, working_display_name):
         """Attempt to find the canonical name for the author of a book.

--- a/selftest.py
+++ b/selftest.py
@@ -129,6 +129,7 @@ class HasSelfTests(object):
         from external_search import ExternalSearchIndex
 
         constructor_method = constructor_method or cls
+        set_trace()
         start = datetime.datetime.utcnow()
         result = SelfTestResult("Initial setup.")
         instance = None

--- a/selftest.py
+++ b/selftest.py
@@ -34,6 +34,9 @@ class SelfTestResult(object):
         # End time of the test.
         self.end = None
 
+        # Collection associated with the test
+        self.collection = None
+
     @property
     def to_dict(self):
         """Convert this SelfTestResult to a dictionary for use in
@@ -57,6 +60,9 @@ class SelfTestResult(object):
         if self.end:
             value['end'] = f(self.end)
 
+        if self.collection:
+            value['collection'] = self.collection.name
+
         # String results will be displayed in a fixed-width font.
         # Lists of strings will be hidden behind an expandable toggle.
         # Other return values have no defined method of display.
@@ -77,8 +83,12 @@ class SelfTestResult(object):
                 exception = " exception=%r" % self.exception
         else:
             exception = ""
-        return "<SelfTestResult: name=%r duration=%.2fsec success=%r%s result=%r>" % (
-            self.name, self.duration, self.success,
+        if self.collection:
+            collection = " collection=%r" % self.collection.name
+        else:
+            collection = ""
+        return "<SelfTestResult: name=%r%s duration=%.2fsec success=%r%s result=%r>" % (
+            self.name, collection, self.duration, self.success,
             exception, self.result
         )
 

--- a/selftest.py
+++ b/selftest.py
@@ -129,7 +129,6 @@ class HasSelfTests(object):
         from external_search import ExternalSearchIndex
 
         constructor_method = constructor_method or cls
-        set_trace()
         start = datetime.datetime.utcnow()
         result = SelfTestResult("Initial setup.")
         instance = None

--- a/testing.py
+++ b/testing.py
@@ -1426,16 +1426,31 @@ class DummyHTTPClient(object):
         return self.responses.pop(0)
 
 
+class MockRequestsRequest(object):
+    """A mock object that simulates an HTTP request from the
+    `requests` library.
+    """
+    def __init__(self, url, method="GET", headers=None):
+        self.url = url
+        self.method = method
+        self.headers = headers or dict()
+
+
 class MockRequestsResponse(object):
     """A mock object that simulates an HTTP response from the
     `requests` library.
     """
-    def __init__(self, status_code, headers={}, content=None, url=None):
+    def __init__(
+        self, status_code, headers={}, content=None, url=None, request=None
+    ):
         self.status_code = status_code
         self.headers = headers
         self.content = content
+        if request and not url:
+            url = request.url
         self.url = url or "http://url/"
         self.encoding = "utf-8"
+        self.request = request
 
     def json(self):
         content = self.content

--- a/tests/files/opds/metadata_wrangler_overdrive.opds
+++ b/tests/files/opds/metadata_wrangler_overdrive.opds
@@ -1,9 +1,10 @@
-<feed xmlns:simplified="http://librarysimplified.org/terms/" xmlns:app="http://www.w3.org/2007/app" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom" xmlns:bibframe="http://bibframe.org/vocab/">
+<feed xmlns:simplified="http://librarysimplified.org/terms/" xmlns:app="http://www.w3.org/2007/app" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom" xmlns:bibframe="http://bibframe.org/vocab/" xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">
   <id>http://localhost:5000/</id>
   <title>Open-Access Content</title>
   <updated>2015-01-02T16:56:40Z</updated>
   <link href="http://localhost:5000/"/>
   <link href="http://localhost:5000/" rel="self"/>
+  <opensearch:totalResults>201</opensearch:totalResults>
   <entry schema:additionalType="http://schema.org/PublicationIssue">
     <id>urn:librarysimplified.org/terms/id/Overdrive%20ID/{OVERDRIVE ID}</id>
     <bibframe:distribution bibframe:ProviderName="Overdrive"/>

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -413,18 +413,13 @@ class TestMetadataWranglerOPDSLookup(OPDSTest):
         ], test_result.result)
 
 
-class OPDSImporterTest(DatabaseTest):
+class OPDSImporterTest(OPDSTest):
 
     def setup(self):
         super(OPDSImporterTest, self).setup()
-        base_path = os.path.split(__file__)[0]
-        self.resource_path = os.path.join(base_path, "files", "opds")
-        self.content_server_feed = open(
-            os.path.join(self.resource_path, "content_server.opds")).read()
-        self.content_server_mini_feed = open(
-            os.path.join(self.resource_path, "content_server_mini.opds")).read()
-        self.audiobooks_opds = open(
-            os.path.join(self.resource_path, "audiobooks.opds")).read()
+        self.content_server_feed = self.sample_opds("content_server.opds")
+        self.content_server_mini_feed = self.sample_opds("content_server_mini.opds")
+        self.audiobooks_opds = self.sample_opds("audiobooks.opds")
         self._default_collection.external_integration.setting('data_source').value = (
             DataSource.OA_CONTENT_SERVER
         )
@@ -724,9 +719,7 @@ class TestOPDSImporter(OPDSImporterTest):
     def test_extract_metadata_from_elementtree_treats_message_as_failure(self):
         data_source = DataSource.lookup(self._db, DataSource.OA_CONTENT_SERVER)
 
-        feed = open(
-            os.path.join(self.resource_path, "unrecognized_identifier.opds")
-        ).read()
+        feed = self.sample_opds("unrecognized_identifier.opds")
         values, failures = OPDSImporter.extract_metadata_from_elementtree(
             feed, data_source
         )
@@ -744,9 +737,7 @@ class TestOPDSImporter(OPDSImporterTest):
 
     def test_extract_messages(self):
         parser = OPDSXMLParser()
-        feed = open(
-            os.path.join(self.resource_path, "unrecognized_identifier.opds")
-        ).read()
+        feed = self.sample_opds("unrecognized_identifier.opds")
         root = etree.parse(StringIO(feed))
         [message] = OPDSImporter.extract_messages(parser, root)
         eq_('urn:librarysimplified.org/terms/id/Gutenberg ID/100', message.urn)
@@ -1143,8 +1134,7 @@ class TestOPDSImporter(OPDSImporterTest):
         that comes from a second previously unknown data source. The
         book is imported and both DataSources are created.
         """
-        feed = open(
-            os.path.join(self.resource_path, "unrecognized_distributor.opds")).read()
+        feed = self.sample_opds("unrecognized_distributor.opds")
         self._default_collection.external_integration.setting('data_source').value = (
             "some new source"
         )
@@ -1173,8 +1163,7 @@ class TestOPDSImporter(OPDSImporterTest):
 
     def test_import_updates_metadata(self):
 
-        path = os.path.join(self.resource_path, "metadata_wrangler_overdrive.opds")
-        feed = open(path).read()
+        feed = self.sample_opds("metadata_wrangler_overdrive.opds")
 
         edition, is_new = self._edition(
             DataSource.OVERDRIVE, Identifier.OVERDRIVE_ID,
@@ -1257,8 +1246,7 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(DataSource.OA_CONTENT_SERVER, crow_pool.data_source.name)
 
     def test_import_from_feed_treats_message_as_failure(self):
-        path = os.path.join(self.resource_path, "unrecognized_identifier.opds")
-        feed = open(path).read()
+        feed = self.sample_opds("unrecognized_identifier.opds")
         imported_editions, imported_pools, imported_works, failures = (
             OPDSImporter(
                 self._db, collection=self._default_collection
@@ -1365,8 +1353,7 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_(None, i2.thumbnail)
 
     def test_import_book_that_offers_no_license(self):
-        path = os.path.join(self.resource_path, "book_without_license.opds")
-        feed = open(path).read()
+        feed = self.sample_opds("book_without_license.opds")
         importer = OPDSImporter(self._db, self._default_collection)
         imported_editions, imported_pools, imported_works, failures = (
             importer.import_from_feed(feed)

--- a/tests/test_selftest.py
+++ b/tests/test_selftest.py
@@ -20,7 +20,7 @@ from ..selftest import (
 
 from ..util.http import IntegrationException
 
-class TestSelfTestResult(object):
+class TestSelfTestResult(DatabaseTest):
 
     now = datetime.datetime.utcnow()
     future = now + datetime.timedelta(seconds=5)
@@ -40,12 +40,21 @@ class TestSelfTestResult(object):
             repr(result)
         )
 
+        # A SelfTestResult may have an associated Collection.
+        self._default_collection.name = "CollectionA"
+        result.collection = self._default_collection
+        eq_(
+            "<SelfTestResult: name='success1' collection='CollectionA' duration=5.00sec success=True result='The result'>",
+            repr(result)
+        )
+
         d = result.to_dict
         eq_("success1", d['name'])
         eq_("The result", d['result'])
         eq_(5.0, d['duration'])
         eq_(True, d['success'])
         eq_(None, d['exception'])
+        eq_('CollectionA', d['collection'])
 
         # A test result can be either a string (which will be displayed
         # in a fixed-width font) or a list of strings (which will be hidden

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -32,6 +32,7 @@ class AtomFeed(object):
     SCHEMA_NS = 'http://schema.org/'
     DRM_NS = 'http://librarysimplified.org/terms/drm'
     OPF_NS = 'http://www.idpf.org/2007/opf'
+    OPENSEARCH_NS = 'http://a9.com/-/spec/opensearch/1.1/'
 
     SIMPLIFIED_NS = "http://librarysimplified.org/terms/"
     BIBFRAME_NS = "http://bibframe.org/vocab/"
@@ -47,7 +48,8 @@ class AtomFeed(object):
         'schema' : SCHEMA_NS,
         'simplified' : SIMPLIFIED_NS,
         'bibframe' : BIBFRAME_NS,
-        'bib': BIB_SCHEMA_NS
+        'bib': BIB_SCHEMA_NS,
+        'opensearch': OPENSEARCH_NS,
     }
 
     default_typemap = {datetime: lambda e, v: _strftime(v)}


### PR DESCRIPTION
This branch implements https://jira.nypl.org/browse/SIMPLY-2421, the first stage of https://jira.nypl.org/browse/SIMPLY-2230.

Calling run_self_tests will check every appropriate collection on the circulation manager against the corresponding collection on the metadata wrangler. Two tests are run for each collection:

1. How many metadata updates were there for items in this collection in the past 24 hours?
2. Is the metadata wrangler waiting for any information (e.g. book covers) on this collection that the circulation manager could provide but hasn't?

In each case, the test is run by making a request to the metadata wrangler that ought to return an OPDS feed in response. The feed is parsed and the list of titles is used as the `.result` of the `SelfTestResult` object.

If the metadata wrangler returns 5xx in response to the request (this is pretty common, especially for #2, which hasn't worked properly for a while), that is useful information that goes into the `.result`.

As part of this work, I changed `HasSelfTests` to accept a `.collection`. This lets us implement `MetadataWranglerOPDSLookup._run_self_tests` to yield a stream of SelfTestResults objects, the same as all other implementations, without losing track of which "past 24 hours" result came from which collection.

I noticed that even when everything is working, the self-test process can take a long time if there are a lot of collections. Not sure what we can do about this -- it's slow because there are a lot of potentially slow HTTP requests happening.

The tests here have a lot of "test method A by verifying that it calls method B, test method B by verifying that it calls method C". So you can visualize it, here's how the methods line up:

```
HasSelfTest.run_self_tests
 MetadataWranglerOPDSLookup._run_self_tests
  MetadataWranglerOPDSLookup._run_collection_self_tests (x number of collections)
   MetadataWranglerOPDSLookup._feed_self_test (2x)
    MetadataWranglerOPDSLookup._annotate_feed_response
```
