### PR TITLE
Explicitly set version numbers for all Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ elasticsearch-dsl==6.4.0
 enum34==1.1.10
 feedparser==5.2.1
 Flask==1.1.2
-Flask-Babel==2.0.0
+Flask-Babel==1.0.0
 funcsigs==1.0.2
 futures==3.3.0
 fuzzywuzzy==0.18.0 # For author name manipulations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,39 +1,53 @@
-# Requirements for core
-boto3
-# feedparser 6.0.0 drops support for Python 2.
-feedparser<6.0.0
-pillow
-psycopg2
-requests>=2.18.4
-sqlalchemy>=1.2.0
-nose
-parameterized
-mock>=3.0.5
-lxml
-flask
-isbnlib
-rdflib
-pyspellchecker
-enum34
-
-elasticsearch>6.0.0,<7.0.0
-elasticsearch-dsl>6.0.0,<7.0.0
-
-python-dateutil
-uwsgi
-loggly-python-handler
-py-bcrypt
-Flask-Babel
-money
-pymarc
-
-# nltk is a textblob dependency, and this is the last release that supports Python 2
-nltk==3.4.5
-textblob
-
-# for author name manipulations
-nameparser>=0.5.1
-fuzzywuzzy
-
-# for cloudwatch logs integration
-watchtower
+# Requirements for the 'core' submodule
+Babel==2.8.0
+boto3==1.15.1
+botocore==1.18.1
+certifi==2020.6.20
+chardet==3.0.4
+click==7.1.2
+elasticsearch==6.8.1
+elasticsearch-dsl==6.4.0
+enum34==1.1.10
+feedparser==5.2.1
+Flask==1.1.2
+Flask-Babel==2.0.0
+funcsigs==1.0.2
+futures==3.3.0
+fuzzywuzzy==0.18.0 # For author name manipulations
+idna==2.10
+ipaddress==1.0.23
+isbnlib==3.10.3
+isodate==0.6.0
+itsdangerous==1.1.0
+Jinja2==2.11.2
+jmespath==0.10.0
+loggly-python-handler==1.0.1
+lxml==4.5.2
+MarkupSafe==1.1.1
+mock==3.0.5
+money==1.3.0
+nameparser==1.0.6 # For author name manipulations
+nltk==3.4.5 # A textblob dependency.
+nose==1.3.7
+parameterized==0.7.4
+Pillow==6.2.2
+pkg-resources==0.0.0
+psycopg2==2.8.6
+py-bcrypt==0.4
+pymarc==3.2.0
+pyparsing==2.4.7
+pyspellchecker==0.5.5
+python-dateutil==2.8.1
+pytz==2020.1
+rdflib==5.0.0
+requests==2.24.0
+requests-futures==1.0.0
+s3transfer==0.3.3
+singledispatch==3.4.0.3
+six==1.15.0
+SQLAlchemy==1.3.19
+textblob==0.15.3
+urllib3==1.25.10
+uWSGI==2.0.19.1
+watchtower==0.8.0 # For Cloudwatch logging integration
+Werkzeug==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,8 @@ Flask==1.1.2
 Flask-Babel==1.0.0
 funcsigs==1.0.2
 futures==3.3.0
-fuzzywuzzy==0.18.0 # For author name manipulations
+# fuzzywuzzy is for author name manipulations
+fuzzywuzzy==0.18.0
 idna==2.10
 ipaddress==1.0.23
 isbnlib==3.10.3
@@ -26,8 +27,10 @@ lxml==4.5.2
 MarkupSafe==1.1.1
 mock==3.0.5
 money==1.3.0
-nameparser==1.0.6 # For author name manipulations
-nltk==3.4.5 # A textblob dependency.
+# nameparser is for author name manipulations
+nameparser==1.0.6
+# nltk is a textblob dependency.
+nltk==3.4.5
 nose==1.3.7
 parameterized==0.7.4
 Pillow==6.2.2
@@ -48,5 +51,6 @@ SQLAlchemy==1.3.19
 textblob==0.15.3
 urllib3==1.25.10
 uWSGI==2.0.19.1
-watchtower==0.8.0 # For Cloudwatch logging integration
+# watchtower is for Cloudwatch logging integration
+watchtower==0.8.0
 Werkzeug==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ nameparser==1.0.6
 # nltk is a textblob dependency.
 nltk==3.4.5
 nose==1.3.7
+# parameterized is used for unit tests.
 parameterized==0.7.4
 Pillow==6.2.2
 psycopg2==2.8.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,6 @@ nltk==3.4.5 # A textblob dependency.
 nose==1.3.7
 parameterized==0.7.4
 Pillow==6.2.2
-pkg-resources==0.0.0
 psycopg2==2.8.6
 py-bcrypt==0.4
 pymarc==3.2.0


### PR DESCRIPTION
This branch is the core portion of https://jira.nypl.org/browse/SIMPLY-3100. All Python dependencies are set to the current latest releases that support Python 2. This will eliminate random breakage in the future caused by dependency releases, especially releases that drop Python 2 support.

I came up with this list by creating a fresh virtual environment and using `pip freeze`.

```
virtualenv env
source env/bin/activate
pip install --use-feature=2020-resolver -r requirements.txt # This is he old requirements.txt
pip freeze > requirements.txt # This is the new one
```

Then I edited the new requirements.txt to preserve comments found in the old one.

In both this branch and the circulation branch I also had to remove this line inserted by `pip freeze`:

```
pkg-resources==0.0.0
```

This looks like [a bug in Ubuntu](https://github.com/pypa/pip/issues/4022).