### PR TITLE
Add an availability facet 'not_now' which finds only books that are _not_ currently available.

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -2476,6 +2476,13 @@ class Filter(SearchBase):
         elif self.availability==FacetConstants.AVAILABLE_OPEN_ACCESS:
             # Only open-access books should be displayed.
             nested_filters['licensepools'].append(open_access)
+        elif self.availability==FacetConstants.AVAILABLE_NOT_NOW:
+            # Only books that are _not_ currently available should be displayed.
+            not_open_access = Term(**{'licensepools.open_access' : False})
+            not_available = Term(**{'licensepools.available' : False})
+            nested_filters['licensepools'].append(
+                Bool(must=[not_open_access, not_available])
+            )
 
         if self.subcollection==FacetConstants.COLLECTION_FEATURED:
             # Exclude books with a quality of less than the library's

--- a/facets.py
+++ b/facets.py
@@ -25,6 +25,8 @@ class FacetConstants(object):
     AVAILABLE_NOW = "now"
     AVAILABLE_ALL = "all"
     AVAILABLE_OPEN_ACCESS = "always"
+    AVAILABLE_NOT_NOW = "not_now" # Used only in QA jackpot feeds -- real patrons don't
+                                  # want to see this.
     AVAILABILITY_FACETS = [
         AVAILABLE_NOW,
         AVAILABLE_ALL,


### PR DESCRIPTION
This is the core portion of https://jira.nypl.org/browse/SIMPLY-3236. It adds a new availability facet which finds books that are not currently available. This facet cannot be configured for use in normal sites, or used in normal `Facets` objects, because patrons don't want to search only books that are not currently available. Instead, the `JackpotFacets` class defined in https://github.com/NYPL-Simplified/circulation/pull/1521 allows it as a possibility.