### PR TITLE
Added the LanguageNames class and its tests.

### DIFF
--- a/tests/util/test_languages.py
+++ b/tests/util/test_languages.py
@@ -7,10 +7,12 @@ from nose.tools import (
     assert_raises,
 )
 
-from ...util import (
+from ...util.languages import (
     LanguageCodes,
+    LanguageNames,
     LookupTable,
 )
+
 
 class TestLookupTable(object):
 
@@ -82,3 +84,90 @@ class TestLanguageCodes(object):
         eq_(u"español/English", m("spa,eng"))
         eq_(u"español/English/Chinese", m(["spa","eng","chi"]))
         assert_raises(ValueError(m, ["eng, nxx"]))
+
+
+class TestLanguageNames(object):
+    """Test our (very rough) ability to map from natural-language names
+    of languages to ISO-639-2 language codes.
+    """
+
+    def test_name_to_codes(self):
+        # Verify that the name_to_codes dictionary was populated
+        # appropriately.
+        d = LanguageNames.name_to_codes
+
+        def coded(name, code):
+            # In almost all cases, a human-readable language name maps to
+            # a set containing a single ISO-639-2 language code.
+            eq_(set([code]), d[name])
+
+        # English-language names work.
+        coded("english", "eng")
+        coded("french", "fre")
+        coded("irish", "gle")
+        coded("tokelau", "tkl")
+        coded("persian", "per")
+
+        # (Some) native-language names work
+        coded("francais", "fre")
+        coded("espanol", "spa")
+        coded("castellano", "spa")
+        for item in LanguageCodes.NATIVE_NAMES_RAW_DATA:
+            coded(item['nativeName'].lower(),
+                  LanguageCodes.two_to_three[item['code']])
+
+        # Languages associated with a historical period are not mapped
+        # to codes.
+        eq_(set(), d['irish, old (to 900)'])
+
+        # This general rule would exclude Greek ("Greek, Modern
+        # (1453-)") and Occitan ("Occitan (post 1500)"), so we added
+        # them manually.
+        coded('greek', 'gre')
+        coded('occitan', 'oci')
+
+        # Languages associated with a geographical area, such as "Luo
+        # (Kenya and Tanzania)", can be looked up without that area.
+        coded('luo', 'luo')
+
+        # This causes a little problem for Tonga: there are two
+        # unrelated languages called 'Tonga', and the geographic area
+        # is the only way to distinguish them. For now, we map 'tonga'
+        # to both ISO codes. (This is why name_to_codes is called that
+        # rather than name_to_code.)
+        eq_(set(['ton', 'tog']), d['tonga'])
+
+        # Language families such as "Himacahli languages" can be
+        # looked up without the " languages".
+        coded('himachali', 'him')
+
+        # Language groups such as "Bantu (Other)" can be looked up
+        # without the "(Other)".
+        coded('south american indian', 'sai')
+        coded('bantu', 'bnt')
+
+        # If a language is known by multiple English names, lookup on
+        # any of those names will work.
+        for i in "Blissymbols; Blissymbolics; Bliss".split(";"):
+            coded(i.strip().lower(), 'zbl')
+
+    def test_name_re(self):
+        # Verify our ability to find language names inside text.
+        def find(text, expect):
+            match = LanguageNames.name_re.search(text)
+            if not match:
+                return match
+            return match.groups()[0]
+
+            eq_(expect, LanguageNames.find_language(text))
+        find("books in Italian", "Italian")
+        find("Chinese Cooking", "Chinese")
+        find("500 spanish verbs", "spanish")
+
+        # Only the first language is returned.
+        find("books in japanese or italian", "japanese")
+        find("english-russian dictionary", "english")
+
+        # The language name must be a standalone word.
+        find("50,000 frenchmen can't be wrong", None)
+        find("visiting Thailand", None)

--- a/tests/util/test_languages.py
+++ b/tests/util/test_languages.py
@@ -157,16 +157,15 @@ class TestLanguageNames(object):
             match = LanguageNames.name_re.search(text)
             if not match:
                 return match
-            return match.groups()[0]
+            return match.groups()
 
-            eq_(expect, LanguageNames.find_language(text))
-        find("books in Italian", "Italian")
-        find("Chinese Cooking", "Chinese")
-        find("500 spanish verbs", "spanish")
+        find("books in Italian", ["Italian"])
+        find("Chinese Cooking", ["Chinese"])
+        find("500 spanish verbs", ["spanish"])
 
         # Only the first language is returned.
-        find("books in japanese or italian", "japanese")
-        find("english-russian dictionary", "english")
+        find("books in japanese or italian", ["japanese"])
+        find("english-russian dictionary", ["english"])
 
         # The language name must be a standalone word.
         find("50,000 frenchmen can't be wrong", None)


### PR DESCRIPTION
This is more precursor work for https://jira.nypl.org/browse/SIMPLY-564. I created a class that contains a regular expression that can match human-readable names of languages, and a dictionary that you can use to map one of those human-readable names to a set of ISO language codes.