### PR TITLE
Remove Work.random

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -1103,7 +1103,6 @@ class CurrentMapping(Mapping):
             'sort_author_keyword' : ['sort_author'],
             'integer': ['series_position', 'work_id'],
             'long': ['last_update_time'],
-            'float': ['random'],
         }
         self.add_properties(fields_by_type)
 

--- a/lane.py
+++ b/lane.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from nose.tools import set_trace
 import datetime
 import logging
-import random
 import time
 import urllib
 
@@ -603,7 +602,6 @@ class DatabaseBackedFacets(Facets):
         FacetConstants.ORDER_TITLE : Edition.sort_title,
         FacetConstants.ORDER_AUTHOR : Edition.sort_author,
         FacetConstants.ORDER_LAST_UPDATE : Work.last_update_time,
-        FacetConstants.ORDER_RANDOM : Work.random,
     }
 
     @classmethod

--- a/migration/20200127-remove-work-random.sql
+++ b/migration/20200127-remove-work-random.sql
@@ -1,0 +1,6 @@
+-- Remove indexes that haven't been used for a very long time.
+drop index if exists ix_works_audience_target_age_quality_random;
+drop index if exists ix_works_audience_fiction_quality_random;
+
+-- Remove the works.random column itself.
+ALTER TABLE works DROP COLUMN if exists random;

--- a/model/work.py
+++ b/model/work.py
@@ -177,9 +177,6 @@ class Work(Base):
     # The overall current popularity of this work.
     popularity = Column(Float, index=True)
 
-    # A random number associated with this work, used for sampling/
-    random = Column(Numeric(4,3), index=True)
-
     appeal_type = Enum(CHARACTER_APPEAL, LANGUAGE_APPEAL, SETTING_APPEAL,
                        STORY_APPEAL, NOT_APPLICABLE_APPEAL, NO_APPEAL,
                        UNKNOWN_APPEAL, name="appeal")
@@ -1225,7 +1222,6 @@ class Work(Base):
         self.presentation_ready = True
         self.presentation_ready_exception = None
         self.presentation_ready_attempt = as_of
-        self.random = random.random()
         if not exclude_search:
             self.external_index_needs_updating()
 
@@ -1429,7 +1425,6 @@ class Work(Base):
              Work.summary_text,
              Work.quality,
              Work.rating,
-             Work.random,
              Work.popularity,
              Work.presentation_ready,
              Work.presentation_edition_id,
@@ -1669,7 +1664,6 @@ class Work(Base):
              works_alias.c.imprint,
              works_alias.c.permanent_work_id,
              works_alias.c.presentation_ready,
-             works_alias.c.random,
              works_alias.c.last_update_time,
 
              # Convert true/false to "Fiction"/"Nonfiction".
@@ -1811,8 +1805,3 @@ class Work(Base):
             .order_by(WorkGenre.affinity.desc()) \
             .first()
         return genre.name if genre else None
-
-
-# Used for quality filter queries.
-Index("ix_works_audience_target_age_quality_random", Work.audience, Work.target_age, Work.quality, Work.random)
-Index("ix_works_audience_fiction_quality_random", Work.audience, Work.fiction, Work.quality, Work.random)

--- a/monitor.py
+++ b/monitor.py
@@ -727,30 +727,6 @@ class CoverageProvidersFailed(Exception):
         )
 
 
-class WorkRandomnessUpdateMonitor(WorkSweepMonitor):
-    """Update the random value associated with each work.
-
-    (This value is used when randomly choosing books to feature.)
-    """
-
-    SERVICE_NAME = "Work Randomness Updater"
-    DEFAULT_BATCH_SIZE = 1000
-
-    def process_batch(self, offset):
-        """Unlike other Monitors, this one leaves process_item() undefined
-        because it works on a large number of Works at once using raw
-        SQL.
-        """
-        new_offset = offset + self.batch_size
-        text = "update works set random=random() where id >= :offset and id < :new_offset;"
-        self._db.execute(text, dict(offset=offset, new_offset=new_offset))
-        [[self.max_work_id]] = self._db.execute('select max(id) from works')
-        if self.max_work_id < new_offset:
-            # We're all done.
-            new_offset = 0
-        return new_offset, self.batch_size
-
-
 class CustomListEntryWorkUpdateMonitor(CustomListEntrySweepMonitor):
 
     """Set or reset the Work associated with each custom list entry."""

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -1008,7 +1008,6 @@ class TestWork(DatabaseTest):
         work.summary_text = self._str
         work.rating = 5
         work.popularity = 4
-        work.random = 0.145
         work.last_update_time = datetime.datetime.utcnow()
 
         # Make sure all of this will show up in a database query.
@@ -1051,7 +1050,6 @@ class TestWork(DatabaseTest):
         eq_(work.quality, search_doc['quality'])
         eq_(work.rating, search_doc['rating'])
         eq_(work.popularity, search_doc['popularity'])
-        eq_(work.random, search_doc['random'])
         eq_(work.presentation_ready, search_doc['presentation_ready'])
         assert_time_match(work.last_update_time, search_doc['last_update_time'])
         eq_(dict(lower=7, upper=8), search_doc['target_age'])

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1403,12 +1403,6 @@ class TestSearchOrder(EndToEndSearchTest):
             collections=[self._default_collection]
         )
 
-        # We can sort by the value of work.random. 0.1 < 0.9
-        assert_order(
-            Facets.ORDER_RANDOM, [self.moby_dick, self.moby_duck, self.untitled],
-            collections=[self._default_collection]
-        )
-
         # We can sort by series position. Here, the books aren't in
         # the same series; in a real scenario we would also filter on
         # the value of 'series'.

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1882,13 +1882,18 @@ class TestFeaturedFacets(EndToEndSearchTest):
         all_featured_facets = FeaturedFacets(
             0, random_seed=Filter.DETERMINISTIC
         )
-        assert_featured(
-            "Works without considering quality",
-            worklist, all_featured_facets,
-            [self.hq_available, self.hq_available_2,
-             self.not_featured_on_list, self.hq_not_available,
-             self.featured_on_list],
+        # We don't know exactly what order the books will be in,
+        # because even without the random element Elasticsearch is
+        # slightly nondeterministic, but we do expect that all of the
+        # available books will show up before all of the unavailable
+        # books.
+        only_availability_matters = worklist.works(
+            self._db, facets, None, self.search, debug=True
         )
+        eq_(5, len(only_availability_matters))
+        last_two = only_availability_matters[-2:]
+        assert self.hq_not_available in last_two
+        assert self.featured_on_list in last_two
 
         # Up to this point we've been avoiding the random element,
         # but we can introduce that now by passing in a numeric seed.

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -893,30 +893,6 @@ class TestMakePresentationReadyMonitor(DatabaseTest):
         eq_(False, self.work.presentation_ready)
 
 
-class TestWorkRandomnessUpdateMonitor(DatabaseTest):
-
-    def test_process_batch(self):
-        """This Monitor sets Work.random to a random value.
-        """
-        work = self._work()
-        old_random = work.random
-        monitor = WorkRandomnessUpdateMonitor(self._db)
-        value, num_processed = monitor.process_batch(work.id)
-        # Since there's only one work, a single batch finishes the job.
-        eq_(0, value)
-
-        # But we don't know that there's only one work, so the 'number
-        # of items processed' is the batch size.
-        eq_(monitor.batch_size, num_processed)
-
-        # This is normally called by run().
-        self._db.commit()
-
-        # This could fail once, spuriously but the odds are much
-        # higher that the code has broken and it's failing reliably.
-        assert work.random != old_random
-
-
 class TestCustomListEntryWorkUpdateMonitor(DatabaseTest):
 
     def test_set_item(self):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -59,7 +59,6 @@ from ..monitor import (
     SubjectSweepMonitor,
     SweepMonitor,
     TimelineMonitor,
-    WorkRandomnessUpdateMonitor,
     WorkReaper,
     WorkSweepMonitor,
 )


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-2518 by removing the `Work.random` field and everything to do with it. This field was once very important -- it's how we made sure the works that showed up in grouped feeds were ordered randomly -- but it's no longer used for anything, and the Monitor that chooses new random values for `Work.random` turns out to be a performance hassle.

This code does remove the capability for a `DatabaseBackedWorkList` to order works in random order, which explains why so many seemingly useful tests are being removed, but right now there are no `DatabaseBackedWorkList`s in the system (outside of the tests), and hopefully we will eventually decide that we can get rid of `DatabaseBackedWorkList` altogether.

(BTW we don't need `Work.random` anymore because we now ensure random ordering of grouped feeds by telling Elasticsearch to assign a small random weight to each search result.)