### PR TITLE
Not raising a ValueError if a language code does not have any name.

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -87,7 +87,10 @@ class TestLanguageCodes(object):
         eq_(u"English/español", m(["eng", "spa"]))
         eq_(u"español/English", m("spa,eng"))
         eq_(u"español/English/Chinese", m(["spa","eng","chi"]))
-        assert_raises(ValueError(m, ["eng, nxx"]))
+        # Ignore any codes that don't have a name,
+        # but return the languages found
+        eq_(u"English", m(["eng", "nxx"]))
+        eq_(u"English/español", m("eng,nxx,spa"))
 
 class DummyAuthor(object):
 

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -649,6 +649,7 @@ zza|||Zaza; Dimili; Dimli; Kirdki; Kirmanjki; Zazaki|zaza; dimili; dimli; kirdki
 
     @classmethod
     def name_for_languageset(cls, languages):
+        """Attempt to find any name for a language code."""
         if isinstance(languages, basestring):
             languages = languages.split(",")
         all_names = []
@@ -661,9 +662,8 @@ zza|||Zaza; Dimili; Dimli; Kirdki; Kirmanjki; Zazaki|zaza; dimili; dimli; kirdki
                 all_names.append(native_names[0])
             else:
                 names = cls.english_names.get(normalized, [])
-                if not names:
-                    raise ValueError("No native or English name for %s" % l)
-                all_names.append(names[0])
+                if names:
+                    all_names.append(names[0])
         if len(all_names) == 1:
             return all_names[0]
         return "/".join(all_names)


### PR DESCRIPTION
Resolves [SIMPLY-458](https://jira.nypl.org/browse/SIMPLY-458). Instead of raising a ValueError for a language code that has no name, just skip over it.