### PR TITLE
Fix cloudwatch debug

### DIFF
--- a/log.py
+++ b/log.py
@@ -349,6 +349,7 @@ class CloudwatchLogs(Logger):
         interval = settings.setting(cls.INTERVAL).value or cls.DEFAULT_INTERVAL
         region = settings.setting(cls.REGION).value or cls.DEFAULT_REGION
         create_group = settings.setting(cls.CREATE_GROUP).value or cls.DEFAULT_CREATE_GROUP
+
         try:
             interval = int(interval)
             if interval <= 0:


### PR DESCRIPTION
## Summary

If `DEBUG` level logging is enabled on a circulation manager with the a Cloudwatch Logs integration it can lead to an infinite loop. 

## Details

When setting the log level to `DEBUG` the `botocore` logger writes log statements when writing out a log leading to an infinite loop.

The solution here is twofold: 
1. Add a filter to the log handler for Cloudwatch Logs that will filter out messages from `botocore` so that the infinite loop is prevented. 
1. Add `botocore` to the loggers that get set to database log level, as it is very verbose at the debug log level and tends to pollute any other logger enabled with unhelpful log statements every time it processes log messages and sends them to Cloudwatch Logs.

## How should this be tested?

Enable cloudwatch logs, set the log level to debug, wait until a log statement is pushed into Cloudwatch and make sure the application doesn't go into an infinite loop.

I believe both @tdilauro and @vbessonov have experienced this infinite loop while debugging with Cloudwatch Logs enabled.