### PR TITLE
Fix real-world problems with the new cached feed changes.

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -83,6 +83,7 @@ from util import (
 )
 from util.problem_detail import ProblemDetail
 from util.accept_language import parse_accept_language
+from util.opds_writer import OPDSFeed
 
 import elasticsearch
 
@@ -1140,9 +1141,9 @@ class WorkList(object):
     By default, these Work objects come from a search index.
     """
 
-    # The set of Works in a WorkList is cacheable for two weeks by
-    # default. Most WorkList subclasses will override this.
-    MAX_CACHE_AGE = 14*24*60*60
+    # The default maximum cache time of a feed derived from a WorkList
+    # is the default cache time for any OPDS feed.
+    MAX_CACHE_AGE = OPDSFeed.DEFAULT_MAX_AGE
 
     # If a certain type of Worklist should always have its OPDS feeds
     # cached under a specific type, define that type as

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -71,6 +71,7 @@ from ..model import (
 )
 from ..problem_details import INVALID_INPUT
 from ..testing import EndToEndSearchTest
+from ..util.opds_writer import OPDSFeed
 
 class TestFacetsWithEntryPoint(DatabaseTest):
 
@@ -1742,6 +1743,14 @@ class TestWorkList(DatabaseTest):
         wl._customlist_ids = None
         wl.list_datasource_id = object()
         eq_(True, wl.uses_customlists)
+
+    def test_max_cache_age(self):
+        # By default, the maximum cache age of an OPDS feed based on a
+        # WorkList is the default cache age for any type of OPDS feed,
+        # no matter what type of feed is being generated.
+        wl = WorkList()
+        eq_(OPDSFeed.DEFAULT_MAX_AGE, wl.max_cache_age(object()))
+
 
     def test_filter(self):
         # Verify that filter() calls modify_search_filter_hook()


### PR DESCRIPTION
This branch fixes a couple problems I noticed testing the recent caching changes in a real environment:

1. When you ask for an OPDSFeedResponse and it's a cache hit, you don't actually get a Response object; you get a CachedFeed. This crashes the app server because it doesn't know how to turn a CachedFeed into a Response.

2. The default cache period for a WorkList is two weeks. At this point none of the feeds should actually be cached that long (because availability changes so rapidly), but I thought it didn't matter because all the different subclasses (Lane, ContributorLane, etc.) define their own default cache period. But there is one case where we use the default: we create a WorkList representing the top level of the lane structure. This is the one place where we _don't_ want a cache time of two weeks. We want SimplyE to fetch new front pages on a regular basis so people are always seeing new books. So I changed the default cache time for a WorkList to 10 minutes, the default cache time for any OPDS feed.