### PR TITLE
Add integration tests for S3Uploader using MinIO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ env:
   global:
     - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_core_test"
     - ES_VERSION="6.3.2" ES_DOWNLOAD="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz"
-    - MINIO_ENDPOINT_URL=http://localhost:9000
+    - MINIO_HOST=localhost:9000
+    - MINIO_ENDPOINT_URL=http://${MINIO_HOST}
     - MINIO_USER=minioadmin
     - MINIO_PASSWORD=minioadmin
-    - MINIO_HOST=localhost:9000
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ env:
   global:
     - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_core_test"
     - ES_VERSION="6.3.2" ES_DOWNLOAD="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz"
+    - MINIO_ENDPOINT_URL=http://localhost:9000
+    - MINIO_USER=minioadmin
+    - MINIO_PASSWORD=minioadmin
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ cache: pip
 
 before_install:
   - pip install --upgrade pip
-  - pip install "setuptools>=18.5"
+  - pip install "setuptools>=44.1.0"
   - docker pull minio/minio
   - docker run -d -p 9000:9000 minio/minio server /data
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - MINIO_ENDPOINT_URL=http://localhost:9000
     - MINIO_USER=minioadmin
     - MINIO_PASSWORD=minioadmin
+    - MINIO_HOST=localhost:9000
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ before_install:
   - pip install "setuptools>=18.5"
   - docker pull minio/minio
   - docker run -d -p 9000:9000 minio/minio server /data
-  - sleep 10
 
 install:
   - wget ${ES_DOWNLOAD}

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 
 services:
   - postgresql
+  - docker
 
 language: python
 
@@ -25,6 +26,8 @@ cache: pip
 before_install:
   - pip install --upgrade pip
   - pip install "setuptools>=18.5"
+  - docker pull minio/minio
+  - docker run -d -p 9000:9000 minio/minio server /data
   - sleep 10
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ env:
   global:
     - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_core_test"
     - ES_VERSION="6.3.2" ES_DOWNLOAD="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz"
-    - MINIO_HOST=localhost:9000
-    - MINIO_ENDPOINT_URL=http://${MINIO_HOST}
-    - MINIO_USER=minioadmin
-    - MINIO_PASSWORD=minioadmin
+    - SIMPLIFIED_MINIO_HOST=localhost:9000
+    - SIMPLIFIED_TEST_MINIO_ENDPOINT_URL=http://${SIMPLIFIED_MINIO_HOST}
+    - SIMPLIFIED_TEST_MINIO_USER=minioadmin
+    - SIMPLIFIED_TEST_MINIO_PASSWORD=minioadmin
 
 services:
   - postgresql

--- a/cdn.py
+++ b/cdn.py
@@ -1,11 +1,9 @@
 """Turn local URLs into CDN URLs."""
-import os, sys
-import urllib
 import urlparse
-from nose.tools import set_trace
 
 from config import Configuration, CannotLoadConfiguration
 from s3 import S3Uploader
+
 
 def cdnify(url, cdns=None):
     """Turn local URLs into CDN URLs"""
@@ -19,7 +17,7 @@ def cdnify(url, cdns=None):
         return url
     scheme, netloc, path, query, fragment = urlparse.urlsplit(url)
 
-    if netloc.endswith('amazonaws.com'):
+    if S3Uploader.is_s3_url(url):
         # This is a URL like "http://bucket.s3.region.amazonaws.com/foo".
         # It's equivalent to "http://bucket/foo".
         # i.e. treat the bucket name as the netloc.

--- a/cdn.py
+++ b/cdn.py
@@ -2,45 +2,6 @@
 import urlparse
 
 from config import Configuration, CannotLoadConfiguration
-from core.mirror import MirrorUploader
-from core.model import ExternalIntegration
-from core.s3 import S3Uploader
-
-
-def _get_mirrors():
-    """Returns a list of configured mirrors
-
-    :return: List of configured mirrors
-    :rtype: List[MirrorUploader]
-    """
-    from model import SessionManager
-    database_url = Configuration.database_url()
-    _db = SessionManager.session(database_url)
-
-    storage_integrations = ExternalIntegration.for_goal(_db, MirrorUploader.STORAGE_GOAL)
-    has_s3_mirror = False
-
-    for storage_integration in storage_integrations:
-        mirror = MirrorUploader.implementation(storage_integration)
-
-        if isinstance(mirror, S3Uploader):
-            has_s3_mirror = True
-
-        yield mirror
-
-    if not has_s3_mirror:
-        # We need to preserve backward compatibility and for S3 based URLs
-        # even when there are no configured S3 integrations
-
-        class CDNfiedS3Uploader(S3Uploader):
-            """Dummy class used for backward compatibility
-                and used for calling S3Uploader's is_self_url and split_url
-            """
-            def __init__(self):
-                """Initializes a new instance of CDNfiedS3Uploader class"""
-                self._host = S3Uploader.S3_HOST
-
-        yield CDNfiedS3Uploader()
 
 
 def cdnify(url, cdns=None):
@@ -56,11 +17,6 @@ def cdnify(url, cdns=None):
 
     scheme, netloc, path, query, fragment = urlparse.urlsplit(url)
 
-    for mirror in _get_mirrors():
-        if mirror.is_self_url(url):
-            netloc, path = mirror.split_url(url, unquote=False)
-            break
-
     if netloc not in cdns:
         # This domain name is not covered by any of our CDNs.
         return url
@@ -68,4 +24,3 @@ def cdnify(url, cdns=None):
     cdn_host = cdns[netloc]
     cdn_scheme, cdn_netloc, i1, i2, i3 = urlparse.urlsplit(cdn_host)
     return urlparse.urlunsplit((cdn_scheme, cdn_netloc, path, query, fragment))
-

--- a/cdn.py
+++ b/cdn.py
@@ -2,30 +2,64 @@
 import urlparse
 
 from config import Configuration, CannotLoadConfiguration
-from s3 import S3Uploader
+from core.mirror import MirrorUploader
+from core.model import ExternalIntegration
+from core.s3 import S3Uploader
+
+
+def _get_mirrors():
+    """Returns a list of configured mirrors
+
+    :return: List of configured mirrors
+    :rtype: List[MirrorUploader]
+    """
+    from model import SessionManager
+    database_url = Configuration.database_url()
+    _db = SessionManager.session(database_url)
+
+    storage_integrations = ExternalIntegration.for_goal(_db, MirrorUploader.STORAGE_GOAL)
+    has_s3_mirror = False
+
+    for storage_integration in storage_integrations:
+        mirror = MirrorUploader.implementation(storage_integration)
+
+        if isinstance(mirror, S3Uploader):
+            has_s3_mirror = True
+
+        yield mirror
+
+    if not has_s3_mirror:
+        # We need to preserve backward compatibility and for S3 based URLs
+        # even when there are no configured S3 integrations
+
+        class CDNfiedS3Uploader(S3Uploader):
+            """Dummy class used for backward compatibility
+                and used for calling S3Uploader's is_self_url and split_url
+            """
+            def __init__(self):
+                """Initializes a new instance of CDNfiedS3Uploader class"""
+                self._host = S3Uploader.S3_HOST
+
+        yield CDNfiedS3Uploader()
 
 
 def cdnify(url, cdns=None):
     """Turn local URLs into CDN URLs"""
     try:
         cdns = cdns or Configuration.cdns()
-    except CannotLoadConfiguration, e:
+    except CannotLoadConfiguration:
         pass
 
     if not cdns:
         # No CDNs configured
         return url
+
     scheme, netloc, path, query, fragment = urlparse.urlsplit(url)
 
-    if S3Uploader.is_s3_url(url):
-        # This is a URL like "http://bucket.s3.region.amazonaws.com/foo".
-        # It's equivalent to "http://bucket/foo".
-        # i.e. treat the bucket name as the netloc.
-        #
-        # Since we are using the 'filename' to generate a URL rather
-        # than talk to S3, we don't want it to be unquoted.
-        #
-        netloc, path = S3Uploader.bucket_and_filename(url, unquote=False)
+    for mirror in _get_mirrors():
+        if mirror.is_self_url(url):
+            netloc, path = mirror.split_url(url, unquote=False)
+            break
 
     if netloc not in cdns:
         # This domain name is not covered by any of our CDNs.

--- a/mirror.py
+++ b/mirror.py
@@ -1,12 +1,16 @@
 import datetime
+from abc import abstractmethod, ABCMeta
+from urlparse import urlsplit
 
 from config import CannotLoadConfiguration
 
 
-class MirrorUploader():
+class MirrorUploader(object):
     """Handles the job of uploading a representation's content to
     a mirror that we control.
     """
+
+    __metaclass__ = ABCMeta
 
     STORAGE_GOAL = u'storage'
 
@@ -81,11 +85,15 @@ class MirrorUploader():
         )
         return implementation_class(integration)
 
-    def __init__(self, integration):
+    def __init__(self, integration, host):
         """Instantiate a MirrorUploader from an ExternalIntegration.
 
         :param integration: An ExternalIntegration configuring the credentials
            used to upload things.
+        :type integration: ExternalIntegration
+
+        :param host: Base host used by the mirror
+        :type host: string
         """
         if integration.goal != self.STORAGE_GOAL:
             # This collection's 'mirror integration' isn't intended to
@@ -94,6 +102,8 @@ class MirrorUploader():
                 "Cannot create an MirrorUploader from an integration with goal=%s" %
                 integration.goal
             )
+
+        self._host = host
 
         # Subclasses will override this to further configure the client
         # based on the credentials in the ExternalIntegration.
@@ -149,5 +159,36 @@ class MirrorUploader():
 
         :return: Signed expirable link
         :rtype: string
+        """
+        raise NotImplementedError()
+
+    def is_self_url(self, url):
+        """Determines whether the URL has the mirror's host or a custom domain
+
+        :param url: The URL
+        :type url: string
+
+        :return: Boolean value indicating whether the URL has the mirror's host or a custom domain
+        :rtype: bool
+        """
+        scheme, netloc, path, query, fragment = urlsplit(url)
+
+        if netloc.endswith(self._host):
+            return True
+        else:
+            return False
+
+    @abstractmethod
+    def split_url(self, url, unquote=True):
+        """Splits the URL into the components: container (bucket) and file path
+
+        :param url: URL
+        :type url: string
+
+        :param unquote: Boolean value indicating whether it's required to unquote URL elements
+        :type unquote: bool
+
+        :return: Tuple (bucket, file path)
+        :rtype: Tuple[string, string]
         """
         raise NotImplementedError()

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -214,6 +214,7 @@ class ExternalIntegration(Base, HasFullTableCache):
 
     # Integrations with STORAGE_GOAL
     S3 = u'Amazon S3'
+    MINIO = u'MinIO'
 
     # Integrations with CDN_GOAL
     CDN = u'CDN'

--- a/s3.py
+++ b/s3.py
@@ -480,10 +480,10 @@ class S3Uploader(MirrorUploader):
         """
         scheme, netloc, path, query, fragment = urlsplit(url)
 
-        if netloc.endswith(S3Uploader.S3_HOST) or netloc.endswith(S3Uploader.MINIO_HOST):
-            return False
-        else:
+        if netloc.endswith(S3Uploader.S3_HOST) or (S3Uploader.MINIO_HOST and netloc.endswith(S3Uploader.MINIO_HOST)):
             return True
+        else:
+            return False
 
     @classmethod
     def bucket_and_filename(cls, url, unquote=True):

--- a/s3.py
+++ b/s3.py
@@ -102,6 +102,12 @@ class S3AddressingStyle(Enum):
 class S3Uploader(MirrorUploader):
     NAME = ExternalIntegration.S3
 
+    # AWS S3 host
+    S3_HOST = 'amazonaws.com'
+
+    # MinIO host used in integration tests (we assume that it's always using port 9000)
+    MINIO_HOST = 'localhost:9000'
+
     S3_REGION = u's3_region'
     S3_DEFAULT_REGION = u'us-east-1'
 
@@ -465,7 +471,7 @@ class S3Uploader(MirrorUploader):
     def bucket_and_filename(cls, url, unquote=True):
         scheme, netloc, path, query, fragment = urlsplit(url)
 
-        if netloc.endswith('amazonaws.com'):
+        if netloc.endswith(S3Uploader.S3_HOST) or netloc.endswith(S3Uploader.MINIO_HOST):
             host_parts = netloc.split('.')
             host_parts_count = len(host_parts)
 

--- a/s3.py
+++ b/s3.py
@@ -641,8 +641,8 @@ class MinIOUploader(S3Uploader):
         super(MinIOUploader, self).__init__(integration, client_class, host)
 
 
-# MirrorUploader.implementation will instantiate an S3Uploader
-# for storage integrations with protocol 'Amazon S3'.
+# MirrorUploader.implementation will instantiate an MinIOUploader instance
+# for storage integrations with protocol 'MinIO'.
 MirrorUploader.IMPLEMENTATION_REGISTRY[MinIOUploader.NAME] = MinIOUploader
 
 

--- a/s3.py
+++ b/s3.py
@@ -107,7 +107,7 @@ class S3Uploader(MirrorUploader):
     S3_HOST = 'amazonaws.com'
 
     # MinIO host used in integration tests (we assume that it's always using port 9000)
-    MINIO_HOST = os.environ.get('MINIO_HOST')
+    SIMPLIFIED_MINIO_HOST = os.environ.get('SIMPLIFIED_MINIO_HOST')
 
     S3_REGION = u's3_region'
     S3_DEFAULT_REGION = u'us-east-1'
@@ -480,7 +480,8 @@ class S3Uploader(MirrorUploader):
         """
         scheme, netloc, path, query, fragment = urlsplit(url)
 
-        if netloc.endswith(S3Uploader.S3_HOST) or (S3Uploader.MINIO_HOST and netloc.endswith(S3Uploader.MINIO_HOST)):
+        if netloc.endswith(S3Uploader.S3_HOST) or \
+                (S3Uploader.SIMPLIFIED_MINIO_HOST and netloc.endswith(S3Uploader.SIMPLIFIED_MINIO_HOST)):
             return True
         else:
             return False

--- a/s3.py
+++ b/s3.py
@@ -1,5 +1,5 @@
+import functools
 import logging
-import os
 import urllib
 from contextlib import contextmanager
 from urlparse import urlsplit
@@ -22,7 +22,7 @@ class MultipartS3Upload():
     def __init__(self, uploader, representation, mirror_to):
         self.uploader = uploader
         self.representation = representation
-        self.bucket, self.filename = uploader.bucket_and_filename(mirror_to)
+        self.bucket, self.filename = uploader.split_url(mirror_to)
         media_type = representation.external_media_type
         self.part_number = 1
         self.parts = []
@@ -105,9 +105,6 @@ class S3Uploader(MirrorUploader):
 
     # AWS S3 host
     S3_HOST = 'amazonaws.com'
-
-    # MinIO host used in integration tests (we assume that it's always using port 9000)
-    SIMPLIFIED_MINIO_HOST = os.environ.get('SIMPLIFIED_MINIO_HOST')
 
     S3_REGION = u's3_region'
     S3_DEFAULT_REGION = u'us-east-1'
@@ -213,14 +210,21 @@ class S3Uploader(MirrorUploader):
 
     SITEWIDE = True
 
-    def __init__(self, integration, client_class=None):
+    def __init__(self, integration, client_class=None, host=S3_HOST):
         """Instantiate an S3Uploader from an ExternalIntegration.
 
         :param integration: An ExternalIntegration
+        :type integration: ExternalIntegration
 
         :param client_class: Mock object (or class) to use (or instantiate)
             instead of boto3.client.
+        :type client_class: Any
+
+        :param host: Host used by this integration
+        :type host: string
         """
+        super(S3Uploader, self).__init__(integration, host)
+
         if not client_class:
             client_class = boto3.client
 
@@ -327,7 +331,7 @@ class S3Uploader(MirrorUploader):
         if not expiration:
             expiration = self._s3_presigned_url_expiration
 
-        bucket, key = self.bucket_and_filename(url)
+        bucket, key = self.split_url(url)
         url = self.client.generate_presigned_url(
             'get_object',
             ExpiresIn=int(expiration),
@@ -468,29 +472,21 @@ class S3Uploader(MirrorUploader):
         parts = [time_part, lane.display_name]
         return root + self.key_join(parts) + ".mrc"
 
-    @classmethod
-    def is_s3_url(cls, url):
-        """Determines whether the URL is S3-based or use a custom domain name
+    def split_url(self, url, unquote=True):
+        """Splits the URL into the components: bucket and file path
 
-        :param url: The URL
+        :param url: URL
         :type url: string
 
-        :return: Boolean value indicating whether the URL is S3-based or use a custom domain name
-        :rtype: bool
+        :param unquote: Boolean value indicating whether it's required to unquote URL elements
+        :type unquote: bool
+
+        :return: Tuple (bucket, file path)
+        :rtype: Tuple[string, string]
         """
         scheme, netloc, path, query, fragment = urlsplit(url)
 
-        if netloc.endswith(S3Uploader.S3_HOST) or \
-                (S3Uploader.SIMPLIFIED_MINIO_HOST and netloc.endswith(S3Uploader.SIMPLIFIED_MINIO_HOST)):
-            return True
-        else:
-            return False
-
-    @classmethod
-    def bucket_and_filename(cls, url, unquote=True):
-        scheme, netloc, path, query, fragment = urlsplit(url)
-
-        if cls.is_s3_url(url):
+        if self.is_self_url(url):
             host_parts = netloc.split('.')
             host_parts_count = len(host_parts)
 
@@ -552,7 +548,7 @@ class S3Uploader(MirrorUploader):
 
         # Turn the original URL into an s3.amazonaws.com URL.
         media_type = representation.external_media_type
-        bucket, remote_filename = self.bucket_and_filename(mirror_to)
+        bucket, remote_filename = self.split_url(mirror_to)
         fh = representation.external_content()
         try:
             result = self.client.upload_fileobj(
@@ -605,6 +601,49 @@ class S3Uploader(MirrorUploader):
 # MirrorUploader.implementation will instantiate an S3Uploader
 # for storage integrations with protocol 'Amazon S3'.
 MirrorUploader.IMPLEMENTATION_REGISTRY[S3Uploader.NAME] = S3Uploader
+
+
+class MinIOUploader(S3Uploader):
+    NAME = ExternalIntegration.MINIO
+
+    ENDPOINT_URL = 'ENDPOINT_URL'
+
+    SETTINGS = [
+        {
+            'key': ENDPOINT_URL,
+            'label': _('Endpoint URL'),
+            'description': _('MinIO\'s endpoint URL'),
+            'required': True
+        }
+    ] + S3Uploader.SETTINGS
+
+    def __init__(self, integration, client_class=None):
+        """Instantiate an S3Uploader from an ExternalIntegration.
+
+        :param integration: An ExternalIntegration
+
+        :param client_class: Mock object (or class) to use (or instantiate)
+            instead of boto3.client.
+        """
+        endpoint_url = integration.setting(
+            self.ENDPOINT_URL).value
+
+        _, host, _, _, _ = urlsplit(endpoint_url)
+
+        if not client_class:
+            client_class = boto3.client
+
+        if callable(client_class):
+            client_class = functools.partial(client_class, endpoint_url=endpoint_url)
+        else:
+            self.client = client_class
+
+        super(MinIOUploader, self).__init__(integration, client_class, host)
+
+
+# MirrorUploader.implementation will instantiate an S3Uploader
+# for storage integrations with protocol 'Amazon S3'.
+MirrorUploader.IMPLEMENTATION_REGISTRY[MinIOUploader.NAME] = MinIOUploader
 
 
 class MockS3Uploader(S3Uploader):

--- a/scripts.py
+++ b/scripts.py
@@ -1,52 +1,39 @@
 import argparse
 import datetime
-import imp
 import logging
 import os
 import random
 import re
-import requests
-import string
 import subprocess
-import time
-import uuid
-from requests.exceptions import (
-    ConnectionError,
-    HTTPError,
-)
 import sys
 import traceback
 import unicodedata
-
+import uuid
 from collections import defaultdict
-from external_search import (
-    ExternalSearchIndex,
-    Filter,
-    SearchIndexCoverageProvider,
-)
-import json
-from nose.tools import set_trace
+
+from enum import Enum
 from sqlalchemy import (
-    create_engine,
     exists,
     and_,
-    or_,
     text,
 )
 from sqlalchemy.exc import ProgrammingError
-from sqlalchemy.sql.functions import func
+from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import (
     NoResultFound,
     MultipleResultsFound,
 )
-from sqlalchemy.orm import Session
 
-from app_server import ComplaintController
 # from axis import Axis360BibliographicCoverageProvider
 from config import Configuration, CannotLoadConfiguration
 from coverage import (
     CollectionCoverageProviderJob,
     CoverageProviderProgress,
+)
+from external_search import (
+    ExternalSearchIndex,
+    Filter,
+    SearchIndexCoverageProvider,
 )
 from lane import Lane
 from metadata_layer import (
@@ -67,7 +54,6 @@ from model import (
     Complaint,
     ConfigurationSetting,
     Contributor,
-    CoverageRecord,
     CustomList,
     DataSource,
     Edition,
@@ -85,7 +71,6 @@ from model import (
     Timestamp,
     Work,
     WorkCoverageRecord,
-    WorkGenre,
     site_configuration_has_changed,
 )
 from model.configuration import ExternalIntegrationLink
@@ -100,19 +85,15 @@ from opds_import import (
 # from oneclick import (
 #     OneClickBibliographicCoverageProvider,
 # )
-from overdrive import OverdriveBibliographicCoverageProvider
 from util import fast_query_count
-from util.opds_writer import OPDSFeed
 from util.personal_names import (
     contributor_name_match_ratio,
-    display_name_to_sort_name,
-    is_corporate_name
+    display_name_to_sort_name
 )
 from util.worker_pools import (
-    DatabaseWorker,
     DatabasePool,
 )
-from functools import cmp_to_key
+
 
 class Script(object):
 
@@ -1790,6 +1771,14 @@ class CustomListManagementScript(Script):
         self._db.commit()
 
 
+class CollectionType(Enum):
+    OPEN_ACCESS = 'OPEN_ACCESS'
+    PROTECTED_ACCESS = 'PROTECTED_ACCESS'
+
+    def __str__(self):
+        return self.name
+
+
 class CollectionInputScript(Script):
     """A script that takes collection names as command line inputs."""
 
@@ -1820,6 +1809,13 @@ class CollectionInputScript(Script):
             help='Collection to use',
             dest='collection_names',
             metavar='NAME', action='append', default=[]
+        )
+        parser.add_argument(
+            '--collection-type',
+            help=u'Collection type. Valid values are: OPEN_ACCESS (default), PROTECTED_ACCESS.',
+            type=CollectionType,
+            choices=list(CollectionType),
+            default=CollectionType.OPEN_ACCESS
         )
         return parser
 
@@ -1875,15 +1871,16 @@ class MirrorResourcesScript(CollectionInputScript):
     def do_run(self, cmd_args=None):
         parsed = self.parse_command_line(self._db, cmd_args=cmd_args)
         collections = parsed.collections
+        collection_type = parsed.collection_type
         if not collections:
             # Assume they mean all collections.
             collections = self._db.query(Collection).all()
 
         # But only process collections that have an associated MirrorUploader.
-        for collection, policy in self.collections_with_uploader(collections):
+        for collection, policy in self.collections_with_uploader(collections, collection_type):
             self.process_collection(collection, policy)
 
-    def collections_with_uploader(self, collections):
+    def collections_with_uploader(self, collections, collection_type=CollectionType.OPEN_ACCESS):
         """Filter out collections that have no MirrorUploader.
 
         :yield: 2-tuples (Collection, ReplacementPolicy). The
@@ -1894,11 +1891,19 @@ class MirrorResourcesScript(CollectionInputScript):
             covers = MirrorUploader.for_collection(
                 collection, ExternalIntegrationLink.COVERS
             )
+            books_mirror_type = \
+                ExternalIntegrationLink.OPEN_ACCESS_BOOKS \
+                if collection_type == CollectionType.OPEN_ACCESS \
+                else ExternalIntegrationLink.PROTECTED_ACCESS_BOOKS
             books = MirrorUploader.for_collection(
-                collection, ExternalIntegrationLink.OPEN_ACCESS_BOOKS
+                collection,
+                books_mirror_type
             )
             if covers or books:
-                mirrors = dict(covers_mirror=covers, books_mirror=books)
+                mirrors = {
+                    ExternalIntegrationLink.COVERS: covers,
+                    books_mirror_type: books
+                }
                 policy = self.replacement_policy(mirrors)
                 yield collection, policy
             else:

--- a/tests/test_cdn.py
+++ b/tests/test_cdn.py
@@ -37,14 +37,6 @@ class TestCDN(DatabaseTest):
                   "bar.com" : "http://cdn2.net/"}
         )
 
-    def test_s3_bucket(self):
-        # Instead of the foo.com URL we accidentally used the full S3
-        # address for the bucket that hosts S3. cdnify() handles this
-        # with no problem.
-        url = "http://s3.amazonaws.com/foo.com/bar+bar%21#baz"
-        self.ceq("https://cdn.org/bar+bar%21#baz", url,
-                 {"foo.com" : "https://cdn.org/"})
-
     def test_relative_url(self):
         # By default, relative URLs are untouched.
         url = "/groups/"

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -110,8 +110,7 @@ class S3UploaderTest(DatabaseTest):
 
 
 class S3UploaderIntegrationTest(S3UploaderTest):
-    MINIO_PORT = os.environ.get('MINIO_PORT', 9000)
-    MINIO_ENDPOINT_URL = os.environ.get('MINIO_ENDPOINT_URL', 'http://localhost:{0}'.format(MINIO_PORT))
+    MINIO_ENDPOINT_URL = os.environ.get('MINIO_ENDPOINT_URL', 'http://localhost:9000')
     MINIO_USER = os.environ.get('MINIO_USER', 'minioadmin')
     MINIO_PASSWORD = os.environ.get('MINIO_PASSWORD', 'minioadmin')
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -110,10 +110,10 @@ class S3UploaderTest(DatabaseTest):
 
 
 class S3UploaderIntegrationTest(S3UploaderTest):
-    MINIO_PORT = 9000
-    MINIO_ENDPOINT_URL = 'http://localhost:{0}'.format(MINIO_PORT)
-    MINIO_USER = 'minioadmin'
-    MINIO_PASSWORD = 'minioadmin'
+    MINIO_PORT = os.environ.get('MINIO_PORT', 9000)
+    MINIO_ENDPOINT_URL = os.environ.get('MINIO_ENDPOINT_URL', 'http://localhost:{0}'.format(MINIO_PORT))
+    MINIO_USER = os.environ.get('MINIO_USER', 'minioadmin')
+    MINIO_PASSWORD = os.environ.get('MINIO_PASSWORD', 'minioadmin')
 
     minio_s3_client = None
     """boto3 client connected to locally running MinIO instance"""

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -110,9 +110,9 @@ class S3UploaderTest(DatabaseTest):
 
 
 class S3UploaderIntegrationTest(S3UploaderTest):
-    MINIO_ENDPOINT_URL = os.environ.get('MINIO_ENDPOINT_URL', 'http://localhost:9000')
-    MINIO_USER = os.environ.get('MINIO_USER', 'minioadmin')
-    MINIO_PASSWORD = os.environ.get('MINIO_PASSWORD', 'minioadmin')
+    SIMPLIFIED_TEST_MINIO_ENDPOINT_URL = os.environ.get('SIMPLIFIED_TEST_MINIO_ENDPOINT_URL', 'http://localhost:9000')
+    SIMPLIFIED_TEST_MINIO_USER = os.environ.get('SIMPLIFIED_TEST_MINIO_USER', 'minioadmin')
+    SIMPLIFIED_TEST_MINIO_PASSWORD = os.environ.get('SIMPLIFIED_TEST_MINIO_PASSWORD', 'minioadmin')
 
     minio_s3_client = None
     """boto3 client connected to locally running MinIO instance"""
@@ -127,13 +127,13 @@ class S3UploaderIntegrationTest(S3UploaderTest):
 
         cls.minio_s3_client = boto3.client(
             's3',
-            aws_access_key_id=TestS3UploaderIntegration.MINIO_USER,
-            aws_secret_access_key=TestS3UploaderIntegration.MINIO_PASSWORD,
-            endpoint_url=TestS3UploaderIntegration.MINIO_ENDPOINT_URL
+            aws_access_key_id=TestS3UploaderIntegration.SIMPLIFIED_TEST_MINIO_USER,
+            aws_secret_access_key=TestS3UploaderIntegration.SIMPLIFIED_TEST_MINIO_PASSWORD,
+            endpoint_url=TestS3UploaderIntegration.SIMPLIFIED_TEST_MINIO_ENDPOINT_URL
         )
         cls.s3_client_class = functools.partial(
             boto3.client,
-            endpoint_url=TestS3UploaderIntegration.MINIO_ENDPOINT_URL
+            endpoint_url=TestS3UploaderIntegration.SIMPLIFIED_TEST_MINIO_ENDPOINT_URL
         )
 
     @classmethod
@@ -181,9 +181,9 @@ class S3UploaderIntegrationTest(S3UploaderTest):
         :rtype: S3Uploader
         """
         if settings and 'username' not in settings:
-            self._add_settings_value(settings, 'username', self.MINIO_USER)
+            self._add_settings_value(settings, 'username', self.SIMPLIFIED_TEST_MINIO_USER)
         if settings and 'password' not in settings:
-            self._add_settings_value(settings, 'password', self.MINIO_PASSWORD)
+            self._add_settings_value(settings, 'password', self.SIMPLIFIED_TEST_MINIO_PASSWORD)
         if not client_class:
             client_class = self.s3_client_class
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 import datetime
 import functools
+import os
 
 import boto3
 import botocore
@@ -9,6 +10,7 @@ from botocore.exceptions import (
     ClientError,
 )
 from mock import MagicMock
+from nose.plugins.attrib import attr
 from nose.tools import (
     assert_raises,
     eq_,
@@ -121,7 +123,7 @@ class S3UploaderIntegrationTest(S3UploaderTest):
 
     @classmethod
     def setup_class(cls):
-        """Initializes the test suite"""
+        """Initializes the test suite by creating a boto3 client set up with MinIO credentials"""
         super(S3UploaderIntegrationTest, cls).setup_class()
 
         cls.minio_s3_client = boto3.client(
@@ -137,7 +139,7 @@ class S3UploaderIntegrationTest(S3UploaderTest):
 
     @classmethod
     def teardown_class(cls):
-        """Deinitializes the test suite"""
+        """Deinitializes the test suite by removing all the buckets from MinIO"""
         response = cls.minio_s3_client.list_buckets()
 
         for bucket in response['Buckets']:
@@ -1178,6 +1180,7 @@ class TestMultiPartS3Upload(S3UploaderTest):
         eq_([], uploader.client.parts)
 
 
+@attr(integration='minio')
 class TestS3UploaderIntegration(S3UploaderIntegrationTest):
     def test_mirror(self):
         # Arrange

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -885,9 +885,12 @@ class TestS3Uploader(S3UploaderTest):
             False
         ),
     ])
-    def test_bucket_and_filename(self, name, url, expected_result, unquote=True):
+    def test_split_url(self, name, url, expected_result, unquote=True):
+        # Arrange
+        s3_uploader = self._create_s3_uploader()
+
         # Act
-        result = S3Uploader.bucket_and_filename(url, unquote)
+        result = s3_uploader.split_url(url, unquote)
 
         # Assert
         eq_(result, expected_result)
@@ -1102,7 +1105,7 @@ class TestS3Uploader(S3UploaderTest):
         url = 'https://{0}.s3.{1}.amazonaws.com/{2}'.format(bucket, region, filename)
         expected_url = url + '?AWSAccessKeyId=KEY&Expires=1&Signature=S'
         s3_uploader = self._create_s3_uploader(region=region, **expiration_settings if expiration_settings else {})
-        s3_uploader.bucket_and_filename = MagicMock(return_value=(bucket, filename))
+        s3_uploader.split_url = MagicMock(return_value=(bucket, filename))
         s3_uploader.client.generate_presigned_url = MagicMock(return_value=expected_url)
 
         # Act
@@ -1110,7 +1113,7 @@ class TestS3Uploader(S3UploaderTest):
 
         # Assert
         eq_(result, expected_url)
-        s3_uploader.bucket_and_filename.assert_called_once_with(url)
+        s3_uploader.split_url.assert_called_once_with(url)
         s3_uploader.client.generate_presigned_url.assert_called_once_with(
             'get_object',
             ExpiresIn=expected_expiration,

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 import os
 import random
 import shutil
@@ -11,20 +10,26 @@ from nose.tools import (
     assert_raises,
     assert_raises_regexp,
     eq_,
-    set_trace,
 )
+from parameterized import parameterized
 
+from core.s3 import S3Uploader, MinIOUploader
 from . import (
     DatabaseTest,
 )
 from ..classifier import Classifier
-
 from ..config import (
     CannotLoadConfiguration,
-    Configuration,
-    temp_config,
 )
 from ..external_search import MockExternalSearchIndex
+from ..lane import (
+    Lane,
+    WorkList,
+)
+from ..metadata_layer import (
+    LinkData,
+    TimestampData,
+)
 from ..mirror import MirrorUploader
 from ..model import (
     create,
@@ -36,29 +41,22 @@ from ..model import (
     ConfigurationSetting,
     Contributor,
     CoverageRecord,
-    CustomList,
     DataSource,
-    Edition,
     ExternalIntegration,
     Hyperlink,
     Identifier,
     Library,
-    LicensePool,
     RightsStatus,
     Timestamp,
     Work,
     WorkCoverageRecord,
 )
 from ..model.configuration import ExternalIntegrationLink
-from ..lane import (
-    Lane,
-    WorkList,
+from ..monitor import (
+    Monitor,
+    CollectionMonitor,
+    ReaperMonitor,
 )
-from ..metadata_layer import (
-    LinkData,
-    TimestampData,
-)
-
 from ..scripts import (
     AddClassificationScript,
     CheckContributorNamesInDB,
@@ -68,7 +66,6 @@ from ..scripts import (
     ConfigureLaneScript,
     ConfigureLibraryScript,
     ConfigureSiteScript,
-    CustomListManagementScript,
     DatabaseMigrationInitializationScript,
     DatabaseMigrationScript,
     Explain,
@@ -101,20 +98,10 @@ from ..scripts import (
     WhereAreMyBooksScript,
     WorkClassificationScript,
     WorkProcessingScript,
-)
-from ..testing import(
-    AlwaysSuccessfulBibliographicCoverageProvider,
-    BrokenBibliographicCoverageProvider,
+    CollectionType)
+from ..testing import (
     AlwaysSuccessfulCollectionCoverageProvider,
     AlwaysSuccessfulWorkCoverageProvider,
-)
-from ..monitor import (
-    Monitor,
-    CollectionMonitor,
-    ReaperMonitor,
-)
-from ..util.opds_writer import (
-    OPDSFeed,
 )
 from ..util.worker_pools import (
     DatabasePool,
@@ -2539,8 +2526,8 @@ class TestListCollectionMetadataIdentifiersScript(DatabaseTest):
         assert expected(c2) in output
         assert '2 collections found.\n' in output
 
-class TestMirrorResourcesScript(DatabaseTest):
 
+class TestMirrorResourcesScript(DatabaseTest):
     def test_do_run(self):
 
         has_uploader = self._collection()
@@ -2550,7 +2537,7 @@ class TestMirrorResourcesScript(DatabaseTest):
 
             processed = []
 
-            def collections_with_uploader(self, collections):
+            def collections_with_uploader(self, collections, collection_type):
                 # Pretend that `has_uploader` is the only Collection
                 # with an uploader.
                 for collection in collections:
@@ -2581,7 +2568,39 @@ class TestMirrorResourcesScript(DatabaseTest):
         processed = script.processed.pop()
         eq_((has_uploader, mock_uploader), processed)
 
-    def test_collections_with_uploader(self):
+    @parameterized.expand([
+        (
+            'containing_open_access_books_with_s3_uploader',
+            CollectionType.OPEN_ACCESS,
+            ExternalIntegrationLink.OPEN_ACCESS_BOOKS,
+            ExternalIntegration.S3,
+            S3Uploader
+        ),
+        (
+            'containing_protected_access_books_with_s3_uploader',
+            CollectionType.PROTECTED_ACCESS,
+            ExternalIntegrationLink.PROTECTED_ACCESS_BOOKS,
+            ExternalIntegration.S3,
+            S3Uploader
+        ),
+        (
+            'containing_open_access_books_with_minio_uploader',
+            CollectionType.OPEN_ACCESS,
+            ExternalIntegrationLink.OPEN_ACCESS_BOOKS,
+            ExternalIntegration.MINIO,
+            MinIOUploader,
+            {MinIOUploader.ENDPOINT_URL: 'http://localhost'}
+        ),
+        (
+            'containing_protected_access_books_with_minio_uploader',
+            CollectionType.PROTECTED_ACCESS,
+            ExternalIntegrationLink.PROTECTED_ACCESS_BOOKS,
+            ExternalIntegration.MINIO,
+            MinIOUploader,
+            {MinIOUploader.ENDPOINT_URL: 'http://localhost'}
+        )
+    ])
+    def test_collections(self, name, collection_type, book_mirror_type, protocol, uploader_class, settings=None):
         class Mock(MirrorResourcesScript):
 
             mock_policy = object()
@@ -2597,8 +2616,12 @@ class TestMirrorResourcesScript(DatabaseTest):
         # This new collection does.
         has_uploader = self._collection()
         mirror = self._external_integration(
-            "S3", ExternalIntegration.STORAGE_GOAL
+            protocol, ExternalIntegration.STORAGE_GOAL
         )
+
+        if settings:
+            for key, value in settings.iteritems():
+                mirror.setting(key).value = value
 
         integration_link = self._external_integration_link(
             integration=has_uploader._external_integration,
@@ -2611,7 +2634,8 @@ class TestMirrorResourcesScript(DatabaseTest):
         # the other collection, pass it into replacement_policy,
         # and yield the result.
         result = script.collections_with_uploader(
-            [self._default_collection, has_uploader, self._default_collection]
+            [self._default_collection, has_uploader, self._default_collection],
+            collection_type
         )
 
         [(collection, policy)] = result
@@ -2619,33 +2643,34 @@ class TestMirrorResourcesScript(DatabaseTest):
         eq_(Mock.mock_policy, policy)
         # The mirror uploader was associated with a purpose of "covers", so we only
         # expect to have one MirrorUploader.
-        eq_(Mock.replacement_policy_called_with[ExternalIntegrationLink.OPEN_ACCESS_BOOKS], None)
+        eq_(Mock.replacement_policy_called_with[book_mirror_type], None)
         assert isinstance(
             Mock.replacement_policy_called_with[ExternalIntegrationLink.COVERS], MirrorUploader
         )
 
         # Add another storage for books.
         another_mirror = self._external_integration(
-            "S3", ExternalIntegration.STORAGE_GOAL
+            protocol, ExternalIntegration.STORAGE_GOAL
         )
 
         integration_link = self._external_integration_link(
             integration=has_uploader._external_integration,
             other_integration=another_mirror,
-            purpose=ExternalIntegrationLink.OPEN_ACCESS_BOOKS
+            purpose=book_mirror_type
         )
 
         result = script.collections_with_uploader(
-            [self._default_collection, has_uploader, self._default_collection]
+            [self._default_collection, has_uploader, self._default_collection],
+            collection_type
         )
 
         [(collection, policy)] = result
         eq_(has_uploader, collection)
         eq_(Mock.mock_policy, policy)
         # There should be two MirrorUploaders, one for each purpose.
-        assert isinstance(Mock.replacement_policy_called_with[ExternalIntegrationLink.COVERS], MirrorUploader)
+        assert isinstance(Mock.replacement_policy_called_with[ExternalIntegrationLink.COVERS], uploader_class)
         assert isinstance(
-            Mock.replacement_policy_called_with[ExternalIntegrationLink.OPEN_ACCESS_BOOKS], MirrorUploader)
+            Mock.replacement_policy_called_with[book_mirror_type], uploader_class)
 
     def test_replacement_policy(self):
         uploader = object()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -13,7 +13,6 @@ from nose.tools import (
 )
 from parameterized import parameterized
 
-from core.s3 import S3Uploader, MinIOUploader
 from . import (
     DatabaseTest,
 )
@@ -57,6 +56,7 @@ from ..monitor import (
     CollectionMonitor,
     ReaperMonitor,
 )
+from ..s3 import S3Uploader, MinIOUploader
 from ..scripts import (
     AddClassificationScript,
     CheckContributorNamesInDB,


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR add integration tests using MinIO as an S3 replacement.

It's based on [PR 1184](https://github.com/NYPL-Simplified/server_core/pull/1184) so it has to be merged first.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There should be a way to perform integration testing of S3Uploader without using real AWS account.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
