### PR TITLE
Use the Accept-Language header to augment the languages available to the search engine

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -787,9 +787,9 @@ class SearchFacets(FacetsWithEntryPoint):
     def from_request(cls, library, config, get_argument, get_header, worklist,
                      default_entrypoint=None, **extra):
 
-        # Searches against a WorkList that has no particular language
-        # restrictions will use the languages defined in the
-        # Accept-Language header used by the client.
+        # Searches against a WorkList will use the union of the
+        # languages allowed by the WorkList and the languages found in
+        # the client's Accept-Language header.
         language_header = get_header("Accept-Language")
         languages = None
         if language_header:
@@ -846,14 +846,26 @@ class SearchFacets(FacetsWithEntryPoint):
         elif self.media:
             filter.media = self.media
 
-        # A language restriction already set by the WorkList or
-        # EntryPoint takes precedence over any language restriction
-        # defined by this SearchFacets object.  That's because
-        # clients always send the Accept-Language header passively --
-        # it's not an explicitly expressed preference the way `media`
-        # is.
-        if self.languages and not filter.languages:
-            filter.languages = self.languages
+        # The languages matched by the filter are the union of the
+        # languages allowed by the WorkList (which were set to
+        # filter.languages upon instantiation) and the languages
+        # mentioned in the the user's Accept-Language header (which
+        # were stuck into the SearchFacets object when _it_ was
+        # instantiated).
+        #
+        # We don't rely solely on the WorkList languages because at
+        # the moment it's hard for people who don't read the dominant
+        # language of the circulation manager to find the right place
+        # to search.
+        #
+        # We don't rely solely on the SearchFacets languages because a
+        # lot of people read in languages other than the one they've
+        # set for their device UI.
+        all_languages = set()
+        for language_list in (self.languages, filter.languages):
+            for language in self._ensure_list(language_list) or []:
+                all_languages.add(language)
+        filter.languages = sorted(all_languages) or None
 
     def items(self):
         """Yields a 2-tuple for every active facet setting.

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1835,12 +1835,15 @@ class TestFeaturedFacets(EndToEndSearchTest):
 
     def test_run(self):
 
+        def works(worklist, facets):
+            return worklist.works(
+                self._db, facets, None, self.search, debug=True
+            )
+
         def assert_featured(description, worklist, facets, expect):
             # Generate a list of featured works for the given `worklist`
             # and compare that list against `expect`.
-            actual = worklist.works(
-                self._db, facets, None, self.search, debug=True
-            )
+            actual = works(worklist, facets)
             self._assert_works(description, expect, actual)
 
         worklist = WorkList()
@@ -1848,15 +1851,17 @@ class TestFeaturedFacets(EndToEndSearchTest):
         facets = FeaturedFacets(1, random_seed=Filter.DETERMINISTIC)
 
         # Even though hq_not_available is higher-quality than
-        # featured_on_list, it shows up first because it's available
-        # right now.
-        #
+        # not_featured_on_list, not_featured_on_list shows up first because
+        # it's available right now.
+        w = works(worklist, facets)
+        assert w.index(self.not_featured_on_list) < w.index(
+            self.hq_not_available
+        )
+
         # not_featured_on_list shows up before featured_on_list because
         # it's higher-quality and list membership isn't relevant.
-        assert_featured(
-            "Normal search", worklist, facets,
-            [self.hq_available, self.hq_available_2, self.not_featured_on_list,
-             self.hq_not_available, self.featured_on_list],
+        assert w.index(self.not_featured_on_list) < w.index(
+            self.featured_on_list
         )
 
         # Create a WorkList that's restricted to best-sellers.

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1194,19 +1194,39 @@ class TestSearchFacets(DatabaseTest):
         facets.modify_search_filter(filter)
         eq_([Edition.BOOK_MEDIUM], filter.media)
 
-        # The language specified in the constructor does *not* override
-        # anything already present in the filter.
+        # The language specified in the constructor _adds_ to any
+        # languages already present in the filter.
         facets = SearchFacets(None, languages=["eng", "spa"])
         filter = Filter(languages="spa")
         facets.modify_search_filter(filter)
-        eq_("spa", filter.languages)
+        eq_(["eng", "spa"], filter.languages)
 
-        # It only takes effect if the filter doesn't have any languages
-        # set.
-        filter = Filter()
+        # It doesn't override those values.
+        facets = SearchFacets(None, languages="eng")
+        filter = Filter(languages="spa")
         facets.modify_search_filter(filter)
         eq_(["eng", "spa"], filter.languages)
 
+        # This may result in modify_search_filter being a no-op.
+        facets = SearchFacets(None, languages="eng")
+        filter = Filter(languages="eng")
+        facets.modify_search_filter(filter)
+        eq_(["eng"], filter.languages)
+
+
+        # If no languages are specified in the SearchFacets, the value
+        # set by the filter is used by itself.
+        facets = SearchFacets(None, languages=None)
+        filter = Filter(languages="spa")
+        facets.modify_search_filter(filter)
+        eq_(["spa"], filter.languages)
+
+        # If neither facets nor filter includes any languages, there
+        # is no language filter.
+        facets = SearchFacets(None, languages=None)
+        filter = Filter(languages=None)
+        facets.modify_search_filter(filter)
+        eq_(None, filter.languages)
 
 class TestPagination(DatabaseTest):
 


### PR DESCRIPTION
Previously the Accept-Language headers were only used to provide a fallback language filter if the Lane doesn't specify a language filter (which is basically never). This makes it hard for patrons who don't read English to search for books in their native language. Before that, the Accept-Language headers were used _exclusively_, which led to complaints by patrons who read in both English and their native language.

This isn't a perfect solution, but I think it's pretty good for the scenario we find ourselves in, given that UX improvements aren't going to happen any time soon.

This fixes https://jira.nypl.org/browse/SIMPLY-2530.