### PR TITLE
Update the Overdrive client to use v2 of the availability API

### DIFF
--- a/overdrive.py
+++ b/overdrive.py
@@ -279,13 +279,18 @@ class OverdriveAPI(object):
     def advantage_library_id(self):
         """The library ID for this library, as we should look for it in
         certain API documents served by Overdrive.
+
+        For ordinary collections, and for consortial collections
+        shared among libraries, this will be -1.
+
+        For Overdrive Advantage accounts, this will be the numeric
+        value of the Overdrive library ID.
         """
         if self.parent_library_id is None:
-            # This is what Overdrive calls a "consortial" collection,
-            # i.e. not an Overdrive Advantage collection.
+            # This is not an Overdrive Advantage collection.
             #
-            # Instead of looking for the library ID itself we should
-            # look for the constant -1.
+            # Instead of looking for the library ID itself in these
+            # documents, we should look for the constant -1.
             return -1
         return int(self.library_id)
 
@@ -648,6 +653,12 @@ class OverdriveRepresentationExtractor(object):
     log = logging.getLogger("Overdrive representation extractor")
 
     def __init__(self, api):
+        """Constructor.
+
+        :param api: An OverdriveAPI object. This will be used when deciding
+        which portions of a JSON representation are relevant to the active
+        Overdrive collection.
+        """
         self.library_id = api.advantage_library_id
 
     @classmethod

--- a/overdrive.py
+++ b/overdrive.py
@@ -111,7 +111,7 @@ class OverdriveAPI(object):
     ALL_PRODUCTS_ENDPOINT = "%(host)s/v1/collections/%(collection_token)s/products?sort=%(sort)s"
     METADATA_ENDPOINT = "%(host)s/v1/collections/%(collection_token)s/products/%(item_id)s/metadata"
     EVENTS_ENDPOINT = "%(host)s/v1/collections/%(collection_token)s/products?lastUpdateTime=%(lastupdatetime)s&sort=%(sort)s&limit=%(limit)s"
-    AVAILABILITY_ENDPOINT = "%(host)s/v1/collections/%(collection_token)s/products/%(product_id)s/availability"
+    AVAILABILITY_ENDPOINT = "%(host)s/v2/collections/%(collection_token)s/products/%(product_id)s/availability"
 
     PATRON_INFORMATION_ENDPOINT = "%(patron_host)s/v1/patrons/me"
     CHECKOUTS_ENDPOINT = "%(patron_host)s/v1/patrons/me/checkouts"
@@ -809,7 +809,6 @@ class OverdriveRepresentationExtractor(object):
                 processed.append(cls.overdrive_role_to_simplified_role[x])
         return processed
 
-
     @classmethod
     def book_info_to_circulation(cls, book):
         """ Note:  The json data passed into this method is from a different file/stream
@@ -823,27 +822,66 @@ class OverdriveRepresentationExtractor(object):
         licenses_available = None
         patrons_in_hold_queue = None
 
+        # TODO: The only reason this works for a NotFound error is the
+        # circulation code sticks the known book ID into `book` ahead
+        # of time. That's a code smell indicating that this system
+        # needs to be refactored.
+        if 'reserveId' in book and not 'id' in book:
+            book['id'] = book['reserveId']
         if not 'id' in book:
             return None
         overdrive_id = book['id']
         primary_identifier = IdentifierData(
             Identifier.OVERDRIVE_ID, overdrive_id
         )
-        if (book.get('isOwnedByCollections') is not False):
+
+        # TODO: We might be able to use this information to avoid the
+        # need for explicit configuration of Advantage collections, or
+        # at least to keep Advantage collections more up-to-date than
+        # they would be otherwise, as a side effect of updating
+        # regular Overdrive collections.
+
+        # TODO: this would be the place to handle simultaneous use
+        # titles -- these can be detected with
+        # availabilityType="AlwaysAvailable" and have their
+        # .licenses_owned set to LicensePool.UNLIMITED_ACCESS.
+        # see http://developer.overdrive.com/apis/library-availability-new
+
+        # TODO: Cost-per-circ titles
+        # (availabilityType="LimitedAvailablility") can be handled
+        # similarly, though those can abruptly become unavailable, so
+        # UNLIMITED_ACCESS is probably not appropriate.
+
+        error_code = book.get('errorCode')
+        # TODO: It's not clear what other error codes there might be.
+        # The current behavior will respond to errors other than
+        # NotFound by leaving the book alone, but this might not be
+        # the right behavior.
+        if error_code == 'NotFound':
+            licenses_owned = 0
+            licenses_available = 0
+            patrons_in_hold_queue = 0
+        elif book.get('isOwnedByCollections') is not False:
             # We own this book.
-            for collection in book['collections']:
-                if 'copiesOwned' in collection:
+            for account in book.get('accounts', []):
+                # Only keep track of copies owned by the account we're
+                # asking about; Overdrive Advantage accounts are
+                # tracked separately.
+                if account.get('id') != -1:
+                    continue
+
+                if 'copiesOwned' in account:
                     if licenses_owned is None:
                         licenses_owned = 0
-                    licenses_owned += int(collection['copiesOwned'])
-                if 'copiesAvailable' in collection:
+                    licenses_owned += int(account['copiesOwned'])
+                if 'copiesAvailable' in account:
                     if licenses_available is None:
                         licenses_available = 0
-                    licenses_available += int(collection['copiesAvailable'])
-                if 'numberOfHolds' in collection:
-                    if patrons_in_hold_queue is None:
-                        patrons_in_hold_queue = 0
-                    patrons_in_hold_queue += collection['numberOfHolds']
+                    licenses_available += int(account['copiesAvailable'])
+            if 'numberOfHolds' in book:
+                if patrons_in_hold_queue is None:
+                    patrons_in_hold_queue = 0
+                patrons_in_hold_queue += book['numberOfHolds']
         return CirculationData(
             data_source=DataSource.OVERDRIVE,
             primary_identifier=primary_identifier,

--- a/tests/files/overdrive/overdrive_availability_advantage.json
+++ b/tests/files/overdrive/overdrive_availability_advantage.json
@@ -1,0 +1,27 @@
+{
+    "accounts": [
+        {
+            "copiesAvailable": 1,
+            "copiesOwned": 1,
+            "id": 61,
+            "shared": false
+        },
+        {
+            "copiesAvailable": 2,
+            "copiesOwned": 2,
+            "id": -1
+        }
+    ],
+    "availabilityType": "Normal",
+    "available": true,
+    "copiesAvailable": 3,
+    "copiesOwned": 3,
+    "links": {
+        "self": {
+            "href": "https://api.overdrive.com/v2/collections/v1L1B4QwAAA2O/products/776ec0c1-582f-4f7a-8d80-bdf5834de7ce/availability",
+            "type": "application/vnd.overdrive.api+json"
+        }
+    },
+    "numberOfHolds": 0,
+    "reserveId": "776ec0c1-582f-4f7a-8d80-bdf5834de7ce"
+}

--- a/tests/files/overdrive/overdrive_availability_information.json
+++ b/tests/files/overdrive/overdrive_availability_information.json
@@ -1,22 +1,21 @@
 {
-    "available": true,
-    "collections": [
+    "accounts": [
         {
-            "copiesAvailable": 5,
-            "copiesOwned": 5,
-            "id": "New York Public Library (NY)",
-            "numberOfHolds": 0
+            "copiesAvailable": 1,
+            "copiesOwned": 3,
+            "id": -1
         }
     ],
-    "copiesAvailable": 5,
-    "copiesOwned": 5,
-    "id": "2a005d55-a417-4053-b90d-7a38ca6d2065",
-    "title": "Blah blah blah",
+    "availabilityType": "Normal",
+    "available": false,
+    "copiesAvailable": 1,
+    "copiesOwned": 3,
     "links": {
         "self": {
-            "href": "http://api.overdrive.com/v1/collections/collection-id/products/2a005d55-a417-4053-b90d-7a38ca6d2065/availability",
+            "href": "https://api.overdrive.com/v2/collections/v1L1BCgAAAA2C/products/2a005d55-a417-4053-b90d-7a38ca6d2065/availability",
             "type": "application/vnd.overdrive.api+json"
         }
     },
-    "numberOfHolds": 0
+    "numberOfHolds": 10,
+    "reserveId": "2a005d55-a417-4053-b90d-7a38ca6d2065"
 }

--- a/tests/files/overdrive/overdrive_availability_not_found.json
+++ b/tests/files/overdrive/overdrive_availability_not_found.json
@@ -1,0 +1,5 @@
+{
+    "errorCode": "NotFound", 
+    "message": "The requested resource could not be found.", 
+    "token": "60a18218-0d25-42b8-80c3-0bf9df782f1b"
+}

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -272,23 +272,30 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
             None
         )
 
-    def test_library_endpoint(self):
-        """Verify that Advantage collections and regular Overdrive
-        collections start at different endpoints.
-        """
-        # Here's an Overdrive collection.
+    def test_advantage_differences(self):
+        # Test the differences between Advantage collections and
+        # regular Overdrive collections.
+
+        # Here's a regular Overdrive collection.
         main = self._collection(
             protocol=ExternalIntegration.OVERDRIVE, external_account_id="1",
         )
         main.external_integration.username = "user"
         main.external_integration.password = "password"
-        main.external_integration.setting('website_id').value = '100'
+        main.external_integration.setting('website_id').value = '101'
         main.external_integration.setting('ils_name').value = 'default'
 
         # Here's an Overdrive API client for that collection.
         overdrive_main = MockOverdriveAPI(self._db, main)
+
+        # Note the "library" endpoint.
         eq_("https://api.overdrive.com/v1/libraries/1",
             overdrive_main._library_endpoint)
+
+        # The advantage_library_id of a non-Advantage Overdrive account
+        # is always -1.
+        eq_("1", overdrive_main.library_id)
+        eq_(-1, overdrive_main.advantage_library_id)
 
         # Here's an Overdrive Advantage collection associated with the
         # main Overdrive collection.
@@ -297,10 +304,20 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         )
         child.parent = main
         overdrive_child = MockOverdriveAPI(self._db, child)
+
+        # In URL-space, the "library" endpoint for the Advantage
+        # collection is beneath the the parent collection's "library"
+        # endpoint.
         eq_(
             'https://api.overdrive.com/v1/libraries/1/advantageAccounts/2',
             overdrive_child._library_endpoint
         )
+
+        # The advantage_library_id of an Advantage collection is the
+        # numeric value of its external_account_id.
+        eq_("2", overdrive_child.library_id)
+        eq_(2, overdrive_child.advantage_library_id)
+
 
 class TestOverdriveRepresentationExtractor(OverdriveTestWithAPI):
 
@@ -344,11 +361,12 @@ class TestOverdriveRepresentationExtractor(OverdriveTestWithAPI):
         eq_(expect, OverdriveRepresentationExtractor.link(raw, "first"))
 
 
-    def test_book_info_with_circulationdata(self):
+    def test_book_info_to_circulation(self):
         # Tests that can convert an overdrive json block into a CirculationData object.
 
         raw, info = self.sample_json("overdrive_availability_information.json")
-        circulationdata = OverdriveRepresentationExtractor.book_info_to_circulation(info)
+        extractor = OverdriveRepresentationExtractor(self.api)
+        circulationdata = extractor.book_info_to_circulation(info)
 
         # NOTE: It's not realistic for licenses_available and
         # patrons_in_hold_queue to both be nonzero; this is just to
@@ -363,13 +381,38 @@ class TestOverdriveRepresentationExtractor(OverdriveTestWithAPI):
         eq_((Identifier.OVERDRIVE_ID, '2a005d55-a417-4053-b90d-7a38ca6d2065'),
             (identifier.type, identifier.identifier))
 
+    def test_book_info_to_circulation_advantage(self):
+        # Overdrive Advantage accounts derive different information
+        # from the same API responses as regular Overdrive accounts.
+        raw, info = self.sample_json("overdrive_availability_advantage.json")
+
+        extractor = OverdriveRepresentationExtractor(self.api)
+        consortial_data = extractor.book_info_to_circulation(info)
+        eq_(2, consortial_data.licenses_owned)
+        eq_(2, consortial_data.licenses_available)
+
+        class MockAPI(object):
+            advantage_library_id = 61
+
+        extractor = OverdriveRepresentationExtractor(MockAPI())
+        advantage_data = extractor.book_info_to_circulation(info)
+        eq_(1, advantage_data.licenses_owned)
+        eq_(1, advantage_data.licenses_available)
+
+        # Both collections have the same information about active
+        # holds, because that information is not split out by
+        # collection.
+        eq_(0, advantage_data.patrons_in_hold_queue)
+        eq_(0, consortial_data.patrons_in_hold_queue)
+
     def test_not_found_error_to_circulationdata(self):
         raw, info = self.sample_json("overdrive_availability_not_found.json")
 
         # By default, a "NotFound" error can't be converted to a
         # CirculationData object, because we don't know _which_ book it
         # was that wasn't found.
-        m = OverdriveRepresentationExtractor.book_info_to_circulation
+        extractor = OverdriveRepresentationExtractor(self.api)
+        m = extractor.book_info_to_circulation
         eq_(None, m(info))
 
         # However, if an ID was added to `info` ahead of time (as the
@@ -650,12 +693,11 @@ class TestOverdriveAdvantageAccount(OverdriveTestWithAPI):
         eq_("The Common Community Library", ac2.name)
 
     def test_to_collection(self):
-        """Test that we can turn an OverdriveAdvantageAccount object into
-        a Collection object.
-        """
+        # Test that we can turn an OverdriveAdvantageAccount object into
+        # a Collection object.
 
         account = OverdriveAdvantageAccount(
-            "parent_id", "child_id", "Library Name",
+            "100", "200", "Library Name",
         )
 
         # We can't just create a Collection object for this object because
@@ -666,13 +708,14 @@ class TestOverdriveAdvantageAccount(OverdriveTestWithAPI):
             account.to_collection, self._db
         )
 
-        # So, create a Collection to be the parent.
+        # So, create a "consortial" Collection to be the parent.
         parent = self._collection(
             name="Parent", protocol=ExternalIntegration.OVERDRIVE,
             external_account_id="parent_id"
         )
 
-        # Now it works.
+        # Now the account can be created as an Overdrive Advantage
+        # Collection.
         p, collection = account.to_collection(self._db)
         eq_(p, parent)
         eq_(parent, collection.parent)

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -717,7 +717,7 @@ class TestOverdriveAdvantageAccount(OverdriveTestWithAPI):
         # a Collection object.
 
         account = OverdriveAdvantageAccount(
-            "100", "200", "Library Name",
+            "parent_id", "child_id", "Library Name",
         )
 
         # We can't just create a Collection object for this object because
@@ -728,14 +728,13 @@ class TestOverdriveAdvantageAccount(OverdriveTestWithAPI):
             account.to_collection, self._db
         )
 
-        # So, create a "consortial" Collection to be the parent.
+        # So, create a Collection to be the parent.
         parent = self._collection(
             name="Parent", protocol=ExternalIntegration.OVERDRIVE,
-            external_account_id="100"
+            external_account_id="parent_id"
         )
 
-        # Now the account can be created as an Overdrive Advantage
-        # Collection.
+        # Now it works.
         p, collection = account.to_collection(self._db)
         eq_(p, parent)
         eq_(parent, collection.parent)

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -282,7 +282,7 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         )
         main.external_integration.username = "user"
         main.external_integration.password = "password"
-        main.external_integration.setting('website_id').value = '101'
+        main.external_integration.setting('website_id').value = '100'
         main.external_integration.setting('ils_name').value = 'default'
 
         # Here's an Overdrive API client for that collection.


### PR DESCRIPTION
This is the core portion of a fix to https://jira.nypl.org/browse/SIMPLY-3302 -- using v2 of the Overdrive availability API instead of v1.

The main change is that in the v2 response, the number we're looking for depends on whether we're trying to update a normal Overdrive account or an Overdrive Advantage account.

I've resisted the urge to refactor this whole thing, but that does need to be done: I filed https://jira.nypl.org/browse/SIMPLY-3343 to track that work and explain why.