### PR TITLE
Make sure admins don't have spaces before / after email address.

### DIFF
--- a/model/admin.py
+++ b/model/admin.py
@@ -19,7 +19,10 @@ from sqlalchemy import (
     UniqueConstraint,
 )
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import (
+    relationship,
+    validates
+)
 from sqlalchemy.orm.session import Session
 
 class Admin(Base, HasFullTableCache):
@@ -48,6 +51,11 @@ class Admin(Base, HasFullTableCache):
         if credential:
             self.credential = credential
         _db.commit()
+
+    @validates('email')
+    def validate_email(self, key, address):
+        # strip any whitespace from email address
+        return address.strip()
 
     @hybrid_property
     def password(self):

--- a/tests/models/test_admin.py
+++ b/tests/models/test_admin.py
@@ -37,6 +37,10 @@ class TestAdmin(DatabaseTest):
         admin2.password = "password2"
         eq_(set([admin, admin2]), set(Admin.with_password(self._db).all()))
 
+    def test_with_email_spaces(self):
+        admin_spaces, ignore = create(self._db, Admin, email=u"test@email.com ")
+        eq_(u"test@email.com", admin_spaces.email)
+
     def test_has_password(self):
         eq_(True, self.admin.has_password(u"password"))
         eq_(False, self.admin.has_password(u"banana"))


### PR DESCRIPTION
This is a followup to: https://github.com/NYPL-Simplified/circulation/pull/1394

One of our hosting clients reported an issue when they created a new admin user. The user could not be deleted through the UI and when showing its details it did not show any possible roles. In the logs we were seeing: 
```
{"name": "root", "level": "ERROR", "timestamp": "2020-02-25T21:14:05.539783", "app": "simplified", "traceback": "Traceback (most recent call last):
  File \"/circulation/env/lib/python2.7/site-packages/flask/app.py\", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File \"/circulation/env/lib/python2.7/site-packages/flask/app.py\", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File \"/circulation/api/admin/routes.py\", line 101, in decorated
    v = f(*args, **kwargs)
  File \"/circulation/api/admin/routes.py\", line 80, in decorated
    return f(*args, **kwargs)
  File \"/circulation/api/admin/routes.py\", line 95, in decorated
    return f(*args, **kwargs)
  File \"/circulation/api/admin/routes.py\", line 373, in individual_admin
    return app.manager.admin_individual_admin_settings_controller.process_delete(email)
  File \"/Users/jgreen/projects/libsimple/circulation/api/admin/controller/individual_admin_settings.py\", line 237, in process_delete
    if admin.is_system_admin():
AttributeError: 'NoneType' object has no attribute 'is_system_admin'", "message": "Exception in web app: 'NoneType' object has no attribute 'is_system_admin'", "filename": "app_server.py"}
```

Turns out you can create a user with a space after the email, but this space isn't used when querying for the user in the future, so you cannot modify or delete them through the UI.

Tagging: @leonardr 