### PR TITLE
Allow an Overdrive integration to use their testing server

### DIFF
--- a/overdrive.py
+++ b/overdrive.py
@@ -213,7 +213,7 @@ class OverdriveAPI(object):
            don't have to pass it in.
         """
         kwargs.update(self.hosts)
-        return url % self.url_args(**kwargs)
+        return url % kwargs
 
     @property
     def token(self):

--- a/overdrive.py
+++ b/overdrive.py
@@ -73,23 +73,29 @@ class OverdriveAPI(object):
     # A lock for threaded usage.
     lock = RLock()
 
-    TOKEN_ENDPOINT = "https://oauth.overdrive.com/token"
-    PATRON_TOKEN_ENDPOINT = "https://oauth-patron.overdrive.com/patrontoken"
+    OAUTH_HOST = "https://oauth.overdrive.com"
+    OAUTH_PATRON_HOST = "https://oauth-patron.overdrive.com"
 
-    LIBRARY_ENDPOINT = "https://api.overdrive.com/v1/libraries/%(library_id)s"
-    ADVANTAGE_LIBRARY_ENDPOINT = "https://api.overdrive.com/v1/libraries/%(parent_library_id)s/advantageAccounts/%(library_id)s"
-    ALL_PRODUCTS_ENDPOINT = "https://api.overdrive.com/v1/collections/%(collection_token)s/products?sort=%(sort)s"
-    METADATA_ENDPOINT = "https://api.overdrive.com/v1/collections/%(collection_token)s/products/%(item_id)s/metadata"
-    EVENTS_ENDPOINT = "https://api.overdrive.com/v1/collections/%(collection_token)s/products?lastUpdateTime=%(lastupdatetime)s&sort=%(sort)s&limit=%(limit)s"
-    AVAILABILITY_ENDPOINT = "https://api.overdrive.com/v1/collections/%(collection_token)s/products/%(product_id)s/availability"
+    HOST = "https://integration.api.overdrive.com"
+    PATRON_HOST = "https://integration-patron.api.overdrive.com"
 
-    PATRON_INFORMATION_ENDPOINT = "https://patron.api.overdrive.com/v1/patrons/me"
-    CHECKOUTS_ENDPOINT = "https://patron.api.overdrive.com/v1/patrons/me/checkouts"
-    CHECKOUT_ENDPOINT = "https://patron.api.overdrive.com/v1/patrons/me/checkouts/%(overdrive_id)s"
-    FORMATS_ENDPOINT = "https://patron.api.overdrive.com/v1/patrons/me/checkouts/%(overdrive_id)s/formats"
-    HOLDS_ENDPOINT = "https://patron.api.overdrive.com/v1/patrons/me/holds"
-    HOLD_ENDPOINT = "https://patron.api.overdrive.com/v1/patrons/me/holds/%(product_id)s"
-    ME_ENDPOINT = "https://patron.api.overdrive.com/v1/patrons/me"
+    TOKEN_ENDPOINT = OAUTH_HOST + "/token"
+    PATRON_TOKEN_ENDPOINT = OAUTH_PATRON_HOST + "/patrontoken"
+
+    LIBRARY_ENDPOINT = HOST + "/v1/libraries/%(library_id)s"
+    ADVANTAGE_LIBRARY_ENDPOINT = HOST + "/v1/libraries/%(parent_library_id)s/advantageAccounts/%(library_id)s"
+    ALL_PRODUCTS_ENDPOINT = HOST + "/v1/collections/%(collection_token)s/products?sort=%(sort)s"
+    METADATA_ENDPOINT = HOST + "/v1/collections/%(collection_token)s/products/%(item_id)s/metadata"
+    EVENTS_ENDPOINT = HOST + "/v1/collections/%(collection_token)s/products?lastUpdateTime=%(lastupdatetime)s&sort=%(sort)s&limit=%(limit)s"
+    AVAILABILITY_ENDPOINT = HOST + "/v1/collections/%(collection_token)s/products/%(product_id)s/availability"
+
+    PATRON_INFORMATION_ENDPOINT = PATRON_HOST + "/v1/patrons/me"
+    CHECKOUTS_ENDPOINT = PATRON_HOST + "/v1/patrons/me/checkouts"
+    CHECKOUT_ENDPOINT = PATRON_HOST + "/v1/patrons/me/checkouts/%(overdrive_id)s"
+    FORMATS_ENDPOINT = PATRON_HOST + "/v1/patrons/me/checkouts/%(overdrive_id)s/formats"
+    HOLDS_ENDPOINT = PATRON_HOST + "/v1/patrons/me/holds"
+    HOLD_ENDPOINT = PATRON_HOST + "/v1/patrons/me/holds/%(product_id)s"
+    ME_ENDPOINT = PATRON_HOST + "/v1/patrons/me"
 
     MAX_CREDENTIAL_AGE = 50 * 60
 

--- a/overdrive.py
+++ b/overdrive.py
@@ -510,14 +510,14 @@ class OverdriveAPI(object):
 
     def _do_get(self, url, headers):
         """This method is overridden in MockOverdriveAPI."""
-        url = url % self.hosts
+        url = self.endpoint(url)
         return Representation.simple_http_get(
             url, headers
         )
 
     def _do_post(self, url, payload, headers, **kwargs):
         """This method is overridden in MockOverdriveAPI."""
-        url = url % self.hosts
+        url = self.endpoint(url)
         return HTTP.post_with_timeout(url, payload, headers=headers, **kwargs)
 
 
@@ -575,7 +575,7 @@ class MockOverdriveAPI(OverdriveAPI):
         to this method separately we remove the need to figure out
         whether to queue a response in a given test.
         """
-        url = url % self.hosts
+        url = self.endpoint(url)
         self.access_token_requests.append((url, payload, headers, kwargs))
         response = self.access_token_response
         return HTTP._process_response(url, response, **kwargs)
@@ -601,7 +601,7 @@ class MockOverdriveAPI(OverdriveAPI):
         return self._make_request(url, *args, **kwargs)
 
     def _make_request(self, url, *args, **kwargs):
-        url = url % self.hosts
+        url = self.endpoint(url)
         response = self.responses.pop()
         self.requests.append((url, args, kwargs))
         return HTTP._process_response(

--- a/overdrive.py
+++ b/overdrive.py
@@ -189,7 +189,10 @@ class OverdriveAPI(object):
         )
         if server_nickname not in self.HOSTS:
             server_nickname = self.PRODUCTION_SERVERS
-        self.hosts = self.HOSTS[server_nickname]
+
+        # Set the hostnames we'll be using. Make a new dictionary just
+        # to be safe.
+        self.hosts = dict(self.HOSTS[server_nickname])
 
         # Use utf8 instead of unicode encoding
         settings = [self.client_key, self.client_secret, self.website_id]

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -112,6 +112,24 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         eq_("http://foo.com?q=%2B%3A%7B%7D",
             OverdriveAPI.make_link_safe("http://foo.com?q=+:{}"))
 
+    def test_endpoint(self):
+        # The .endpoint() method performs string interpolation, including
+        # the names of servers.
+        template = "%(host)s %(patron_host)s %(oauth_host)s %(oauth_patron_host)s %(extra)s"
+        result = self.api.endpoint(template, extra="val")
+
+        # The host names and the 'extra' argument have been used to
+        # fill in the string interpolations.
+        expect_args = dict(self.api.hosts)
+        expect_args['extra'] = 'val'
+        eq_(result, template % expect_args)
+
+        # The string has been completel interpolated.
+        assert '%' not in result
+
+        # Once interpolation has happened, doing it again has no effect.
+        eq_(result, self.api.endpoint(result, extra="something else"))
+
     def test_token_post_success(self):
         self.api.queue_response(200, content="some content")
         response = self.api.token_post(self._url, "the payload")

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -112,6 +112,27 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         eq_("http://foo.com?q=%2B%3A%7B%7D",
             OverdriveAPI.make_link_safe("http://foo.com?q=+:{}"))
 
+    def test_hosts(self):
+        c = OverdriveAPI
+
+        # By default, OverdriveAPI is initialized with the production
+        # set of hostnames.
+        eq_(self.api.hosts, c.HOSTS[c.PRODUCTION_SERVERS])
+
+        # You can instead initialize it to use the testing set of
+        # hostnames.
+        def api_with_setting(x):
+            integration = self.collection.external_integration
+            integration.setting(c.SERVER_NICKNAME).value = x
+            return c(self._db, self.collection)
+        testing = api_with_setting(c.TESTING_SERVERS)
+        eq_(testing.hosts, c.HOSTS[c.TESTING_SERVERS])
+
+        # If the setting doesn't make sense, we default to production
+        # hostnames.
+        bad = api_with_setting("nonsensical")
+        eq_(bad.hosts, c.HOSTS[c.PRODUCTION_SERVERS])
+
     def test_endpoint(self):
         # The .endpoint() method performs string interpolation, including
         # the names of servers.

--- a/util/http.py
+++ b/util/http.py
@@ -310,7 +310,6 @@ class HTTP(object):
                 or series in allowed_response_codes
         )):
             error_message = status_code_not_in_allowed
-
         if error_message:
             raise BadResponseException(
                 url,


### PR DESCRIPTION
This is the core portion of https://jira.nypl.org/browse/SIMPLY-2486. It creates a new setting controlling whether a given OverdriveAPI hits the production or testing servers, and it replaces the hard-coded hostnames in endpoint constants with string interpolation variables.

Any time you reference a URL, you should call the endpoint() method to interpolate the appropriate hostname. _do_get or _do_post will call endpoint() for you -- but this will only  work for URLs like TOKEN_ENDPOINT, where the hostname is the _only_ string interpolation variable.

I designed this to make it easy to manually verify that we haven't missed any endpoint() calls.