### PR TITLE
Don't show breadcrumbs for lanes between the library root and a lane that's a root for some patron type.

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -994,9 +994,13 @@ class AcquisitionFeed(OPDSFeed):
             previous_url = annotator.search_url(lane, query, previous_page, facets)
             AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, rel="previous", href=previous_url)
 
-        # Add "up" link and breadcrumbs
+        # Add "up" link.
         AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, rel="up", href=annotator.lane_url(lane), title=unicode(lane.display_name))
-        opds_feed.add_breadcrumbs(lane, include_lane=True)
+
+        # We do not add breadcrumbs to this feed since you're not
+        # technically searching the this lane; you are searching the
+        # library's entire collection, using _some_ of the constraints
+        # imposed by this lane (notably language and audience).
 
         annotator.annotate_feed(opds_feed, lane)
         return OPDSFeedResponse(response=unicode(opds_feed), **response_kwargs)

--- a/opds.py
+++ b/opds.py
@@ -6,6 +6,7 @@ from collections import (
 )
 
 from lxml import etree
+from nose.tools import set_trace
 from sqlalchemy.orm.session import Session
 
 from cdn import cdnify
@@ -1435,10 +1436,10 @@ class AcquisitionFeed(OPDSFeed):
             full_parentage = list(lane.parentage)
             usable_parentage = []
             for ancestor in lane.parentage:
+                usable_parentage.append(ancestor)
                 if isinstance(ancestor, Lane) and ancestor.root_for_patron_type:
                     # Root lane for a specific patron type.
                     break
-                usable_parentage.append(ancestor)
 
             for ancestor in reversed(usable_parentage):
                 lane_url = annotator.lane_url(ancestor)

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -2050,6 +2050,8 @@ class TestAcquisitionFeed(DatabaseTest):
         # the breadcrumbs will be start at that lane -- we won't see
         # the sublane's parent or the library root.
         sublane.root_for_patron_type = ["ya"]
+        assert_breadcrumbs([], sublane)
+
         assert_breadcrumbs(
             [sublane, subsublane],
             subsubsublane

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1903,14 +1903,13 @@ class TestAcquisitionFeed(DatabaseTest):
         ep = AudiobooksEntryPoint
 
         # The top level with no entrypoint
-        # Top Level Title >
+        # Top Level Title
         feed = MockFeed()
         feed.add_breadcrumbs(lane)
-        children = getElementChildren(feed)
+        [top] = getElementChildren(feed)
 
-        eq_(len(children), 1)
-        eq_(children[0].attrib.get("href"), TestAnnotator.default_lane_url())
-        eq_(children[0].attrib.get("title"), TestAnnotator.top_level_title())
+        eq_(top.attrib.get("href"), TestAnnotator.default_lane_url())
+        eq_(top.attrib.get("title"), TestAnnotator.top_level_title())
 
         # The top level with an entrypoint
         # Top Level Title > Audio

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1287,19 +1287,13 @@ class TestOPDS(DatabaseTest):
 
         eq_(work2.title, parsed['entries'][0]['title'])
 
-        # The feed has breadcrumb links
+        # The feed has no breadcrumb links, since we're not
+        # searching the lane -- just using some aspects of the lane
+        # to guide the search.
         parentage = list(fantasy_lane.parentage)
         root = ET.fromstring(feed)
         breadcrumbs = root.find("{%s}breadcrumbs" % AtomFeed.SIMPLIFIED_NS)
-        links = breadcrumbs.getchildren()
-        eq_(len(parentage) + 2, len(links))
-        eq_(TestAnnotator.top_level_title(), links[0].get("title"))
-        eq_(TestAnnotator.default_lane_url(), links[0].get("href"))
-        for i, lane in enumerate(parentage):
-            eq_(lane.display_name, links[i+1].get("title"))
-            eq_(TestAnnotator.lane_url(lane), links[i+1].get("href"))
-        eq_(fantasy_lane.display_name, links[-1].get("title"))
-        eq_(TestAnnotator.lane_url(fantasy_lane), links[-1].get("href"))
+        eq_(None, breadcrumbs)
 
     def test_cache(self):
         work1 = self._work(title="The Original Title",


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-3129. It changes `AcquisitionFeed.add_breadcrumbs` to omit breadcrumbs for lanes that are between the library root and a lane that is the root lane for a specific patron type.

If there is no patron-specific root lane between the lane being breadcrumbed and the library root, the code should work exactly as before. Effectively, this means that Open eBooks and The SimplyE Collection are the only sites currently affected.

If an entry point is selected, the selection is always presumed to have happened in the second breadcrumb.

To use Open eBooks as an example (and ignoring the fact that Open eBooks doesn't have selectable entrypoints), let's say your patron type puts your root lane as "Early Grades", you've navigated from there to the "Early Grades > Animals" lane, and you have the "Audio" point selected.

Breadcrumbs before:

All books > Audio > Early Grades > Animals

Breadcrumbs after:

Early Grades > Audio > Animals

Note that this means you may start at "All books", click into "Early Grades", and lose your breadcrumb back to "All books". Fixing this will take an extra effort since we don't currently vary the contents of most feeds based on the authenticated patron.

Since this is a complex feature that I've made more complex, I put a lot of work into refactoring the test so that a) test assertions are easy to write and easy to understand, b) the test makes an exact assertion about the URL of every breadcrumb, not just an assertion about the title plus some general assertions about some of the URLs.