### PR TITLE
Store the last time the patron successfully synced their loans with external APIs

### DIFF
--- a/migration/20200702-add-licensepool-self_hosted-field.sql
+++ b/migration/20200702-add-licensepool-self_hosted-field.sql
@@ -1,1 +1,11 @@
-ALTER TABLE licensepools ADD COLUMN self_hosted BOOLEAN;
+DO $$ 
+ BEGIN
+  -- Add the 'self_hosted' column
+  BEGIN
+   ALTER TABLE licensepools ADD COLUMN self_hosted BOOLEAN;
+  EXCEPTION
+   WHEN duplicate_column THEN RAISE NOTICE 'column licensepools.self_hosted already exists, not creating it.';
+  END;
+ END;
+$$;
+

--- a/migration/20200803-patron-external-sync.sql
+++ b/migration/20200803-patron-external-sync.sql
@@ -2,7 +2,7 @@ DO $$
  BEGIN
   -- Add the 'last_loan_activity_sync' column
   BEGIN
-   ALTER TABLE patrons ADD COLUMN last_loan_activity_sync datetime;
+   ALTER TABLE patrons ADD COLUMN last_loan_activity_sync timestamp;
   EXCEPTION
    WHEN duplicate_column THEN RAISE NOTICE 'column patrons.last_loan_activity_sync already exists, not creating it.';
   END;

--- a/migration/20200803-patron-external-sync.sql
+++ b/migration/20200803-patron-external-sync.sql
@@ -1,0 +1,10 @@
+DO $$ 
+ BEGIN
+  -- Add the 'last_loan_activity_sync' column
+  BEGIN
+   ALTER TABLE patrons ADD COLUMN last_loan_activity_sync datetime;
+  EXCEPTION
+   WHEN duplicate_column THEN RAISE NOTICE 'column patrons.last_loan_activity_sync already exists, not creating it.';
+  END;
+ END;
+$$;

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -806,7 +806,7 @@ class LicensePool(Base):
             # This action creates uncertainty about what the patron's
             # loan activity actually is. We'll need to sync with the
             # vendor APIs.
-            patron.last_loan_activity_sync = None
+            patron_or_client.last_loan_activity_sync = None
         else:
             # An IntegrationClient can have multiple loans, so this always creates
             # a new loan rather than returning an existing loan.
@@ -831,7 +831,7 @@ class LicensePool(Base):
             # This action creates uncertainty about what the patron's
             # loan activity actually is. We'll need to sync with the
             # vendor APIs.
-            patron.last_loan_activity_sync = None
+            patron_or_client.last_loan_activity_sync = None
         else:
             # An IntegrationClient can have multiple holds, so this always creates
             # a new hold rather than returning an existing loan.

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -803,10 +803,11 @@ class LicensePool(Base):
                 create_method_kwargs=kwargs
             )
 
-            # This action creates uncertainty about what the patron's
-            # loan activity actually is. We'll need to sync with the
-            # vendor APIs.
-            patron_or_client.last_loan_activity_sync = None
+            if is_new:
+                # This action creates uncertainty about what the patron's
+                # loan activity actually is. We'll need to sync with the
+                # vendor APIs.
+                patron_or_client.last_loan_activity_sync = None
         else:
             # An IntegrationClient can have multiple loans, so this always creates
             # a new loan rather than returning an existing loan.
@@ -831,7 +832,8 @@ class LicensePool(Base):
             # This action creates uncertainty about what the patron's
             # loan activity actually is. We'll need to sync with the
             # vendor APIs.
-            patron_or_client.last_loan_activity_sync = None
+            if new:
+                patron_or_client.last_loan_activity_sync = None
         else:
             # An IntegrationClient can have multiple holds, so this always creates
             # a new hold rather than returning an existing loan.

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -800,7 +800,13 @@ class LicensePool(Base):
         if isinstance(patron_or_client, Patron):
             loan, is_new = get_one_or_create(
                 _db, Loan, patron=patron_or_client, license_pool=self,
-                create_method_kwargs=kwargs)
+                create_method_kwargs=kwargs
+            )
+
+            # This action creates uncertainty about what the patron's
+            # loan activity actually is. We'll need to sync with the
+            # vendor APIs.
+            patron.last_loan_activity_sync = None
         else:
             # An IntegrationClient can have multiple loans, so this always creates
             # a new loan rather than returning an existing loan.
@@ -820,7 +826,12 @@ class LicensePool(Base):
         start = start or datetime.datetime.utcnow()
         if isinstance(patron_or_client, Patron):
             hold, new = get_one_or_create(
-                _db, Hold, patron=patron_or_client, license_pool=self)
+                _db, Hold, patron=patron_or_client, license_pool=self
+            )
+            # This action creates uncertainty about what the patron's
+            # loan activity actually is. We'll need to sync with the
+            # vendor APIs.
+            patron.last_loan_activity_sync = None
         else:
             # An IntegrationClient can have multiple holds, so this always creates
             # a new hold rather than returning an existing loan.

--- a/model/patron.py
+++ b/model/patron.py
@@ -248,7 +248,7 @@ class Patron(Base):
         TODO: This is currently a constant, but in the future it could become
         a per-library setting.
         """
-        return 30 * 60
+        return 15 * 60
 
     @hybrid_property
     def last_loan_activity_sync(self):

--- a/model/patron.py
+++ b/model/patron.py
@@ -89,8 +89,13 @@ class Patron(Base):
     username = Column(Unicode)
 
     # The last time this record was synced up with an external library
-    # system.
+    # system such as an ILS.
     last_external_sync = Column(DateTime)
+
+    # The last time this record was synced with the corresponding
+    # records managed by the vendors who provide the library with
+    # ebooks.
+    last_loan_activity_sync = Column(DateTime)
 
     # The time, if any, at which the user's authorization to borrow
     # books expires.
@@ -227,6 +232,39 @@ class Patron(Base):
         if work.audience in allowed:
             return True
         return False
+
+    @property
+    def loan_activity_max_age(self):
+        """How long should loan activity be considered 'fresh' for this
+        patron?
+
+        This is currently a constant, but in the future it could become
+        a per-library setting.
+        """
+        return 30 * 60
+
+    def seconds_until_loan_activity_stale(self, max_age=None):
+        if max_age is None:
+            max_age = self.loan_activity_max_age
+
+        if not self.last_loan_activity_sync:
+            # We don't know about any loan activity at all, so
+            # we're stale right now.
+            return 0
+
+        now = datetime.datetime.utcnow()
+        difference = max_age - (
+            now - self.last_loan_activity_sync
+        ).total_seconds
+        return max(difference, 0)
+
+    def loan_activity_fresher_than(self, max_age=None):
+        """Was the patron's loan activity refreshed more recently than
+        the given number of seconds?
+
+        :param max_age: An integer number of seconds.
+        """
+        return self.seconds_until_loan_activity_stale(max_age) > 0
 
     @hybrid_property
     def synchronize_annotations(self):

--- a/tests/models/test_patron.py
+++ b/tests/models/test_patron.py
@@ -525,6 +525,34 @@ class TestPatron(DatabaseTest):
         eq_(self._db.query(Annotation).all(), [])
         eq_(self._db.query(Credential).all(), [])
 
+    def test_loan_activity_max_age(self):
+        # Currently, patron.loan_activity_max_age is a constant
+        # and cannot be changed.
+        eq_(30*60, self._patron().loan_activity_max_age)
+
+    def test_last_loan_activity_sync(self):
+        # Verify that last_loan_activity_sync is cleared out
+        # beyond a certain point.
+        patron = self._patron()
+        now = datetime.datetime.utcnow()
+        max_age = patron.loan_activity_max_age
+        recently = now - datetime.timedelta(seconds=max_age/2)
+        long_ago = now - datetime.timedelta(seconds=max_age*2)
+
+        # So long as last_loan_activity_sync is relatively recent,
+        # it's treated as a normal piece of data.
+        patron.last_loan_activity_sync = recently
+        eq_(recently, patron._last_loan_activity_sync)
+        eq_(recently, patron.last_loan_activity_sync)
+        
+        # If it's _not_ relatively recent, attempting to access it
+        # clears it out.
+        patron.last_loan_activity_sync = long_ago
+        eq_(long_ago, patron._last_loan_activity_sync)
+        eq_(None, patron.last_loan_activity_sync)
+        eq_(None, patron._last_loan_activity_sync)
+
+
 class TestPatronProfileStorage(DatabaseTest):
 
     def setup(self):

--- a/tests/models/test_patron.py
+++ b/tests/models/test_patron.py
@@ -528,7 +528,7 @@ class TestPatron(DatabaseTest):
     def test_loan_activity_max_age(self):
         # Currently, patron.loan_activity_max_age is a constant
         # and cannot be changed.
-        eq_(30*60, self._patron().loan_activity_max_age)
+        eq_(15*60, self._patron().loan_activity_max_age)
 
     def test_last_loan_activity_sync(self):
         # Verify that last_loan_activity_sync is cleared out


### PR DESCRIPTION
This is the core component of the work for https://jira.nypl.org/browse/SIMPLY-2922. It adds a field "last_loan_activity_sync" to the `patrons` table which tracks the last time we successfully synced our model of a patron's loans and holds with the sources of truth -- external vendor APIs.

This field is cleared out for a given patron whenever a loan or hold is created for that patron. (It's also cleared out when a loan or hold is removed, but that's handled in circulation.) It's also cleared out after fifteen minutes, no matter what -- this lets us quickly notice cases where the patron uses a vendor website or app to conduct a transaction.