### PR TITLE
Add a database index for loan's external_identifier field

### DIFF
--- a/migration/20200925-add-index-on-loan-external_identifier.sql
+++ b/migration/20200925-add-index-on-loan-external_identifier.sql
@@ -1,0 +1,1 @@
+CREATE index ix_loan_external_identifier on loans (external_identifier);

--- a/model/patron.py
+++ b/model/patron.py
@@ -338,6 +338,8 @@ class Loan(Base, LoanAndHoldMixin):
         start = self.start or datetime.datetime.utcnow()
         return start + default_loan_period
 
+Index("ix_loan_external_identifier", Loan.external_identifier)
+
 class Hold(Base, LoanAndHoldMixin):
     """A patron is in line to check out a book.
     """


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds a new database index for `loans`'s `external_identifier` field.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This index is required in the case of LCP when we are not able to use a library name as a part of endpoint URLs and have to use LCP license ID (loan's external identifier) to fetch a library: loan -> patron -> library.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
