### PR TITLE
Add LCP support

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,45 @@
+class BaseError(Exception):
+    """Base class for all errors"""
+
+    def __init__(self, message=None, inner_exception=None):
+        """Initializes a new instance of BaseError class
+
+        :param message: String containing description of the error occurred
+        :param inner_exception: (Optional) Inner exception
+        """
+        if inner_exception and not message:
+            message = inner_exception.message
+
+        super(BaseError, self).__init__(message)
+
+        self._inner_exception = inner_exception
+
+    @property
+    def inner_exception(self):
+        """Returns an inner exception
+
+        :return: Inner exception
+        :rtype: Exception
+        """
+        return self._inner_exception
+
+    def __eq__(self, other):
+        """Compares two BaseError objects
+
+        :param other: BaseError object
+        :type other: BaseError
+
+        :return: Boolean value indicating whether two items are equal
+        :rtype: bool
+        """
+        if not isinstance(other, BaseError):
+            return False
+
+        return self.message == other.message
+
+    def __repr__(self):
+        return '<BaseError(message={0}, inner_exception={1})>'.format(
+            self.message,
+            self.inner_exception
+        )
+

--- a/lcp/credential.py
+++ b/lcp/credential.py
@@ -1,0 +1,128 @@
+import logging
+
+from enum import Enum
+
+from .exceptions import LCPError
+from ..model import Credential, DataSource
+
+
+class LCPCredentialType(Enum):
+    """Contains an enumeration of different LCP credential types"""
+
+    PATRON_ID = 'Patron ID passed to the LCP License Server'
+    LCP_PASSPHRASE = 'LCP Passphrase passed to the LCP License Server'
+    LCP_HASHED_PASSPHRASE = 'Hashed LCP Passphrase passed to the LCP License Server'
+
+
+class LCPCredentialFactory(object):
+    """Generates patron's credentials used by the LCP License Server"""
+
+    def __init__(self):
+        """Initializes a new instance of LCPCredentialFactory class"""
+        self._logger = logging.getLogger(__name__)
+
+    def _get_or_create_persistent_token(self, db, patron, data_source_type, credential_type, value=None):
+        """Gets or creates a new persistent token
+
+        :param db: Database session
+        :type db: sqlalchemy.orm.session.Session
+
+        :param patron: Patron object
+        :type patron: core.model.patron.Patron
+
+        :param value: Optional value of the token
+        :type value: Optional[string]
+        """
+        self._logger.info(
+            'Getting or creating "{0}" credentials for {1} in "{2}" data source with value "{3}"'.format(
+                credential_type, patron, data_source_type, value
+            )
+        )
+
+        data_source = DataSource.lookup(db, data_source_type)
+
+        transaction = db.begin_nested()
+        credential, is_new = Credential.persistent_token_create(db, data_source, credential_type, patron, value)
+        transaction.commit()
+
+        self._logger.info(
+            'Successfully {0} "{1}" {2} for {3} in "{4}" data source with value "{5}"'.format(
+                'created new' if is_new else 'fetched existing',
+                credential_type,
+                credential,
+                patron,
+                data_source_type,
+                value
+            )
+        )
+
+        return credential.credential, is_new
+
+    def get_patron_id(self, db, patron):
+        """Generates a new or returns an existing patron's ID associated with an LCP license
+
+        :param db: Database session
+        :type db: sqlalchemy.orm.session.Session
+
+        :param patron: Patron object
+        :type patron: core.model.patron.Patron
+
+        :return: Newly generated or existing patron's ID associated with an LCP license
+        :rtype: string
+        """
+        patron_id, _ = self._get_or_create_persistent_token(
+            db, patron, DataSource.INTERNAL_PROCESSING, LCPCredentialType.PATRON_ID.value)
+
+        return patron_id
+
+    def get_patron_passphrase(self, db, patron):
+        """Generates a new or returns an existing patron's passphrase associated with an LCP license
+
+        :param db: Database session
+        :type db: sqlalchemy.orm.session.Session
+
+        :param patron: Patron object
+        :type patron: core.model.patron.Patron
+
+        :return: Newly generated or existing patron's passphrase associated with an LCP license
+        :rtype: string
+        """
+        patron_passphrase, _ = self._get_or_create_persistent_token(
+            db, patron, DataSource.INTERNAL_PROCESSING, LCPCredentialType.LCP_PASSPHRASE.value)
+
+        return patron_passphrase
+
+    def get_hashed_passphrase(self, db, patron):
+        """Returns an existing hashed passphrase
+
+        :param db: Database session
+        :type db: sqlalchemy.orm.session.Session
+
+        :param patron: Patron object
+        :type patron: core.model.patron.Patron
+
+        :return: Existing hashed passphrase
+        :rtype: string
+        """
+        hashed_passphrase, is_new = self._get_or_create_persistent_token(
+            db, patron, DataSource.INTERNAL_PROCESSING, LCPCredentialType.LCP_HASHED_PASSPHRASE.value)
+
+        if is_new:
+            raise LCPError('Passphrase have to be explicitly set')
+
+        return hashed_passphrase
+
+    def set_hashed_passphrase(self, db, patron, hashed_passphrase):
+        """Stores the hashed passphrase as a persistent token
+
+        :param db: Database session
+        :type db: sqlalchemy.orm.session.Session
+
+        :param patron: Patron object
+        :type patron: core.model.patron.Patron
+
+        :param hashed_passphrase: Existing hashed passphrase
+        :type hashed_passphrase: string
+        """
+        self._get_or_create_persistent_token(
+            db, patron, DataSource.INTERNAL_PROCESSING, LCPCredentialType.LCP_HASHED_PASSPHRASE.value, hashed_passphrase)

--- a/lcp/exceptions.py
+++ b/lcp/exceptions.py
@@ -1,0 +1,5 @@
+from ..exceptions import BaseError
+
+
+class LCPError(BaseError):
+    """Base class for all LCP related exceptions"""

--- a/marc.py
+++ b/marc.py
@@ -560,11 +560,13 @@ class MARCExporter(object):
         for integration in integrations:
             # Only add an integration to choose from if it has a 
             # MARC File Bucket field in its settings.
-            [configuration_setting] = [s for s in integration.settings if s.key=="marc_bucket"]
-            if configuration_setting.value:
-                cls.SETTING['options'].append(
-                    dict(key=str(integration.id), label=integration.name)
-                )
+            configuration_settings = [s for s in integration.settings if s.key=="marc_bucket"]
+
+            if configuration_settings:
+                if configuration_settings[0].value:
+                    cls.SETTING['options'].append(
+                        dict(key=str(integration.id), label=integration.name)
+                    )
         
         return cls.SETTING
 

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -866,7 +866,8 @@ class MetaToModelUtility(object):
             )
 
         # Mirror it.
-        mirror.mirror_one(representation, mirror_url)
+        collection = pools[0].collection if pools else None
+        mirror.mirror_one(representation, mirror_to=mirror_url, collection=collection)
 
         # If we couldn't mirror an open/protected access link representation, suppress
         # the license pool until someone fixes it manually.
@@ -896,7 +897,7 @@ class MetaToModelUtility(object):
             if is_new:
                 # A thumbnail was created distinct from the original
                 # image. Mirror it as well.
-                mirror.mirror_one(thumbnail, thumbnail_url)
+                mirror.mirror_one(thumbnail, mirror_to=thumbnail_url, collection=collection)
 
         if link_obj.rel in Hyperlink.SELF_HOSTED_BOOKS:
             # If we mirrored book content successfully, remove it from

--- a/mirror.py
+++ b/mirror.py
@@ -111,8 +111,18 @@ class MirrorUploader(object):
     def do_upload(self, representation):
         raise NotImplementedError()
 
-    def mirror_one(self, representation):
-        """Mirror a single Representation."""
+    def mirror_one(self, representation, mirror_to, collection=None):
+        """Mirror a single Representation.
+
+        :param representation: Book's representation
+        :type representation: Representation
+
+        :param mirror_to: Mirror URL
+        :type mirror_to: string
+
+        :param collection: Collection
+        :type collection: Optional[Collection]
+        """
         now = datetime.datetime.utcnow()
         exception = self.do_upload(representation)
         representation.mirror_exception = exception
@@ -125,7 +135,7 @@ class MirrorUploader(object):
         """Mirror a batch of Representations at once."""
 
         for representation in representations:
-            self.mirror_one(representation)
+            self.mirror_one(representation, '')
 
     def book_url(self, identifier, extension='.epub', open_access=True,
                  data_source=None, title=None):

--- a/model/constants.py
+++ b/model/constants.py
@@ -40,6 +40,7 @@ class DataSourceConstants(object):
     FEEDBOOKS = u"FeedBooks"
     BIBBLIO = u"Bibblio"
     ENKI = u"Enki"
+    LCP = u"LCP"
 
     DEPRECATED_NAMES = {
         u"3M" : BIBLIOTHECA,

--- a/model/credential.py
+++ b/model/credential.py
@@ -163,11 +163,12 @@ class Credential(Base):
         return credential, is_new
 
     @classmethod
-    def persistent_token_create(self, _db, data_source, type, patron):
+    def persistent_token_create(self, _db, data_source, type, patron, token_string=None):
         """Create or retrieve a persistent token for the given
         data_source/type/patron.
         """
-        token_string = str(uuid.uuid1())
+        if token_string is None:
+            token_string = str(uuid.uuid1())
         credential, is_new = get_one_or_create(
             _db, Credential, data_source=data_source, type=type, patron=patron,
             create_method_kwargs=dict(credential=token_string)
@@ -193,6 +194,24 @@ class Credential(Base):
         )
         if device_id_obj:
             _db.delete(device_id_obj)
+
+    def __repr__(self):
+        return \
+            '<Credential(' \
+            'data_source_id={0}, ' \
+            'patron_id={1}, ' \
+            'collection_id={2}, ' \
+            'type={3}, ' \
+            'credential={4}, ' \
+            'expires={5}>)'.format(
+                    self.data_source_id,
+                    self.patron_id,
+                    self.collection_id,
+                    self.type,
+                    self.credential,
+                    self.expires
+                )
+
 
 class DRMDeviceIdentifier(Base):
     """A device identifier for a particular DRM scheme.

--- a/model/work.py
+++ b/model/work.py
@@ -1166,7 +1166,7 @@ class Work(Base):
                     # We have an unlimited source for this book.
                     # There's no need to keep looking.
                     break
-            elif p.self_hosted:
+            elif p.unlimited_access or p.self_hosted:
                 active_license_pool = p
             elif edition and edition.title and p.licenses_owned > 0:
                 active_license_pool = p
@@ -1529,10 +1529,12 @@ class Work(Base):
                 LicensePool.open_access.label('open_access'),
                 LicensePool.suppressed,
                 or_(
+                    LicensePool.unlimited_access,
                     LicensePool.self_hosted,
                     LicensePool.licenses_available > 0,
                 ).label('available'),
                 or_(
+                    LicensePool.unlimited_access,
                     LicensePool.self_hosted,
                     LicensePool.licenses_owned > 0
                 ).label('licensed'),
@@ -1549,6 +1551,7 @@ class Work(Base):
                 work_presentation_edition_id_column==Edition.id,
                 or_(
                     LicensePool.open_access,
+                    LicensePool.unlimited_access,
                     LicensePool.self_hosted,
                     LicensePool.licenses_owned>0,
                 ),

--- a/scripts.py
+++ b/scripts.py
@@ -1774,6 +1774,7 @@ class CustomListManagementScript(Script):
 class CollectionType(Enum):
     OPEN_ACCESS = 'OPEN_ACCESS'
     PROTECTED_ACCESS = 'PROTECTED_ACCESS'
+    LCP = 'LCP'
 
     def __str__(self):
         return self.name

--- a/tests/lcp/test_credential.py
+++ b/tests/lcp/test_credential.py
@@ -1,0 +1,64 @@
+from mock import patch
+from nose.tools import eq_, assert_raises
+from parameterized import parameterized
+
+from ...testing import DatabaseTest
+from ...lcp.credential import LCPCredentialFactory, LCPCredentialType
+from ...lcp.exceptions import LCPError
+from ...model import Credential, DataSource
+
+
+class TestCredentialFactory(DatabaseTest):
+    def setup(self, mock_search=True):
+        super(TestCredentialFactory, self).setup(mock_search)
+
+        self._factory = LCPCredentialFactory()
+        self._patron = self._patron()
+        self._data_source = DataSource.lookup(self._db, DataSource.INTERNAL_PROCESSING, autocreate=True)
+
+    @parameterized.expand([
+        (
+                'get_patron_id',
+                LCPCredentialType.PATRON_ID.value,
+                'get_patron_id',
+                '52a190d1-cd69-4794-9d7a-1ec50392697f'
+        ),
+        (
+                'get_patron_passphrase',
+                LCPCredentialType.LCP_PASSPHRASE.value,
+                'get_patron_passphrase',
+                '52a190d1-cd69-4794-9d7a-1ec50392697f'
+        )
+    ])
+    def test_getter(self, _, credential_type, method_name, expected_result):
+        # Arrange
+        credential = Credential(credential=expected_result)
+
+        with patch.object(Credential, 'persistent_token_create') as persistent_token_create_mock:
+            persistent_token_create_mock.return_value = (credential, True)
+
+            method = getattr(self._factory, method_name)
+
+            # Act
+            result = method(self._db, self._patron)
+
+            # Assert
+            eq_(result, expected_result)
+            persistent_token_create_mock.assert_called_once_with(
+                self._db, self._data_source, credential_type, self._patron, None)
+
+    def test_get_hashed_passphrase_raises_exception_when_there_is_no_passphrase(self):
+        # Act, assert
+        with assert_raises(LCPError):
+            self._factory.get_hashed_passphrase(self._db, self._patron)
+
+    def test_get_hashed_passphrase_returns_existing_hashed_passphrase(self):
+        # Arrange
+        expected_result = '12345'
+
+        # Act
+        self._factory.set_hashed_passphrase(self._db, self._patron, expected_result)
+        result = self._factory.get_hashed_passphrase(self._db, self._patron)
+
+        # Assert
+        eq_(result, expected_result)

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -1211,6 +1211,27 @@ class TestWork(DatabaseTest):
         eq_(set([collection1.id, collection2.id]),
             set([x['collection_id'] for x in search_doc['licensepools']]))
 
+    def test_unlimited_access_books_are_available_by_default(self):
+        # Set up an edition and work.
+        edition, pool = self._edition(authors=[self._str, self._str], with_license_pool=True)
+        work = self._work(presentation_edition=edition)
+
+        pool.open_access = False
+        pool.self_hosted = False
+        pool.unlimited_access = True
+
+        # Make sure all of this will show up in a database query.
+        self._db.flush()
+
+        search_doc = work.to_search_document()
+
+        # Each LicensePool for the Work is listed in
+        # the 'licensepools' section.
+        licensepools = search_doc['licensepools']
+        eq_(1, len(licensepools))
+        eq_(licensepools[0]['open_access'], False)
+        eq_(licensepools[0]['available'], True)
+
     def test_self_hosted_books_are_available_by_default(self):
         # Set up an edition and work.
         edition, pool = self._edition(authors=[self._str, self._str], with_license_pool=True)

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -66,7 +66,7 @@ from ..coverage import CoverageFailure
 from ..s3 import (
     S3Uploader,
     MockS3Uploader,
-)
+    S3UploaderConfiguration)
 from ..selftest import SelfTestResult
 from ..testing import (
     DummyHTTPClient,
@@ -1887,7 +1887,7 @@ class TestMirroring(OPDSImporterTest):
         integration = self._external_integration(
             ExternalIntegration.S3, ExternalIntegration.STORAGE_GOAL,
             username="username", password="password",
-            settings = {S3Uploader.BOOK_COVERS_BUCKET_KEY : "some-covers"}
+            settings = {S3UploaderConfiguration.BOOK_COVERS_BUCKET_KEY : "some-covers"}
         )
         # Associate the collection's integration with the storage integration
         # for the purpose of 'covers'.
@@ -1904,7 +1904,8 @@ class TestMirroring(OPDSImporterTest):
         mirrors = importer.mirrors
 
         assert isinstance(mirrors[ExternalIntegrationLink.COVERS], S3Uploader)
-        eq_("some-covers", mirrors[ExternalIntegrationLink.COVERS].get_bucket(S3Uploader.BOOK_COVERS_BUCKET_KEY))
+        eq_("some-covers", mirrors[ExternalIntegrationLink.COVERS].get_bucket(
+            S3UploaderConfiguration.BOOK_COVERS_BUCKET_KEY))
         eq_(mirrors[ExternalIntegrationLink.OPEN_ACCESS_BOOKS], None)
 
 
@@ -1912,7 +1913,7 @@ class TestMirroring(OPDSImporterTest):
         integration = self._external_integration(
             ExternalIntegration.S3, ExternalIntegration.STORAGE_GOAL,
             username="username", password="password",
-            settings = {S3Uploader.OA_CONTENT_BUCKET_KEY : "some-books"}
+            settings={S3UploaderConfiguration.OA_CONTENT_BUCKET_KEY : "some-books"}
         )
         # Associate the collection's integration with the storage integration
         # for the purpose of 'covers'.
@@ -1926,8 +1927,10 @@ class TestMirroring(OPDSImporterTest):
         mirrors = importer.mirrors
 
         assert isinstance(mirrors[ExternalIntegrationLink.OPEN_ACCESS_BOOKS], S3Uploader)
-        eq_("some-books", mirrors[ExternalIntegrationLink.OPEN_ACCESS_BOOKS].get_bucket(S3Uploader.OA_CONTENT_BUCKET_KEY))
-        eq_("some-covers", mirrors[ExternalIntegrationLink.COVERS].get_bucket(S3Uploader.BOOK_COVERS_BUCKET_KEY))
+        eq_("some-books", mirrors[ExternalIntegrationLink.OPEN_ACCESS_BOOKS].get_bucket(
+            S3UploaderConfiguration.OA_CONTENT_BUCKET_KEY))
+        eq_("some-covers", mirrors[ExternalIntegrationLink.COVERS].get_bucket(
+            S3UploaderConfiguration.BOOK_COVERS_BUCKET_KEY))
 
     def test_resources_are_mirrored_on_import(self):
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -56,7 +56,7 @@ from ..monitor import (
     CollectionMonitor,
     ReaperMonitor,
 )
-from ..s3 import S3Uploader, MinIOUploader
+from ..s3 import S3Uploader, MinIOUploader, MinIOUploaderConfiguration
 from ..scripts import (
     AddClassificationScript,
     CheckContributorNamesInDB,
@@ -2589,7 +2589,7 @@ class TestMirrorResourcesScript(DatabaseTest):
             ExternalIntegrationLink.OPEN_ACCESS_BOOKS,
             ExternalIntegration.MINIO,
             MinIOUploader,
-            {MinIOUploader.ENDPOINT_URL: 'http://localhost'}
+            {MinIOUploaderConfiguration.ENDPOINT_URL: 'http://localhost'}
         ),
         (
             'containing_protected_access_books_with_minio_uploader',
@@ -2597,7 +2597,7 @@ class TestMirrorResourcesScript(DatabaseTest):
             ExternalIntegrationLink.PROTECTED_ACCESS_BOOKS,
             ExternalIntegration.MINIO,
             MinIOUploader,
-            {MinIOUploader.ENDPOINT_URL: 'http://localhost'}
+            {MinIOUploaderConfiguration.ENDPOINT_URL: 'http://localhost'}
         )
     ])
     def test_collections(self, name, collection_type, book_mirror_type, protocol, uploader_class, settings=None):

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -39,6 +39,8 @@ class AtomFeed(object):
     BIBFRAME_NS = "http://bibframe.org/vocab/"
     BIB_SCHEMA_NS = "http://bib.schema.org/"
 
+    LCP_NS = 'http://readium.org/lcp-specs/ns'
+
     nsmap = {
         None: ATOM_NS,
         'app': APP_NS,
@@ -51,6 +53,7 @@ class AtomFeed(object):
         'bibframe' : BIBFRAME_NS,
         'bib': BIB_SCHEMA_NS,
         'opensearch': OPENSEARCH_NS,
+        'lcp': LCP_NS
     }
 
     default_typemap = {datetime: lambda e, v: _strftime(v)}


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds LCP support to Circulation Manager.
The main changes:
1. Configuration framework in core/model/configuration.py
2. `S3Uploader`'s settings refactoring
3. `MirrorUploader.mirror_one` signature change

Linked PRs:
- [PR # 1472](https://github.com/NYPL-Simplified/circulation/pull/1472) in `circulation`
- [PR # 125](https://github.com/NYPL-Simplified/circulation-docker/pull/125) in `circulation-docker`
- [PR # 279](https://github.com/NYPL-Simplified/opds-web-client/pull/279) in `opds-web-client`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
