### PR TITLE
Add new audiences

### DIFF
--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -1294,6 +1294,8 @@ class WorkClassifier(object):
         ya_weight = w.get(Classifier.AUDIENCE_YOUNG_ADULT, 0)
         adult_weight = w.get(Classifier.AUDIENCE_ADULT, 0)
         adults_only_weight = w.get(Classifier.AUDIENCE_ADULTS_ONLY, 0)
+        all_ages_weight = w.get(Classifier.AUDIENCE_ALL_AGES, 0)
+        research_weight = w.get(Classifier.AUDIENCE_RESEARCH, 0)
 
         total_adult_weight = adult_weight + adults_only_weight
         total_weight = sum(w.values())
@@ -1323,6 +1325,10 @@ class WorkClassifier(object):
             audience = Classifier.AUDIENCE_YOUNG_ADULT
         elif total_adult_weight > 0:
             audience = Classifier.AUDIENCE_ADULT
+        elif all_ages_weight > 0:
+            audience = Classifier.AUDIENCE_ALL_AGES
+        elif research_weight > 0:
+            audience = Classifier.AUDIENCE_RESEARCH
 
         # If the 'adults only' weight is more than 1/4 of the total adult
         # weight, classify as 'adults only' to be safe.

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -250,7 +250,7 @@ class Classifier(object):
             # likely the data is simply missing.
             return None
         if not lower:
-            if upper >= cls.AUDIENCE_ADULT:
+            if upper >= cls.AUDIENCE_ADULT_AGE_CUTOFF:
                 # e.g. "up to 20 years", though this doesn't
                 # really make sense.
                 #

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -1314,7 +1314,11 @@ class WorkClassifier(object):
         # If the 'children' weight passes the threshold on its own
         # we go with 'children'.
         total_juvenile_weight = children_weight + ya_weight
-        if children_weight > threshold and children_weight > ya_weight:
+        if (research_weight > (total_adult_weight + all_ages_weight) and
+            research_weight > (total_juvenile_weight + all_ages_weight) and
+            research_weight > threshold):
+            audience = Classifier.AUDIENCE_RESEARCH
+        elif children_weight > threshold and children_weight > ya_weight:
             audience = Classifier.AUDIENCE_CHILDREN
         elif ya_weight > threshold:
             audience = Classifier.AUDIENCE_YOUNG_ADULT
@@ -1323,9 +1327,6 @@ class WorkClassifier(object):
             # combined they do pass the threshold. Go with
             # 'Young Adult' to be safe.
             audience = Classifier.AUDIENCE_YOUNG_ADULT
-        elif (research_weight > (total_adult_weight + all_ages_weight) and
-            research_weight > (total_juvenile_weight + all_ages_weight)):
-            audience = Classifier.AUDIENCE_RESEARCH
         elif (all_ages_weight > total_adult_weight and
             all_ages_weight > total_juvenile_weight):
             audience = Classifier.AUDIENCE_ALL_AGES

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -1318,6 +1318,9 @@ class WorkClassifier(object):
             research_weight > (total_juvenile_weight + all_ages_weight) and
             research_weight > threshold):
             audience = Classifier.AUDIENCE_RESEARCH
+        elif (all_ages_weight > total_adult_weight and
+            all_ages_weight > total_juvenile_weight):
+            audience = Classifier.AUDIENCE_ALL_AGES
         elif children_weight > threshold and children_weight > ya_weight:
             audience = Classifier.AUDIENCE_CHILDREN
         elif ya_weight > threshold:
@@ -1327,9 +1330,6 @@ class WorkClassifier(object):
             # combined they do pass the threshold. Go with
             # 'Young Adult' to be safe.
             audience = Classifier.AUDIENCE_YOUNG_ADULT
-        elif (all_ages_weight > total_adult_weight and
-            all_ages_weight > total_juvenile_weight):
-            audience = Classifier.AUDIENCE_ALL_AGES
         elif total_adult_weight > 0:
             audience = Classifier.AUDIENCE_ADULT
 

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -1323,12 +1323,14 @@ class WorkClassifier(object):
             # combined they do pass the threshold. Go with
             # 'Young Adult' to be safe.
             audience = Classifier.AUDIENCE_YOUNG_ADULT
+        elif (research_weight > (total_adult_weight + all_ages_weight) and
+            research_weight > (total_juvenile_weight + all_ages_weight)):
+            audience = Classifier.AUDIENCE_RESEARCH
+        elif (all_ages_weight > total_adult_weight and
+            all_ages_weight > total_juvenile_weight):
+            audience = Classifier.AUDIENCE_ALL_AGES
         elif total_adult_weight > 0:
             audience = Classifier.AUDIENCE_ADULT
-        elif all_ages_weight > 0:
-            audience = Classifier.AUDIENCE_ALL_AGES
-        elif research_weight > 0:
-            audience = Classifier.AUDIENCE_RESEARCH
 
         # If the 'adults only' weight is more than 1/4 of the total adult
         # weight, classify as 'adults only' to be safe.

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -74,6 +74,8 @@ class Classifier(object):
     AUDIENCE_ADULTS_ONLY = "Adults Only"
     AUDIENCE_YOUNG_ADULT = "Young Adult"
     AUDIENCE_CHILDREN = "Children"
+    AUDIENCE_ALL_AGES = "All Ages"
+    AUDIENCE_RESEARCH = "Research"
 
     # A book for a child younger than 14 is a children's book.
     # A book for a child 14 or older is a young adult book.
@@ -81,10 +83,17 @@ class Classifier(object):
 
     ADULT_AGE_CUTOFF = 18
 
-    AUDIENCES_JUVENILE = [AUDIENCE_CHILDREN, AUDIENCE_YOUNG_ADULT]
-    AUDIENCES_ADULT = [AUDIENCE_ADULT, AUDIENCE_ADULTS_ONLY]
+    # "All ages" actually means "all ages with reading fluency".
+    ALL_AGES_AGE_CUTOFF = 8
+
+    AUDIENCES_JUVENILE = [AUDIENCE_CHILDREN, AUDIENCE_YOUNG_ADULT,
+                          AUDIENCE_ALL_AGES]
+    AUDIENCES_ADULT = [AUDIENCE_ADULT, AUDIENCE_ADULTS_ONLY, AUDIENCE_ALL_AGES]
     AUDIENCES = set([AUDIENCE_ADULT, AUDIENCE_ADULTS_ONLY, AUDIENCE_YOUNG_ADULT,
-                     AUDIENCE_CHILDREN])
+                     AUDIENCE_CHILDREN, AUDIENCE_ALL_AGES, AUDIENCE_RESEARCH])
+    AUDIENCES_NO_RESEARCH = [
+        x for x in AUDIENCES if x != AUDIENCE_RESEARCH
+    ]
 
     SIMPLIFIED_GENRE = "http://librarysimplified.org/terms/genres/Simplified/"
     SIMPLIFIED_FICTION_STATUS = "http://librarysimplified.org/terms/fiction/"
@@ -237,11 +246,17 @@ class Classifier(object):
         lower = range[0]
         upper = range[1]
         if not lower and not upper:
+            # You could interpret this as 'all ages' but it's more
+            # likely the data is simply missing.
             return None
         if not lower:
-            if upper > 18:
-                # e.g. "up to 20 years", though that doesn't
-                # make much sense.
+            if upper >= cls.AUDIENCE_ADULT:
+                # e.g. "up to 20 years", though this doesn't
+                # really make sense.
+                #
+                # The 'all ages' interpretation is more plausible here
+                # but it's still more likely that this is simply a
+                # book for grown-ups and no lower bound was provided.
                 return cls.AUDIENCE_ADULT
             elif upper > cls.YOUNG_ADULT_AGE_CUTOFF:
                 # e.g. "up to 15 years"
@@ -255,6 +270,12 @@ class Classifier(object):
             return cls.AUDIENCE_ADULT
         elif lower >= cls.YOUNG_ADULT_AGE_CUTOFF:
             return cls.AUDIENCE_YOUNG_ADULT
+        elif lower <= cls.ALL_AGES_CUTOFF and (
+            upper is not None and upper >= cls.ADULT_CUTOFF
+        ):
+            # e.g. "for children ages 7-77". The 'all ages' reading
+            # is here the most plausible.
+            return cls.AUDIENCE_ALL_AGES
         elif lower >= 12 and (not upper or upper >= cls.YOUNG_ADULT_AGE_CUTOFF):
             # Although we treat "Young Adult" as starting at 14, many
             # outside sources treat it as starting at 12. As such we
@@ -479,6 +500,7 @@ class AgeClassifier(Classifier):
 
     @classmethod
     def audience(cls, identifier, name, require_explicit_age_marker=False):
+
         target_age = cls.target_age(identifier, name, require_explicit_age_marker)
         return cls.default_audience_for_target_age(target_age)
 
@@ -522,6 +544,7 @@ class AgeClassifier(Classifier):
                     if young > old:
                         young, old = old, young
                     return cls.range_tuple(young, old)
+
         return cls.range_tuple(None, None)
 
     @classmethod
@@ -865,6 +888,12 @@ class AgeOrGradeClassifier(Classifier):
         return age
 
 class FreeformAudienceClassifier(AgeOrGradeClassifier):
+    # NOTE: In practice, subjects like "books for all ages" tend to be
+    # more like advertising slogans than reliable indicators of an
+    # ALL_AGES audience. So the only subject of this type we handle is
+    # the literal string "all ages", as it would appear, e.g., in the
+    # output of the metadata wrangler.
+
     @classmethod
     def audience(cls, identifier, name):
         if identifier in ('children', 'pre-adolescent', 'beginning reader'):
@@ -876,6 +905,8 @@ class FreeformAudienceClassifier(AgeOrGradeClassifier):
             return cls.AUDIENCE_ADULT
         elif identifier == 'adults only':
             return cls.AUDIENCE_ADULTS_ONLY
+        elif identifier == 'all ages':
+            return cls.AUDIENCE_ALL_AGES
         return AgeOrGradeClassifier.audience(identifier, name)
 
     @classmethod
@@ -886,7 +917,10 @@ class FreeformAudienceClassifier(AgeOrGradeClassifier):
             return cls.range_tuple(9, 12)
         if identifier == 'early adolescents':
             return cls.range_tuple(13, 15)
-
+        if identifier == 'all ages':
+            return cls.range_tuple(
+                cls.ALL_AGES_AGE_CUTOFF, cls.ADULT_AGE_CUTOFF
+            )
         strict_age = AgeClassifier.target_age(identifier, name, True)
         if strict_age[0] or strict_age[1]:
             return strict_age
@@ -1068,7 +1102,11 @@ class WorkClassifier(object):
                     self.audience_weights[Classifier.AUDIENCE_YOUNG_ADULT] += (weight * 0.6)
                     self.audience_weights[Classifier.AUDIENCE_CHILDREN] += (weight * 0.4)
                     for audience in Classifier.AUDIENCES_ADULT:
-                        self.audience_weights[audience] -= weight * 0.5
+                        if audience != Classifier.ALL_AGES:
+                            # 'All Ages' is considered an adult audience,
+                            # but a generic 'juvenile' classification
+                            # is not evidence against it.
+                            self.audience_weights[audience] -= weight * 0.5
                 else:
                     self.audience_weights[subject.audience] += weight
 

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -270,8 +270,8 @@ class Classifier(object):
             return cls.AUDIENCE_ADULT
         elif lower >= cls.YOUNG_ADULT_AGE_CUTOFF:
             return cls.AUDIENCE_YOUNG_ADULT
-        elif lower <= cls.ALL_AGES_CUTOFF and (
-            upper is not None and upper >= cls.ADULT_CUTOFF
+        elif lower <= cls.ALL_AGES_AGE_CUTOFF and (
+            upper is not None and upper >= cls.ADULT_AGE_CUTOFF
         ):
             # e.g. "for children ages 7-77". The 'all ages' reading
             # is here the most plausible.
@@ -1102,7 +1102,7 @@ class WorkClassifier(object):
                     self.audience_weights[Classifier.AUDIENCE_YOUNG_ADULT] += (weight * 0.6)
                     self.audience_weights[Classifier.AUDIENCE_CHILDREN] += (weight * 0.4)
                     for audience in Classifier.AUDIENCES_ADULT:
-                        if audience != Classifier.ALL_AGES:
+                        if audience != Classifier.AUDIENCE_ALL_AGES:
                             # 'All Ages' is considered an adult audience,
                             # but a generic 'juvenile' classification
                             # is not evidence against it.

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -250,7 +250,7 @@ class Classifier(object):
             # likely the data is simply missing.
             return None
         if not lower:
-            if upper >= cls.AUDIENCE_ADULT_AGE_CUTOFF:
+            if upper >= cls.ADULT_AGE_CUTOFF:
                 # e.g. "up to 20 years", though this doesn't
                 # really make sense.
                 #

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -907,6 +907,8 @@ class FreeformAudienceClassifier(AgeOrGradeClassifier):
             return cls.AUDIENCE_ADULTS_ONLY
         elif identifier == 'all ages':
             return cls.AUDIENCE_ALL_AGES
+        elif identifier == 'research':
+            return cls.AUDIENCE_RESEARCH
         return AgeOrGradeClassifier.audience(identifier, name)
 
     @classmethod

--- a/external_search.py
+++ b/external_search.py
@@ -42,6 +42,7 @@ from classifier import (
     KeywordBasedClassifier,
     GradeLevelClassifier,
     AgeClassifier,
+    Classifier,
 )
 from facets import FacetConstants
 from metadata_layer import IdentifierData
@@ -2339,6 +2340,11 @@ class Filter(SearchBase):
         probably also include the 'All Ages' audience, and it may exclude
         the 'Research' audience.
         """
+
+        as_is = self._audiences
+        if isinstance(as_is, basestring):
+            as_is = [as_is]
+
         if not as_is:
             # An empty list of audiences means every audience _except_
             # for RESEARCH. RESEARCH must be explicitly specified to
@@ -2348,23 +2354,22 @@ class Filter(SearchBase):
         # At this point we know we have a specific list of audiences.
         # We're either going to return that list as-is, or we'll
         # return that list plus ALL_AGES.
-        as_is = self._audiences
-        with_all_ages = as_is + [all_ages]
+        with_all_ages = as_is + [Classifier.AUDIENCE_ALL_AGES]
 
-        if all_ages in as_is:
+        if Classifier.AUDIENCE_ALL_AGES in as_is:
             # ALL_AGES is explicitly included.
             return as_is
 
         # If YOUNG_ADULT or ADULT is an audience, then ALL_AGES is
         # always going to be an additional audience.
-        if any(x in as_is for x in [Classifier.YOUNG_ADULT_AUDIENCE,
-                                    Classifier.ADULT_AUDIENCE]):
+        if any(x in as_is for x in [Classifier.AUDIENCE_YOUNG_ADULT,
+                                    Classifier.AUDIENCE_ADULT]):
             return with_all_ages
 
         # At this point, if CHILDREN is _not_ included, we know that
         # ALL_AGES is not included. Specifically, ALL_AGES content
         # does _not_ belong in ADULTS_ONLY or RESEARCH.
-        if Classifier.CHILDREN_AUDIENCE not in as_is:
+        if Classifier.AUDIENCE_CHILDREN not in as_is:
             return as_is
 
         # Now we know that CHILDREN is an audience. It's going to come

--- a/external_search.py
+++ b/external_search.py
@@ -2337,8 +2337,7 @@ class Filter(SearchBase):
         """Return the appropriate audiences for this query.
 
         This will be whatever audiences were provided, but it will
-        probably also include the 'All Ages' audience, and it may exclude
-        the 'Research' audience.
+        probably also include the 'All Ages' audience.
         """
 
         if not self._audiences:

--- a/external_search.py
+++ b/external_search.py
@@ -2341,15 +2341,12 @@ class Filter(SearchBase):
         the 'Research' audience.
         """
 
+        if not self._audiences:
+            return self._audiences
+
         as_is = self._audiences
         if isinstance(as_is, basestring):
             as_is = [as_is]
-
-        if not as_is:
-            # An empty list of audiences means every audience _except_
-            # for RESEARCH. RESEARCH must be explicitly specified to
-            # be included in lists or search results.
-            return Classifier.AUDIENCES_NO_RESEARCH
 
         # At this point we know we have a specific list of audiences.
         # We're either going to return that list as-is, or we'll
@@ -2446,6 +2443,8 @@ class Filter(SearchBase):
 
         if self.audiences:
             f = chain(f, Terms(audience=scrub_list(self.audiences)))
+        else:
+            f = chain(f, Bool(must_not=[Term(audience=Classifier.AUDIENCE_RESEARCH)]))
 
         target_age_filter = self.target_age_filter
         if target_age_filter:

--- a/external_search.py
+++ b/external_search.py
@@ -2443,7 +2443,8 @@ class Filter(SearchBase):
         if self.audiences:
             f = chain(f, Terms(audience=scrub_list(self.audiences)))
         else:
-            f = chain(f, Bool(must_not=[Term(audience=Classifier.AUDIENCE_RESEARCH)]))
+            research = self._scrub(Classifier.AUDIENCE_RESEARCH)
+            f = chain(f, Bool(must_not=[Term(audience=research)]))
 
         target_age_filter = self.target_age_filter
         if target_age_filter:

--- a/migration/20200103-add-audiences.sql
+++ b/migration/20200103-add-audiences.sql
@@ -1,0 +1,2 @@
+alter type audience add value 'All Ages';
+alter type audience add value 'Research';

--- a/model/classification.py
+++ b/model/classification.py
@@ -118,7 +118,8 @@ class Subject(Base):
     # the book's audience.
     audience = Column(
         Enum("Adult", "Young Adult", "Children", "Adults Only",
-             name="audience"),
+            "All Ages", "Research",
+            name="audience"),
         default=None, index=True)
 
     # For children's books, the target age implied by this subject.

--- a/tests/classifiers/test_classifier.py
+++ b/tests/classifiers/test_classifier.py
@@ -564,8 +564,8 @@ class TestWorkClassifier(DatabaseTest):
             Classifier.AUDIENCE_ADULTS_ONLY : 30,
             Classifier.AUDIENCE_ALL_AGES : 10,
             Classifier.AUDIENCE_CHILDREN : 30,
-            Classifier.AUDIENCE_YOUNG_ADULT : 40,
-            Classifier.AUDIENCE_RESEARCH : 100,
+            Classifier.AUDIENCE_YOUNG_ADULT : 150,
+            Classifier.AUDIENCE_RESEARCH : 200,
         }
         eq_(Classifier.AUDIENCE_RESEARCH, self.classifier.audience())
 

--- a/tests/classifiers/test_classifier.py
+++ b/tests/classifiers/test_classifier.py
@@ -495,6 +495,7 @@ class TestWorkClassifier(DatabaseTest):
         # Now it's overwhelming. (the 'children' weight is more than twice
         # the combined 'adult' + 'adults only' weight.
         self.classifier.audience_weights[Classifier.AUDIENCE_CHILDREN] = 23
+        self.classifier.audience_weights[Classifier.AUDIENCE_ALL_AGES] = 40
         eq_(Classifier.AUDIENCE_CHILDREN, self.classifier.audience())
 
         # Now it's overwhelmingly likely to be a YA book.

--- a/tests/classifiers/test_classifier.py
+++ b/tests/classifiers/test_classifier.py
@@ -119,6 +119,7 @@ class TestClassifier(object):
 
         # All ages for audiences that are younger than the "all ages
         # age cutoff" and older than the "adult age cutoff".
+        aud(5, 18, Classifier.AUDIENCE_ALL_AGES)
         aud(5, 25, Classifier.AUDIENCE_ALL_AGES)
 
     def test_and_up(self):

--- a/tests/classifiers/test_classifier.py
+++ b/tests/classifiers/test_classifier.py
@@ -545,6 +545,17 @@ class TestWorkClassifier(DatabaseTest):
         }
         eq_(Classifier.AUDIENCE_ALL_AGES, self.classifier.audience())
 
+        # This works even if 'Children' looks much better than 'Adult'.
+        # 'All Ages' looks even better than that, so it wins.
+        self.classifier.audience_weights = {
+            Classifier.AUDIENCE_ADULT : 1,
+            Classifier.AUDIENCE_ADULTS_ONLY : 0,
+            Classifier.AUDIENCE_ALL_AGES : 1000,
+            Classifier.AUDIENCE_CHILDREN : 30,
+            Classifier.AUDIENCE_YOUNG_ADULT : 29,
+        }
+        eq_(Classifier.AUDIENCE_ALL_AGES, self.classifier.audience())
+
         # If the All Ages weight is smaller than the total adult weight,
         # the audience is adults.
         self.classifier.audience_weights = {

--- a/tests/classifiers/test_classifier.py
+++ b/tests/classifiers/test_classifier.py
@@ -438,8 +438,10 @@ class TestWorkClassifier(DatabaseTest):
         # The adult audiences have been reduced, to reduce the chance
         # that splitting up the weight between YA and Children will
         # cause the work to be mistakenly classified as Adult.
-        for aud in Classifier.AUDIENCES_ADULT:
-            eq_(-50, weights[aud])
+        eq_(-50, weights[Classifier.AUDIENCE_ADULT])
+        eq_(-50, weights[Classifier.AUDIENCE_ADULTS_ONLY])
+        # The juvenile classification doesn't make the all ages less likely.
+        eq_(0, weights[Classifier.AUDIENCE_ALL_AGES])
 
     def test_childrens_book_when_evidence_is_overwhelming(self):
         # There is some evidence in the 'adult' and 'adults only'

--- a/tests/classifiers/test_classifier.py
+++ b/tests/classifiers/test_classifier.py
@@ -278,6 +278,7 @@ class TestFreeformAudienceClassifier(DatabaseTest):
         eq_(audience('adult'), Classifier.AUDIENCE_ADULT)
         eq_(audience('adults only'), Classifier.AUDIENCE_ADULTS_ONLY)
         eq_(audience('all ages'), Classifier.AUDIENCE_ALL_AGES)
+        eq_(audience('research'), Classifier.AUDIENCE_RESEARCH)
 
         eq_(audience('books for all ages'), None)
 

--- a/tests/classifiers/test_classifier.py
+++ b/tests/classifiers/test_classifier.py
@@ -533,18 +533,28 @@ class TestWorkClassifier(DatabaseTest):
         eq_(Classifier.AUDIENCE_ADULTS_ONLY, self.classifier.audience(genres))
     
     def test_all_ages_audience(self):
+        # If the All Ages weight is more than the total adult weight and
+        # the total juvenile weight, then assign all ages as the audience.
         self.classifier.audience_weights = {
-            Classifier.AUDIENCE_ADULT : 0,
-            Classifier.AUDIENCE_ALL_AGES : 10,
-            Classifier.AUDIENCE_CHILDREN : 0,
+            Classifier.AUDIENCE_ADULT : 50,
+            Classifier.AUDIENCE_ADULTS_ONLY : 30,
+            Classifier.AUDIENCE_ALL_AGES : 100,
+            Classifier.AUDIENCE_CHILDREN : 30,
+            Classifier.AUDIENCE_YOUNG_ADULT : 40,
         }
         eq_(Classifier.AUDIENCE_ALL_AGES, self.classifier.audience())
     
     def test_research_audience(self):
+        # If the research weight is larger than the total adult weight +
+        # all ages weight and larger than the total juvenile weight +
+        # all ages weight, then assign research as the audience
         self.classifier.audience_weights = {
-            Classifier.AUDIENCE_ADULT : 0,
-            Classifier.AUDIENCE_RESEARCH : 10,
-            Classifier.AUDIENCE_CHILDREN : 0,
+            Classifier.AUDIENCE_ADULT : 50,
+            Classifier.AUDIENCE_ADULTS_ONLY : 30,
+            Classifier.AUDIENCE_ALL_AGES : 10,
+            Classifier.AUDIENCE_CHILDREN : 30,
+            Classifier.AUDIENCE_YOUNG_ADULT : 40,
+            Classifier.AUDIENCE_RESEARCH : 100,
         }
         eq_(Classifier.AUDIENCE_RESEARCH, self.classifier.audience())
 

--- a/tests/classifiers/test_classifier.py
+++ b/tests/classifiers/test_classifier.py
@@ -531,6 +531,23 @@ class TestWorkClassifier(DatabaseTest):
         genres = { classifier.Erotica : 50,
                    classifier.Science_Fiction: 50}
         eq_(Classifier.AUDIENCE_ADULTS_ONLY, self.classifier.audience(genres))
+    
+    def test_all_ages_audience(self):
+        self.classifier.audience_weights = {
+            Classifier.AUDIENCE_ADULT : 0,
+            Classifier.AUDIENCE_ALL_AGES : 10,
+            Classifier.AUDIENCE_CHILDREN : 0,
+        }
+        eq_(Classifier.AUDIENCE_ALL_AGES, self.classifier.audience())
+    
+    def test_research_audience(self):
+        self.classifier.audience_weights = {
+            Classifier.AUDIENCE_ADULT : 0,
+            Classifier.AUDIENCE_RESEARCH : 10,
+            Classifier.AUDIENCE_CHILDREN : 0,
+        }
+        eq_(Classifier.AUDIENCE_RESEARCH, self.classifier.audience())
+
 
     def test_format_classification_from_license_source_is_used(self):
         # This book will be classified as a comic book, because
@@ -560,6 +577,8 @@ class TestWorkClassifier(DatabaseTest):
             Classifier.AUDIENCE_ADULT : 0,
             Classifier.AUDIENCE_ADULTS_ONLY : 0,
             Classifier.AUDIENCE_CHILDREN : 1,
+            Classifier.AUDIENCE_RESEARCH : 0,
+            Classifier.AUDIENCE_ALL_AGES : 0,
         }
         eq_(Classifier.AUDIENCE_CHILDREN, self.classifier.audience())
 
@@ -571,6 +590,8 @@ class TestWorkClassifier(DatabaseTest):
             Classifier.AUDIENCE_ADULT : 4,
             Classifier.AUDIENCE_ADULTS_ONLY : 2,
             Classifier.AUDIENCE_CHILDREN : 4,
+            Classifier.AUDIENCE_RESEARCH : 0,
+            Classifier.AUDIENCE_ALL_AGES : 0,
         }
         eq_(Classifier.AUDIENCE_ADULTS_ONLY, self.classifier.audience())
 

--- a/tests/classifiers/test_classifier.py
+++ b/tests/classifiers/test_classifier.py
@@ -543,6 +543,17 @@ class TestWorkClassifier(DatabaseTest):
             Classifier.AUDIENCE_YOUNG_ADULT : 40,
         }
         eq_(Classifier.AUDIENCE_ALL_AGES, self.classifier.audience())
+
+        # If the All Ages weight is smaller than the total adult weight,
+        # the audience is adults.
+        self.classifier.audience_weights = {
+            Classifier.AUDIENCE_ADULT : 70,
+            Classifier.AUDIENCE_ADULTS_ONLY : 10,
+            Classifier.AUDIENCE_ALL_AGES : 79,
+            Classifier.AUDIENCE_CHILDREN : 30,
+            Classifier.AUDIENCE_YOUNG_ADULT : 40,
+        }
+        eq_(Classifier.AUDIENCE_ADULT, self.classifier.audience())
     
     def test_research_audience(self):
         # If the research weight is larger than the total adult weight +
@@ -557,6 +568,19 @@ class TestWorkClassifier(DatabaseTest):
             Classifier.AUDIENCE_RESEARCH : 100,
         }
         eq_(Classifier.AUDIENCE_RESEARCH, self.classifier.audience())
+
+        # If the research weight is not larger than either total adults weight
+        # and all ages weight or total juvenile weight and all ages weight,
+        # then we get those audience values instead.
+        self.classifier.audience_weights = {
+            Classifier.AUDIENCE_ADULT : 80,
+            Classifier.AUDIENCE_ADULTS_ONLY : 10,
+            Classifier.AUDIENCE_ALL_AGES : 20,
+            Classifier.AUDIENCE_CHILDREN : 35,
+            Classifier.AUDIENCE_YOUNG_ADULT : 40,
+            Classifier.AUDIENCE_RESEARCH : 100,
+        }
+        eq_(Classifier.AUDIENCE_ADULT, self.classifier.audience())
 
 
     def test_format_classification_from_license_source_is_used(self):

--- a/tests/classifiers/test_classifier.py
+++ b/tests/classifiers/test_classifier.py
@@ -495,7 +495,6 @@ class TestWorkClassifier(DatabaseTest):
         # Now it's overwhelming. (the 'children' weight is more than twice
         # the combined 'adult' + 'adults only' weight.
         self.classifier.audience_weights[Classifier.AUDIENCE_CHILDREN] = 23
-        self.classifier.audience_weights[Classifier.AUDIENCE_ALL_AGES] = 40
         eq_(Classifier.AUDIENCE_CHILDREN, self.classifier.audience())
 
         # Now it's overwhelmingly likely to be a YA book.

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -90,7 +90,7 @@ from ..testing import (
     EndToEndSearchTest,
 )
 
-DEFAULT_AUDIENCE = Terms(audience=['youngadult', 'allages', 'adult', 'adultsonly', 'children'])
+RESEARCH = Term(audience=Classifier.AUDIENCE_RESEARCH)
 
 class TestExternalSearch(ExternalSearchTest):
 
@@ -539,7 +539,8 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
 
         self.sherlock = _work(
             title="The Adventures of Sherlock Holmes",
-            with_open_access_download=True
+            with_open_access_download=True,
+            audience=Classifier.AUDIENCE_ADULT
         )
         self.sherlock.presentation_edition.language = "eng"
 
@@ -2293,7 +2294,7 @@ class TestQuery(DatabaseTest):
         quality_range = Filter._match_range(
             'quality', 'gte', self._default_library.minimum_featured_quality
         )
-        eq_(Q('bool', must=[quality_range, DEFAULT_AUDIENCE]), quality_filter)
+        eq_(Q('bool', must=[quality_range], must_not=[RESEARCH]), quality_filter)
 
         # When using the AVAILABLE_OPEN_ACCESS availability restriction...
         built = from_facets(Facets.COLLECTION_FULL,
@@ -3360,13 +3361,12 @@ class TestFilter(DatabaseTest):
         """Helper method for the most common case, where a
         Filter.build() returns a main filter and no nested filters.
         """
+        final_query = {'bool': {'must_not': [RESEARCH.to_dict()]}}
         
         if expect:
-            expect = {'bool': {'must': expect + [DEFAULT_AUDIENCE.to_dict()]}}
-        else:
-            expect = DEFAULT_AUDIENCE.to_dict()
+            final_query['bool']['must'] = expect
         main, nested = filter.build(_chain_filters)
-        eq_(expect, main.to_dict())
+        eq_(final_query, main.to_dict())
 
         return main, nested
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1955,7 +1955,8 @@ class TestWorkList(DatabaseTest):
 
         # A Filter object was created to match only works that belong
         # in the MockWorkList.
-        eq_([Classifier.AUDIENCE_CHILDREN], filter.audiences)
+        eq_([Classifier.AUDIENCE_CHILDREN, Classier.AUDIENCE_ALL_AGES],
+            filter.audiences)
 
         # A default Pagination object was created.
         eq_(0, pagination.offset)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1955,7 +1955,7 @@ class TestWorkList(DatabaseTest):
 
         # A Filter object was created to match only works that belong
         # in the MockWorkList.
-        eq_([Classifier.AUDIENCE_CHILDREN, Classier.AUDIENCE_ALL_AGES],
+        eq_([Classifier.AUDIENCE_CHILDREN, Classifier.AUDIENCE_ALL_AGES],
             filter.audiences)
 
         # A default Pagination object was created.
@@ -1976,7 +1976,8 @@ class TestWorkList(DatabaseTest):
 
         # The Filter incorporates restrictions imposed by both the
         # MockWorkList and the Facets.
-        eq_([Classifier.AUDIENCE_CHILDREN], filter.audiences)
+        eq_([Classifier.AUDIENCE_CHILDREN, Classifier.AUDIENCE_ALL_AGES],
+            filter.audiences)
         eq_(["chi"], filter.languages)
 
     def test_search_failures(self):


### PR DESCRIPTION
This branch resolves https://jira.nypl.org/browse/SIMPLY-538 by introducing two new audiences, "All Ages" and "Research".

An "All Ages" book will show up in Adult and Young Adult queries. It will show up in "Children" queries so long as the query includes children eight years old or older. (This is my guesstimate as to when children are expected to have the appropriate reading fluency -- it doesn't make sense to give Sherlock Holmes to three-year-olds. If this turns out to be inaccurate, we can change the cutoff age in the code and the new age will take effect immediately with no database changes)

A "Research" book will be excluded from all queries unless "Research" is explicitly listed as an audience.

Right now the only way for a book to be classified as 'All Ages' or 'Research' is for it to have a Classification associated with a schema:audience Subject with the name "All Ages" or "Research". This can happen through the admin interface or through the metadata wrangler. This is because there's no standard way of conveying this audience information in BISAC, DDC, etc.