### PR TITLE
Checking collection for the title during opds import

### DIFF
--- a/model/licensing.py
+++ b/model/licensing.py
@@ -203,6 +203,18 @@ class LicensePool(Base):
         )
 
     @classmethod
+    def exists(self, _db, identifier, collection_id, data_source_name):
+        """Determine if we have a license pool for the given id, collection, and datasource"""
+        from datasource import DataSource
+
+        q = _db.query(LicensePool).join(DataSource).filter(LicensePool.collection_id == collection_id,
+                LicensePool.identifier_id == identifier.id,
+                DataSource.name == data_source_name,
+                LicensePool.data_source_id == DataSource.id)
+
+        return _db.query(q.exists()).scalar()
+
+    @classmethod
     def for_foreign_id(self, _db, data_source, foreign_id_type, foreign_id,
                        rights_status=None, collection=None, autocreate=True):
         """Find or create a LicensePool for the given foreign ID."""

--- a/opds_import.py
+++ b/opds_import.py
@@ -1911,6 +1911,17 @@ class OPDSImportMonitor(CollectionMonitor, HasSelfTests):
                 )
                 return True
 
+            # The imported title might be known already but not in the collection we are importing,
+            # check for that condition
+            has_pool = LicensePool.exists(self._db, identifier, self.collection_id, self.importer.data_source_name)
+            if not has_pool:
+                # The collection doesnt have this title. Importing it will create a LicensePool
+                self.log.info(
+                    "Counting %s as new because it is not in the collection.",
+                    identifier
+                )
+                return True
+
     def follow_one_link(self, url, do_get=None):
         """Download a representation of a URL and extract the useful
         information.

--- a/opds_import.py
+++ b/opds_import.py
@@ -1911,16 +1911,16 @@ class OPDSImportMonitor(CollectionMonitor, HasSelfTests):
                 )
                 return True
 
-            # The imported title might be known already but not in the collection we are importing,
-            # check for that condition
-            has_pool = LicensePool.exists(self._db, identifier, self.collection_id, self.importer.data_source_name)
-            if not has_pool:
-                # The collection doesnt have this title. Importing it will create a LicensePool
-                self.log.info(
-                    "Counting %s as new because it is not in the collection.",
-                    identifier
-                )
-                return True
+        # The imported title might be known already but not in the collection we are importing,
+        # check for that condition
+        has_pool = LicensePool.exists(self._db, identifier, self.collection_id, self.importer.data_source_name)
+        if not has_pool:
+            # The collection doesnt have this title. Importing it will create a LicensePool
+            self.log.info(
+                "Counting %s as new because it is not in the collection.",
+                identifier
+            )
+            return True
 
     def follow_one_link(self, url, do_get=None):
         """Download a representation of a URL and extract the useful


### PR DESCRIPTION
Ticket: https://jira.nypl.org/projects/SIMPLY/issues/SIMPLY-2780

This branch will check the licensepools table during an opds import to see if the title that is being imported is already known to the system, but not in the collection that is being imported.  It uses the item identifier, collection id, and data source name in the licensepool lookupquery.  I'm not sure if data source name is needed here - or if this query will cover all situations, but this fixed the issue I was having when importing two collections that had significant title overlap.