### PR TITLE
Make it possible to search for books that are in _some_ series without caring about _which_ series

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -2443,8 +2443,12 @@ class Filter(SearchBase):
 
         if self.series:
             if self.series is True:
-                # The book must belong to _some_ series
+                # The book must belong to _some_ series.
+                #
+                # That is, series must exist (have a non-null value) and
+                # have a value other than the empty string.
                 f = chain(f, Exists(field="series"))
+                f = chain(f, Bool(must_not=[Term(**{"series.keyword": ""})]))
             else:
                 f = chain(f, Term(**{"series.keyword": self.series}))
 

--- a/external_search.py
+++ b/external_search.py
@@ -2232,6 +2232,7 @@ class Filter(SearchBase):
         copies will be excluded from results.
 
         :param series: If this is set to a string, only books in a matching
+        series will be included. If set to True, books that belong to _any_
         series will be included.
 
         :param author: If this is set to a Contributor or
@@ -2441,7 +2442,11 @@ class Filter(SearchBase):
             f = chain(f, Term(fiction=value))
 
         if self.series:
-            f = chain(f, Term(**{"series.keyword": self.series}))
+            if self.series is True:
+                # The book must belong to _some_ series
+                f = chain(f, Exists(field="series"))
+            else:
+                f = chain(f, Term(**{"series.keyword": self.series}))
 
         if self.audiences:
             f = chain(f, Terms(audience=scrub_list(self.audiences)))

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -497,6 +497,7 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
         self.ya_romance.presentation_edition.subtitle = (
             "Modern Fairytale Series, Volume 7"
         )
+        self.ya_romance.presentation_edition.series = "Modern Fairytales"
 
         self.no_age = _work()
         self.no_age.summary_text = "President Barack Obama's election in 2008 energized the United States"
@@ -705,7 +706,7 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
         expect(self.moby_dick, "moby", classics)
 
         # This finds books that belong to _some_ series.
-        expect(self.moby_dick, "", Filter(series=True))
+        expect([self.moby_dick, self.ya_romance], "", Filter(series=True))
 
         # Find results based on genre.
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -710,7 +710,9 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
         expect(self.moby_dick, "moby", classics)
 
         # This finds books that belong to _some_ series.
-        expect([self.moby_dick, self.ya_romance], "", Filter(series=True))
+        some_series = Filter(series=True)
+        expect([self.moby_dick, self.ya_romance], "", some_series,
+               ordered=False)
 
         # Find results based on genre.
 

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -502,6 +502,10 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
         self.no_age = _work()
         self.no_age.summary_text = "President Barack Obama's election in 2008 energized the United States"
 
+        # Set the series to the empty string rather than None -- this isn't counted
+        # as the book belonging to a series.
+        self.no_age.presentation_edition.series = ""
+
         self.age_4_5 = _work()
         self.age_4_5.target_age = NumericRange(4, 5, '[]')
         self.age_4_5.summary_text = "President Barack Obama's election in 2008 energized the United States"
@@ -3712,11 +3716,16 @@ class TestFilter(DatabaseTest):
         # matter.
         f = Filter(series=True)
         built, nested = f.build()
+
         eq_({}, nested)
+        # The book must have an indexed series.
         eq_(
             built.to_dict()['bool']['must'],
             [{'exists': {'field': 'series'}}]
         )
+
+        # But the 'series' that got indexed must not be the empty string.
+        assert {'term': {'series.keyword': ''}} in built.to_dict()['bool']['must_not']
 
     def test_sort_order(self):
         # Test the Filter.sort_order property.


### PR DESCRIPTION
This is a support branch for https://jira.nypl.org/browse/SIMPLY-3235. It makes it possible to create a `Filter` object that matches only books that are in _some_ series. The series can be anything, but the 'series' field must have been indexed and must be a non-empty string.

I did not implement the opposite feature -- using `series=False` to find books that _don't_ belong to a series -- because there's no current use case for it and implementing new Elasticsearch filtering features is always a pain, both to do at first and to maintain.