### PR TITLE
Add new optional MeasurementReaper

### DIFF
--- a/config.py
+++ b/config.py
@@ -99,6 +99,9 @@ class Configuration(ConfigurationConstants):
     # ConfigurationSetting key for the base url of the app.
     BASE_URL_KEY = u'base_url'
 
+    # ConfigurationSetting to enable the MeasurementReaper script
+    MEASUREMENT_REAPER = 'measurement_reaper_enabled'
+
     # Policies, mostly circulation specific
     POLICIES = "policies"
     LANES_POLICY = "lanes"
@@ -200,6 +203,12 @@ class Configuration(ConfigurationConstants):
             "description": _("Audiobooks from these data sources will be hidden from the collection, even if they would otherwise show up as available."),
             "default": None,
             "required": True,
+        },
+        {
+            "key": MEASUREMENT_REAPER,
+            "label": _("Cleanup old measurement data"), "type": "select",
+            "description": _("If this settings is 'true' old book measurement data will be cleaned out of the database. Some sites may want to keep this data for later analysis."),
+            "options": { "true": "true", "false": "false" }, "default": "true",
         },
     ]
 

--- a/monitor.py
+++ b/monitor.py
@@ -10,11 +10,13 @@ from sqlalchemy.sql.functions import func
 from sqlalchemy.sql.expression import (
     or_,
     and_,
-    outerjoin,
+    outerjoin, delete,
 )
 
 import log # This sets the appropriate log format and level.
+from model.configuration import ConfigurationSetting
 from config import Configuration
+
 from coverage import CoverageFailure
 from metadata_layer import TimestampData
 from model import (
@@ -37,6 +39,7 @@ from model import (
     Timestamp,
     Work,
     WorkCoverageRecord,
+    Measurement,
 )
 
 
@@ -771,10 +774,10 @@ class ReaperMonitor(Monitor):
     REGISTRY = []
 
     def __init__(self, *args, **kwargs):
-        self.SERVICE_NAME = "Reaper for %s.%s" % (
-            self.MODEL_CLASS.__name__,
-            self.TIMESTAMP_FIELD
-        )
+        self.SERVICE_NAME = "Reaper for %s" % self.MODEL_CLASS.__name__
+        if self.TIMESTAMP_FIELD is not None:
+            self.SERVICE_NAME += ".%s" % self.TIMESTAMP_FIELD
+
         super(ReaperMonitor, self).__init__(*args, **kwargs)
 
     @property
@@ -899,6 +902,30 @@ class CollectionReaper(ReaperMonitor):
         """
         collection.delete()
 ReaperMonitor.REGISTRY.append(CollectionReaper)
+
+
+class MeasurementReaper(ReaperMonitor):
+    """Remove measurements that are not the most recent"""
+    MODEL_CLASS = Measurement
+    MEASUREMENT_REAPER_ENABLED = 'MeasurementReaper.enabled'
+
+    def run(self):
+        enabled = ConfigurationSetting.sitewide(self._db, Configuration.MEASUREMENT_REAPER).bool_value
+        if enabled is not None and not enabled:
+            self.log.info("{} skipped because it is disabled in configuration.".format(self.service_name))
+            return
+        return super(ReaperMonitor, self).run()
+
+    @property
+    def where_clause(self):
+        return Measurement.is_most_recent == False
+
+    def run_once(self, *args, **kwargs):
+        rows_deleted = self.query().delete()
+        self._db.commit()
+        return TimestampData(achievements=u"Items deleted: %d" % rows_deleted)
+
+ReaperMonitor.REGISTRY.append(MeasurementReaper)
 
 
 class ScrubberMonitor(ReaperMonitor):

--- a/monitor.py
+++ b/monitor.py
@@ -907,7 +907,6 @@ ReaperMonitor.REGISTRY.append(CollectionReaper)
 class MeasurementReaper(ReaperMonitor):
     """Remove measurements that are not the most recent"""
     MODEL_CLASS = Measurement
-    MEASUREMENT_REAPER_ENABLED = 'MeasurementReaper.enabled'
 
     def run(self):
         enabled = ConfigurationSetting.sitewide(self._db, Configuration.MEASUREMENT_REAPER).bool_value


### PR DESCRIPTION
## Description

This adds a new database reaper to reap the measurements table. This reaper is enabled by default, but can be disabled with a configuration setting. 

## Motivation and Context

On some of the LYRASIS servers the measurements table is taking up 100s of GB of space. After running this reaper and letting the database vacuum complete, these tables are taking up only 100mb. 

The large measurements table is slowing down our instances and putting unnecessary stress on our database server. It seems likely there are other issues that is the root, causing so many measurements to be recorded. These will be addressed separately, but this will clean up old unused measurements. 

Speaking to @leonardr he would like to keep old measurements for future analysis purposes, so I've added a configuration setting to disable this reaper. The reaper is enabled by default however, as I think most people will want to clean up old measurements. 




