### PR TITLE
Create a separate boto client for generating unsigned URLs

### DIFF
--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -128,10 +128,25 @@ class TestS3Uploader(S3UploaderTest):
         # attribute on the S3Uploader object.
         eq_('a transform', uploader.url_transform)
 
-    def test_empty_string(self):
+    @parameterized.expand([
+        (
+            'empty_credentials',
+            None,
+            None
+        ),
+        (
+            'empty_string_credentials',
+            '',
+            ''
+        ),
+        (
+            'empty_string_credentials',
+            'username',
+            'password'
+        )
+    ])
+    def test_initialization(self, name, username, password):
         # Arrange
-        username = 'username'
-        password = 'password'
         settings = {'username': username, 'password': password}
         integration = self._external_integration(
             ExternalIntegration.S3, goal=ExternalIntegration.STORAGE_GOAL, settings=settings
@@ -162,8 +177,8 @@ class TestS3Uploader(S3UploaderTest):
         aws_secret_access_key = client_class.call_args_list[1].kwargs['aws_secret_access_key']
         eq_(service_name, 's3')
         eq_(region_name, S3Uploader.S3_DEFAULT_REGION)
-        eq_(aws_access_key_id, username)
-        eq_(aws_secret_access_key, password)
+        eq_(aws_access_key_id, username if username != '' else None)
+        eq_(aws_secret_access_key, password if password != '' else None)
         assert 'config' not in client_class.call_args_list[1].kwargs
 
     def test_custom_client_class(self):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -140,7 +140,7 @@ class TestS3Uploader(S3UploaderTest):
             ''
         ),
         (
-            'empty_string_credentials',
+            'non_empty_string_credentials',
             'username',
             'password'
         )

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 import datetime
 
+import botocore
 from botocore.exceptions import (
     BotoCoreError,
     ClientError,
@@ -129,7 +130,9 @@ class TestS3Uploader(S3UploaderTest):
 
     def test_empty_string(self):
         # Arrange
-        settings = {'username': '', 'password': ''}
+        username = ''
+        password = ''
+        settings = {'username': username, 'password': password}
         integration = self._external_integration(
             ExternalIntegration.S3, goal=ExternalIntegration.STORAGE_GOAL, settings=settings
         )
@@ -139,19 +142,29 @@ class TestS3Uploader(S3UploaderTest):
         S3Uploader(integration, client_class=client_class)
 
         # Assert
-        eq_(client_class.call_count, 1)
+        eq_(client_class.call_count, 2)
 
-        service_name = client_class.call_args.args
-        region_name = client_class.call_args.kwargs['region_name']
-        aws_access_key_id = client_class.call_args.kwargs['aws_access_key_id']
-        aws_secret_access_key = client_class.call_args.kwargs['aws_secret_access_key']
-        config = client_class.call_args.kwargs['config']
-
-        eq_(service_name, ('s3',))
+        service_name = client_class.call_args_list[0].args[0]
+        region_name = client_class.call_args_list[0].kwargs['region_name']
+        aws_access_key_id = client_class.call_args_list[0].kwargs['aws_access_key_id']
+        aws_secret_access_key = client_class.call_args_list[0].kwargs['aws_secret_access_key']
+        config = client_class.call_args_list[0].kwargs['config']
+        eq_(service_name, 's3')
         eq_(region_name, S3Uploader.S3_DEFAULT_REGION)
         eq_(aws_access_key_id, None)
         eq_(aws_secret_access_key, None)
+        eq_(config.signature_version, botocore.UNSIGNED)
         eq_(config.s3['addressing_style'], S3Uploader.S3_DEFAULT_ADDRESSING_STYLE)
+
+        service_name = client_class.call_args_list[1].args[0]
+        region_name = client_class.call_args_list[1].kwargs['region_name']
+        aws_access_key_id = client_class.call_args_list[1].kwargs['aws_access_key_id']
+        aws_secret_access_key = client_class.call_args_list[1].kwargs['aws_secret_access_key']
+        eq_(service_name, 's3')
+        eq_(region_name, S3Uploader.S3_DEFAULT_REGION)
+        eq_(aws_access_key_id, username)
+        eq_(aws_secret_access_key, password)
+        assert 'config' not in client_class.call_args_list[1].kwargs
 
     def test_custom_client_class(self):
         """You can specify a client class to use instead of boto3.client."""
@@ -187,10 +200,25 @@ class TestS3Uploader(S3UploaderTest):
             None
         ),
         (
+            's3_dummy_url_with_path_without_slash',
+            'dummy',
+            'dummy',
+            'https://dummy.s3.amazonaws.com/dummy',
+            None
+        ),
+        (
             's3_path_style_url_with_path_without_slash',
             'a-bucket',
             'a-path',
             'https://s3.amazonaws.com/a-bucket/a-path',
+            None,
+            S3AddressingStyle.PATH.value
+        ),
+        (
+            's3_path_style_dummy_url_with_path_without_slash',
+            'dummy',
+            'dummy',
+            'https://s3.amazonaws.com/dummy/dummy',
             None,
             S3AddressingStyle.PATH.value
         ),

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -130,8 +130,8 @@ class TestS3Uploader(S3UploaderTest):
 
     def test_empty_string(self):
         # Arrange
-        username = ''
-        password = ''
+        username = 'username'
+        password = 'password'
         settings = {'username': username, 'password': password}
         integration = self._external_integration(
             ExternalIntegration.S3, goal=ExternalIntegration.STORAGE_GOAL, settings=settings


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR changes S3Uploader initialisation logic, it creates two boto3 clients:
- the first one **without** authentication used for generating unsigned URLs
- the second one **with** authentication for working with S3: uploading files, etc.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes the authentication issue in S3Uploader caused by [PR 1179](https://github.com/NYPL-Simplified/server_core/pull/1179).
Steps to reproduce the issue:
1. Create a MARC or ONIX collection
2. Try to import it using `bin/directory_import` with valid S3 credentials
In the output you'll see an authentication error.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested it by importing an ONIX collection into S3 with `bin/directory_import` script using the steps described above.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
