### PR TITLE
Apply lane visibility rules to the top-level WorkList

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -1492,7 +1492,7 @@ class WorkList(object):
     def is_self_or_descendant(self, ancestor):
         """Is this WorkList the given WorkList or one of its descendants?
 
-        :param target: A WorkList.
+        :param ancestor: A WorkList.
         :return: A boolean.
         """
         for candidate in [self] + list(self.parentage):
@@ -2637,6 +2637,22 @@ class Lane(Base, DatabaseBackedWorkList, HierarchyWorkList):
                 raise ValueError("Lane parentage loop detected")
             seen.add(grandparent)
             yield grandparent
+
+    def is_self_or_descendant(self, ancestor):
+        """Is this WorkList the given WorkList or one of its descendants?
+
+        :param ancestor: A WorkList.
+        :return: A boolean.
+        """
+        if super(Lane, self).is_self_or_descendant(ancestor):
+            return True
+
+        # A TopLevelWorkList won't show up in a Lane's parentage,
+        # because it's not a Lane, but if they share the same library
+        # it can be presumed to be the lane's ultimate ancestor.
+        if isinstance(ancestor, TopLevelWorkList) and self.library_id==ancestor.library_id:
+            return True
+        return False
 
     @property
     def depth(self):

--- a/lane.py
+++ b/lane.py
@@ -2074,7 +2074,6 @@ class HierarchyWorkList(WorkList):
             return True
 
         root_lane = patron.root_lane
-        set_trace()
         if root_lane and not self.is_self_or_descendant(root_lane):
             # In addition, a HierarchyWorkList that's not in
             # scope of the patron's root lane is not accessible,

--- a/lane.py
+++ b/lane.py
@@ -1286,7 +1286,7 @@ class WorkList(object):
 
         # This WorkList contains every title available to this library
         # in one of the media supported by the default client.
-        wl = WorkList()
+        wl = TopLevelWorkList()
 
         wl.initialize(
             library, display_name=library.name, children=top_level_lanes,
@@ -2049,6 +2049,51 @@ class WorkList(object):
                 yield work, lane
 
 
+class HierarchyWorkList(WorkList):
+    """A WorkList representing part of a hierarchical view of a a
+    library's collection. (As opposed to a non-hierarchical view such
+    as search results or "books by author X".)
+    """
+
+    def accessible_to(self, patron):
+        """As a matter of library policy, is the given `Patron` allowed
+        to access this `WorkList`?
+
+        Most of the logic is inherited from `WorkList`, but there's also
+        a restriction based on the site hierarchy.
+
+        :param patron: A Patron
+        :return: A boolean
+        """
+
+        # All the rules of WorkList apply.
+        if not super(HierarchyWorkList, self).accessible_to(patron):
+            return False
+
+        if patron is None:
+            return True
+
+        root_lane = patron.root_lane
+        set_trace()
+        if root_lane and not self.is_self_or_descendant(root_lane):
+            # In addition, a HierarchyWorkList that's not in
+            # scope of the patron's root lane is not accessible,
+            # period. Even if all of the books in the WorkList are
+            # age-appropriate, it's in a different part of the
+            # navigational structure and navigating to it is not
+            # allowed.
+            return False
+
+        return True
+
+
+class TopLevelWorkList(HierarchyWorkList):
+    """A special WorkList representing the top-level view of
+    a library's collection.
+    """
+    pass
+
+
 class DatabaseBackedWorkList(WorkList):
     """A WorkList that can get its works from the database in addition to
     (or possibly instead of) the search index.
@@ -2404,7 +2449,7 @@ Genre.lane_genres = relationship(
 )
 
 
-class Lane(Base, DatabaseBackedWorkList):
+class Lane(Base, DatabaseBackedWorkList, HierarchyWorkList):
     """A WorkList that draws its search criteria from a row in a
     database table.
 
@@ -2613,32 +2658,6 @@ class Lane(Base, DatabaseBackedWorkList):
     @visible.setter
     def visible(self, value):
         self._visible = value
-
-    def accessible_to(self, patron):
-        """As a matter of library policy, is the given `Patron` allowed
-        to access this `Lane`?
-
-        :param patron: A Patron
-        :return: A boolean
-        """
-
-        # All the rules of WorkList apply.
-        if not super(Lane, self).accessible_to(patron):
-            return False
-
-        if patron is None:
-            return True
-
-        root_lane = patron.root_lane
-        if root_lane and not self.is_self_or_descendant(root_lane):
-            # In addition, a database Lane that's not in scope of the
-            # patron's root lane is not accessible, period. Even if all
-            # of the books in the Lane are age-appropriate, it's in a
-            # different part of the navigational structure and
-            # navigating to it is not allowed.
-            return False
-
-        return True
 
     @property
     def url_name(self):


### PR DESCRIPTION
This fixes a problem I found doing QA of https://jira.nypl.org/browse/SIMPLY-3125: the lane visibility rules are not applied to the top-level WorkList, because it's not a Lane.

This poses a small problem: all authenticated patrons can see the top-level WorkList, but a patron with a root lane should not be able to see it.

This branch does more work than is strictly necessary to solve this problem because I introduced a new type of WorkList -- TopLevelWorkList -- that interacts with Lane, and I wanted to make sure that a TopLevelWorkList appears to be an ancestor of every Lane in the same Library.

I'm concerned about deploying this change to production because the currently deployed https://catalog.openebooks.us/ seems to depend on the top-level grouped feed being accessible to all authenticated users. My original idea was to make that feed redirect when appropriate (like the IndexController does) rather than deny access. This implementation turned out to be much easier, but if we want to deploy to Open eBooks production before updating the web catalog, I should probably take another look at the redirect idea.
