### PR TITLE
Make it possible to cache a Representation under some URL other than the one used to make the HTTP request

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -2354,7 +2354,7 @@ class Filter(SearchBase):
         # At this point we know we have a specific list of audiences.
         # We're either going to return that list as-is, or we'll
         # return that list plus ALL_AGES.
-        with_all_ages = as_is + [Classifier.AUDIENCE_ALL_AGES]
+        with_all_ages = list(as_is) + [Classifier.AUDIENCE_ALL_AGES]
 
         if Classifier.AUDIENCE_ALL_AGES in as_is:
             # ALL_AGES is explicitly included.

--- a/model/resource.py
+++ b/model/resource.py
@@ -673,17 +673,59 @@ class Representation(Base, MediaTypes):
     def get(cls, _db, url, do_get=None, extra_request_headers=None,
             accept=None, max_age=None, pause_before=0, allow_redirects=True,
             presumed_media_type=None, debug=True, response_reviewer=None,
-            exception_handler=None):
+            exception_handler=None, url_normalizer=None):
         """Retrieve a representation from the cache if possible.
         If not possible, retrieve it from the web and store it in the
         cache.
+
+        :param _db: A database connection.
+
+        :param url: The URL to use as the target of any HTTP request.
+
         :param do_get: A function that takes arguments (url, headers)
-        and retrieves a representation over the network.
+           and retrieves a representation over the network.
+
+        :param extra_request_headers: Any additional HTTP headers to
+           include with the request.
+
+        :param accept:
+
         :param max_age: A timedelta object representing the maximum
         time to consider a cached representation fresh. (We ignore the
         caching directives from web servers because they're usually
         far too conservative for our purposes.)
+
+        :param pause_before: A number of seconds to pause before sending
+            the HTTP request. This is for use in situations where 
+            HTTP requests are subject to throttling.
+
+        :param allow_redirects: Not currently used. (TODO: this seems like
+            a problem!)
+
+        :param presumed_media_type: If the response does not contain a
+            Content-Type header, or if the specified Content-Type is
+            too generic to use, the representation will be presumed to be
+            of this media type.
+
+        :param debug: If True, progress reports on the HTTP request will
+           be logged.
+
+        :param response_reviewer: A function that takes a 3-tuple
+           (status_code, headers, content) and raises an exception if
+           the response should not be treated as cacheable.
+
+        :param exception_handler: A function that takes a 3-tuple
+            (Representation, Exception, traceback) and handles
+            an exceptional condition that occured during the HTTP request.
+
+        :param url_normalizer: A function that takes the URL to be used in 
+            the HTTP request, and returns the URL to use when storing
+            the corresponding Representation in the database. This can be
+            used to strip irrelevant or sensitive information from
+            URLs to increase the chances of a cache hit.
+
         :return: A 2-tuple (representation, obtained_from_cache)
+
         """
         representation = None
         do_get = do_get or cls.simple_http_get
@@ -698,7 +740,12 @@ class Representation(Base, MediaTypes):
         # the data sources we currently use, so for now we can treat
         # different representations of a URL as interchangeable.
 
-        a = dict(url=url)
+        if url_normalizer:
+            normalized_url = url_normalizer(url)
+        else:
+            normalized_url = url
+
+        a = dict(url=normalized_url)
         if accept:
             a['media_type'] = accept
         representation = get_one(_db, Representation, 'interchangeable', **a)
@@ -777,9 +824,11 @@ class Representation(Base, MediaTypes):
         # we had.
         if (not usable_representation
             or media_type != representation.media_type
-            or url != representation.url):
+            or normalized_url != representation.url):
             representation, is_new = get_one_or_create(
-                _db, Representation, url=url, media_type=unicode(media_type))
+                _db, Representation, url=normalized_url,
+                media_type=unicode(media_type)
+            )
 
         if fetch_exception:
             exception_handler(
@@ -871,7 +920,8 @@ class Representation(Base, MediaTypes):
         representation.fetch_exception = traceback
 
     @classmethod
-    def post(cls, _db, url, data, max_age=None, response_reviewer=None):
+    def post(cls, _db, url, data, max_age=None, response_reviewer=None,
+             **kwargs):
         """Finds or creates POST request as a Representation"""
 
         def do_post(url, headers, **kwargs):
@@ -880,7 +930,7 @@ class Representation(Base, MediaTypes):
 
         return cls.get(
             _db, url, do_get=do_post, max_age=max_age,
-            response_reviewer=response_reviewer
+            response_reviewer=response_reviewer, **kwargs
         )
 
     @property

--- a/model/resource.py
+++ b/model/resource.py
@@ -685,18 +685,18 @@ class Representation(Base, MediaTypes):
         :param do_get: A function that takes arguments (url, headers)
            and retrieves a representation over the network.
 
+        :param accept: A value for the Accept HTTP header.
+
         :param extra_request_headers: Any additional HTTP headers to
            include with the request.
 
-        :param accept:
-
         :param max_age: A timedelta object representing the maximum
-        time to consider a cached representation fresh. (We ignore the
-        caching directives from web servers because they're usually
-        far too conservative for our purposes.)
+           time to consider a cached representation fresh. (We ignore the
+           caching directives from web servers because they're usually
+           far too conservative for our purposes.)
 
         :param pause_before: A number of seconds to pause before sending
-            the HTTP request. This is for use in situations where 
+            the HTTP request. This is for use in situations where
             HTTP requests are subject to throttling.
 
         :param allow_redirects: Not currently used. (TODO: this seems like
@@ -718,7 +718,7 @@ class Representation(Base, MediaTypes):
             (Representation, Exception, traceback) and handles
             an exceptional condition that occured during the HTTP request.
 
-        :param url_normalizer: A function that takes the URL to be used in 
+        :param url_normalizer: A function that takes the URL to be used in
             the HTTP request, and returns the URL to use when storing
             the corresponding Representation in the database. This can be
             used to strip irrelevant or sensitive information from

--- a/model/resource.py
+++ b/model/resource.py
@@ -924,9 +924,11 @@ class Representation(Base, MediaTypes):
              **kwargs):
         """Finds or creates POST request as a Representation"""
 
+        original_do_get = kwargs.pop('do_get', cls.simple_http_post)
+
         def do_post(url, headers, **kwargs):
             kwargs.update({'data' : data})
-            return cls.simple_http_post(url, headers, **kwargs)
+            return original_do_get(url, headers, **kwargs)
 
         return cls.get(
             _db, url, do_get=do_post, max_age=max_age,

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -3312,7 +3312,7 @@ class TestFilter(DatabaseTest):
         parent.media = Edition.AUDIO_MEDIUM
         parent.languages = ["eng", "fra"]
         parent.fiction = True
-        parent.audiences = [Classifier.AUDIENCE_CHILDREN]
+        parent.audiences = set([Classifier.AUDIENCE_CHILDREN])
         parent.target_age = NumericRange(10, 11, '[]')
         parent.genres = [self.horror, self.fantasy]
         parent.customlists = [self.best_sellers]


### PR DESCRIPTION
This is core work for https://jira.nypl.org/browse/SIMPLY-2532.

Basically, our NoveList integration needs to be able to make a request to `http://novelist/book?credentials=abc`, but store the results under `http://novelist/book`. This lets us share cached NoveList data among different libraries on the same system, even though different libraries will have different NoveList credentials.

The existing solution modifies `Representation.url` after the database row has been created. The problem is that `Representation.url` isn't just a random field; it's part of a unique index. If multiple patrons are requesting the same NoveList data at the same time, this causes a race condition which makes spurious 500 errors show up in the logs. Multiple threads all believe they have a brand-new database row, then they all try to set its `Representation.url` to the same value and only one of them succeeds.

This solution allows the caller to pass in a hook function that converts "the URL used in the HTTP request" to "the URL stored in Representation.url". This lets us know the value we want to use `Representation.url` ahead of time, allowing us to look up an existing cached row if it exists. If there is no matching row, then `Representation.url` has the correct value right from the start, greatly reducing the risk of a race condition.