### PR TITLE
For URLs, use only path component to guess content type.

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -521,7 +521,7 @@ class LinkData(object):
 
         if self.href:
             # Take a guess.
-            return Representation.guess_media_type(self.href)
+            return Representation.guess_url_media_type_from_path(self.href)
 
         # No idea.
         # TODO: We might be able to take a further guess based on the

--- a/model/resource.py
+++ b/model/resource.py
@@ -650,6 +650,14 @@ class Representation(Base, MediaTypes):
         ])
 
     @classmethod
+    def guess_url_media_type_from_path(cls, url):
+        """Guess a likely media type from the URL's path component."""
+        if not url:
+            return None
+        path = urlparse.urlparse(url).path
+        return cls.guess_media_type(path)
+
+    @classmethod
     def guess_media_type(cls, filename):
         """Guess a likely media type from a filename."""
         if not filename:
@@ -898,7 +906,7 @@ class Representation(Base, MediaTypes):
         the default value. If there's no default value, we'll try to
         derive one from the URL extension.
         """
-        default = default or cls.guess_media_type(url)
+        default = default or cls.guess_url_media_type_from_path(url)
         if not headers or not 'content-type' in headers:
             return default
         headers_type = headers['content-type'].lower()

--- a/tests/models/test_resource.py
+++ b/tests/models/test_resource.py
@@ -199,6 +199,8 @@ class TestRepresentation(DatabaseTest):
         m_url = Representation.guess_url_media_type_from_path
         jpg_file = "file.jpg"
         zip_file = "file.ZIP"
+        zip_file_rel_path = "relatively/pathed/file.zip"
+        zip_file_abs_path = "/absolutely/pathed/file.zIp"
 
         eq_(Representation.JPEG_MEDIA_TYPE, m_file(jpg_file))
         eq_(Representation.ZIP_MEDIA_TYPE, m_file(zip_file))
@@ -217,7 +219,7 @@ class TestRepresentation(DatabaseTest):
         eq_(Representation.ZIP_MEDIA_TYPE, m_file(zip_url))
         # ... but will get these wrong.
         zip_url_with_query = "https://some_url/path/file.zip?Policy=xyz123&Key-Pair-Id=xxx"
-        zip_url_misleading = "https://some_url/path/file.zip?Policy=xyz123&associate_cover=image.jpg"
+        zip_url_misleading = "https://some_url/path/file.zip?Policy=xyz123&associated_cover=image.jpg"
         eq_(None, m_file(zip_url_with_query))  # We get None, but want Zip
         eq_(Representation.JPEG_MEDIA_TYPE, m_file(zip_url_misleading))  # We get JPEG, but want Zip
 
@@ -226,6 +228,13 @@ class TestRepresentation(DatabaseTest):
         #   ... but will get these wrong.
         eq_(Representation.ZIP_MEDIA_TYPE, m_url(zip_url_with_query))
         eq_(Representation.ZIP_MEDIA_TYPE, m_url(zip_url_misleading))
+
+        # And we can handle local file cases
+        eq_(Representation.ZIP_MEDIA_TYPE, m_url(zip_file))
+        eq_(Representation.ZIP_MEDIA_TYPE, m_url(zip_file_rel_path))
+        eq_(Representation.ZIP_MEDIA_TYPE, m_url(zip_file_abs_path))
+
+
 
     def test_external_media_type_and_extension(self):
         """Test the various transformations that might happen to media type

--- a/tests/models/test_resource.py
+++ b/tests/models/test_resource.py
@@ -195,18 +195,37 @@ class TestRepresentation(DatabaseTest):
         eq_(False, representation.mirrorable_media_type)
 
     def test_guess_media_type(self):
-        m = Representation.guess_media_type
+        m_file = Representation.guess_media_type
+        m_url = Representation.guess_url_media_type_from_path
+        jpg_file = "file.jpg"
+        zip_file = "file.ZIP"
 
-        eq_(Representation.JPEG_MEDIA_TYPE, m("file.jpg"))
-        eq_(Representation.ZIP_MEDIA_TYPE, m("file.ZIP"))
+        eq_(Representation.JPEG_MEDIA_TYPE, m_file(jpg_file))
+        eq_(Representation.ZIP_MEDIA_TYPE, m_file(zip_file))
 
         for extension, media_type in Representation.MEDIA_TYPE_FOR_EXTENSION.items():
             filename = "file" + extension
-            eq_(media_type, m(filename))
+            eq_(media_type, m_file(filename))
 
-        eq_(None, m(None))
-        eq_(None, m("file"))
-        eq_(None, m("file.unknown-extension"))
+        eq_(None, m_file(None))
+        eq_(None, m_file("file"))
+        eq_(None, m_file("file.unknown-extension"))
+
+        # URLs should be handled differently
+        # Simple file-based guess will get this right, ...
+        zip_url = "https://some_url/path/file.zip"
+        eq_(Representation.ZIP_MEDIA_TYPE, m_file(zip_url))
+        # ... but will get these wrong.
+        zip_url_with_query = "https://some_url/path/file.zip?Policy=xyz123&Key-Pair-Id=xxx"
+        zip_url_misleading = "https://some_url/path/file.zip?Policy=xyz123&associate_cover=image.jpg"
+        eq_(None, m_file(zip_url_with_query))  # We get None, but want Zip
+        eq_(Representation.JPEG_MEDIA_TYPE, m_file(zip_url_misleading))  # We get JPEG, but want Zip
+
+        # Taking URL structure into account should get them all right.
+        eq_(Representation.ZIP_MEDIA_TYPE, m_url(zip_url))
+        #   ... but will get these wrong.
+        eq_(Representation.ZIP_MEDIA_TYPE, m_url(zip_url_with_query))
+        eq_(Representation.ZIP_MEDIA_TYPE, m_url(zip_url_misleading))
 
     def test_external_media_type_and_extension(self):
         """Test the various transformations that might happen to media type


### PR DESCRIPTION
## Description

This branch adds a method that uses only the `path` component of a URL when attempting to guess the content type based on the "file" extension inferred from URL. Also updated some code where a simpler method meant for files was being used for URLs.

## Motivation and Context

URLs with query strings don't end with a type-hinting "file" extension that can help us guess at the associated content type. Unless we base our guess on the URL's path, we can end up failing to guess or even being mislead by the end of the query string.

## How Has This Been Tested?

- Added new tests to verify that only the `path` component of the URL is used for guessing the content type.
- Ran test suite.
- Ran [Circulation Manager](https://github.com/NYPL-Simplified/circulation) test suite against this submodule branch.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All tests in [Circulation Manager](https://github.com/NYPL-Simplified/circulation) test suite passed.
