### PR TITLE
Replace raise e with raise to save the original exception's callstack

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -252,10 +252,10 @@ class ExternalSearchIndex(HasSelfTests):
         if works_index and integration and not in_testing:
             try:
                 self.set_works_index_and_alias(_db)
-            except RequestError, e:
+            except RequestError:
                 # This is almost certainly a problem with our code,
                 # not a communications error.
-                raise e
+                raise
             except ElasticsearchException, e:
                 raise CannotLoadConfiguration(
                     "Exception communicating with Elasticsearch server: %s" %

--- a/migration/20170908-change-metadata-wrangler-settings.py
+++ b/migration/20170908-change-metadata-wrangler-settings.py
@@ -29,6 +29,6 @@ try:
                 setting.value = None
         _db.commit()
     _db.close()
-except Exception as e:
+except Exception:
     _db.close()
-    raise e
+    raise

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -88,9 +88,9 @@ def get_one(db, model, on_multiple='error', constraint=None, **kwargs):
 
     try:
         return q.one()
-    except MultipleResultsFound, e:
+    except MultipleResultsFound:
         if on_multiple == 'error':
-            raise e
+            raise
         elif on_multiple == 'interchangeable':
             # These records are interchangeable so we can use
             # whichever one we want.

--- a/model/hasfulltablecache.py
+++ b/model/hasfulltablecache.py
@@ -118,7 +118,7 @@ class HasFullTableCache(object):
 
                 # That didn't work. Re-raise the original exception.
                 logging.error("Unable to look up a fresh copy of %r", obj)
-                raise e
+                raise
         return obj, new
 
     @classmethod

--- a/scripts.py
+++ b/scripts.py
@@ -174,7 +174,7 @@ class Script(object):
             )
             stack_trace = traceback.format_exc()
             self.update_timestamp(None, start_time, stack_trace)
-            raise e
+            raise
 
     def load_configuration(self):
         if not Configuration.cdns_loaded_from_database():
@@ -2078,7 +2078,7 @@ class DatabaseMigrationScript(Script):
             # If _none_ of those worked, something is wrong on a
             # deeper level.
             if exception:
-                raise e
+                raise exception
 
             if not results:
                 # Make sure there's a row for this service in the timestamps
@@ -3005,9 +3005,9 @@ class WhereAreMyBooksScript(CollectionInputScript):
         self.output = output or sys.stdout
         try:
             self.search = search or ExternalSearchIndex(_db)
-        except CannotLoadConfiguration, e:
+        except CannotLoadConfiguration:
             self.out("Here's your problem: the search integration is missing or misconfigured.")
-            raise e
+            raise
 
     def out(self, s, *args):
         if not s.endswith("\n"):

--- a/testing.py
+++ b/testing.py
@@ -121,7 +121,7 @@ def package_setup():
                 # on this server, and the tables don't exist yet.
                 pass
             else:
-                raise e
+                raise
 
 
 def package_teardown():

--- a/util/worker_pools.py
+++ b/util/worker_pools.py
@@ -170,9 +170,9 @@ class Job(object):
     def run(self, *args, **kwargs):
         try:
             self.do_run(*args, **kwargs)
-        except Exception as e:
+        except Exception:
             self.rollback(*args, **kwargs)
-            raise e
+            raise
         else:
             self.finalize(*args, **kwargs)
 


### PR DESCRIPTION
# Description

This PR replaces `raise e` statements with `raise` statements to save the callstack of the original exception.
Corresponding JIRA ticket: [SIMPLY-3165](https://jira.nypl.org/browse/SIMPLY-3165).

<!--- Describe your changes -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
