### PR TITLE
Facets filter worklist

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -1941,17 +1941,18 @@ class DatabaseBackedWorkList(WorkList):
 
         :param _db: A database connection.
         :param facets: A Facets object which may place additional
-           constraints on WorkList membership.
+           constraints on WorkList membership. Other objects are ignored.
         :param pagination: A Pagination object indicating which part of
            the WorkList the caller is looking at.
         :param kwargs: Ignored -- only included for compatibility with works().
         :return: A Query.
         """
         if facets is not None and not isinstance(facets, Facets):
-            raise ValueError(
-                "Incompatible faceting object for DatabaseBackedWorkList: %r" %
+            logging.warning(
+                "Ignoring incompatible faceting object for DatabaseBackedWorkList: %r",
                 facets
             )
+            facets = None
 
         qu = self.base_query(_db)
 

--- a/lane.py
+++ b/lane.py
@@ -151,6 +151,14 @@ class BaseFacets(FacetConstants):
         """
         return filter
 
+    def modify_database_query(cls, _db, qu):
+        """If necessary, modify a database query so that resulting
+        items conform the constraints of this faceting object.
+
+        The default behavior is to not modify the query.
+        """
+        return qu
+
     def scoring_functions(self, filter):
         """Create a list of ScoringFunction objects that modify how
         works in the given WorkList should be ordered.
@@ -1940,19 +1948,13 @@ class DatabaseBackedWorkList(WorkList):
         lanes can be generated through search engine queries.
 
         :param _db: A database connection.
-        :param facets: A Facets object which may place additional
-           constraints on WorkList membership. Other objects are ignored.
+        :param facets: A faceting object, which may place additional
+           constraints on WorkList membership.
         :param pagination: A Pagination object indicating which part of
            the WorkList the caller is looking at.
         :param kwargs: Ignored -- only included for compatibility with works().
         :return: A Query.
         """
-        if facets is not None and not isinstance(facets, Facets):
-            logging.warning(
-                "Ignoring incompatible faceting object for DatabaseBackedWorkList: %r",
-                facets
-            )
-            facets = None
 
         qu = self.base_query(_db)
 

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -1884,7 +1884,7 @@ class TestWorkList(DatabaseTest):
             """Mock the process of turning work IDs into WorkSearchResult
             objects."""
             fake_work_list = "a list of works"
-            def works_for_hits(self, _db, work_ids):
+            def works_for_hits(self, _db, work_ids, facets=None):
                 self.called_with = (_db, work_ids)
                 return self.fake_work_list
 
@@ -1938,7 +1938,7 @@ class TestWorkList(DatabaseTest):
         # Verify that WorkList.works_for_hits() just calls
         # works_for_resultsets().
         class Mock(WorkList):
-            def works_for_resultsets(self, _db, resultsets):
+            def works_for_resultsets(self, _db, resultsets, facets=None):
                 self.called_with = (_db, resultsets)
                 return [["some", "results"]]
         wl = Mock()
@@ -3779,7 +3779,7 @@ class TestWorkListGroupsEndToEnd(EndToEndSearchTest):
 
         # Here's an entry point that applies a language filter
         # that only finds one book.
-        class LQRomanceEntryPoint(object):
+        class LQRomanceEntryPoint(EntryPoint):
             URI = ""
             @classmethod
             def modify_search_filter(cls, filter):
@@ -3936,7 +3936,7 @@ class TestWorkListGroups(DatabaseTest):
                 self.overview_facets_calls.append((_db, facets))
                 return super(MockWorkList, self).overview_facets(_db, facets)
 
-            def works_for_resultsets(self, _db, resultsets):
+            def works_for_resultsets(self, _db, resultsets, facets=None):
                 # Take some lists of (mocked) of search results and turn
                 # them into lists of (mocked) Works.
                 self.works_for_resultsets_calls.append((_db, resultsets))

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -2275,15 +2275,6 @@ class TestDatabaseBackedWorkList(DatabaseTest):
                 self.wl.stages.append(distinct)
                 return distinct
 
-        # MockFacets has to subclass DatabaseBasedFacets because we check
-        # for this, in an attempt to avoid bugs caused by passing a normal
-        # Facets into works_from_database().
-        assert_raises_regexp(
-            ValueError,
-            "Incompatible faceting object for DatabaseBackedWorkList: 'bad facet'",
-            wl.works_from_database, self._db, facets="bad facet"
-        )
-
         class MockPagination(object):
             def __init__(self, wl):
                 self.wl = wl


### PR DESCRIPTION
## JIRA Ticket

https://jira.nypl.org/browse/SIMPLY-2706

## What does this PR do?

Currently, SimplyE and other clients sometimes display works that aren't available even though "Available Now” is selected. This happens when the search index and database are out of sync and can lead to user confusion and, thus, poor UX.

This PR prevents propagation of <entry>s for these unavailable works to the client when the `availability` facet is now. It does so, by applying constraints corresponding to the active facets to the database query. Because these changes act more broadly on the currently active facets, it may ameliorate future search/database sync UX issues, as well.

## Change description

These changes
- factor the constraint-based facet filtering from `DatabaseBackedFacets.modify_database_query` to a new `Facets.modify_database_query` and
- propagate the active `Facets` object to `DatabaseBackedWorklist.works_from_database`, which uses it to filter the database query.

## How should this be tested?

Added test to ensure that availability faceting results in correct filtering. Most of the functionality is already tested in:
- `tests/test_lane.py:TestDatabaseBackedFacets.test_modify_database_query`

Existing tests have been updated:
- Add optional facet to some method signatures;
- Assign a more specific superclass to a mock; and
- Remove a no-longer applicable assertion.

I have performed manual live testing to demonstrate that unavailable items are no longer propagated.

Can also add tests to ensure faceting object is properly  propagated, if needed. 

## Interested parties