### PR TITLE
Don't propagate missing properties to manifests.

### DIFF
--- a/tests/util/test_web_publication_manifest.py
+++ b/tests/util/test_web_publication_manifest.py
@@ -74,6 +74,22 @@ class TestManifest(object):
             dict['resources']
         )
 
+    def test_null_properties_not_propagated(self):
+        manifest = Manifest()
+        additional_properties = dict(extra="value", missing=None)
+
+        manifest.add_link("http://foo/", "self", **additional_properties)
+        manifest.add_reading_order("http://foo/", "text/html", "Chapter 1", **additional_properties)
+        manifest.add_resource("http://foo/", "text/html", **additional_properties)
+
+        manifest_dict = manifest.as_dict
+        top_level_properties = ["links", "readingOrder", "resources"]
+        for prop in top_level_properties:
+            [entry] = manifest_dict["links"]
+            assert "extra" in entry
+            eq_("value", entry["extra"])
+            assert "missing" not in entry
+
 
 class TestUpdateBibliographicMetadata(DatabaseTest):
 

--- a/util/web_publication_manifest.py
+++ b/util/web_publication_manifest.py
@@ -67,7 +67,8 @@ class Manifest(JSONable):
         return 'links', 'readingOrder', 'resources'
 
     def _append(self, append_to, **kwargs):
-        append_to.append(kwargs)
+        # Omit properties with None values, rather than propagating nulls to manifest.
+        append_to.append(dict((k, v) for k, v in kwargs.items() if v is not None))
 
     def add_link(self, href, rel, **kwargs):
         self._append(self.links, href=href, rel=rel, **kwargs)


### PR DESCRIPTION
## Description

This branch improves [Web Publication Manifest](https://github.com/readium/webpub-manifest) generation by avoiding propagation of "missing" properties (those that are `None`) into the manifest's JSON serialization, where they would produce `null`s.

## Motivation and Context

Some clients don't treat a `null` manifest property as if that property had not been specified. The presence of properties with `null` values may cause errors in those clients.

This PR depends on [Circulation Manager PR 1479](https://github.com/NYPL-Simplified/circulation/pull/1479), which fixes an overly narrow test. That has been merged and now all CM tests pass.

- https://jira.nypl.org/browse/SIMPLY-3004

## How Has This Been Tested?

- Added new tests to verify that the missing values were not propagated.
- Ran test suite.
- Ran [Circulation Manager](https://github.com/NYPL-Simplified/circulation) test suite against this submodule branch.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Ran full [Circulation Manager](https://github.com/NYPL-Simplified/circulation) test suite and the following tests failed:
