### PR TITLE
Fix marc record generator

### DIFF
--- a/marc.py
+++ b/marc.py
@@ -483,7 +483,6 @@ class MARCExporter(object):
     WEB_CLIENT_URL = u'marc_web_client_url'
     INCLUDE_SUMMARY = u'include_summary'
     INCLUDE_SIMPLIFIED_GENRES = u'include_simplified_genres'
-    STORAGE_PROTOCOL = u'storage_protocol'
 
     LIBRARY_SETTINGS = [
         { "key": UPDATE_FREQUENCY,
@@ -639,7 +638,7 @@ class MARCExporter(object):
         # We mirror the content, if it's not empty. If it's empty, we create a CachedMARCFile
         # and Representation, but don't actually mirror it.
         if not mirror:
-            storage_protocol = mirror_integration.setting(self.STORAGE_PROTOCOL).value
+            storage_protocol = mirror_integration.protocol
             mirror = MirrorUploader.implementation(mirror_integration)
             if mirror.NAME != storage_protocol:
                 raise Exception("Mirror integration does not match configured storage protocol")

--- a/migration/20200506-externalintegrationlink-marc.sql
+++ b/migration/20200506-externalintegrationlink-marc.sql
@@ -1,0 +1,13 @@
+-- It is possible that, since multiple storage integrations were introduced, mixed
+-- use of string literals and a corresponding ExternalIntegrationLink-scoped
+-- constant may have resulted in an incorrect values in the database.
+-- This migration normalizes to the value of the ExternalIntegrationLink constant.
+
+UPDATE externalintegrationslinks SET purpose='covers_mirror' WHERE purpose='covers';
+UPDATE externalintegrationslinks SET purpose='books_mirror' WHERE purpose='books';
+UPDATE externalintegrationslinks SET purpose='MARC_mirror' WHERE purpose='MARC';
+
+-- Also, the Marc Export integration may now have vestigial "storage_protocol" setting,
+-- which would need removal, if present.
+
+DELETE FROM configurationsettings WHERE key='storage_protocol';

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -40,6 +40,8 @@ class ExternalIntegrationLink(Base, HasFullTableCache):
 
     NO_MIRROR_INTEGRATION = u"NO_MIRROR"
     # Possible purposes that a storage external integration can be used for.
+    # These string literals may be stored in the database, so changes to them
+    # may need to be accompanied by a DB migration.
     COVERS = "covers_mirror"
     BOOKS = "books_mirror"
     MARC = "MARC_mirror"

--- a/s3.py
+++ b/s3.py
@@ -121,7 +121,7 @@ class S3Uploader(MirrorUploader):
               },
           ],
           "default": URL_TEMPLATE_DEFAULT,
-          "description" : _("A file mirrored to S3 is available at <code>http://s3.amazonaws.com/{bucket}/{filename}</code>. If you've set up your DNS so that http:///[bucket]/ or https://[bucket]/ points to the appropriate S3 bucket, you can configure this S3 integration to shorten the URLs. <p>If you haven't set up your S3 buckets, don't change this from the default -- you'll get URLs that don't work.</p>")
+          "description" : _("A file mirrored to S3 is available at <code>http://s3.amazonaws.com/{bucket}/{filename}</code>. If you've set up your DNS so that http://[bucket]/ or https://[bucket]/ points to the appropriate S3 bucket, you can configure this S3 integration to shorten the URLs. <p>If you haven't set up your S3 buckets, don't change this from the default -- you'll get URLs that don't work.</p>")
         },
     ]
 

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -505,8 +505,6 @@ class TestMARCExporter(DatabaseTest):
         search_engine = MockExternalSearchIndex()
         search_engine.bulk_update([w1, w2])
 
-        integration.setting(MARCExporter.STORAGE_PROTOCOL).value = ExternalIntegration.S3
-
         # If there's a storage protocol but not corresponding storage integration,
         # it raises an exception.
         assert_raises(Exception, exporter.records, lane, annotator)


### PR DESCRIPTION
## Description

This PR fixes some issues related to MARC export:
- provides a db migration to account for:
  - possible mixing of uses of the literal "MARC" and the constant `ExternalIntegrationLink.MARC` for `ExternalIntegrationLink`'s purpose, and
  - deprecation of `MARC_Exporter.STORAGE_PROTOCOL`; and
- minor changes to code and tests to account for deprecation of `MARC_Exporter.STORAGE_PROTOCOL`.

## Motivation and Context

See JIRA issue https://jira.nypl.org/browse/SIMPLY-2759

Fix database inconsistencies for instances that have configured MARC Exporter since [3.0.2cm](https://github.com/NYPL-Simplified/circulation/releases/tag/3.0.2) and eliminate unnecessary settings and code.

## How Has This Been Tested?

Successfully ran a MARC Export to a test S3 instance for Carnegie Library of Pittsburg.

Ran all tests.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
