### PR TITLE
Make works_updated_since more like our other complex queries, and improve performance

### DIFF
--- a/model/collection.py
+++ b/model/collection.py
@@ -627,13 +627,14 @@ class Collection(Base, HasFullTableCache):
         return query
 
     def works_updated_since(self, _db, timestamp):
-        """Finds all works in a collection's catalog that have been updated
-           since the timestamp. Used in the metadata wrangler.
+        """Finds all LicensePools in a collection's catalog whose Works' OPDS
+        entries have been updated since the timestamp. Used by the
+        metadata wrangler.
 
-           :return: a Query that yields (Work, LicensePool,
-              Identifier) 3-tuples. This gives caller all the
-              information necessary to create full OPDS entries for
-              the works.
+           :return: a Query that yields LicensePools. The Work and
+              Identifier associated with each LicensePool have been
+              pre-loaded, giving the caller all the information
+              necessary to create full OPDS entries for the works.
         """
         opds_operation = WorkCoverageRecord.GENERATE_OPDS_OPERATION
         qu = _db.query(

--- a/model/collection.py
+++ b/model/collection.py
@@ -645,7 +645,8 @@ class Collection(Base, HasFullTableCache):
         ).join(
             Work.coverage_records,
         ).join(
-            Identifier.collections,
+            CollectionIdentifier,
+            Identifier.id==CollectionIdentifier.identifier_id
         )
         qu = qu.filter(
             WorkCoverageRecord.operation==opds_operation,
@@ -653,8 +654,8 @@ class Collection(Base, HasFullTableCache):
         )
         qu = qu.options(
             contains_eager(LicensePool.work),
+            contains_eager(LicensePool.identifier),
         )
-        qu = qu.options(contains_eager(LicensePool.identifier))
 
         if timestamp:
             qu = qu.filter(

--- a/model/collection.py
+++ b/model/collection.py
@@ -631,10 +631,13 @@ class Collection(Base, HasFullTableCache):
         entries have been updated since the timestamp. Used by the
         metadata wrangler.
 
-           :return: a Query that yields LicensePools. The Work and
-              Identifier associated with each LicensePool have been
-              pre-loaded, giving the caller all the information
-              necessary to create full OPDS entries for the works.
+        :param _db: A database connection,
+        :param timestamp: A datetime.timestamp object
+
+        :return: a Query that yields LicensePools. The Work and
+           Identifier associated with each LicensePool have been
+           pre-loaded, giving the caller all the information
+           necessary to create full OPDS entries for the works.
         """
         opds_operation = WorkCoverageRecord.GENERATE_OPDS_OPERATION
         qu = _db.query(

--- a/model/collection.py
+++ b/model/collection.py
@@ -46,7 +46,6 @@ from sqlalchemy.orm import (
     backref,
     contains_eager,
     joinedload,
-    lazyload,
     mapper,
     relationship,
 )

--- a/model/collection.py
+++ b/model/collection.py
@@ -626,7 +626,7 @@ class Collection(Base, HasFullTableCache):
 
         return query
 
-    def works_updated_since(self, _db, timestamp):
+    def licensepools_with_works_updated_since(self, _db, timestamp):
         """Finds all LicensePools in a collection's catalog whose Works' OPDS
         entries have been updated since the timestamp. Used by the
         metadata wrangler.

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -571,14 +571,18 @@ class TestCollection(DatabaseTest):
         # Only the failing identifier is in the query.
         eq_([unresolved_id], result.all())
 
-    def test_works_updated_since(self):
+    def test_licensepools_with_works_updated_since(self):
+        m = self.collection.licensepools_with_works_updated_since
+
+        # Verify our ability to find LicensePools with works whose
+        # OPDS entries were updated since a given time.
         w1 = self._work(with_license_pool=True)
         w2 = self._work(with_license_pool=True)
         w3 = self._work(with_license_pool=True)
 
         # An empty catalog returns nothing.
         timestamp = datetime.datetime.utcnow()
-        eq_([], self.collection.works_updated_since(self._db, timestamp).all())
+        eq_([], m(self._db, timestamp).all())
 
         self.collection.catalog_identifier(w1.license_pools[0].identifier)
         self.collection.catalog_identifier(w2.license_pools[0].identifier)
@@ -595,7 +599,7 @@ class TestCollection(DatabaseTest):
         # When no timestamp is passed, all LicensePeols in the catalog
         # are returned, in order of the WorkCoverageRecord
         # timestamp on the associated Work.
-        lp1, lp2 = self.collection.works_updated_since(self._db, None).all()
+        lp1, lp2 = m(self._db, None).all()
         eq_(w1, lp1.work)
         eq_(w2, lp2.work)
 
@@ -607,12 +611,7 @@ class TestCollection(DatabaseTest):
         ]
         w1_coverage_record.timestamp = datetime.datetime.utcnow()
         eq_(
-            [w1],
-            [
-                x.work for x in self.collection.works_updated_since(
-                    self._db, timestamp
-                )
-            ]
+            [w1], [x.work for x in m(self._db, timestamp)]
         )
 
     def test_isbns_updated_since(self):

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -592,30 +592,28 @@ class TestCollection(DatabaseTest):
             in_other_catalog.license_pools[0].identifier
         )
 
-        # When no timestamp is passed, all works in the catalog are returned.
-        # in order of their WorkCoverageRecord timestamp.
-        t1, t2 = self.collection.works_updated_since(self._db, None).all()
-        eq_(w1, t1[0])
-        eq_(w2, t2[0])
+        # When no timestamp is passed, all LicensePeols in the catalog
+        # are returned, in order of the WorkCoverageRecord
+        # timestamp on the associated Work.
+        lp1, lp2 = self.collection.works_updated_since(self._db, None).all()
+        eq_(w1, lp1.work)
+        eq_(w2, lp2.work)
 
-        # The return value is a sequence of 5-tuples, each containing
-        # (Work, LicensePool, Identifier, WorkCoverageRecord,
-        # CollectionIdentifier). This gives the caller all the information
-        # necessary to understand the path by which a given Work belongs to
-        # a given Collection.
-        _w1, lp1, i1 = t1
-        [pool] = w1.license_pools
-        eq_(pool, lp1)
-        eq_(pool.identifier, i1)
-
-        # When a timestamp is passed, only works that have been updated
-        # since then will be returned
+        # When a timestamp is passed, only LicensePools whose works
+        # have been updated since then will be returned.
         [w1_coverage_record] = [
             c for c in w1.coverage_records
             if c.operation == WorkCoverageRecord.GENERATE_OPDS_OPERATION
         ]
         w1_coverage_record.timestamp = datetime.datetime.utcnow()
-        eq_([w1], [x[0] for x in self.collection.works_updated_since(self._db, timestamp)])
+        eq_(
+            [w1],
+            [
+                x.work for x in self.collection.works_updated_since(
+                    self._db, timestamp
+                )
+            ]
+        )
 
     def test_isbns_updated_since(self):
         i1 = self._identifier(identifier_type=Identifier.ISBN, foreign_id=self._isbn)


### PR DESCRIPTION
This branch is the core part of the fix to https://jira.nypl.org/browse/SIMPLY-2427.

Previously, works_updated_since was returning 3-tuples of (Work, LicensePool, Identifier) objects, which isn't generally how we do this kind of query. I changed it to return LicensePool objects with the Work and Identifier pre-loaded. This let me apply the "Work and Identifier objects are pre-loaded" optimization using `contains_eager`, dramatically improving performance. Previously we were using `joinedload`, which I think was incorrect -- it makes the database do _more_ work.