### PR TITLE
Don't filter out self-hosted books and books with unlimited access

### DIFF
--- a/model/collection.py
+++ b/model/collection.py
@@ -762,7 +762,12 @@ class Collection(Base, HasFullTableCache):
         # If we don't allow holds, hide any books with no available copies.
         if not allow_holds:
             query = query.filter(
-                or_(LicensePool.licenses_available > 0, LicensePool.open_access)
+                or_(
+                    LicensePool.licenses_available > 0,
+                    LicensePool.open_access,
+                    LicensePool.self_hosted,
+                    LicensePool.unlimited_access
+                )
             )
         return query
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR modifies logic of `Collection.restrict_to_ready_deliverable_works`, making it conformant with all other parts of the source code, i.e., it excludes self-hosted books and books with unlimited access from filtration conditions.

**NOTE**: This PR introduced breaking changes by renaming `publicationDate` parameter in `DatabaseTest._edition` to `publication_date` which will make `circulation` tests to fail. The corresponding fix can be found in [PR # 1519 in circulation](https://github.com/NYPL-Simplified/circulation/pull/1519).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[SIMPLY-3269](https://jira.nypl.org/browse/SIMPLY-3269)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
