### PR TITLE
Add 'relevance' as an explicit ordering for SearchFacets and make sure that the default value for a facet group is always enabled.

### DIFF
--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -2211,10 +2211,9 @@ class TestEntrypointLinkInsertion(DatabaseTest):
         eq_(first_page_url, make_link(EbooksEntryPoint))
 
     def test_search(self):
-        """When AcquisitionFeed.search() generates the first page of
-        search results, it will link to related searches for different
-        entry points, assuming the WorkList has different entry points.
-        """
+        # When AcquisitionFeed.search() generates the first page of
+        # search results, it will link to related searches for different
+        # entry points, assuming the WorkList has different entry points.
         def run(wl=None, facets=None, pagination=None):
             """Call search() and see what add_entrypoint_links
             was called with.
@@ -2257,7 +2256,7 @@ class TestEntrypointLinkInsertion(DatabaseTest):
 
         # The make_link function that was passed in calls
         # TestAnnotator.search_url() when passed an EntryPoint.
-        first_page_url = 'http://wl/?available=all&collection=full&entrypoint=Book'
+        first_page_url = 'http://wl/?available=all&collection=full&entrypoint=Book&order=relevance'
         eq_(first_page_url, make_link(EbooksEntryPoint))
 
         # Pagination information is not propagated through entry point links


### PR DESCRIPTION
This addresses some problems Adriana found while working on https://jira.nypl.org/browse/SIMPLY-2538:

1. "Order search results by relevance" is the default ordering for a SearchFacets, but up until now it didn't actually have a name, because there was no other way to order things. Now it has its own name, `relevance`.
2. If there is a conflict between a `Facets` object's default facet for some facet group, and the list of enabled facets for that group, then the default facet is automatically added to the list of enabled facets. There's no reason why a facet would ever be the default but _not_ be enabled.