### PR TITLE
Allow SearchFacets to take a sort order field so search results can be sorted by title or author

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -424,7 +424,7 @@ class ExternalSearchIndex(HasSelfTests):
         if debug:
             search = search.extra(explain=True)
 
-        if filter.min_score is not None:
+        if filter is not None and filter.min_score is not None:
             search = search.extra(min_score=filter.min_score)
 
         fields = None
@@ -489,7 +489,6 @@ class ExternalSearchIndex(HasSelfTests):
             each containing the search results from that
             (query string, Filter, Pagination) 3-tuple.
         """
-        debug = True
         # If the works alias is not set, all queries return empty.
         #
         # TODO: Maybe an unset works_alias should raise
@@ -499,7 +498,7 @@ class ExternalSearchIndex(HasSelfTests):
             for q in queries:
                 yield []
 
-        # Create a MultiSearch. 
+        # Create a MultiSearch.
         multi = MultiSearch(using=self.__client)
 
         # Give it a Search object for every query definition passed in

--- a/external_search.py
+++ b/external_search.py
@@ -424,6 +424,9 @@ class ExternalSearchIndex(HasSelfTests):
         if debug:
             search = search.extra(explain=True)
 
+        if filter.min_score is not None:
+            search = search.extra(min_score=filter.min_score)
+
         fields = None
         if debug:
             # Don't restrict the fields at all -- get everything.
@@ -486,6 +489,7 @@ class ExternalSearchIndex(HasSelfTests):
             each containing the search results from that
             (query string, Filter, Pagination) 3-tuple.
         """
+        debug = True
         # If the works alias is not set, all queries return empty.
         #
         # TODO: Maybe an unset works_alias should raise
@@ -530,7 +534,7 @@ class ExternalSearchIndex(HasSelfTests):
                     self.log.debug(
                         '%02d "%s" (%s) work=%s score=%.3f shard=%s',
                         i, result.sort_title, result.sort_author, result.meta['id'],
-                        result.meta['score'] or 0, result.meta['shard']
+                        result.meta.explanation['value'] or 0, result.meta['shard']
                     )
 
         for i, results in enumerate(resultset):
@@ -2299,6 +2303,8 @@ class Filter(SearchBase):
         self.series = kwargs.pop('series', None)
 
         self.author = kwargs.pop('author', None)
+
+        self.min_score = kwargs.pop('min_score', None)
 
         self.match_nothing = kwargs.pop('match_nothing', False)
 

--- a/lane.py
+++ b/lane.py
@@ -797,10 +797,13 @@ class SearchFacets(Facets):
         languages = kwargs.pop('languages', None)
         media = kwargs.pop('media', None)
 
-        # Default values for collection, availability, and order will
-        # be filled in by default_facets. This eliminates the need to
-        # explicitly specify a library (since the library is only used
-        # to determine these defaults).
+        # Our default_facets implementation will fill in values for
+        # the facet groups defined by the Facets class. This
+        # eliminates the need to explicitly specify a library, since
+        # the library is mainly used to determine these defaults --
+        # SearchFacets itself doesn't need one. However, in real
+        # usage, a Library will be provided via
+        # SearchFacets.from_request.
         kwargs.setdefault('library', None)
         kwargs.setdefault('collection', None)
         kwargs.setdefault('availability', None)

--- a/lane.py
+++ b/lane.py
@@ -398,7 +398,7 @@ class Facets(FacetsWithEntryPoint):
                      default_entrypoint=None, **extra):
         """Load a faceting object from an HTTP request."""
 
-        values = Facets._values_from_request(config, get_argument, get_header)
+        values = cls._values_from_request(config, get_argument, get_header)
         if isinstance(values, ProblemDetail):
             return values
         extra.update(values)
@@ -844,7 +844,7 @@ class SearchFacets(Facets):
 
     @classmethod
     def from_request(cls, library, config, get_argument, get_header, worklist,
-                     default_entrypoint=None, **extra):
+                     default_entrypoint=EverythingEntryPoint, **extra):
 
         values = cls._values_from_request(config, get_argument, get_header)
         if isinstance(values, ProblemDetail):

--- a/lane.py
+++ b/lane.py
@@ -789,17 +789,20 @@ class SearchFacets(Facets):
     # If search results are to be ordered by some field other than
     # score, we need a cutoff point so that marginal matches don't get
     # top billing just because they're first alphabetically. This is
-    # the default cutoff point.
+    # the default cutoff point, determined empirically.
     DEFAULT_MIN_SCORE = 500
 
     def __init__(self, **kwargs):
         # Unless we hear differently via kwargs, we should search all
         # books in the entire collection.
+        kwargs.setdefault('library', None)
         kwargs.setdefault('collection', self.COLLECTION_FULL)
         kwargs.setdefault('availability', self.AVAILABLE_ALL)
+        kwargs.setdefault('order', None)
 
         languages = kwargs.pop('languages', None)
         media = kwargs.pop('media', None)
+        self.min_score = kwargs.pop('min_score', self.DEFAULT_MIN_SCORE)
 
         super(SearchFacets, self).__init__(**kwargs)
         if media == Edition.ALL_MEDIUM:
@@ -809,7 +812,6 @@ class SearchFacets(Facets):
         self.media_argument = media
 
         self.languages = self._ensure_list(languages)
-        self.min_score = kwargs.pop('min_score', self.DEFAULT_MIN_SCORE)
 
     def _ensure_list(self, x):
         """Make sure x is a list of values, if there is a value at all."""

--- a/lane.py
+++ b/lane.py
@@ -793,16 +793,18 @@ class SearchFacets(Facets):
     DEFAULT_MIN_SCORE = 500
 
     def __init__(self, **kwargs):
-        # Unless we hear differently via kwargs, we should search all
-        # books in the entire collection.
-        kwargs.setdefault('library', None)
-        kwargs.setdefault('collection', self.COLLECTION_FULL)
-        kwargs.setdefault('availability', self.AVAILABLE_ALL)
-        kwargs.setdefault('order', None)
-
         languages = kwargs.pop('languages', None)
         media = kwargs.pop('media', None)
         self.min_score = kwargs.pop('min_score', self.DEFAULT_MIN_SCORE)
+
+        # Default values for collection, availability, and order will
+        # be filled in by default_facets. This eliminates the need to
+        # explicitly specify a library (since the library is only used
+        # to determine these defaults).
+        kwargs.setdefault('library', None)
+        kwargs.setdefault('collection', None)
+        kwargs.setdefault('availability', None)
+        kwargs.setdefault('order', None)
 
         super(SearchFacets, self).__init__(**kwargs)
         if media == Edition.ALL_MEDIUM:
@@ -812,6 +814,24 @@ class SearchFacets(Facets):
         self.media_argument = media
 
         self.languages = self._ensure_list(languages)
+
+    @classmethod
+    def default_facet(cls, ignore, group_name):
+        """The default facet settings for SearchFacets are hard-coded.
+
+        By default, we will search the full collection and all
+        availabilities, and order by match quality rather than any
+        bibliographic field.
+        """
+        if group_name == cls.COLLECTION_FACET_GROUP_NAME:
+            return cls.COLLECTION_FULL
+
+        if group_name == cls.AVAILABILITY_FACET_GROUP_NAME:
+            return cls.AVAILABLE_ALL
+
+        if group_name == cls.ORDER_FACET_GROUP_NAME:
+            return None
+        return None
 
     def _ensure_list(self, x):
         """Make sure x is a list of values, if there is a value at all."""

--- a/lane.py
+++ b/lane.py
@@ -790,12 +790,7 @@ class SearchFacets(Facets):
     # score, we need a cutoff point so that marginal matches don't get
     # top billing just because they're first alphabetically. This is
     # the default cutoff point.
-    #
-    # Note that this is the same value as
-    # Query.FILTER_WAS_A_QUERY_WEIGHT. That allows a user to search
-    # for everything in a certain genre and sort the results
-    # alphabetically.
-    DEFAULT_MIN_SCORE = 600
+    DEFAULT_MIN_SCORE = 500
 
     def __init__(self, **kwargs):
         # Unless we hear differently via kwargs, we should search all

--- a/lane.py
+++ b/lane.py
@@ -796,7 +796,6 @@ class SearchFacets(Facets):
     def __init__(self, **kwargs):
         languages = kwargs.pop('languages', None)
         media = kwargs.pop('media', None)
-        self.min_score = kwargs.pop('min_score', self.DEFAULT_MIN_SCORE)
 
         # Default values for collection, availability, and order will
         # be filled in by default_facets. This eliminates the need to
@@ -805,7 +804,13 @@ class SearchFacets(Facets):
         kwargs.setdefault('library', None)
         kwargs.setdefault('collection', None)
         kwargs.setdefault('availability', None)
-        kwargs.setdefault('order', None)
+        order = kwargs.setdefault('order', None)
+
+        if order:
+            default_min_score = self.DEFAULT_MIN_SCORE
+        else:
+            default_min_score = None
+        self.min_score = kwargs.pop('min_score', default_min_score)
 
         super(SearchFacets, self).__init__(**kwargs)
         if media == Edition.ALL_MEDIUM:
@@ -951,12 +956,15 @@ class SearchFacets(Facets):
         """Yields a 2-tuple for every active facet setting.
 
         This means the EntryPoint (handled by the superclass)
-        as well as a setting for 'media'.
+        as well as possible settings for 'media' and "min_score".
         """
         for k, v in super(SearchFacets, self).items():
             yield k, v
         if self.media_argument:
             yield ("media", self.media_argument)
+
+        if self.min_score is not None:
+            yield ('min_score', unicode(self.min_score))
 
     def navigate(self, **kwargs):
         min_score = kwargs.pop('min_score', self.min_score)

--- a/overdrive.py
+++ b/overdrive.py
@@ -215,11 +215,11 @@ class OverdriveAPI(object):
            The server hostname will be interpolated automatically; you
            don't have to pass it in.
         """
-        try:
-            kwargs.update(self.hosts)
-            return url % kwargs
-        except Exception, e:
-            set_trace()
+        if not '%(' in url:
+            # Nothing to interpolate.
+            return url
+        kwargs.update(self.hosts)
+        return url % kwargs
 
     @property
     def token(self):

--- a/overdrive.py
+++ b/overdrive.py
@@ -215,8 +215,11 @@ class OverdriveAPI(object):
            The server hostname will be interpolated automatically; you
            don't have to pass it in.
         """
-        kwargs.update(self.hosts)
-        return url % kwargs
+        try:
+            kwargs.update(self.hosts)
+            return url % kwargs
+        except Exception, e:
+            set_trace()
 
     @property
     def token(self):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -47,6 +47,7 @@ from ..lane import (
     FeaturedFacets,
     Lane,
     Pagination,
+    SearchFacets,
     WorkList,
 )
 from ..metadata_layer import (
@@ -1031,6 +1032,53 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
         biography_wl = WorkList()
         biography_wl.initialize(self._default_library, genres=[biography])
         eq_([[self.lincoln, self.obama]], pages(biography_wl))
+
+        # Search results may be sorted by some field other than search
+        # quality.
+        f = SearchFacets
+        by_author = f(
+            library=self._default_library, collection=f.COLLECTION_FULL,
+            availability=f.AVAILABLE_ALL, order=f.ORDER_AUTHOR
+        )
+        by_author = Filter(facets=by_author)
+
+        by_title = f(
+            library=self._default_library, collection=f.COLLECTION_FULL,
+            availability=f.AVAILABLE_ALL, order=f.ORDER_TITLE
+        )
+        by_title = Filter(facets=by_title)
+
+        # By default, search results sorted by a bibliographic field
+        # are also filtered to eliminate low-quality results.  In a
+        # real collection the default filter level works well, but it
+        # makes it difficult to test the feature in this limited test
+        # collection.
+        expect([self.moby_dick], "moby dick", by_author)
+        expect([self.ya_romance], "romance", by_author)
+        expect([], "moby", by_author)
+        expect([], "president", by_author)
+
+        # Let's lower the score so we can test the ordering properly.
+        by_title.min_score = 50
+        by_author.min_score = 50
+
+        expect([self.moby_dick, self.moby_duck], "moby", by_title)
+        expect([self.moby_duck, self.moby_dick], "moby", by_author)
+        expect([self.ya_romance, self.modern_romance], "romance", by_title)
+        expect([self.modern_romance, self.ya_romance], "romance", by_author)
+
+        # Lower it even more and we can start picking up search results
+        # that only match because of words in the description.
+        by_title.min_score=10
+        by_author.min_score=10
+        results = [self.no_age, self.age_4_5, self.dodger,
+                   self.age_9_10, self.obama]
+        expect(results, "president", by_title)
+
+        # Reverse the sort order to demonstrate that these works are being
+        # sorted by title rather than randomly.
+        by_title.order_ascending = False
+        expect(list(reversed(results)), "president", by_title)
 
         # Finally, verify that we can run multiple queries
         # simultaneously.
@@ -3101,6 +3149,7 @@ class TestFilter(DatabaseTest):
         audiences = ["somestring"]
         author = object()
         match_nothing = object()
+        min_score = object()
 
         # Test the easy stuff -- these arguments just get stored on
         # the Filter object. If necessary, they'll be cleaned up
@@ -3108,7 +3157,7 @@ class TestFilter(DatabaseTest):
         filter = Filter(
             media=media, languages=languages,
             fiction=fiction, audiences=audiences, author=author,
-            match_nothing=match_nothing
+            match_nothing=match_nothing, min_score=min_score
         )
         eq_(media, filter.media)
         eq_(languages, filter.languages)
@@ -3116,6 +3165,7 @@ class TestFilter(DatabaseTest):
         eq_(audiences, filter.audiences)
         eq_(author, filter.author)
         eq_(match_nothing, filter.match_nothing)
+        eq_(min_score, filter.min_score)
 
         # Test the `collections` argument.
 
@@ -3396,7 +3446,7 @@ class TestFilter(DatabaseTest):
         Filter.build() returns a main filter and no nested filters.
         """
         final_query = {'bool': {'must_not': [RESEARCH.to_dict()]}}
-        
+
         if expect:
             final_query['bool']['must'] = expect
         main, nested = filter.build(_chain_filters)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1027,7 +1027,8 @@ class TestSearchFacets(DatabaseTest):
         eq_(None, defaults.entrypoint)
         eq_(None, defaults.languages)
         eq_(None, defaults.media)
-        eq_(m.DEFAULT_MIN_SCORE, defaults.min_score)
+        eq_(None, defaults.order)
+        eq_(None, defaults.min_score)
 
         mock_entrypoint = object()
 
@@ -1059,6 +1060,13 @@ class TestSearchFacets(DatabaseTest):
         mock_min_score = object()
         with_min_score = m(min_score=mock_min_score)
         eq_(mock_min_score, with_min_score.min_score)
+
+        # Pass in a value for order, and you automatically get a
+        # reasonably tight value for min_score.
+        order = object()
+        with_order = m(order=order)
+        eq_(order, with_order.order)
+        eq_(SearchFacets.DEFAULT_MIN_SCORE, with_order.min_score)
 
     def test_from_request(self):
         # An HTTP client can customize which SearchFacets object
@@ -1116,7 +1124,7 @@ class TestSearchFacets(DatabaseTest):
         facets = from_request()
         eq_(None, facets.media)
         eq_(None, facets.languages)
-        eq_(facets.DEFAULT_MIN_SCORE, facets.min_score)
+        eq_(None, facets.min_score)
 
         # Reading the language query with acceptable Accept-Language header
         # but not passing that value through.
@@ -1167,7 +1175,8 @@ class TestSearchFacets(DatabaseTest):
     def test_items(self):
         facets = SearchFacets(
             entrypoint=EverythingEntryPoint,
-            media=Edition.BOOK_MEDIUM, languages=['eng']
+            media=Edition.BOOK_MEDIUM, languages=['eng'],
+            min_score=123
         )
 
         # When we call items(), e.g. to create a query string that
@@ -1181,7 +1190,9 @@ class TestSearchFacets(DatabaseTest):
             [('entrypoint', EverythingEntryPoint.INTERNAL_NAME),
              (Facets.AVAILABILITY_FACET_GROUP_NAME, Facets.AVAILABLE_ALL),
              (Facets.COLLECTION_FACET_GROUP_NAME, Facets.COLLECTION_FULL),
-             ('media', Edition.BOOK_MEDIUM)],
+             ('media', Edition.BOOK_MEDIUM),
+             ('min_score', '123'),
+            ],
             list(facets.items())
         )
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1081,8 +1081,8 @@ class TestSearchFacets(DatabaseTest):
 
         def from_request(**extra):
             return SearchFacets.from_request(
-                unused, self._default_library, get_argument, get_header,
-                unused, **extra
+                self._default_library, self._default_library, get_argument,
+                get_header, unused, **extra
             )
 
         facets = from_request(extra="value")
@@ -1100,8 +1100,8 @@ class TestSearchFacets(DatabaseTest):
         eq_([Edition.AUDIO_MEDIUM], facets.media)
 
         # The SearchFacets implementation turned the 'min_score'
-        # argument into a minimum score.
-        eq_(123, min_score)
+        # argument into a numeric minimum score.
+        eq_(123, facets.min_score)
 
         # The SearchFacets implementation turned the 'Accept-Language'
         # header into a set of language codes.
@@ -1186,17 +1186,21 @@ class TestSearchFacets(DatabaseTest):
         )
 
     def test_navigation(self):
-        """Navigating from one SearchFacets to another
-        gives a new SearchFacets object, even though SearchFacets doesn't
-        define navigate().
-
-        I.e. this is really a test of FacetsWithEntryPoint.navigate().
+        """Navigating from one SearchFacets to another gives a new
+        SearchFacets object. A number of fields can be changed,
+        including min_score, which is SearchFacets-specific.
         """
-        facets = SearchFacets(entrypoint=object())
+        facets = SearchFacets(
+            entrypoint=object(), order="field1", min_score=100
+        )
         new_ep = object()
-        new_facets = facets.navigate(new_ep)
+        new_facets = facets.navigate(
+            entrypoint=new_ep, order="field2", min_score=120
+        )
         assert isinstance(new_facets, SearchFacets)
         eq_(new_ep, new_facets.entrypoint)
+        eq_("field2", new_facets.order)
+        eq_(120, new_facets.min_score)
 
     def test_modify_search_filter(self):
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1185,7 +1185,7 @@ class TestSearchFacets(DatabaseTest):
 
         I.e. this is really a test of FacetsWithEntryPoint.navigate().
         """
-        facets = SearchFacets(object())
+        facets = SearchFacets(entrypoint=object())
         new_ep = object()
         new_facets = facets.navigate(new_ep)
         assert isinstance(new_facets, SearchFacets)
@@ -1194,27 +1194,29 @@ class TestSearchFacets(DatabaseTest):
     def test_modify_search_filter(self):
 
         # Test superclass behavior -- filter is modified by entrypoint.
-        facets = SearchFacets(AudiobooksEntryPoint)
+        facets = SearchFacets(entrypoint=AudiobooksEntryPoint)
         filter = Filter()
         facets.modify_search_filter(filter)
         eq_([Edition.AUDIO_MEDIUM], filter.media)
 
         # The medium specified in the constructor overrides anything
         # already present in the filter.
-        facets = SearchFacets(None, Edition.BOOK_MEDIUM)
+        facets = SearchFacets(entrypoint=None, media=Edition.BOOK_MEDIUM)
         filter = Filter(media=Edition.AUDIO_MEDIUM)
         facets.modify_search_filter(filter)
         eq_([Edition.BOOK_MEDIUM], filter.media)
 
         # It also overrides anything specified by the EntryPoint.
-        facets = SearchFacets(AudiobooksEntryPoint, Edition.BOOK_MEDIUM)
+        facets = SearchFacets(
+            entrypoint=AudiobooksEntryPoint, media=Edition.BOOK_MEDIUM
+        )
         filter = Filter()
         facets.modify_search_filter(filter)
         eq_([Edition.BOOK_MEDIUM], filter.media)
 
         # The language specified in the constructor _adds_ to any
         # languages already present in the filter.
-        facets = SearchFacets(None, languages=["eng", "spa"])
+        facets = SearchFacets(entrypoint=None, languages=["eng", "spa"])
         filter = Filter(languages="spa")
         facets.modify_search_filter(filter)
         eq_(["eng", "spa"], filter.languages)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1997,7 +1997,7 @@ class TestWorkList(DatabaseTest):
 
         # Now let's try a search with specific Pagination and Facets
         # objects.
-        facets = SearchFacets(None, languages=["chi"])
+        facets = SearchFacets(languages=["chi"])
         pagination = object()
         results = wl.search(self._db, query, client, pagination, facets,
                             debug=True)

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1033,7 +1033,10 @@ class TestSearchFacets(DatabaseTest):
 
         # If you pass in a single value for medium or language
         # they are turned into a list.
-        with_single_value = m(mock_entrypoint, Edition.BOOK_MEDIUM, "eng")
+        with_single_value = m(
+            entrypoint=mock_entrypoint, media=Edition.BOOK_MEDIUM,
+            languages="eng"
+        )
         eq_(mock_entrypoint, with_single_value.entrypoint)
         eq_([Edition.BOOK_MEDIUM], with_single_value.media)
         eq_(["eng"], with_single_value.languages)
@@ -1041,13 +1044,15 @@ class TestSearchFacets(DatabaseTest):
         # If you pass in a list of values, it's left alone.
         media = [Edition.BOOK_MEDIUM, Edition.AUDIO_MEDIUM]
         languages = ["eng", "spa"]
-        with_multiple_values = m(None, media, languages)
+        with_multiple_values = m(
+            media=media, languages=languages
+        )
         eq_(media, with_multiple_values.media)
         eq_(languages, with_multiple_values.languages)
 
         # The only exception is if you pass in Edition.ALL_MEDIUM
         # as 'medium' -- that's passed through as is.
-        every_medium = m(None, Edition.ALL_MEDIUM)
+        every_medium = m(media=Edition.ALL_MEDIUM)
         eq_(Edition.ALL_MEDIUM, every_medium.media)
 
         # Pass in a value for min_score, and it's stored for later.
@@ -1174,6 +1179,8 @@ class TestSearchFacets(DatabaseTest):
         # string.
         eq_(
             [('entrypoint', EverythingEntryPoint.INTERNAL_NAME),
+             (Facets.AVAILABILITY_FACET_GROUP_NAME, Facets.AVAILABLE_ALL),
+             (Facets.COLLECTION_FACET_GROUP_NAME, Facets.COLLECTION_FULL),
              ('media', Edition.BOOK_MEDIUM)],
             list(facets.items())
         )
@@ -1216,19 +1223,19 @@ class TestSearchFacets(DatabaseTest):
 
         # The language specified in the constructor _adds_ to any
         # languages already present in the filter.
-        facets = SearchFacets(entrypoint=None, languages=["eng", "spa"])
+        facets = SearchFacets(languages=["eng", "spa"])
         filter = Filter(languages="spa")
         facets.modify_search_filter(filter)
         eq_(["eng", "spa"], filter.languages)
 
         # It doesn't override those values.
-        facets = SearchFacets(None, languages="eng")
+        facets = SearchFacets(languages="eng")
         filter = Filter(languages="spa")
         facets.modify_search_filter(filter)
         eq_(["eng", "spa"], filter.languages)
 
         # This may result in modify_search_filter being a no-op.
-        facets = SearchFacets(None, languages="eng")
+        facets = SearchFacets(languages="eng")
         filter = Filter(languages="eng")
         facets.modify_search_filter(filter)
         eq_(["eng"], filter.languages)
@@ -1236,14 +1243,14 @@ class TestSearchFacets(DatabaseTest):
 
         # If no languages are specified in the SearchFacets, the value
         # set by the filter is used by itself.
-        facets = SearchFacets(None, languages=None)
+        facets = SearchFacets(languages=None)
         filter = Filter(languages="spa")
         facets.modify_search_filter(filter)
         eq_(["spa"], filter.languages)
 
         # If neither facets nor filter includes any languages, there
         # is no language filter.
-        facets = SearchFacets(None, languages=None)
+        facets = SearchFacets(languages=None)
         filter = Filter(languages=None)
         facets.modify_search_filter(filter)
         eq_(None, filter.languages)

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -145,11 +145,16 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         expect_args['extra'] = 'val'
         eq_(result, template % expect_args)
 
-        # The string has been completel interpolated.
+        # The string has been completely interpolated.
         assert '%' not in result
 
         # Once interpolation has happened, doing it again has no effect.
         eq_(result, self.api.endpoint(result, extra="something else"))
+
+        # This is important because an interpolated URL may superficially
+        # appear to contain extra formatting characters.
+        eq_(result + "%3A",
+            self.api.endpoint(result +"%3A", extra="something else"))
 
     def test_token_post_success(self):
         self.api.queue_response(200, content="some content")


### PR DESCRIPTION
This is a support branch for https://jira.nypl.org/browse/SIMPLY-2538 and https://jira.nypl.org/browse/SIMPLY-2539. It also includes a small fix for https://jira.nypl.org/browse/SIMPLY-2585.

This branch makes SearchFacets a subclass of the normal Facets object. All of the features of Facets are available--you can search for only available books, or only popular books. But the feature we're really interested right now in is the ability to _sort_ search results by title or author.

Naively sorting search results by title creates a situation where your alphabetically-sorted search results include a ton of terrible results that would normally be at the bottom. So this branch also starts using the Elasticsearch `min_score` feature. If `Filter.min_score` is set, then only works that score higher than that number are included in the search results. The `SearchFacets` class knows how to set appropriate values for `min_score`, as well as all the functionality it inherits from `Facets` -- sorting by fields like title or author, showing all books vs. only currently available books, etc.

You can customize all this stuff using the same HTTP query string parameters as `Facets`, and you can also specify a custom `min_score` using the `min_score` query string parameter. So a URL might look like `http://localhost:6500/search?q=cozy+mystery&order=author&min_score=1000`

While testing, I noticed that a good value for `min_score` depends on what type of search you're running, so I think Adriana will need to add some kind of configuration control on the client side. Maybe a slider that runs from 'more results' (min_score=0) to "fewer results" (min_score=2000).