### PR TITLE
Fix relevance sort error message

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -396,6 +396,9 @@ class Facets(FacetsWithEntryPoint):
     Despite the generic name, this is only used in 'page' type OPDS
     feeds that list all the works in some WorkList.
     """
+
+    ORDER_BY_RELEVANCE = "relevance"
+
     @classmethod
     def default(cls, library, collection=None, availability=None, order=None,
                 entrypoint=None):
@@ -647,7 +650,10 @@ class Facets(FacetsWithEntryPoint):
 
         filter.availability = self.availability
         filter.subcollection = self.collection
-        if self.order:
+
+        # No order and relevance order both signify the default and,
+        # thus, either should leave `filter.order` unset.
+        if self.order and self.order != self.ORDER_BY_RELEVANCE:
             order = self.SORT_ORDER_TO_ELASTICSEARCH_FIELD_NAME.get(self.order)
             if order:
                 filter.order = order
@@ -889,8 +895,6 @@ class SearchFacets(Facets):
     # top billing just because they're first alphabetically. This is
     # the default cutoff point, determined empirically.
     DEFAULT_MIN_SCORE = 500
-
-    ORDER_BY_RELEVANCE = "relevance"
 
     def __init__(self, **kwargs):
         languages = kwargs.pop('languages', None)


### PR DESCRIPTION
## Description

This branch changes `Facets.modify_search_filter` so that it treats a `Facets.order` of "relevant" the same way it already treats a Falsy one (i.e., don't set the filter order and don't log the error
```
Unrecognized sort order: relevance
```

## Motivation and Context

JIRA: https://jira.nypl.org/browse/SIMPLY-2821

Relevance score descending is the default ElasticSearch sort order, but does not map to an ElasticSearch field name. The absence of a search filter order indicates this default, but Facets.modify_search_filter only tests for valid explicit sort orders from FacetConstants.SORT_ORDER_TO_ELASTICSEARCH_FIELD_NAME. If it doesn't find one of the valid ones, it complains, leaves the order unset, and continues. When "relevance" is specified as the order, we get the right behavior, but the irritating error message along with it).

## How Has This Been Tested?

Added new test class to ensure that error message is emitted only when an invalid sort order is specified.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.