### PR TITLE
Don't allow a book to become presentation-ready if it has no medium

### DIFF
--- a/model/constants.py
+++ b/model/constants.py
@@ -231,6 +231,10 @@ class MediaTypes(object):
     AUDIOBOOK_MANIFEST_MEDIA_TYPE = u"application/audiobook+json"
     MARC_MEDIA_TYPE = u"application/marc"
 
+    AUDIOBOOK_MEDIA_TYPES = [
+        AUDIOBOOK_MANIFEST_MEDIA_TYPE,
+    ]
+
     BOOK_MEDIA_TYPES = [
         EPUB_MEDIA_TYPE,
         PDF_MEDIA_TYPE,

--- a/model/work.py
+++ b/model/work.py
@@ -1233,6 +1233,15 @@ class Work(Base):
     def set_presentation_ready(
         self, as_of=None, search_index_client=None, exclude_search=False
     ):
+        """Set this work as presentation-ready, no matter what.
+
+        This assumes that we know the work has the minimal information
+        necessary to be found with typical queries and that patrons
+        will be able to understand what work we're talking about.
+
+        In most cases you should call set_presentation_ready_based_on_content
+        instead, which runs those checks.
+        """
         as_of = as_of or datetime.datetime.utcnow()
         self.presentation_ready = True
         self.presentation_ready_exception = None
@@ -1243,24 +1252,29 @@ class Work(Base):
     def set_presentation_ready_based_on_content(self, search_index_client=None):
         """Set this work as presentation ready, if it appears to
         be ready based on its data.
+
         Presentation ready means the book is ready to be shown to
         patrons and (pending availability) checked out. It doesn't
         necessarily mean the presentation is complete.
-        The absolute minimum data necessary is a title, a language,
-        and a fiction/nonfiction status. We don't need a cover or an
-        author -- we can fill in that info later if it exists.
-        """
 
+        The absolute minimum data necessary is a title, a language,
+        and a medium. We don't need a cover or an author -- we can
+        fill in that info later if it exists.
+
+        TODO: search_index_client is redundant here.
+        """
         if (not self.presentation_edition
             or not self.license_pools
             or not self.title
             or not self.language
+            or not self.presentation_edition.medium
         ):
             self.presentation_ready = False
             # The next time the search index WorkCoverageRecords are
             # processed, this work will be removed from the search
             # index.
             self.external_index_needs_updating()
+            logging.warn("Work is not presentation ready: %r", self)
         else:
             self.set_presentation_ready(search_index_client=search_index_client)
 

--- a/opds_import.py
+++ b/opds_import.py
@@ -1474,18 +1474,18 @@ class OPDSImporter(object):
 
     @classmethod
     def get_medium_from_links(cls, links):
-        """Get medium type if found in the links."""
-        links = [l for l in links if 'http://opds-spec.org/acquisition/' in l.rel]
-        derived_medium = None
+        """Get medium if derivable from information in an acquisition link."""
+        derived = None
         for link in links:
-            if link.media_type == MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE:
-                derived_medium = Edition.AUDIO_MEDIUM
+            if (not link.rel
+                or not link.media_type
+                or not link.rel.startswith('http://opds-spec.org/acquisition/')
+            ):
+                continue
+            derived = Edition.medium_from_media_type(link.media_type)
+            if derived:
                 break
-            elif link.media_type in MediaTypes.BOOK_MEDIA_TYPES:
-                derived_medium = Edition.BOOK_MEDIUM
-                break
-
-        return derived_medium
+        return derived
 
     @classmethod
     def extract_identifier(cls, identifier_tag):
@@ -1497,19 +1497,28 @@ class OPDSImporter(object):
             return None
 
     @classmethod
-    def extract_medium(cls, entry_tag, derived_medium):
-        """Derive a value for Edition.medium from <atom:entry
-        schema:additionalType>.
-        """
+    def extract_medium(cls, entry_tag, default=Edition.BOOK_MEDIUM):
+        """Derive a value for Edition.medium from schema:additionalType or
+        from a <dcterms:format> subtag.
 
-        # If no additionalType is given, assume we're talking about an
-        # ebook.
-        default_additional_type = Edition.medium_to_additional_type[
-            derived_medium or Edition.BOOK_MEDIUM
-        ]
-        additional_type = entry_tag.get('{http://schema.org/}additionalType',
-                                        default_additional_type)
-        return Edition.additional_type_to_medium.get(additional_type)
+        :param entry_tag: A <atom:entry> tag.
+        :param default: The value to use if nothing is found.
+        """
+        if not entry_tag:
+            return default
+
+        medium = None
+        additional_type = entry_tag.get('{http://schema.org/}additionalType')
+        if additional_type:
+            medium = Edition.additional_type_to_medium.get(
+                additional_type, None
+            )
+        if not medium:
+            format_tag = entry_tag.find('{http://purl.org/dc/terms/}format')
+            if format_tag is not None:
+                media_type = format_tag.text
+                medium = Edition.medium_from_media_type(media_type)
+        return medium or default
 
     @classmethod
     def extract_contributor(cls, parser, author_tag):

--- a/opds_import.py
+++ b/opds_import.py
@@ -1481,7 +1481,7 @@ class OPDSImporter(object):
             if link.media_type == MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE:
                 derived_medium = Edition.AUDIO_MEDIUM
                 break
-            elif link.media_type == MediaTypes.EPUB_MEDIA_TYPE:
+            elif link.media_type in MediaTypes.BOOK_MEDIA_TYPES:
                 derived_medium = Edition.BOOK_MEDIUM
                 break
 

--- a/tests/files/opds/book_without_license.opds
+++ b/tests/files/opds/book_without_license.opds
@@ -3,7 +3,7 @@
   <title>Lookup results</title>
   <updated>2016-06-29T16:04:36Z</updated>
   <link href="http://content/lookup?urn=https%3A%2F%2Funglue.it%2Fapi%2Fid%2Fwork%2F98398%2F" rel="self"/>
-  <entry schema:additionalType="http://schema.org/EBook">
+  <entry>
     <id>https://unglue.it/api/id/work/98398/</id>
     <title>Howards End</title>
     <bibframe:distribution bibframe:ProviderName="unglue.it"/>
@@ -22,6 +22,7 @@
     <category term="18" scheme="http://schema.org/typicalAgeRange" label="18"/>
     <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction"/>
     <dcterms:language>en</dcterms:language>
+    <dcterms:format>application/audiobook+json;protection="http://www.feedbooks.com/audiobooks/access-restriction"</dcterms:format>
     <published>2016-01-22T17:39:23Z</published>
   </entry>
 </feed>

--- a/tests/models/test_edition.py
+++ b/tests/models/test_edition.py
@@ -10,17 +10,34 @@ from ...model import (
     get_one_or_create,
     PresentationCalculationPolicy,
 )
+from ...model.constants import MediaTypes
 from ...model.coverage import CoverageRecord
 from ...model.contributor import Contributor
 from ...model.datasource import DataSource
 from ...model.edition import Edition
 from ...model.identifier import Identifier
+from ...model.licensing import DeliveryMechanism
 from ...model.resource import (
     Hyperlink,
     Representation,
 )
 
 class TestEdition(DatabaseTest):
+
+    def test_medium_from_media_type(self):
+        # Verify that we can guess a value for Edition.medium from a
+        # media type.
+
+        m = Edition.medium_from_media_type
+        for audio_type in MediaTypes.AUDIOBOOK_MEDIA_TYPES:
+            eq_(Edition.AUDIO_MEDIUM, m(audio_type))
+            eq_(Edition.AUDIO_MEDIUM, m(audio_type + ";param=value"))
+
+        for book_type in MediaTypes.BOOK_MEDIA_TYPES:
+            eq_(Edition.BOOK_MEDIUM, m(book_type))
+            eq_(Edition.BOOK_MEDIUM, m(book_type + ";param=value"))
+
+        eq_(Edition.BOOK_MEDIUM, m(DeliveryMechanism.ADOBE_DRM))
 
     def test_license_pools(self):
         # Here are two collections that provide access to the same book.

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -471,7 +471,7 @@ class TestWork(DatabaseTest):
         m([i1.id, i2.id], [], [])
         eq_(l1.resource.representation.content, w.summary_text)
 
-    def test_set_presentation_ready(self):
+    def test_set_presentation_ready_based_on_content(self):
 
         work = self._work(with_license_pool=True)
 
@@ -491,30 +491,55 @@ class TestWork(DatabaseTest):
 
         # But the work of adding it to the search engine has been
         # registered.
-        [record] = [
-            x for x in work.coverage_records
-            if x.operation==WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION
-        ]
-        eq_(WorkCoverageRecord.REGISTERED, record.status)
+        def assert_record():
+            # Verify the search index WorkCoverageRecord for this work
+            # is in the REGISTERED state.
+            [record] = [
+                x for x in work.coverage_records
+                if x.operation==WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION
+            ]
+            eq_(WorkCoverageRecord.REGISTERED, record.status)
+        assert_record()
 
-        # This work is presentation ready because it has a title
-
+        # This work is presentation ready because it has a title.
         # Remove the title, and the work stops being presentation
         # ready.
         presentation.title = None
         work.set_presentation_ready_based_on_content(search_index_client=search)
         eq_(False, work.presentation_ready)
 
-        # The work has been removed from the search index.
-        eq_([], search.docs.keys())
+        # The search engine WorkCoverageRecord is still in the
+        # REGISTERED state, but its meaning has changed -- the work
+        # will now be _removed_ from the search index, rather than
+        # updated.
+        assert_record()
 
         # Restore the title, and everything is fixed.
         presentation.title = u"foo"
         work.set_presentation_ready_based_on_content(search_index_client=search)
         eq_(True, work.presentation_ready)
 
+        # Remove the medium, and the work stops being presentation ready.
+        presentation.medium = None
+        work.set_presentation_ready_based_on_content(search_index_client=search)
+        eq_(False, work.presentation_ready)
+
+        presentation.medium = Edition.BOOK_MEDIUM
+        work.set_presentation_ready_based_on_content(search_index_client=search)
+        eq_(True, work.presentation_ready)
+
+        # Remove the language, and it stops being presentation ready.
+        presentation.language = None
+        work.set_presentation_ready_based_on_content(search_index_client=search)
+        eq_(False, work.presentation_ready)
+
+        presentation.language = 'eng'
+        work.set_presentation_ready_based_on_content(search_index_client=search)
+        eq_(True, work.presentation_ready)
+
         # Remove the fiction status, and the work is still
-        # presentation ready.
+        # presentation ready. Fiction status used to make a difference, but
+        # it no longer does.
         work.fiction = None
         work.set_presentation_ready_based_on_content(search_index_client=search)
         eq_(True, work.presentation_ready)

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -551,13 +551,19 @@ class TestOPDSImporter(OPDSImporterTest):
 
     def test_get_medium_from_links(self):
         audio_links = [
-            LinkData(href="url", rel="http://opds-spec.org/acquisition/", media_type="application/audiobook+json"),
+            LinkData(href="url", rel="http://opds-spec.org/acquisition/",
+                     media_type="application/audiobook+json;param=value"
+            ),
             LinkData(href="url", rel="http://opds-spec.org/image"),
         ]
         book_links = [
             LinkData(href="url", rel="http://opds-spec.org/image"),
-            LinkData(href="url", rel="http://opds-spec.org/acquisition/",
-                     media_type=random.choice(MediaTypes.BOOK_MEDIA_TYPES)),
+            LinkData(
+                href="url", rel="http://opds-spec.org/acquisition/",
+                media_type=random.choice(
+                    MediaTypes.BOOK_MEDIA_TYPES
+                ) + ";param=value"
+            ),
         ]
 
         m = OPDSImporter.get_medium_from_links
@@ -750,6 +756,51 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_('urn:librarysimplified.org/terms/id/Gutenberg ID/100', message.urn)
         eq_(404, message.status_code)
         eq_("I've never heard of this work.", message.message)
+
+    def test_extract_medium(self):
+        m = OPDSImporter.extract_medium
+
+        # No tag -- the default is used.
+        eq_("Default", m(None, "Default"))
+
+        def medium(additional_type, format, default="Default"):
+            # Make an <atom:entry> tag with the given tags.
+            # Parse it and call extract_medium on it.
+            entry= '<entry xmlns:schema="http://schema.org/" xmlns:dcterms="http://purl.org/dc/terms/"'
+            if additional_type:
+                entry += ' schema:additionalType="%s"' % additional_type
+            entry += '>'
+            if format:
+                entry += '<dcterms:format>%s</dcterms:format>' % format
+            entry += '</entry>'
+            tag = etree.parse(StringIO(entry))
+            return m(tag.getroot(), default=default)
+
+        audio_type = random.choice(MediaTypes.AUDIOBOOK_MEDIA_TYPES) + ";param=value"
+        ebook_type = random.choice(MediaTypes.BOOK_MEDIA_TYPES) + ";param=value"
+
+        # schema:additionalType is checked first. If present, any
+        # potentially contradictory information in dcterms:format is
+        # ignored.
+        eq_(
+            Edition.AUDIO_MEDIUM,
+            medium("http://bib.schema.org/Audiobook", ebook_type)
+        )
+        eq_(
+            Edition.BOOK_MEDIUM,
+            medium("http://schema.org/EBook", audio_type)
+        )
+
+        # When schema:additionalType is missing or not useful, the
+        # value of dcterms:format is mapped to a medium using
+        # Edition.medium_from_media_type.
+        eq_(Edition.AUDIO_MEDIUM, medium("something-else", audio_type))
+        eq_(Edition.BOOK_MEDIUM, medium(None, ebook_type))
+
+        # If both pieces of information are missing or useless, the
+        # default is used.
+        eq_("Default", medium(None, None))
+        eq_("Default", medium("something-else", "image/jpeg"))
 
     def test_handle_failure(self):
         axis_id = self._identifier(identifier_type=Identifier.AXIS_360_ID)

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -1,5 +1,6 @@
 import os
 import datetime
+import random
 import urllib
 from StringIO import StringIO
 from nose.tools import (
@@ -52,6 +53,7 @@ from ..model import (
     Identifier,
     Edition,
     Measurement,
+    MediaTypes,
     Representation,
     RightsStatus,
     Subject,
@@ -554,7 +556,8 @@ class TestOPDSImporter(OPDSImporterTest):
         ]
         book_links = [
             LinkData(href="url", rel="http://opds-spec.org/image"),
-            LinkData(href="url", rel="http://opds-spec.org/acquisition/", media_type="application/epub+zip"),
+            LinkData(href="url", rel="http://opds-spec.org/acquisition/",
+                     media_type=random.choice(MediaTypes.BOOK_MEDIA_TYPES)),
         ]
 
         m = OPDSImporter.get_medium_from_links

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -1423,6 +1423,10 @@ class TestOPDSImporter(OPDSImporterTest):
         eq_([], imported_pools)
         eq_([], imported_works)
 
+        # We were able to figure out the medium of the Edition
+        # based on its <dcterms:format> tag.
+        eq_(Edition.AUDIO_MEDIUM, edition.medium)
+
     def test_build_identifier_mapping(self):
         """Reverse engineers an identifier_mapping based on a list of URNs"""
 


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-2555. I'll do a small circulation branch but it'll probably just be cleanup.

If we don't know whether a book is an ebook or an audiobook, it shouldn't become presentation-ready. This is generally a failure of the import process and indicates some missing code.

In particular, I noticed the `<dcterms:format>` tag (which is required in ODL feeds, and could show up in OPDS feeds) can be used to derive the medium of the work, but our core code ignores it and our circulation code only uses it to detect audiobooks. If the incoming title is an ebook it doesn't do anything.

I also noticed that if a book in an OPDS feed is only available as a PDF, our OPDS importer won't recognize it as an ebook.

This branch makes the OPDS importer more robust and makes it check for a `<dcterms:format>` tag. It makes "no medium" a reason not to set a work as presentation-ready. If a work does end up not presentation-ready, `logging.warn` is used to indicate that there's probably a problem.