### PR TITLE
Compression updates (rather than overwriting) HTTP "Vary" header.

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -169,8 +169,7 @@ def compressible(f):
             response.data = buffer.getvalue()
 
             response.headers['Content-Encoding'] = 'gzip'
-            # TODO: This is bad if Vary is already set.
-            response.headers['Vary'] = 'Accept-Encoding'
+            response.vary.add('Accept-Encoding')
             response.headers['Content-Length'] = len(response.data)
 
             return response


### PR DESCRIPTION
## Description

This branch fixes HTTP content compression to not augment, rather than overwriting, an existing `Vary` header when it exists.

## Motivation and Context

In some cases we were seeing an `Access-Control-Allow-Origin` without `Origin` appearing in a `Vary` header. This caused spurious cache hits on clients. In manual testing, we were seeing the correct headers in the preflight `OPTIONS` call, but the header was missing on a corresponding fetch.

https://jira.nypl.org/browse/SIMPLY-2912

## How Has This Been Tested?

- Manual testing with `Postman` and `curl`.
- Ran full test suite for this repo.
- Ran full test suite for [Circulation Manger](https://github.com/NYPL-Simplified/circulation).

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
