### PR TITLE
Peg nltk to the final Python 2 release.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ nose
 lxml
 flask
 isbnlib
-textblob
 rdflib
 pyspellchecker
 
@@ -24,6 +23,10 @@ py-bcrypt
 Flask-Babel
 money
 pymarc
+
+# nltk is a textblob dependency, and this is the last release that supports Python 2
+nltk==3.4.5
+textblob
 
 # for author name manipulations
 nameparser>=0.5.1


### PR DESCRIPTION
Ticket: https://jira.nypl.org/browse/SIMPLY-2705

NLTK 3.4.5 was [the final release to support Python 2](https://www.nltk.org/news.html). A Python 3-only release was put out early this week, and now anyone who tries to set up a circ manager will get a release of NLTK that won't work, installed as a dependency on textblob. This branch pegs the version of NLTK in use to the final Python 2 release.
