### PR TITLE
Make sure 'available' and 'licensed' are always booleans when turning a Work into a search document

### DIFF
--- a/migration/20201117-remove-all-search-coverage.sql
+++ b/migration/20201117-remove-all-search-coverage.sql
@@ -1,0 +1,3 @@
+-- Remove all WorkCoverageRecords pertaining to the search index. This
+-- will force a complete reindex on the next run of bin/search_index_refresh.
+delete from workcoveragerecords where operation='update-search-index';

--- a/model/work.py
+++ b/model/work.py
@@ -1549,7 +1549,6 @@ class Work(Base):
         def explicit_bool(label, t):
             # Ensure we always generate True/False instead of
             # True/None. Elasticsearch can't filter on null values.
-            return t.label(label)
             return case([(t, True)], else_=False).label(label)
 
         licensepools = select(

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -1117,7 +1117,9 @@ class TestWork(DatabaseTest):
             eq_(pool.suppressed, match['suppressed'])
             eq_(pool.data_source_id, match['data_source_id'])
 
+            assert isinstance(match['available'], bool)
             eq_(pool.licenses_available > 0, match['available'])
+            assert isinstance(match['licensed'], bool)
             eq_(pool.licenses_owned > 0, match['licensed'])
 
             # The work quality is stored in the main document, but


### PR DESCRIPTION
I was not able to reproduce this problem in a unit test scenario, but it was easy to reproduce against NYPL's QA server while doing QA on https://jira.nypl.org/browse/SIMPLY-3236. The only thing I can think of is that it might depend on which version of Postgres you're running.

The problem happens when a book is not available through a given LicensePool: in this case Work.to_search_document gives "null" instead of "false" for "licensepools.availability". Previously this wasn't a problem because we only ever looked for books that were available -- i.e. had a "true" value for licensepools.availability. Thanks to 3236, we now look for books that are _not_ available, and Elasticsearch doesn't treat "null" as a "false" value -- it doesn't seem possible to filter on a null value at all.

This branch changes the SQL so that we are always guaranteed to get either True or False for 'availability' and 'licensed'. I believe there is a "falsey" value being returned in some cases which SQLAlchemy turns into null instead of False. But I don't know when this value is being returned as opposed to False.