### PR TITLE
Always go to the database to find out whether the site configuration has been updated; caching this information locally is false economy

### DIFF
--- a/config.py
+++ b/config.py
@@ -519,14 +519,22 @@ class Configuration(ConfigurationConstants):
         :return: a datetime object.
 
         """
+
         now = datetime.datetime.utcnow()
 
+        # NOTE: Currently we never check the database (because timeout is
+        # never set to None). This code will hopefully be removed soon.
         if _db and timeout is None:
             from model import ConfigurationSetting
             timeout = ConfigurationSetting.sitewide(
                 _db, cls.SITE_CONFIGURATION_TIMEOUT
             ).int_value
+
         if timeout is None:
+            # NOTE: this only happens if timeout is explicitly set to
+            # None _and_ no database value is present. Right now that
+            # never happens because timeout is never explicitly set to
+            # None.
             timeout = 60
 
         last_check = cls.instance.get(

--- a/config.py
+++ b/config.py
@@ -478,6 +478,10 @@ class Configuration(ConfigurationConstants):
 
     # A sitewide configuration setting controlling *how often* to check
     # whether the database configuration has changed.
+    #
+    # NOTE: This setting is currently not used; the most reliable
+    # value seems to be zero. Assuming that's true, this whole
+    # subsystem can be removed.
     SITE_CONFIGURATION_TIMEOUT = 'site_configuration_timeout'
 
     # The name of the service associated with a Timestamp that tracks

--- a/config.py
+++ b/config.py
@@ -495,7 +495,7 @@ class Configuration(ConfigurationConstants):
 
     @classmethod
     def site_configuration_last_update(cls, _db, known_value=None,
-                                       timeout=None):
+                                       timeout=0):
         """Check when the site configuration was last updated.
 
         Updates Configuration.instance[Configuration.SITE_CONFIGURATION_LAST_UPDATE].
@@ -508,8 +508,9 @@ class Configuration(ConfigurationConstants):
 
         :param timeout: We will only call out to the database once in
             this number of seconds. If we are asked again before this
-            number of seconds elapses, we will assume site configuration
-            has not changed.
+            number of seconds elapses, we will assume site
+            configuration has not changed. By default, we call out to
+            the database every time.
 
         :return: a datetime object.
 


### PR DESCRIPTION
This branch changes the default `timeout` for `site_configuration_last_update` to zero. Previously this value was `None`, meaning that the actual value was controlled by a database setting. But acquiring the database setting caused potentially serious warnings -- conceivably even causing [SIMPLY-2983](https://jira.nypl.org/browse/SIMPLY-2983).

Here's what I'm more certain about: any value for `timeout` other than zero caused problems on any site with multiple app servers: specifically problems like [SIMPLY-2991](https://jira.nypl.org/browse/SIMPLY-2991) and [SIMPLY-2514](https://jira.nypl.org/browse/SIMPLY-2514). Setting the value to zero makes these problems go away with a minimal effect on site performance. So I think we should peg this value to zero; that's what this branch does.

This branch takes a minimally invasive approach -- the configuration setting is still around, as is the code to fetch its value, but we never actually fetch it. That's so we can change back easily if this turns out to be a mistake.

The other change I made was renaming the `timeout` variable in `site_configuration_has_changed` to `cooldown`. Previously we had two related timeouts: `site_configuration_last_update` had a `timeout` that controlled how often we went to the database to check a certain Timestamp, and `site_configuration_has_changed` had a `timeout` (now called `cooldown`) that controlled how often we wrote new values to that Timestamp. I don't think `cooldown` is behind any SIMPLY-2991-like problems, because the amounts of time are so small -- less than a second -- but theoretically we could peg `cooldown` to zero with minimal effect on performance, since configuration changes are so rare. It shouldn't make a difference if we end up writing to that Timestamp two or three times in a single request.