### PR TITLE
Adding qa_feed function to return a feed of works based on filters.

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -563,40 +563,6 @@ class AcquisitionFeed(OPDSFeed):
     FACET_REL = "http://opds-spec.org/facet"
 
     @classmethod
-    def qa_feed(cls, _db, title, url, annotator,
-               search_engine=None, filter_list=None,
-               **response_kwargs
-    ):
-        """The acquisition feed for items to QA from all collections, with
-        media type of ebook or audiobook, and different availability.
-
-        :param response_kwargs: Extra keyword arguments to pass into
-            the OPDSFeedResponse constructor.
-        
-        :return: An OPDSFeedResponse containing the feed.
-        """
-        pagination = Pagination(size=5)
-        queries = []
-        for (collection, medium, availability) in filter_list:
-            from external_search import Filter
-            filter = Filter(collections=collection, media=medium, languages=["eng"])
-            filter.availability = availability
-            queries.append((None, filter, pagination))
-
-        resultsets = list(search_engine.query_works_multi(queries))
-        l = Lane()
-        results = l.works_for_resultsets(_db, resultsets)
-
-        flat_list = [item for sublist in results for item in sublist]
-        opds_feed = AcquisitionFeed(
-            _db, title, url, flat_list, annotator=annotator
-        )
-
-        return OPDSFeedResponse(
-            response=opds_feed,
-        )
-
-    @classmethod
     def groups(cls, _db, title, url, worklist, annotator,
                facets=None, max_age=None,
                search_engine=None, search_debug=False,

--- a/opds.py
+++ b/opds.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import urllib
+from nose.tools import set_trace
 from collections import (
     defaultdict,
 )
@@ -560,6 +561,40 @@ class VerboseAnnotator(Annotator):
 class AcquisitionFeed(OPDSFeed):
 
     FACET_REL = "http://opds-spec.org/facet"
+
+    @classmethod
+    def qa_feed(cls, _db, title, url, annotator,
+               search_engine=None, filter_list=None,
+               **response_kwargs
+    ):
+        """The acquisition feed for items to QA from all collections, with
+        media type of ebook or audiobook, and different availability.
+
+        :param response_kwargs: Extra keyword arguments to pass into
+            the OPDSFeedResponse constructor.
+        
+        :return: An OPDSFeedResponse containing the feed.
+        """
+        pagination = Pagination(size=5)
+        queries = []
+        for (collection, medium, availability) in filter_list:
+            from external_search import Filter
+            filter = Filter(collections=collection, media=medium, languages=["eng"])
+            filter.availability = availability
+            queries.append((None, filter, pagination))
+
+        resultsets = list(search_engine.query_works_multi(queries))
+        l = Lane()
+        results = l.works_for_resultsets(_db, resultsets)
+
+        flat_list = [item for sublist in results for item in sublist]
+        opds_feed = AcquisitionFeed(
+            _db, title, url, flat_list, annotator=annotator
+        )
+
+        return OPDSFeedResponse(
+            response=opds_feed,
+        )
 
     @classmethod
     def groups(cls, _db, title, url, worklist, annotator,


### PR DESCRIPTION
@leonardr still a WIP but can you review this and https://github.com/NYPL-Simplified/circulation/pull/1490?

I noticed when trying to use a `SearchFacets` object that it applied only when calling `query_works_multi` so only the last set of facets combination was applied. Instead, I'm adding a filter which seems to return what is specified. One thing missing is that it's on a per library basis rather than including all potential libraries in the database.