### PR TITLE
Peg feedparser to a version that supports Python 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Requirements for core
 boto3
+# feedparser 6.0.1 drops support for Python 2.
 feedparser<=6.0.1
 pillow
 psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Requirements for core
 boto3
-# feedparser 6.0.1 drops support for Python 2.
-feedparser<=6.0.1
+# feedparser 6.0.0 drops support for Python 2.
+feedparser<=6.0.0
 pillow
 psycopg2
 requests>=2.18.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for core
 boto3
-feedparser
+feedparser<=6.0.1
 pillow
 psycopg2
 requests>=2.18.4


### PR DESCRIPTION
Feedparser 6.0.0 was just released, and drops support for Python 2. This branch pegs our feedparser to a version that supports Python 2.

We're getting pretty close to being able to migrate to Python 3, so hopefully this won't keep happening for much longer.