### PR TITLE
Copy the @compressible annotator over from library_registry.

### DIFF
--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -1,3 +1,5 @@
+import gzip
+from io import BytesIO
 import os
 import json
 
@@ -38,6 +40,7 @@ from ..app_server import (
     URNLookupHandler,
     ErrorHandler,
     ComplaintController,
+    compressible,
     load_facets_from_request,
     load_pagination_from_request,
 )
@@ -518,3 +521,71 @@ class TestErrorHandler(DatabaseTest):
                 u"A debug_message which should only appear in debug mode.\n\n"
                 u'Traceback (most recent call last)'
             )
+
+
+class TestCompressibleAnnotator(object):
+    """Test the @compressible annotator."""
+
+    def __init__(self):
+        self.app = Flask(__name__)
+
+    def test_compressible(self):
+        # Test the @compressible annotator.
+
+        # Prepare a value and a gzipped version of the value.
+        value = "Compress me! (Or not.)"
+
+        buffer = BytesIO()
+        gzipped = gzip.GzipFile(mode='wb', fileobj=buffer)
+        gzipped.write(value)
+        gzipped.close()
+        compressed = buffer.getvalue()
+
+        # Spot-check the compressed value
+        assert '-(J-.V' in compressed
+
+        # This compressible controller function always returns the
+        # same value.
+        @compressible
+        def function():
+            return value
+
+        def ask_for_compression(compression, header='Accept-Encoding'):
+            """This context manager simulates the entire Flask
+            request-response cycle, including a call to
+            process_response(), which triggers the @after_this_request
+            hooks.
+
+            :return: The Response object.
+            """
+            headers = {}
+            if compression:
+                headers[header] = compression
+            with self.app.test_request_context(headers=headers):
+                response = flask.Response(function())
+                self.app.process_response(response)
+                return response
+
+        # If the client asks for gzip through Accept-Encoding, the
+        # representation is compressed.
+        response = ask_for_compression("gzip")
+        eq_(compressed, response.data)
+        eq_("gzip", response.headers['Content-Encoding'])
+
+        # If the client doesn't ask for compression, the value is
+        # passed through unchanged.
+        response = ask_for_compression(None)
+        eq_(value, response.data)
+        assert 'Content-Encoding' not in response.headers
+
+        # Similarly if the client asks for an unsupported compression
+        # mechanism.
+        response = ask_for_compression('compress')
+        eq_(value, response.data)
+        assert 'Content-Encoding' not in response.headers
+
+        # Or if the client asks for a compression mechanism through
+        # Accept-Transfer-Encoding, which is currently unsupported.
+        response = ask_for_compression("gzip", "Accept-Transfer-Encoding")
+        eq_(value, response.data)
+        assert 'Content-Encoding' not in response.headers


### PR DESCRIPTION
This branch copies the @compressible annotator over from library registry. The annotator itself is exactly the same as what I put into https://github.com/NYPL-Simplified/library_registry/pull/163, and the test class has only minor changes.

This is the core portion of https://jira.nypl.org/browse/SIMPLY-2667; the circulation portion will probably just be adding @compressible to a few controller functions.