### PR TITLE
Closer summaries are better

### DIFF
--- a/model/work.py
+++ b/model/work.py
@@ -1028,8 +1028,9 @@ class Work(Base):
             Work. Summaries associated with these IDs will be
             used only if none are found from direct_identifier_ids.
 
-        :param licensed_data_sources: A list of DataSources that provide
-            LicensePools
+        :param licensed_data_sources: A list of DataSources that should be
+            given priority -- either because they provided the books or because
+            they are trusted sources such as library staff.
         """
         _db = Session.object_session(self)
         staff_data_source = DataSource.lookup(

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -429,7 +429,7 @@ class TestWork(DatabaseTest):
         source2 = DataSource.lookup(self._db, DataSource.BIBLIOTHECA)
 
         i1 = self._identifier()
-        i1.add_link(
+        l1, ignore = i1.add_link(
             Hyperlink.DESCRIPTION, None, source1,
             content="ok summary"
         )
@@ -471,6 +471,14 @@ class TestWork(DatabaseTest):
         source3 = DataSource.lookup(self._db, DataSource.AXIS_360)
         m([i1.id], [], [source3])
         eq_(good_summary, w.summary_text)
+
+        # LIBRARY_STAFF is always considered a good source of
+        # descriptions.
+        l1.data_source = DataSource.lookup(
+            self._db, DataSource.LIBRARY_STAFF
+        )
+        m([i1.id, i2.id], [], [])
+        eq_(l1.resource.representation.content, w.summary_text)
 
     def test_set_presentation_ready(self):
 

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -82,8 +82,20 @@ class TestWork(DatabaseTest):
 
         all_identifier_ids = work.all_identifier_ids()
         eq_(3, len(all_identifier_ids))
-        eq_(set([lp.identifier.id, lp2.identifier.id, identifier.id]),
-            set(all_identifier_ids))
+        expect_all_ids = set(
+            [lp.identifier.id, lp2.identifier.id, identifier.id]
+        )
+
+        eq_(expect_all_ids, all_identifier_ids)
+
+        # If we don't ask for a unified list, we get two lists.  The
+        # first list contains IDs for Identifiers directly associated
+        # with the Work's LicensePools. The second list contains
+        # _all_ relevant IDs.
+        direct_ids, all_ids = work.all_identifier_ids(unified=False)
+        eq_(set([x.identifier.id for x in work.license_pools]),
+            set(direct_ids))
+        eq_(expect_all_ids, all_ids)
 
     def test_from_identifiers(self):
         # Prep a work to be identified and a work to be ignored.

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -89,15 +89,6 @@ class TestWork(DatabaseTest):
 
         eq_(expect_all_ids, all_identifier_ids)
 
-        # The default is to get one unified list of Identifier IDs,
-        # but we can instead get a list and a set. The list contains
-        # IDs for Identifiers directly associated with the Work's
-        # LicensePools. The set contains _all_ relevant IDs.
-        direct_ids, all_ids = work.all_identifier_ids(unified=False)
-        eq_(set([x.identifier.id for x in work.license_pools]),
-            set(direct_ids))
-        eq_(expect_all_ids, all_ids)
-
     def test_from_identifiers(self):
         # Prep a work to be identified and a work to be ignored.
         work = self._work(with_license_pool=True, with_open_access_download=True)


### PR DESCRIPTION
This branch breaks into two stages the procedure for choosing a summary for a work. First, summaries associated with an Identifier that is associated with one of the Work's LicensePools are considered. Second, summaries associated with Identifiers equivalent to those original Identifiers are considered. If nothing works, the Work's summary is cleared out.

This doesn't resolve https://jira.nypl.org/browse/SIMPLY-1696 as described, but it solves the most common real-world problem (which I think is exemplified by https://jira.nypl.org/browse/SIMPLY-1891). It's possible for a nice-looking (to a computer) summary to be chosen for a work, even if it has obvious (to a human) problems such as being in a different language. By checking descriptions close to the work first, we ensure that the two most common sources of good descriptions -- library staff and ebook vendors -- are always considered first.

We've had cases where the ebook vendor doesn't provide a description and we have to fill it in from elsewhere (in which case the second stage of this algorithm will run), but all commercial vendors currently provide decent descriptions, and the only case where the book vendor provides _bad_ descriptions is Project Gutenberg. That case can trip up this new algorithm, but we don't have Gutenberg titles in our system anymore, so I don't think it's a big deal.
