### PR TITLE
Add a constant for the manifest file used by the AxisNow  access control system

### DIFF
--- a/model/licensing.py
+++ b/model/licensing.py
@@ -1397,6 +1397,7 @@ class DeliveryMechanism(Base, HasFullTableCache):
     NO_DRM = None
     ADOBE_DRM = u"application/vnd.adobe.adept+xml"
     FINDAWAY_DRM = u"application/vnd.librarysimplified.findaway.license+json"
+    AXISNOW_DRM = "application/vnd.librarysimplified.axisnow+json"
     KINDLE_DRM = u"Kindle DRM"
     NOOK_DRM = u"Nook DRM"
     STREAMING_DRM = u"Streaming"


### PR DESCRIPTION
This branch adds a constant in service of https://github.com/NYPL-Simplified/circulation/pull/1445 and [SIMPLY-2815](https://jira.nypl.org/browse/SIMPLY-2815).

The document that tells an authorized client how to get an AxisNow book is advertised with a new custom media type of `application/vnd.librarysimplified.axisnow+json`.