### PR TITLE
Make sure works are removed from ES

### DIFF
--- a/model/collection.py
+++ b/model/collection.py
@@ -775,14 +775,6 @@ class Collection(Base, HasFullTableCache):
             )
 
         _db = Session.object_session(self)
-        if not search_index:
-            try:
-                from ..external_search import ExternalSearchIndex
-                search_index = ExternalSearchIndex(_db)
-            except CannotLoadConfiguration, e:
-                # No search index is configured. This is fine -- just skip
-                # that part.
-                pass
 
         # Delete all the license pools. This should be the only part
         # of the application where LicensePools are permanently
@@ -792,9 +784,8 @@ class Collection(Base, HasFullTableCache):
             _db.delete(pool)
             if not i % 100:
                 _db.commit()
-            if work and search_index and not work.license_pools:
-                search_index.remove_work(work)
-                _db.delete(work)
+            if work and not work.license_pools:
+                work.delete(search_index)
 
         # Now delete the Collection itself.
         _db.delete(self)

--- a/monitor.py
+++ b/monitor.py
@@ -859,6 +859,14 @@ class WorkReaper(ReaperMonitor):
     """
     MODEL_CLASS = Work
 
+    def __init__(self, *args, **kwargs):
+        from external_search import ExternalSearchIndex
+        search_index_client = kwargs.pop('search_index_client', None)
+        super(WorkReaper, self).__init__(*args, **kwargs)
+        self.search_index_client = (
+            search_index_client or ExternalSearchIndex(self._db)
+        )
+
     def query(self):
         return self._db.query(Work).outerjoin(Work.license_pools).filter(
             LicensePool.id==None
@@ -866,7 +874,7 @@ class WorkReaper(ReaperMonitor):
 
     def delete(self, work):
         """Delete work from elasticsearch and database."""
-        work.delete()
+        work.delete(self.search_index_client)
 
 ReaperMonitor.REGISTRY.append(WorkReaper)
 

--- a/monitor.py
+++ b/monitor.py
@@ -859,23 +859,14 @@ class WorkReaper(ReaperMonitor):
     """
     MODEL_CLASS = Work
 
-    def __init__(self, *args, **kwargs):
-        from external_search import ExternalSearchIndex
-        search_index_client = kwargs.pop('search_index_client', None)
-        super(WorkReaper, self).__init__(*args, **kwargs)
-        self.search_index_client = (
-            search_index_client or ExternalSearchIndex(self._db)
-        )
-
     def query(self):
         return self._db.query(Work).outerjoin(Work.license_pools).filter(
             LicensePool.id==None
         )
 
     def delete(self, work):
-        """Delete work from elasicsearch and database."""
-        self.search_index_client.remove_work(work)
-        self._db.delete(work)
+        """Delete work from elasticsearch and database."""
+        work.delete()
 
 ReaperMonitor.REGISTRY.append(WorkReaper)
 

--- a/monitor.py
+++ b/monitor.py
@@ -859,10 +859,23 @@ class WorkReaper(ReaperMonitor):
     """
     MODEL_CLASS = Work
 
+    def __init__(self, *args, **kwargs):
+        from external_search import ExternalSearchIndex
+        search_index_client = kwargs.pop('search_index_client', None)
+        super(WorkReaper, self).__init__(*args, **kwargs)
+        self.search_index_client = (
+            search_index_client or ExternalSearchIndex(self._db)
+        )
+
     def query(self):
         return self._db.query(Work).outerjoin(Work.license_pools).filter(
             LicensePool.id==None
         )
+
+    def delete(self, work):
+        """Delete work from elasicsearch and database."""
+        self.search_index_client.remove_work(work)
+        self._db.delete(work)
 
 ReaperMonitor.REGISTRY.append(WorkReaper)
 

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -1494,6 +1494,20 @@ class TestWork(DatabaseTest):
         pool2.presentation_edition.title = None
         eq_(pool1, work.active_license_pool())
 
+    def test_delete_work(self):
+        # Search mock
+        class MockSearchIndex():
+            removed = []
+            def remove_work(self, work):
+                self.removed.append(work)
+
+        s = MockSearchIndex();
+        work = self._work(with_license_pool=True)
+        work.delete(search_index=s)
+
+        eq_([], self._db.query(Work).filter(Work.id==work.id).all())
+        eq_(1, len(s.removed))
+        eq_(s.removed, [work])
 
 class TestWorkConsolidation(DatabaseTest):
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,6 +1,5 @@
 from nose.tools import (
     eq_,
-    ok_,
     set_trace,
     assert_raises,
     assert_raises_regexp,
@@ -1005,12 +1004,6 @@ class TestReaperMonitor(DatabaseTest):
 class TestWorkReaper(DatabaseTest):
 
     def test_end_to_end(self):
-        # Search mock
-        class MockSearchIndex():
-            removed = []
-
-            def remove_work(self, work):
-                self.removed.append(work)
 
         # First, create three works.
 
@@ -1068,16 +1061,8 @@ class TestWorkReaper(DatabaseTest):
         self._db.commit()
 
         # Run the reaper.
-        s = MockSearchIndex()
-        m = WorkReaper(self._db, search_index_client=s)
-        print m.search_index_client
+        m = WorkReaper(self._db)
         m.run_once()
-
-        # Search index was updated
-        eq_(2, len(s.removed))
-        ok_(has_license_pool not in s.removed)
-        ok_(had_license_pool in s.removed)
-        ok_(never_had_license_pool in s.removed)
 
         # Only the work with a license pool remains.
         eq_([has_license_pool], [x for x in works])


### PR DESCRIPTION
When works are reaped by the DB reaper script make sure they are also reaped from elastic-search so they don't get out of sync. 

This came out of a problem LYRASIS was seeing where lanes were not displaying a full list of works. This turned out to be because ES was returning works that no longer existed in the database. 

@leonardr 