### PR TITLE
Updating the URNLookupController to URNLookupHandler.

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -266,8 +266,15 @@ class HeartbeatController(object):
 
 
 class URNLookupController(object):
+    """A controller for looking up OPDS entries for specific books,
+    identified in terms of their Identifier URNs.
+    """
 
     def __init__(self, _db):
+        """Constructor.
+
+        :param _db: A database connection.
+        """
         self._db = _db
 
     def work_lookup(self, annotator, route_name='lookup', **process_urn_kwargs):
@@ -286,16 +293,27 @@ class URNLookupController(object):
             precomposed_entries=handler.precomposed_entries,
         )
         return feed_response(opds_feed)
-    
+
     def process_urns(self, urns, **process_urn_kwargs):
+        """Process a number of URNs by instantiating a URNLookupHandler
+        and having it do the work.
+
+        The information gathered by the URNLookupHandler can be used
+        by the caller to generate an OPDS feed.
+
+        :return: A URNLookupHandler, or a ProblemDetail if
+            there's a problem with the request.
+        """
         handler = URNLookupHandler(self._db)
         handler.process_urns(urns, **process_urn_kwargs)
         return handler
 
     def permalink(self, urn, annotator, route_name='work'):
+        """Look up a single identifier and generate an OPDS feed.
+
+        TODO: This method is tested, but it might not be used and it
+        may be possible to remove it.
         """
-        TODO: Check if this method is being used.
-        Look up a single identifier and generate an OPDS feed."""
         handler = URNLookupHandler(self._db)
         this_url = cdn_url_for(route_name, _external=True, urn=urn)
         handler.process_urns([urn])
@@ -352,7 +370,7 @@ class URNLookupHandler(object):
         """Turn a URN into a Work suitable for use in an OPDS feed.
         """
         if not identifier.licensed_through:
-            # The default URNLookupController cannot look up an
+            # The default URNLookupHandler cannot look up an
             # Identifier that has no associated LicensePool.
             return self.add_message(urn, 404, self.UNRECOGNIZED_IDENTIFIER)
 
@@ -382,14 +400,13 @@ class URNLookupHandler(object):
         self.precomposed_entries.append(
             OPDSMessage(urn, status_code, message)
         )
-    
+
     def post_lookup_hook(self):
         """Run after looking up a number of Identifiers.
 
         By default, does nothing.
         """
         pass
-
 
 
 class ComplaintController(object):

--- a/app_server.py
+++ b/app_server.py
@@ -311,8 +311,8 @@ class URNLookupController(object):
     def permalink(self, urn, annotator, route_name='work'):
         """Look up a single identifier and generate an OPDS feed.
 
-        TODO: This method is tested, but it might not be used and it
-        may be possible to remove it.
+        TODO: This method is tested, but it seems unused and it
+        should be possible to remove it.
         """
         handler = URNLookupHandler(self._db)
         this_url = cdn_url_for(route_name, _external=True, urn=urn)

--- a/app_server.py
+++ b/app_server.py
@@ -299,7 +299,6 @@ class URNLookupController(object):
         handler = URNLookupHandler(self._db)
         this_url = cdn_url_for(route_name, _external=True, urn=urn)
         handler.process_urns([urn])
-        self.post_lookup_hook()
 
         # A LookupAcquisitionFeed's .works is a list of (identifier,
         # work) tuples, but an AcquisitionFeed's .works is just a
@@ -340,6 +339,7 @@ class URNLookupHandler(object):
 
         for urn, identifier in identifiers_by_urn.items():
             self.process_identifier(identifier, urn, **process_urn_kwargs)
+        self.post_lookup_hook()
 
     def add_urn_failure_messages(self, failures):
         for urn in failures:

--- a/app_server.py
+++ b/app_server.py
@@ -313,8 +313,11 @@ class URNLookupController(object):
 
 
 class URNLookupHandler(object):
-    """A generic controller that takes URNs as input and looks up their
-    OPDS entries.
+    """A helper for URNLookupController that takes URNs as input and looks
+    up their OPDS entries.
+
+    This is a separate class from URNLookupController because
+    URNLookupController is designed to not keep state.
     """
 
     UNRECOGNIZED_IDENTIFIER = "This work is not in the collection."

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -117,6 +117,16 @@ class TestURNLookupHandler(DatabaseTest):
         eq_(code, obj.status_code)
         eq_(message, obj.message)
         eq_([], self.handler.works)
+
+    def test_process_urns_hook_method(self):
+        # Verify that process_urns() calls post_lookup_hook() once
+        # it's done.
+        class Mock(URNLookupHandler):
+            def post_lookup_hook(self):
+                self.called = True
+        handler = Mock(self._db)
+        handler.process_urns([])
+        eq_(True, handler.called)
     
     def test_process_urns_invalid_urn(self):
         urn = "not even a URN"


### PR DESCRIPTION
This is a collaboration between @EdwinGuzman and myself to fix https://jira.nypl.org/browse/SIMPLY-2432.

All code in `URNLookupController` that keeps state is split out into a new class, `URNLookupHandler`. The controller code performs pre-request processing, instantiates a `URNLookupHandler` (a new one on every request), and uses the state stored in _that_ object to generate an OPDS feed.

The behavior is the same as before, but we've added test cases for a couple small bits of untested code, and a test that verifies that SIMPLY-2432 has been fixed.

This branch requires minor changes to the circulation branch and medium-sized refactoring in the metadata branch (which is where the main problem is happening). Those PRs are forthcoming.