### PR TITLE
S3: Add support for LicensePool.self_hosted

### DIFF
--- a/model/work.py
+++ b/model/work.py
@@ -1532,7 +1532,10 @@ class Work(Base):
                     LicensePool.self_hosted,
                     LicensePool.licenses_available > 0,
                 ).label('available'),
-                (LicensePool.licenses_owned > 0).label('licensed'),
+                or_(
+                    LicensePool.self_hosted,
+                    LicensePool.licenses_owned > 0
+                ).label('licensed'),
                 work_quality_column,
                 Edition.medium,
                 func.extract(

--- a/opds.py
+++ b/opds.py
@@ -1595,7 +1595,7 @@ class AcquisitionFeed(OPDSFeed):
             else:
                 status = 'reserved'
                 since = hold.start
-        elif (license_pool.open_access or (
+        elif (license_pool.open_access or license_pool.self_hosted or (
                 license_pool.licenses_available > 0 and
                 license_pool.licenses_owned > 0)
           ):
@@ -1613,9 +1613,8 @@ class AcquisitionFeed(OPDSFeed):
         tags.append(availability_tag)
 
         # Open-access pools do not need to display <opds:holds> or <opds:copies>.
-        if license_pool.open_access:
+        if license_pool.open_access or license_pool.self_hosted:
             return tags
-
 
         holds_kw = dict()
         total = license_pool.patrons_in_hold_queue or 0

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -553,6 +553,7 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
             title="A Tiny Book", with_license_pool=True,
             collection=self.tiny_collection
         )
+        self.tiny_book.license_pools[0].self_hosted = True
 
         # Both collections contain 'The Adventures of Sherlock
         # Holmes", but each collection licenses the book through a

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1558,6 +1558,24 @@ class TestAcquisitionFeed(DatabaseTest):
         assert 'position' not in holds.attrib
         eq_('1', holds.attrib['total'])
 
+    def test_license_tags_show_self_hosted_books(self):
+        # Arrange
+        edition, pool = self._edition(with_license_pool=True)
+        pool.self_hosted = True
+        pool.open_access = False
+        pool.licenses_available = 0
+        pool.licenses_owned = 0
+
+        # Act
+        tags = AcquisitionFeed.license_tags(
+            pool, None, None
+        )
+
+        # Assert
+        eq_(1, len(tags))
+        assert 'status' in tags[0].attrib
+        eq_('available', tags[0].attrib['status'])
+
     def test_single_entry(self):
 
         # Here's a Work with two LicensePools.


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR contains changes required for S3 Content Hosting feature and adds more support for `LicensePool.self_hosted`:
1. Adds `LicensePool.self_hosted` to OPDS generator
2. Adds `LicensePool.self_hosted` to Elasticsearch query generator

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
