### PR TITLE
Cache control infrastructure

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -13,7 +13,6 @@ from flask import url_for, make_response
 from flask_babel import lazy_gettext as _
 from io import BytesIO
 from util.flask_util import problem
-from util.opds_writer import OPDSFeed
 from util.problem_detail import ProblemDetail
 import traceback
 import logging

--- a/app_server.py
+++ b/app_server.py
@@ -21,7 +21,7 @@ from opds import (
     AcquisitionFeed,
     LookupAcquisitionFeed,
 )
-from util.flask_util import OPDSFeedResponselike
+from util.flask_util import OPDSFeedResponse
 from util.opds_writer import (
     OPDSFeed,
     OPDSMessage,
@@ -320,7 +320,7 @@ class URNLookupController(object):
             self._db, "Lookup results", this_url, handler.works, annotator,
             precomposed_entries=handler.precomposed_entries,
         )
-        return OPDSFeedResponselike(opds_feed).response
+        return OPDSFeedResponse(opds_feed)
 
     def process_urns(self, urns, **process_urn_kwargs):
         """Process a number of URNs by instantiating a URNLookupHandler
@@ -354,7 +354,7 @@ class URNLookupController(object):
             self._db, urn, this_url, works, annotator,
             precomposed_entries=handler.precomposed_entries
         )
-        return OPDSFeedResponselike(opds_feed).response
+        return OPDSFeedResponse(opds_feed)
 
 
 class URNLookupHandler(object):

--- a/app_server.py
+++ b/app_server.py
@@ -66,41 +66,6 @@ def load_lending_policy(policy):
                         audience)
     return policy
 
-def feed_response(feed, acquisition=True, cache_for=None):
-    """Create a response for an OPDS feed.
-
-    For a feed created through WorkList, you shouldn't need this, because
-    WorkList methods generally return a flask_utils.Responselike.
-    """
-    if acquisition:
-        content_type = OPDSFeed.ACQUISITION_FEED_TYPE
-    else:
-        content_type = OPDSFeed.NAVIGATION_FEED_TYPE
-    return _make_response(feed, content_type, cache_for)
-
-def entry_response(entry, cache_for=None):
-    content_type = OPDSFeed.ENTRY_TYPE
-    return _make_response(entry, content_type, cache_for)
-
-def _make_response(content, content_type, cache_for):
-    if isinstance(content, etree._Element):
-        content = etree.tostring(content)
-    elif not isinstance(content, (bytes, unicode)):
-        content = unicode(content)
-
-    if isinstance(cache_for, int):
-        # A CDN should hold on to the cached representation only half
-        # as long as the end-user.
-        client_cache = cache_for
-        cdn_cache = cache_for / 2
-        cache_control = "public, no-transform, max-age=%d, s-maxage=%d" % (
-            client_cache, cdn_cache)
-    else:
-        cache_control = "private, no-cache"
-
-    return make_response(content, 200, {"Content-Type": content_type,
-                                        "Cache-Control": cache_control})
-
 def load_facets_from_request(
         facet_config=None, worklist=None, base_class=Facets,
         base_class_constructor_kwargs=None, default_entrypoint=None

--- a/app_server.py
+++ b/app_server.py
@@ -69,8 +69,8 @@ def load_lending_policy(policy):
 def feed_response(feed, acquisition=True, cache_for=None):
     """Create a response for an OPDS feed.
 
-    NOTE: You probably want to use flask_utils.Responselike instead,
-    and it's possible that this can be deprecated.
+    For a feed created through WorkList, you shouldn't need this, because
+    WorkList methods generally return a flask_utils.Responselike.
     """
     if acquisition:
         content_type = OPDSFeed.ACQUISITION_FEED_TYPE

--- a/app_server.py
+++ b/app_server.py
@@ -13,6 +13,7 @@ from flask import url_for, make_response
 from flask_babel import lazy_gettext as _
 from io import BytesIO
 from util.flask_util import problem
+from util.opds_writer import OPDSFeed
 from util.problem_detail import ProblemDetail
 import traceback
 import logging
@@ -21,6 +22,7 @@ from opds import (
     AcquisitionFeed,
     LookupAcquisitionFeed,
 )
+from util.flask_util import OPDSFeedResponselike
 from util.opds_writer import (
     OPDSFeed,
     OPDSMessage,
@@ -319,7 +321,7 @@ class URNLookupController(object):
             self._db, "Lookup results", this_url, handler.works, annotator,
             precomposed_entries=handler.precomposed_entries,
         )
-        return feed_response(opds_feed)
+        return OPDSFeedResponselike(opds_feed).response
 
     def process_urns(self, urns, **process_urn_kwargs):
         """Process a number of URNs by instantiating a URNLookupHandler
@@ -353,8 +355,7 @@ class URNLookupController(object):
             self._db, urn, this_url, works, annotator,
             precomposed_entries=handler.precomposed_entries
         )
-
-        return feed_response(opds_feed)
+        return OPDSFeedResponselike(opds_feed).response
 
 
 class URNLookupHandler(object):

--- a/app_server.py
+++ b/app_server.py
@@ -66,7 +66,7 @@ def load_lending_policy(policy):
                         audience)
     return policy
 
-def feed_response(feed, acquisition=True, cache_for=AcquisitionFeed.FEED_CACHE_TIME):
+def feed_response(feed, acquisition=True, cache_for=None):
     """Create a response for an OPDS feed.
 
     NOTE: You probably want to use flask_utils.Responselike instead,
@@ -78,7 +78,7 @@ def feed_response(feed, acquisition=True, cache_for=AcquisitionFeed.FEED_CACHE_T
         content_type = OPDSFeed.NAVIGATION_FEED_TYPE
     return _make_response(feed, content_type, cache_for)
 
-def entry_response(entry, cache_for=AcquisitionFeed.FEED_CACHE_TIME):
+def entry_response(entry, cache_for=None):
     content_type = OPDSFeed.ENTRY_TYPE
     return _make_response(entry, content_type, cache_for)
 

--- a/app_server.py
+++ b/app_server.py
@@ -67,6 +67,11 @@ def load_lending_policy(policy):
     return policy
 
 def feed_response(feed, acquisition=True, cache_for=AcquisitionFeed.FEED_CACHE_TIME):
+    """Create a response for an OPDS feed.
+
+    NOTE: You probably want to use flask_utils.Responselike instead,
+    and it's possible that this can be deprecated.
+    """
     if acquisition:
         content_type = OPDSFeed.ACQUISITION_FEED_TYPE
     else:

--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -23,7 +23,7 @@ from sqlalchemy import (
 from sqlalchemy.sql.expression import (
     and_,
 )
-from ..util.flask_util import OPDSFeedResponselike
+from ..util.flask_util import OPDSFeedResponse
 
 class CachedFeed(Base):
 
@@ -108,12 +108,12 @@ class CachedFeed(Base):
             specified, a default value will be calculated based on
             WorkList and Facets configuration. Setting this value to
             zero will force a refresh.
-        :param raw: If this is False (the default), a Responselike ready to be
+        :param raw: If this is False (the default), a Response ready to be
             converted into a Flask Response object will be returned. If this
             is True, the CachedFeed object itself will be returned. In most
             non-test situations the default is better.
 
-        :return: A Responselike or CachedFeed containing up-to-date content.
+        :return: A Response or CachedFeed containing up-to-date content.
         """
 
         # Gather the information necessary to uniquely identify this
@@ -184,9 +184,9 @@ class CachedFeed(Base):
         # response-type object.
         #
         # In almost all cases these values are correct, and in cases
-        # where they're not correct the caller can modify the Responselike
+        # where they're not correct the caller can modify the Response
         # before turning it into a Response.
-        return OPDSFeedResponselike(
+        return OPDSFeedResponse(
             response=feed_obj.content,
             status=200,
             max_age=max_age

--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
 from sqlalchemy.sql.expression import (
     and_,
 )
+from ..util.opds_writer import OPDSFeed
 from ..util.flask_util import Responselike
 
 class CachedFeed(Base):
@@ -83,7 +84,7 @@ class CachedFeed(Base):
 
     @classmethod
     def fetch(cls, _db, worklist, facets, pagination, refresher_method,
-              max_age=None, format=CachedFeed
+              max_age=None, format=None
     ):
         """Retrieve a cached feed from the database if possible.
 
@@ -179,8 +180,13 @@ class CachedFeed(Base):
         if format is Responselike:
             # We have the information necessary to create a useful
             # response-type object.
+            #
+            # In almost all cases these values are correct, and in cases
+            # where they're not correct the caller can modify the Responselike
+            # before turning it into a Response.
             return Responselike(
                 response=feed_obj.content,
+                status=200,
                 mimetype=OPDSFeed.ACQUISITION_FEED_TYPE,
                 max_age=max_age
             )

--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -23,7 +23,6 @@ from sqlalchemy import (
 from sqlalchemy.sql.expression import (
     and_,
 )
-from ..util.opds_writer import OPDSFeed
 from ..util.flask_util import OPDSFeedResponselike
 
 class CachedFeed(Base):

--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -83,7 +83,7 @@ class CachedFeed(Base):
 
     @classmethod
     def fetch(cls, _db, worklist, facets, pagination, refresher_method,
-              max_age=None, raw=False
+              max_age=None, raw=False, **response_kwargs
     ):
         """Retrieve a cached feed from the database if possible.
 
@@ -183,13 +183,11 @@ class CachedFeed(Base):
         # We have the information necessary to create a useful
         # response-type object.
         #
-        # In almost all cases these values are correct, and in cases
-        # where they're not correct the caller can modify the Response
-        # before turning it into a Response.
+        # Set some defaults in case the caller didn't pass them in.
+        response_kwargs.setdefault('max_age', max_age)
         return OPDSFeedResponse(
             response=feed_obj.content,
-            status=200,
-            max_age=max_age
+            **response_kwargs
         )
 
     @classmethod

--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -177,11 +177,12 @@ class CachedFeed(Base):
             feed_obj.timestamp = generation_time
 
         if format is Responselike:
-            headers = {
-                "Content-Type": OPDSFeed.ACQUISITION_FEED_TYPE
-            }
+            # We have the information necessary to create a useful
+            # response-type object.
             return Responselike(
-                content=feed_obj.content, headers=headers, max_age=max_age
+                response=feed_obj.content,
+                mimetype=OPDSFeed.ACQUISITION_FEED_TYPE,
+                max_age=max_age
             )
         return feed_obj
 

--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -24,7 +24,7 @@ from sqlalchemy.sql.expression import (
     and_,
 )
 from ..util.opds_writer import OPDSFeed
-from ..util.flask_util import Responselike
+from ..util.flask_util import OPDSFeedResponselike
 
 class CachedFeed(Base):
 
@@ -187,10 +187,9 @@ class CachedFeed(Base):
         # In almost all cases these values are correct, and in cases
         # where they're not correct the caller can modify the Responselike
         # before turning it into a Response.
-        return Responselike(
+        return OPDSFeedResponselike(
             response=feed_obj.content,
             status=200,
-            mimetype=OPDSFeed.ACQUISITION_FEED_TYPE,
             max_age=max_age
         )
 

--- a/opds.py
+++ b/opds.py
@@ -59,8 +59,8 @@ from lane import (
 )
 
 from util.flask_util import (
-    OPDSFeedResponselike,
-    Responselike,
+    OPDSFeedResponse,
+    Response,
 )
 from util.opds_writer import (
     AtomFeed,
@@ -598,7 +598,7 @@ class AcquisitionFeed(OPDSFeed):
 
         :param facets: A GroupsFacet object.
 
-        :return: A Responselike containing the feed.
+        :return: A Response containing the feed.
         """
         annotator = cls._make_annotator(annotator)
         facets = facets or FeaturedFacets.default(worklist.get_library(_db))
@@ -697,7 +697,7 @@ class AcquisitionFeed(OPDSFeed):
     ):
         """Create a feed representing one page of works from a given lane.
 
-        :return: A Responselike containing the feed.
+        :return: A Response containing the feed.
         """
         library = worklist.get_library(_db)
         facets = facets or Facets.default(library)
@@ -782,6 +782,9 @@ class AcquisitionFeed(OPDSFeed):
         TODO: This is used by the circulation manager admin interface.
         Investigating replacing the code that uses this so that it uses
         the search index.
+
+        TODO: This cannot currently return Response because the
+        admin interface modifies the feed after it's generated.
         """
         page_of_works = pagination.modify_database_query(_db, query)
         pagination.total_size = int(query.count())
@@ -947,7 +950,7 @@ class AcquisitionFeed(OPDSFeed):
         :param max_age: An integer number of seconds to use in the outgoing
             Cache-Control header.
 
-        :return: A Responselike
+        :return: A Response
         """
         facets = facets or SearchFacets()
         pagination = pagination or Pagination.default()
@@ -995,7 +998,7 @@ class AcquisitionFeed(OPDSFeed):
         opds_feed.add_breadcrumbs(lane, include_lane=True)
 
         annotator.annotate_feed(opds_feed, lane)
-        return OPDSFeedResponselike(
+        return OPDSFeedResponse(
             unicode(opds_feed), max_age=max_age
         )
 
@@ -1014,7 +1017,7 @@ class AcquisitionFeed(OPDSFeed):
         :param max_age: An integer number of seconds to use in the outgoing
             Cache-Control header.
         :param raw: If this is True, the e
-        :return: A Responselike, if `raw` is false; otherwise an OPDSMessage
+        :return: A Response, if `raw` is false; otherwise an OPDSMessage
             or an etree._Element -- whatever was returned by
             OPDSFeed.create_entry.
         """
@@ -1050,7 +1053,7 @@ class AcquisitionFeed(OPDSFeed):
             max_age = None
         elif isinstance(entry, etree._Element):
             entry = etree.tostring(entry)
-        return Responselike(
+        return Response(
             response=entry, mimetype=OPDSFeed.ENTRY_TYPE, max_age=max_age
         )
 

--- a/opds.py
+++ b/opds.py
@@ -58,7 +58,10 @@ from lane import (
     WorkList,
 )
 
-from util.flask_util import Responselike
+from util.flask_util import (
+    OPDSFeedResponselike,
+    Responselike,
+)
 from util.opds_writer import (
     AtomFeed,
     OPDSFeed,
@@ -993,9 +996,8 @@ class AcquisitionFeed(OPDSFeed):
         opds_feed.add_breadcrumbs(lane, include_lane=True)
 
         annotator.annotate_feed(opds_feed, lane)
-        return Responselike(
-            unicode(opds_feed), mimetype=OPDSFeed.ACQUISITION_FEED_TYPE,
-            max_age=max_age
+        return OPDSFeedResponselike(
+            unicode(opds_feed), max_age=max_age
         )
 
     @classmethod
@@ -1050,8 +1052,7 @@ class AcquisitionFeed(OPDSFeed):
         elif isinstance(entry, etree._Element):
             entry = etree.tostring(entry)
         return Responselike(
-            response=entry,
-            mimetype=OPDSFeed.ENTRY_TYPE, max_age=max_age
+            response=entry, mimetype=OPDSFeed.ENTRY_TYPE, max_age=max_age
         )
 
     @classmethod

--- a/opds.py
+++ b/opds.py
@@ -1004,8 +1004,7 @@ class AcquisitionFeed(OPDSFeed):
 
     @classmethod
     def single_entry(
-            cls, _db, work, annotator, force_create=False, max_age=None,
-            raw=False
+            cls, _db, work, annotator, force_create=False, raw=False, **kwargs
     ):
         """Create a single-entry OPDS document for one specific work.
 
@@ -1016,8 +1015,12 @@ class AcquisitionFeed(OPDSFeed):
             if there's already a cached one.
         :param max_age: An integer number of seconds to use in the outgoing
             Cache-Control header.
-        :param raw: If this is True, the e
-        :return: A Response, if `raw` is false; otherwise an OPDSMessage
+        :param raw: If this is False (the default), a Flask Response will be returned,
+            ready to be sent over the network. Otherwise an object representing
+            the underlying OPDS entry will be returned.
+        :param kwargs: These keyword arguments will be passed into the Response
+            constructor, if it's invoked.
+        :return: A Response, if `raw` is false. Otherwise, an OPDSMessage
             or an etree._Element -- whatever was returned by
             OPDSFeed.create_entry.
         """
@@ -1054,7 +1057,8 @@ class AcquisitionFeed(OPDSFeed):
         elif isinstance(entry, etree._Element):
             entry = etree.tostring(entry)
         return Response(
-            response=entry, mimetype=OPDSFeed.ENTRY_TYPE, max_age=max_age
+            response=entry, mimetype=OPDSFeed.ENTRY_TYPE,
+            max_age=max_age, **kwargs
         )
 
     @classmethod

--- a/opds.py
+++ b/opds.py
@@ -57,7 +57,7 @@ from lane import (
     SearchFacets,
     WorkList,
 )
-from util.flask_utils import Responselike
+from util.flask_util import Responselike
 from util.opds_writer import (
     AtomFeed,
     OPDSFeed,

--- a/opds.py
+++ b/opds.py
@@ -57,7 +57,7 @@ from lane import (
     SearchFacets,
     WorkList,
 )
-from util.flask_util import Responselike
+
 from util.opds_writer import (
     AtomFeed,
     OPDSFeed,
@@ -607,7 +607,7 @@ class AcquisitionFeed(OPDSFeed):
 
         return CachedFeed.fetch(
             _db, worklist=worklist, facets=facets, pagination=None,
-            refresher_method=refresh, max_age=max_age, format=Responselike
+            refresher_method=refresh, max_age=max_age
         )
 
     @classmethod
@@ -708,7 +708,7 @@ class AcquisitionFeed(OPDSFeed):
 
         return CachedFeed.fetch(
             _db, worklist=worklist, facets=facets, pagination=pagination,
-            refresher_method=refresh, max_age=max_age, format=Responselike
+            refresher_method=refresh, max_age=max_age
         )
 
     @classmethod
@@ -1675,7 +1675,7 @@ class NavigationFeed(OPDSFeed):
             facets=facets,
             pagination=None,
             refresher_method=refresh,
-            max_age=max_age, format=Responselike
+            max_age=max_age
         )
         # Change the default mimetype.
         response.mimetype=OPDSFeed.NAVIGATION_FEED_TYPE

--- a/opds.py
+++ b/opds.py
@@ -811,6 +811,9 @@ class AcquisitionFeed(OPDSFeed):
 
         return feed
 
+    def response(self, **kwargs):
+        return OPDSFeedResponse(self, **kwargs)
+
     @classmethod
     def _make_annotator(cls, annotator):
         """Helper method to make sure there's some kind of Annotator."""

--- a/opds.py
+++ b/opds.py
@@ -951,7 +951,6 @@ class AcquisitionFeed(OPDSFeed):
         """
         facets = facets or SearchFacets()
         pagination = pagination or Pagination.default()
-        max_age = max_age or OPDSFeed.DEFAULT_MAX_AGE
         results = lane.search(
             _db, query, search_engine, pagination=pagination, facets=facets
         )

--- a/opds.py
+++ b/opds.py
@@ -813,9 +813,14 @@ class AcquisitionFeed(OPDSFeed):
         return feed
 
     def as_response(self, **kwargs):
+        """Convert this feed into an OPDSFEedResponse."""
         return OPDSFeedResponse(self, **kwargs)
 
     def as_error_response(self, **kwargs):
+        """Convert this feed into an OPDSFEedResponse that should be treated
+        by intermediaries as an error -- that is, treated as private
+        and not cached.
+        """
         kwargs['max_age'] = 0
         kwargs['private'] = True
         return self.as_response(**kwargs)

--- a/opds.py
+++ b/opds.py
@@ -59,6 +59,7 @@ from lane import (
 )
 
 from util.flask_util import (
+    OPDSEntryResponse,
     OPDSFeedResponse,
     Response,
 )
@@ -811,8 +812,13 @@ class AcquisitionFeed(OPDSFeed):
 
         return feed
 
-    def response(self, **kwargs):
+    def as_response(self, **kwargs):
         return OPDSFeedResponse(self, **kwargs)
+
+    def as_error_response(self, **kwargs):
+        kwargs['max_age'] = 0
+        kwargs['private'] = True
+        return self.as_response(**kwargs)
 
     @classmethod
     def _make_annotator(cls, annotator):
@@ -1070,9 +1076,7 @@ class AcquisitionFeed(OPDSFeed):
         response_kwargs.setdefault('max_age', 0)
         response_kwargs.setdefault('private', True)
 
-        return Response(
-            response=entry, mimetype=OPDSFeed.ENTRY_TYPE, **response_kwargs
-        )
+        return OPDSEntryResponse(response=entry, **response_kwargs)
 
     @classmethod
     def error_message(cls, identifier, error_status, error_message):

--- a/opds.py
+++ b/opds.py
@@ -57,6 +57,7 @@ from lane import (
     SearchFacets,
     WorkList,
 )
+from util.flask_utils import Responselike
 from util.opds_writer import (
     AtomFeed,
     OPDSFeed,
@@ -599,7 +600,7 @@ class AcquisitionFeed(OPDSFeed):
 
         :param facets: A GroupsFacet object.
 
-        :return: A Unicode string containing a (potentially cached) OPDS feed.
+        :return: A Responselike containing the feed.
         """
         annotator = cls._make_annotator(annotator)
         facets = facets or FeaturedFacets.default(worklist.get_library(_db))
@@ -614,7 +615,7 @@ class AcquisitionFeed(OPDSFeed):
             _db, worklist=worklist, facets=facets, pagination=None,
             refresher_method=refresh, max_age=max_age
         )
-        return cached.content
+        return Responselike(body=cached.content, max_age=max_age)
 
     @classmethod
     def _generate_groups(
@@ -699,7 +700,7 @@ class AcquisitionFeed(OPDSFeed):
     ):
         """Create a feed representing one page of works from a given lane.
 
-        :return: A Unicode string containing a (potentially cached) OPDS feed.
+        :return: A Responselike containing the feed.
         """
         library = worklist.get_library(_db)
         facets = facets or Facets.default(library)
@@ -716,7 +717,8 @@ class AcquisitionFeed(OPDSFeed):
             _db, worklist=worklist, facets=facets, pagination=pagination,
             refresher_method=refresh, max_age=max_age
         )
-        return cached.content
+        max_age = getattr(cached, 'max_age', max_age)
+        return Responselike(body=cached.content, max_age=cached.max_age)
 
     @classmethod
     def _generate_page(

--- a/tests/models/test_cachedfeed.py
+++ b/tests/models/test_cachedfeed.py
@@ -16,7 +16,7 @@ from ...lane import (
 from ...model.cachedfeed import CachedFeed
 from ...model.configuration import ConfigurationSetting
 from ...opds import AcquisitionFeed
-from ...util.flask_util import Responselike
+from ...util.flask_util import Response
 from ...util.opds_writer import OPDSFeed
 
 class MockFeedGenerator(object):
@@ -346,7 +346,7 @@ class TestCachedFeed(DatabaseTest):
 
     def test_responselike_format(self):
         # Verify that fetch() can be told to return an appropriate
-        # Responselike object. This is the default behavior, since
+        # Response object. This is the default behavior, since
         # it preserves some useful information that would otherwise be
         # lost.
         facets = Facets.default(self._default_library)
@@ -360,7 +360,7 @@ class TestCachedFeed(DatabaseTest):
         rl = CachedFeed.fetch(
             self._db, wl, facets, pagination, refresh, max_age=102,
         )
-        assert isinstance(rl, Responselike)
+        assert isinstance(rl, Response)
         eq_(200, rl.status_code)
         eq_(OPDSFeed.ACQUISITION_FEED_TYPE, rl.content_type)
         eq_(102, rl.max_age)

--- a/tests/models/test_cachedfeed.py
+++ b/tests/models/test_cachedfeed.py
@@ -344,7 +344,7 @@ class TestCachedFeed(DatabaseTest):
         eq_(None, result2.content)
         eq_(tomorrow, result2.timestamp)
 
-    def test_responselike_format(self):
+    def test_response_format(self):
         # Verify that fetch() can be told to return an appropriate
         # Response object. This is the default behavior, since
         # it preserves some useful information that would otherwise be
@@ -357,14 +357,20 @@ class TestCachedFeed(DatabaseTest):
         def refresh():
             return "Here's a feed."
 
-        rl = CachedFeed.fetch(
+        private=object()
+        r = CachedFeed.fetch(
             self._db, wl, facets, pagination, refresh, max_age=102,
+            private=private
         )
-        assert isinstance(rl, Response)
-        eq_(200, rl.status_code)
-        eq_(OPDSFeed.ACQUISITION_FEED_TYPE, rl.content_type)
-        eq_(102, rl.max_age)
-        eq_("Here's a feed.", rl.data)
+        assert isinstance(r, Response)
+        eq_(200, r.status_code)
+        eq_(OPDSFeed.ACQUISITION_FEED_TYPE, r.content_type)
+        eq_(102, r.max_age)
+        eq_("Here's a feed.", r.data)
+
+        # The extra argument `private`, not used by CachedFeed.fetch, was
+        # passed on to the Response constructor.
+        eq_(private, r.private)
 
         # The CachedFeed was created; just not returned.
         cf = self._db.query(CachedFeed).one()

--- a/tests/models/test_cachedfeed.py
+++ b/tests/models/test_cachedfeed.py
@@ -345,11 +345,10 @@ class TestCachedFeed(DatabaseTest):
         eq_(tomorrow, result2.timestamp)
 
     def test_responselike_format(self):
-        """Verify that fetch() can be told to return an appropriate
-        Responselike object. This is the default behavior, and
-        preserves some information that's useful when turning the feed
-        into an HTTP response.
-        """
+        # Verify that fetch() can be told to return an appropriate
+        # Responselike object. This is the default behavior, since
+        # it preserves some useful information that would otherwise be
+        # lost.
         facets = Facets.default(self._default_library)
         pagination = Pagination.default()
         wl = WorkList()
@@ -362,10 +361,10 @@ class TestCachedFeed(DatabaseTest):
             self._db, wl, facets, pagination, refresh, max_age=102,
         )
         assert isinstance(rl, Responselike)
-        eq_(200, rl.status)
-        eq_(OPDSFeed.ACQUISITION_FEED_TYPE, rl.mimetype)
+        eq_(200, rl.status_code)
+        eq_(OPDSFeed.ACQUISITION_FEED_TYPE, rl.content_type)
         eq_(102, rl.max_age)
-        eq_("Here's a feed.", rl._response)
+        eq_("Here's a feed.", rl.data)
 
         # The CachedFeed was created; just not returned.
         cf = self._db.query(CachedFeed).one()

--- a/tests/models/test_cachedfeed.py
+++ b/tests/models/test_cachedfeed.py
@@ -555,7 +555,7 @@ class TestCachedFeed(DatabaseTest):
         # Fetch a cached feed from the database. It comes out updated.
         refresher = MockFeedGenerator()
         args = (self._db, lane, facets, pagination, refresher)
-        feed = CachedFeed.fetch(*args, max_age=0)
+        feed = CachedFeed.fetch(*args, max_age=0, raw=True)
         eq_("This is feed #1", feed.content)
 
         eq_(pagination.query_string, feed.pagination)
@@ -563,11 +563,11 @@ class TestCachedFeed(DatabaseTest):
         eq_(lane.id, feed.lane_id)
 
         # Fetch it again, with a high max_age, and it's cached!
-        feed = CachedFeed.fetch(*args, max_age=1000)
+        feed = CachedFeed.fetch(*args, max_age=1000, raw=True)
         eq_("This is feed #1", feed.content)
 
         # Fetch it with a low max_age, and it gets updated again.
-        feed = CachedFeed.fetch(*args, max_age=0)
+        feed = CachedFeed.fetch(*args, max_age=0, raw=True)
         eq_("This is feed #2", feed.content)
 
         # The special constant CACHE_FOREVER means it's always cached.
@@ -583,7 +583,7 @@ class TestCachedFeed(DatabaseTest):
         # Fetch a cached feed from the database. It comes out updated.
         refresher = MockFeedGenerator()
         args = (self._db, lane, facets, pagination, refresher)
-        feed = CachedFeed.fetch(*args, max_age=0)
+        feed = CachedFeed.fetch(*args, max_age=0, raw=True)
         eq_("This is feed #1", feed.content)
 
         eq_(pagination.query_string, feed.pagination)
@@ -592,13 +592,15 @@ class TestCachedFeed(DatabaseTest):
         eq_(lane.unique_key, feed.unique_key)
 
         # Fetch it again, with a high max_age, and it's cached!
-        feed = CachedFeed.fetch(*args, max_age=1000)
+        feed = CachedFeed.fetch(*args, max_age=1000, raw=True)
         eq_("This is feed #1", feed.content)
 
         # Fetch it with a low max_age, and it gets updated again.
-        feed = CachedFeed.fetch(*args, max_age=0)
+        feed = CachedFeed.fetch(*args, max_age=0, raw=True)
         eq_("This is feed #2", feed.content)
 
         # The special constant CACHE_FOREVER means it's always cached.
-        feed = CachedFeed.fetch(*args, max_age=CachedFeed.CACHE_FOREVER)
+        feed = CachedFeed.fetch(
+            *args, max_age=CachedFeed.CACHE_FOREVER, raw=True
+        )
         eq_("This is feed #2", feed.content)

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -69,7 +69,7 @@ from ..opds import (
     TestUnfulfillableAnnotator
 )
 
-from ..util.flask_util import Responselike
+from ..util.flask_util import Response
 from ..util.opds_writer import (
     AtomFeed,
     OPDSFeed,
@@ -1501,7 +1501,7 @@ class TestAcquisitionFeed(DatabaseTest):
         entry = AcquisitionFeed.single_entry(
             self._db, work, TestAnnotator
         )
-        assert isinstance(entry, Responselike)
+        assert isinstance(entry, Response)
         entry = unicode(entry)
         assert original_pool.presentation_edition.title in entry
         assert new_pool.presentation_edition.title not in entry
@@ -1654,13 +1654,13 @@ class TestAcquisitionFeed(DatabaseTest):
         response = AcquisitionFeed.single_entry(
             self._db, work, TestUnfulfillableAnnotator,
         )
-        assert isinstance(response, Responselike)
+        assert isinstance(response, Response)
         expect = AcquisitionFeed.error_message(
             pool.identifier, 403,
             "I know about this work but can offer no way of fulfilling it."
         )
         # The status code equivalent inside the OPDS message has not affected
-        # the status code of the Responselike itself.
+        # the status code of the Response itself.
         eq_(200, response.status_code)
         eq_(unicode(expect), unicode(response))
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -2429,6 +2429,10 @@ class TestNavigationFeed(DatabaseTest):
         eq_(42, response.max_age)
         eq_(private, response.private)
 
+        # The media type of this response is different than from the
+        # typical OPDSFeedResponse.
+        eq_(OPDSFeed.NAVIGATION_FEED_TYPE, response.content_type)
+
         parsed = feedparser.parse(response.data)
 
         eq_("Navigation", parsed["feed"]["title"])

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1152,7 +1152,7 @@ class TestOPDS(DatabaseTest):
 
         # The feed has breadcrumb links
         ancestors = list(self.fantasy.parentage)
-        root = ET.fromstring(cached_groups)
+        root = ET.fromstring(cached_groups.data)
         breadcrumbs = root.find("{%s}breadcrumbs" % AtomFeed.SIMPLIFIED_NS)
         links = breadcrumbs.getchildren()
         eq_(len(ancestors) + 1, len(links))
@@ -1614,13 +1614,13 @@ class TestAcquisitionFeed(DatabaseTest):
         )
 
         # We got an OPDS entry containing the message.
-        assert isinstance(OPDSEntryResponse)
+        assert isinstance(response, OPDSEntryResponse)
         eq_(200, response.status_code)
         assert '500' in response.data
         assert 'oops' in response.data
 
         # Our caching preferences were overridden.
-        eq_(False, response.private)
+        eq_(True, response.private)
         eq_(0, response.max_age)
 
     def test_entry_cache_adds_missing_drm_namespace(self):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1205,7 +1205,7 @@ class TestOPDS(DatabaseTest):
             )
         response = make_page(pagination)
         eq_(OPDSFeed.DEFAULT_MAX_AGE, response.max_age)
-        eq_(OPDSFeed.ACQUISITION_FEED_TYPE, response.mimetype)
+        eq_(OPDSFeed.ACQUISITION_FEED_TYPE, response.content_type)
         feed = unicode(response)
         parsed = feedparser.parse(feed)
         eq_(work1.title, parsed['entries'][0]['title'])
@@ -1517,7 +1517,7 @@ class TestAcquisitionFeed(DatabaseTest):
         entry = AcquisitionFeed.single_entry(self._db, work, TestAnnotator)
 
         expected = str(work.presentation_edition.issued.date())
-        assert expected in entry._response
+        assert expected in entry.data
 
     def test_entry_cache_adds_missing_drm_namespace(self):
 
@@ -1661,7 +1661,7 @@ class TestAcquisitionFeed(DatabaseTest):
         )
         # The status code equivalent inside the OPDS message has not affected
         # the status code of the Responselike itself.
-        eq_(None, response.status)
+        eq_(200, response.status_code)
         eq_(unicode(expect), unicode(response))
 
     def test_format_types(self):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -933,8 +933,8 @@ class TestOPDS(DatabaseTest):
                 self._db, "test", self._url, lane, TestAnnotator,
                 pagination=pagination, search_engine=search_engine
             )
-        cached_works = make_page(pagination)
-        parsed = feedparser.parse(unicode(cached_works))
+        cached_works = unicode(make_page(pagination))
+        parsed = feedparser.parse(cached_works)
         eq_(work1.title, parsed['entries'][0]['title'])
 
         # Make sure the links are in place.
@@ -953,7 +953,7 @@ class TestOPDS(DatabaseTest):
         eq_([], self.links(parsed, 'previous'))
 
         # Now get the second page and make sure it has a 'previous' link.
-        cached_works = make_page(pagination.next_page)
+        cached_works = unicode(make_page(pagination.next_page))
         parsed = feedparser.parse(cached_works)
         [previous] = self.links(parsed, 'previous')
         eq_(TestAnnotator.feed_url(lane, facets, pagination), previous['href'])
@@ -1011,7 +1011,7 @@ class TestOPDS(DatabaseTest):
         eq_([], self.links(parsed, 'previous'))
 
         # Now get the second page and make sure it has a 'previous' link.
-        cached_works = make_page(pagination.next_page)
+        cached_works = unicode(make_page(pagination.next_page))
         parsed = feedparser.parse(cached_works)
         [previous] = self.links(parsed, 'previous')
         eq_(TestAnnotator.feed_url(lane, facets, pagination), previous['href'])
@@ -1107,6 +1107,7 @@ class TestOPDS(DatabaseTest):
             max_age=0, search_engine=search_engine,
             search_debug=True
         )
+        cached_groups = unicode(cached_groups)
         parsed = feedparser.parse(cached_groups)
 
         # There are three entries in three lanes.
@@ -1269,8 +1270,8 @@ class TestOPDS(DatabaseTest):
                 pagination=Pagination.default(), search_engine=search_engine
             )
 
-        feed1 = make_page()
-        assert work1.title in feed1
+        response1 = make_page()
+        assert work1.title in unicode(response1)
         cached = get_one(self._db, CachedFeed, lane=fantasy_lane)
         old_timestamp = cached.timestamp
 
@@ -1282,16 +1283,16 @@ class TestOPDS(DatabaseTest):
 
         # The new work does not show up in the feed because
         # we get the old cached version.
-        feed2 = make_page()
-        assert work2.title not in feed2
+        response2 = make_page()
+        assert work2.title not in unicode(response2)
         assert cached.timestamp == old_timestamp
 
         # Change the WorkList's MAX_CACHE_AGE to disable caching, and
         # we get a brand new page with the new work.
         fantasy_lane.MAX_CACHE_AGE = 0
-        feed3 = make_page()
+        response3 = make_page()
         assert cached.timestamp > old_timestamp
-        assert work2.title in feed3
+        assert work2.title in unicode(response3)
 
 
 class TestAcquisitionFeed(DatabaseTest):

--- a/tests/util/test_flask_util.py
+++ b/tests/util/test_flask_util.py
@@ -44,6 +44,10 @@ class TestResponse(object):
         assert_not_cached(max_age=0)
         assert_not_cached(max_age="Not a number")
 
+        # Test the case where the response is public but should not be cached.
+        headers = Response(max_age=0, public=True).headers
+        eq_("public, no-cache" % public, headers['Cache-Control'])
+
         # Test the case where the response _should_ be cached.
         max_age = 60*60*24*12
         obj = Response(max_age=max_age)

--- a/tests/util/test_flask_util.py
+++ b/tests/util/test_flask_util.py
@@ -9,7 +9,11 @@ import datetime
 import time
 from flask import Response
 from wsgiref.handlers import format_date_time
-from ...util.flask_util import Responselike
+from ...util.flask_util import (
+    OPDSFeedResponselike,
+    Responselike,
+)
+from ...util.opds_writer import OPDSFeed
 
 class TestResponselike(object):
 
@@ -68,3 +72,28 @@ class TestResponselike(object):
         # for use in a test.
         obj = Responselike(u"some data")
         eq_(u"some data", unicode(obj))
+
+
+class TestOPDSFeedResponselike(object):
+    """Test the OPDS feed-specific specialization of Responselike."""
+    def test_defaults(self):
+        # OPDSFeedResponselike provides reasonable defaults for
+        # `mimetype` and `max_age`.
+        c = OPDSFeedResponselike
+
+        use_defaults = c("a feed")
+        eq_(OPDSFeed.ACQUISITION_FEED_TYPE, use_defaults.mimetype)
+        eq_(OPDSFeed.DEFAULT_MAX_AGE, use_defaults.max_age)
+
+        # These defaults can be overridden.
+        override_defaults = c(
+            "a feed", 200, dict(Header="value"), "mime/type",
+            "content/type", True, 1002
+        )
+        eq_(1002, override_defaults.max_age)
+        eq_("mime/type", override_defaults.mimetype)
+
+        # A max_age of zero is retained, not replaced by the default.
+        do_not_cache = c(max_age=0)
+        eq_(0, do_not_cache.max_age)
+

--- a/tests/util/test_flask_util.py
+++ b/tests/util/test_flask_util.py
@@ -36,7 +36,9 @@ class TestResponse(object):
         assert 'Expires' in headers
 
     def test_headers(self):
-        # First test cases where the response should not private and not cached.
+        # First, test cases where the response should be private and
+        # not cached. These are the kinds of settings used for error
+        # messages.
         def assert_not_cached(max_age):
             headers = Response(max_age=max_age).headers
             eq_("private, no-cache", headers['Cache-Control'])
@@ -70,6 +72,14 @@ class TestResponse(object):
         # unfortunate timing.
         expires = headers['Expires']
         eq_(expires[:17], expect_expires_string[:17])
+
+        # It's possible to have a response that is private but should
+        # be cached. The feed of a patron's current loans is a good
+        # example.
+        response = Response(max_age=30, private=True)
+        cache_control = response.headers['Cache-Control']
+        assert 'private' in cache_control
+        assert 'max-age=30' in cache_control
 
     def test_unicode(self):
         # You can easily convert a Response object to Unicode

--- a/tests/util/test_flask_util.py
+++ b/tests/util/test_flask_util.py
@@ -7,29 +7,28 @@ from nose.tools import (
 )
 import datetime
 import time
-from flask import Response
+from flask import Response as FlaskResponse
 from wsgiref.handlers import format_date_time
 from ...util.flask_util import (
-    OPDSFeedResponselike,
-    Responselike,
+    OPDSFeedResponse,
+    Response,
 )
 from ...util.opds_writer import OPDSFeed
 
-class TestResponselike(object):
+class TestResponse(object):
 
-    def test_response(self):
-        obj = Responselike(
+    def test_constructor(self):
+        response = Response(
             "content", 401, dict(Header="value"), "mime/type",
             "content/type", True, 1002
         )
-        response = obj.response
-        eq_(1002, obj.max_age)
-        assert isinstance(response, Response)
+        eq_(1002, response.max_age)
+        assert isinstance(response, FlaskResponse)
         eq_(401, response.status_code)
         eq_("content", response.data)
         eq_(True, response.direct_passthrough)
 
-        # Responselike.headers is tested in more detail below.
+        # Response.headers is tested in more detail below.
         headers = response.headers
         eq_("value", headers['Header'])
         assert 'Cache-Control' in headers
@@ -38,7 +37,7 @@ class TestResponselike(object):
     def test_headers(self):
         # First test cases where the response should not be cached at all
         def assert_not_cached(max_age):
-            headers = Responselike(max_age=max_age).headers
+            headers = Response(max_age=max_age).headers
             eq_("private, no-cache", headers['Cache-Control'])
             assert 'Expires' not in headers
         assert_not_cached(max_age=None)
@@ -47,7 +46,7 @@ class TestResponselike(object):
 
         # Test the case where the response _should_ be cached.
         max_age = 60*60*24*12
-        obj = Responselike(max_age=max_age)
+        obj = Response(max_age=max_age)
 
         headers = obj.headers
         cc = headers['Cache-Control']
@@ -68,22 +67,26 @@ class TestResponselike(object):
         eq_(expires[:17], expect_expires_string[:17])
 
     def test_unicode(self):
-        # You can easily convert a Responselike object to Unicode
+        # You can easily convert a Response object to Unicode
         # for use in a test.
-        obj = Responselike(u"some data")
+        obj = Response(u"some data")
         eq_(u"some data", unicode(obj))
 
 
-class TestOPDSFeedResponselike(object):
-    """Test the OPDS feed-specific specialization of Responselike."""
+class TestOPDSFeedResponse(object):
+    """Test the OPDS feed-specific specialization of Response."""
     def test_defaults(self):
-        # OPDSFeedResponselike provides reasonable defaults for
+        # OPDSFeedResponse provides reasonable defaults for
         # `mimetype` and `max_age`.
-        c = OPDSFeedResponselike
+        c = OPDSFeedResponse
 
         use_defaults = c("a feed")
-        eq_(OPDSFeed.ACQUISITION_FEED_TYPE, use_defaults.mimetype)
+        eq_(OPDSFeed.ACQUISITION_FEED_TYPE, use_defaults.content_type)
         eq_(OPDSFeed.DEFAULT_MAX_AGE, use_defaults.max_age)
+
+        # Flask Response.mimetype is the same as content_type but
+        # with parameters removed.
+        eq_(OPDSFeed.ATOM_TYPE, use_defaults.mimetype)
 
         # These defaults can be overridden.
         override_defaults = c(
@@ -91,7 +94,11 @@ class TestOPDSFeedResponselike(object):
             "content/type", True, 1002
         )
         eq_(1002, override_defaults.max_age)
-        eq_("mime/type", override_defaults.mimetype)
+
+        # In Flask code, if mimetype and content_type conflict,
+        # content_type takes precedence.
+        eq_("content/type", override_defaults.content_type)
+        eq_("content/type", override_defaults.mimetype)
 
         # A max_age of zero is retained, not replaced by the default.
         do_not_cache = c(max_age=0)

--- a/tests/util/test_flask_util.py
+++ b/tests/util/test_flask_util.py
@@ -10,6 +10,7 @@ import time
 from flask import Response as FlaskResponse
 from wsgiref.handlers import format_date_time
 from ...util.flask_util import (
+    OPDSEntryResponse,
     OPDSFeedResponse,
     Response,
 )
@@ -108,3 +109,21 @@ class TestOPDSFeedResponse(object):
         do_not_cache = c(max_age=0)
         eq_(0, do_not_cache.max_age)
 
+class TestOPDSEntryResponse(object):
+    """Test the OPDS entry-specific specialization of Response."""
+    def test_defaults(self):
+        # OPDSEntryResponse provides a reasonable defaults for
+        # `mimetype`.
+        c = OPDSEntryResponse
+
+        use_defaults = c("an entry")
+        eq_(OPDSFeed.ENTRY_TYPE, use_defaults.content_type)
+
+        # Flask Response.mimetype is the same as content_type but
+        # with parameters removed.
+        eq_(OPDSFeed.ATOM_TYPE, use_defaults.mimetype)
+
+        # These defaults can be overridden.
+        override_defaults = c("an entry", content_type= "content/type")
+        eq_("content/type", override_defaults.content_type)
+        eq_("content/type", override_defaults.mimetype)

--- a/tests/util/test_flask_util.py
+++ b/tests/util/test_flask_util.py
@@ -1,0 +1,70 @@
+# encoding: utf-8
+"""Test functionality of util/flask_util.py."""
+
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+import datetime
+import time
+from flask import Response
+from wsgiref.handlers import format_date_time
+from ...util.flask_util import Responselike
+
+class TestResponselike(object):
+
+    def test_response(self):
+        obj = Responselike(
+            "content", 401, dict(Header="value"), "mime/type",
+            "content/type", True, 1002
+        )
+        response = obj.response
+        eq_(1002, obj.max_age)
+        assert isinstance(response, Response)
+        eq_(401, response.status_code)
+        eq_("content", response.data)
+        eq_(True, response.direct_passthrough)
+
+        # Responselike.headers is tested in more detail below.
+        headers = response.headers
+        eq_("value", headers['Header'])
+        assert 'Cache-Control' in headers
+        assert 'Expires' in headers
+
+    def test_headers(self):
+        # First test cases where the response should not be cached at all
+        def assert_not_cached(max_age):
+            headers = Responselike(max_age=max_age).headers
+            eq_("private, no-cache", headers['Cache-Control'])
+            assert 'Expires' not in headers
+        assert_not_cached(max_age=None)
+        assert_not_cached(max_age=0)
+        assert_not_cached(max_age="Not a number")
+
+        # Test the case where the response _should_ be cached.
+        max_age = 60*60*24*12
+        obj = Responselike(max_age=max_age)
+
+        headers = obj.headers
+        cc = headers['Cache-Control']
+        eq_(cc, 'public, no-transform, max-age=1036800, s-maxage=518400')
+
+        # We expect the Expires header to look basically like this.
+        expect_expires = (
+            datetime.datetime.utcnow() + datetime.timedelta(seconds=max_age)
+        )
+        expect_expires_string = format_date_time(
+            time.mktime(expect_expires.timetuple())
+        )
+
+        # We'll only check the date part of the Expires header, to
+        # minimize the changes of spurious failures based on
+        # unfortunate timing.
+        expires = headers['Expires']
+        eq_(expires[:17], expect_expires_string[:17])
+
+    def test_unicode(self):
+        # You can easily convert a Responselike object to Unicode
+        # for use in a test.
+        obj = Responselike(u"some data")
+        eq_(u"some data", unicode(obj))

--- a/tests/util/test_flask_util.py
+++ b/tests/util/test_flask_util.py
@@ -35,7 +35,7 @@ class TestResponse(object):
         assert 'Expires' in headers
 
     def test_headers(self):
-        # First test cases where the response should not be cached at all
+        # First test cases where the response should not private and not cached.
         def assert_not_cached(max_age):
             headers = Response(max_age=max_age).headers
             eq_("private, no-cache", headers['Cache-Control'])
@@ -45,8 +45,8 @@ class TestResponse(object):
         assert_not_cached(max_age="Not a number")
 
         # Test the case where the response is public but should not be cached.
-        headers = Response(max_age=0, public=True).headers
-        eq_("public, no-cache" % public, headers['Cache-Control'])
+        headers = Response(max_age=0, private=False).headers
+        eq_("public, no-cache", headers['Cache-Control'])
 
         # Test the case where the response _should_ be cached.
         max_age = 60*60*24*12

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -17,3 +17,43 @@ def problem(type, status, title, detail=None, instance=None, headers={}):
     status, headers, data = problem_raw(
         type, status, title, detail, instance, headers)
     return Response(data, status, headers)
+
+
+class Responselike(object):
+    """An object similar to a Flask Response object, but with some improvements.
+
+    The improvements focus around making it easy to calculating header values
+    such as Cache-Control based on standard rules for this system.
+    """
+
+    def __init__(self, status_code=200, body="", headers=None, max_age=None):
+        """Constructor.
+
+        :param max_age: The number of seconds for which clients
+            should cache this response.
+        """
+        self.status_code = status_code
+        self.body = body
+        self._headers = headers or {}
+        self.max_age = max_age
+
+    def __unicode__(self):
+        """This object can be treated as a string, e.g. in tests."""
+        return self.body
+
+    @property
+    def response(self):
+        """Convert to a real Flask response."""
+        return Response(
+            status_code=self.status_code,
+            body=self.body,
+            headers=self.headers
+        )
+
+    @property
+    def headers(self):
+        headers = dict(self._headers)
+        # Set Cache-Control based on max-age.
+
+        # Explicitly set Expires based on max-age; some clients need this.
+        return headers

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -115,27 +115,6 @@ class Response(FlaskResponse):
 
         return headers
 
-    def modified(self, status=None, mimetype=None, content_type=None,
-                 max_age=None, private=None):
-        """Create a new Response with a different status code,
-        content type or max_age.
-
-        It's not safe to just set these fields because the Response
-        constructor derives other values from these fields.
-
-        TODO get rid of this.
-        """
-        if private is None:
-            private = self.private
-        return self.__class__(
-            response=self.response,
-            status=status or self.status,
-            headers=self.headers,
-            mimetype=mimetype or self.mimetype,
-            content_type=content_type or self.content_type,
-            direct_passthrough=self.direct_passthrough,
-            max_age=max_age or self.max_age
-        )
 
 class OPDSFeedResponse(Response):
     """A convenience specialization of Response for typical OPDS feeds."""
@@ -143,6 +122,7 @@ class OPDSFeedResponse(Response):
                  content_type=None, direct_passthrough=False, max_age=None):
 
         mimetype = mimetype or OPDSFeed.ACQUISITION_FEED_TYPE
+        status = status or 200
         if max_age is None:
             max_age = OPDSFeed.DEFAULT_MAX_AGE
         super(OPDSFeedResponse, self).__init__(

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -1,6 +1,6 @@
 """Utilities for Flask applications."""
 import flask
-from flask import Respons
+from flask import Response
 from wsgiref.handlers import format_date_time
 import time
 
@@ -68,7 +68,6 @@ class Responselike(object):
             mimetype=self.mimetype,
             content_type=self.content_type,
             body=self.body,
-            headers=self.headers
         )
 
     @property

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -74,7 +74,7 @@ class Responselike(object):
     def response(self):
         """Convert to a real Flask response."""
         return Response(
-            response=self.entity_body
+            response=self.entity_body,
             status=self.status,
             headers=self.headers,
             mimetype=self.mimetype,

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -141,6 +141,6 @@ class OPDSFeedResponse(Response):
 
 class OPDSEntryResponse(Response):
     """A convenience specialization of Response for typical OPDS entries."""
-    def __init__(self, **kwargs):
+    def __init__(self, response=None, **kwargs):
         kwargs.setdefault('mimetype', OPDSFeed.ENTRY_TYPE)
-        super(OPDSEntryResponse, self).__init__(**kwargs)
+        super(OPDSEntryResponse, self).__init__(response, **kwargs)

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -26,26 +26,42 @@ class Responselike(object):
     such as Cache-Control based on standard rules for this system.
     """
 
-    def __init__(self, status_code=200, body="", headers=None, max_age=None):
+    def __init__(self, response=None, status=None, headers=None, mimetype=None,
+                 content_type=None, direct_passthrough=False, max_age=None):
         """Constructor.
 
-        :param max_age: The number of seconds for which clients
-            should cache this response.
+        All parameters are the same as for the Flask/Werkzeug Response class,
+        with these additions:
+
+        :param max_age: The number of seconds for which clients should
+            cache this response. Used to set a value for the
+            Cache-Control header.
         """
-        self.status_code = status_code
-        self.body = body
-        self._headers = headers or {}
+        self._response = response
+        self.status = status
+        self._headers = dict(headers) or {}
+        self.mimetype = mimetype
+        self.content_type = content_type
+        self.direct_passthrough = direct_passthrough
+
         self.max_age = max_age
 
     def __unicode__(self):
-        """This object can be treated as a string, e.g. in tests."""
-        return self.body
+        """This object can be treated as a string, e.g. in tests.
+
+        :return: The entity-body portion of the response.
+        """
+        return self._response
 
     @property
     def response(self):
         """Convert to a real Flask response."""
         return Response(
-            status_code=self.status_code,
+            response=self.response,
+            status=self.status,
+            headers=self.headers,
+            mimetype=self.mimetype,
+            content_type=self.content_type,
             body=self.body,
             headers=self.headers
         )

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -36,8 +36,8 @@ class Response(FlaskResponse):
     """
 
     def __init__(self, response=None, status=None, headers=None, mimetype=None,
-                 content_type=None, direct_passthrough=False, max_age=None,
-                 private=False):
+                 content_type=None, direct_passthrough=False, max_age=0,
+                 private=None):
         """Constructor.
 
         All parameters are the same as for the Flask/Werkzeug Response class,
@@ -50,7 +50,15 @@ class Response(FlaskResponse):
             information from an authenticated client and should not be stored
             in intermediate caches.
         """
-        self.max_age = max_age
+        self.max_age = max_age or 0
+        if private is None:
+            if max_age == 0:
+                # The most common reason for max_age to be set to 0 is that a resource
+                # is _also_ private.
+                private = True
+            else:
+                private = False
+        self.private = private
 
         body = response
         if isinstance(body, etree._Element):
@@ -114,6 +122,8 @@ class Response(FlaskResponse):
 
         It's not safe to just set these fields because the Response
         constructor derives other values from these fields.
+
+        TODO get rid of this.
         """
         if private is None:
             private = self.private

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -130,3 +130,10 @@ class OPDSFeedResponse(Response):
             mimetype=mimetype, content_type=content_type,
             direct_passthrough=direct_passthrough, max_age=max_age
         )
+
+
+class OPDSEntryResponse(Response):
+    """A convenience specialization of Response for typical OPDS entries."""
+    def __init__(self, **kwargs):
+        kwargs.setdefault('mimetype', OPDSFeed.ENTRY_TYPE)
+        super(OPDSEntryResponse, self).__init__(**kwargs)

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -9,6 +9,7 @@ import time
 from . import (
     problem_detail,
 )
+from opds_writer import OPDSFeed
 
 def problem_raw(type, status, title, detail=None, instance=None, headers={}):
     data = problem_detail.json(type, status, title, detail, instance)
@@ -111,3 +112,18 @@ class Responselike(object):
         headers['Cache-Control'] = cache_control
 
         return headers
+
+
+class OPDSFeedResponselike(Responselike):
+    """A convenience specialization of Responselike for typical OPDS feeds."""
+    def __init__(self, response=None, status=None, headers=None, mimetype=None,
+                 content_type=None, direct_passthrough=False, max_age=None):
+
+        mimetype = mimetype or OPDSFeed.ACQUISITION_FEED_TYPE
+        if max_age is None:
+            max_age = OPDSFeed.DEFAULT_MAX_AGE
+        super(OPDSFeedResponselike, self).__init__(
+            response=response, status=status, headers=headers,
+            mimetype=mimetype, content_type=content_type,
+            direct_passthrough=direct_passthrough, max_age=max_age
+        )

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -1,6 +1,7 @@
 """Utilities for Flask applications."""
 import datetime
 import flask
+from lxml import etree
 from flask import Response
 from wsgiref.handlers import format_date_time
 import time
@@ -43,6 +44,7 @@ class Responselike(object):
             cache this response. Used to set a value for the
             Cache-Control header.
         """
+
         self._response = response
         self.status = status
         self._headers = headers or {}
@@ -57,13 +59,22 @@ class Responselike(object):
 
         :return: The entity-body portion of the response.
         """
-        return self._response
+        return self.entity_body
+
+    @property
+    def entity_body(self):
+        body = self._response
+        if isinstance(body, etree._Element):
+            body = etree.tostring(body)
+        elif not isinstance(body, (bytes, unicode)):
+            body = unicode(body)
+        return body
 
     @property
     def response(self):
         """Convert to a real Flask response."""
         return Response(
-            response=self._response,
+            response=self.entity_body
             status=self.status,
             headers=self.headers,
             mimetype=self.mimetype,

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -119,7 +119,8 @@ class Response(FlaskResponse):
 class OPDSFeedResponse(Response):
     """A convenience specialization of Response for typical OPDS feeds."""
     def __init__(self, response=None, status=None, headers=None, mimetype=None,
-                 content_type=None, direct_passthrough=False, max_age=None):
+                 content_type=None, direct_passthrough=False, max_age=None,
+                 private=None):
 
         mimetype = mimetype or OPDSFeed.ACQUISITION_FEED_TYPE
         status = status or 200
@@ -128,7 +129,8 @@ class OPDSFeedResponse(Response):
         super(OPDSFeedResponse, self).__init__(
             response=response, status=status, headers=headers,
             mimetype=mimetype, content_type=content_type,
-            direct_passthrough=direct_passthrough, max_age=max_age
+            direct_passthrough=direct_passthrough, max_age=max_age,
+            private=private
         )
 
 

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -99,8 +99,8 @@ class Response(FlaskResponse):
 
         return headers
 
-    def modify(self, status=None, mimetype=None, content_type=None,
-               max_age=None):
+    def modified(self, status=None, mimetype=None, content_type=None,
+                 max_age=None):
         """Create a new Response with a different status code,
         content type or max_age.
 

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -99,6 +99,23 @@ class Response(FlaskResponse):
 
         return headers
 
+    def modify(self, status=None, mimetype=None, content_type=None,
+               max_age=None):
+        """Create a new Response with a different status code,
+        content type or max_age.
+
+        It's not safe to just set these fields because the Response
+        constructor derives other values from these fields.
+        """
+        return self.__class__(
+            response=self.response,
+            status=status or self.status,
+            headers=self.headers,
+            mimetype=mimetype or self.mimetype,
+            content_type=content_type or self.content_type,
+            direct_passthrough=self.direct_passthrough,
+            max_age=max_age or self.max_age
+        )
 
 class OPDSFeedResponse(Response):
     """A convenience specialization of Response for typical OPDS feeds."""

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -68,6 +68,7 @@ class Responselike(object):
             headers=self.headers,
             mimetype=self.mimetype,
             content_type=self.content_type,
+            direct_passthrough=self.direct_passthrough
         )
 
     @property
@@ -77,7 +78,7 @@ class Responselike(object):
         headers = dict(self._headers)
 
         # Set Cache-Control based on max-age.
-        if isinstance(self.max_age, int):
+        if self.max_age and isinstance(self.max_age, int):
             # A CDN should hold on to the cached representation only half
             # as long as the end-user.
             client_cache = self.max_age
@@ -94,7 +95,7 @@ class Responselike(object):
                 time.mktime(expires_at.timetuple())
             )
         else:
-            # No max-age means don't cache at all.
+            # Missing, invalid or zero max-age means don't cache at all.
             cache_control = "private, no-cache"
         headers['Cache-Control'] = cache_control
 

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -1,4 +1,5 @@
 """Utilities for Flask applications."""
+import datetime
 import flask
 from flask import Response
 from wsgiref.handlers import format_date_time
@@ -62,12 +63,11 @@ class Responselike(object):
     def response(self):
         """Convert to a real Flask response."""
         return Response(
-            response=self.response,
+            response=self._response,
             status=self.status,
             headers=self.headers,
             mimetype=self.mimetype,
             content_type=self.content_type,
-            body=self.body,
         )
 
     @property
@@ -80,15 +80,15 @@ class Responselike(object):
         if isinstance(self.max_age, int):
             # A CDN should hold on to the cached representation only half
             # as long as the end-user.
-            client_cache = max_age
-            cdn_cache = max_age / 2
+            client_cache = self.max_age
+            cdn_cache = self.max_age / 2
             cache_control = "public, no-transform, max-age=%d, s-maxage=%d" % (
                 client_cache, cdn_cache
             )
 
             # Explicitly set Expires based on max-age; some clients need this.
             expires_at = datetime.datetime.utcnow() + datetime.timedelta(
-                seconds=max_age
+                seconds=self.max_age
             )
             headers['Expires'] = format_date_time(
                 time.mktime(expires_at.timetuple())

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -1,6 +1,7 @@
 
 import datetime
 import logging
+from flask import Response
 
 from lxml import builder, etree
 from nose.tools import set_trace
@@ -146,13 +147,19 @@ class AtomFeed(object):
         return cls.E.updated(*args, **kwargs)
 
 
-    def __init__(self, title, url):
+    def __init__(self, title, url, **kwargs):
+        """Constructor.
+
+        :param title: The title of this feed.
+        :param url: The URL at which clients can expect to find this feed.
+        """
         self.feed = self.E.feed(
             self.E.id(url),
             self.E.title(unicode(title)),
             self.E.updated(self._strftime(datetime.datetime.utcnow())),
             self.E.link(href=url, rel="self"),
         )
+        super(AtomFeed, self).__init__(**kwargs)
 
 
     # TODO PYTHON3 rename to __str__
@@ -161,7 +168,6 @@ class AtomFeed(object):
             return None
 
         return etree.tounicode(self.feed, pretty_print=True)
-
 
 
 class OPDSFeed(AtomFeed):

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -189,6 +189,10 @@ class OPDSFeed(AtomFeed):
     REVOKE_LOAN_REL = "http://librarysimplified.org/terms/rel/revoke"
     NO_TITLE = "http://librarysimplified.org/terms/problem/no-title"
 
+    # Most types of OPDS feeds can be cached client-side for at least ten
+    # minutes.
+    DEFAULT_MAX_AGE = 60 * 10
+
     def __init__(self, title, url):
         super(OPDSFeed, self).__init__(title, url)
 


### PR DESCRIPTION
This is the core branch for https://jira.nypl.org/browse/SIMPLY-2633. It introduces a subclass of the Flask `Response` class, which contains some extra logic making it easy to calculate values for the `Cache-Control` and `Expires` headers. There are also convenience subclasses `OPDSFeedResponse` and `OPDSEntryResponse` which offer additional defaults for OPDS feeds and entries.

Here's what you can do with our `Response` subclasses that you would have to do manually with a normal Flask `Response`:

* Set a `max_age` number which controls how long the client (or an intermediary such as a CDN) can cache 
* Set a `private` flag which controls whether or not intermediaries such as web proxies can cache this document. 
* Manually set the Content-Type header to the appropriate subtype of the Atom media type.

In core, the most important use of `Response` is `CachedFeed.fetch`, which is the bit of code that figures out how long an OPDS feed needs to be cached _internally_. As of this branch, OPDS feeds are cached on the client side (via the `Cache-Control` header) for the same amount of time and using the same logic. To pass the "how long should this be cached?" knowledge out of `fetch`, I changed `fetch` to return a `Response` object instead of the `CachedFeed` object itself. The old behavior is still available (you pass in `raw=True`), but it's now only used in tests.

With one exception, all methods in `opds.py` that used to return OPDS feeds or entries now return `Response` objects instead. This is a bigger change than absolutely necessary--we could get most of the performance benefits just by changing the methods that call `CachedFeed.fetch` but it lets me simplify the circulation code quite a bit and it avoids bugs caused by forgetting which methods return `Response` and which don't. This also let me get rid of the `feed_response` and `entry_response` utility functions, which were used in circulation to turn OPDS feeds into Flask `Response` objects. Now the feeds are `Response` objects from the beginning.