### PR TITLE
Fix OPDS importer to handle improved DPLA/Feedbooks OPDS 1.x+ODL feed

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1360,6 +1360,7 @@ class Metadata(MetaToModelUtility):
             data_source_last_updated=None,
             # Note: brought back to keep callers of bibliographic extraction process_one() methods simple.
             circulation=None,
+            **kwargs
     ):
         # data_source is where the data comes from (e.g. overdrive, metadata wrangler, admin interface),
         # and not necessarily where the associated Identifier's LicencePool's lending licenses are coming from.

--- a/model/collection.py
+++ b/model/collection.py
@@ -275,6 +275,16 @@ class Collection(Base, HasFullTableCache):
         for child in self.children:
             child.protocol = new_protocol
 
+    @hybrid_property
+    def primary_identifier_source(self):
+        """ Identify if should try to use another identifier than <id> """
+        return self.external_integration.primary_identifier_source
+
+    @primary_identifier_source.setter
+    def primary_identifier_source(self, new_primary_identifier_source):
+        """ Modify the primary identifier source in use by this Collection."""
+        self.external_integration.primary_identifier_source = new_primary_identifier_source
+
     # For collections that can control the duration of the loans they
     # create, the durations are stored in these settings and new loans are
     # expected to be created using these settings. For collections

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -269,7 +269,7 @@ class ExternalIntegration(Base, HasFullTableCache):
     CUSTOM_ACCEPT_HEADER = u"custom_accept_header"
 
     # If want to use an identifier different from <id>, use this config.
-    PRIMARY_IDENTIFIER_SOURCE = u"PRIMARY_IDENTIFIER_SOURCE"
+    PRIMARY_IDENTIFIER_SOURCE = u"primary_identifier_source"
     DCTERMS_IDENTIFIER = u"first_dcterms_identifier"
 
     _cache = HasFullTableCache.RESET

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -265,6 +265,13 @@ class ExternalIntegration(Base, HasFullTableCache):
     USERNAME = u"username"
     PASSWORD = u"password"
 
+    # If the request should use a custom headers, put it here.
+    CUSTOM_ACCEPT_HEADER = u"custom_accept_header"
+
+    # If want to use an identifier different from <id>, use this config.
+    CUSTOM_IDENTIFIER = u"custom_identifier"
+    DCTERMS_IDENTIFIER = u"first_dcterms_identifier"
+
     _cache = HasFullTableCache.RESET
     _id_cache = HasFullTableCache.RESET
 
@@ -487,6 +494,22 @@ class ExternalIntegration(Base, HasFullTableCache):
     @password.setter
     def password(self, new_password):
         return self.set_setting(self.PASSWORD, new_password)
+
+    @hybrid_property
+    def custom_accept_header(self):
+        return self.setting(self.CUSTOM_ACCEPT_HEADER).value
+
+    @custom_accept_header.setter
+    def custom_accept_header(self, new_custom_accept_header):
+        return self.set_setting(self.CUSTOM_ACCEPT_HEADER, new_custom_accept_header)
+
+    @hybrid_property
+    def custom_identifier(self):
+        return self.setting(self.CUSTOM_IDENTIFIER).value
+
+    @custom_identifier.setter
+    def custom_identifier(self, new_custom_identifier):
+        return self.set_setting(self.CUSTOM_IDENTIFIER, new_custom_identifier)
 
     def explain(self, library=None, include_secrets=False):
         """Create a series of human-readable strings to explain an

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -269,7 +269,7 @@ class ExternalIntegration(Base, HasFullTableCache):
     CUSTOM_ACCEPT_HEADER = u"custom_accept_header"
 
     # If want to use an identifier different from <id>, use this config.
-    CUSTOM_IDENTIFIER = u"custom_identifier"
+    PRIMARY_IDENTIFIER_SOURCE = u"PRIMARY_IDENTIFIER_SOURCE"
     DCTERMS_IDENTIFIER = u"first_dcterms_identifier"
 
     _cache = HasFullTableCache.RESET
@@ -504,12 +504,13 @@ class ExternalIntegration(Base, HasFullTableCache):
         return self.set_setting(self.CUSTOM_ACCEPT_HEADER, new_custom_accept_header)
 
     @hybrid_property
-    def custom_identifier(self):
-        return self.setting(self.CUSTOM_IDENTIFIER).value
+    def primary_identifier_source(self):
+        return self.setting(self.PRIMARY_IDENTIFIER_SOURCE).value
 
-    @custom_identifier.setter
-    def custom_identifier(self, new_custom_identifier):
-        return self.set_setting(self.CUSTOM_IDENTIFIER, new_custom_identifier)
+    @primary_identifier_source.setter
+    def primary_identifier_source(self, new_primary_identifier_source):
+        return self.set_setting(self.PRIMARY_IDENTIFIER_SOURCE,
+                                new_primary_identifier_source)
 
     def explain(self, library=None, include_secrets=False):
         """Create a series of human-readable strings to explain an

--- a/opds2_import.py
+++ b/opds2_import.py
@@ -823,7 +823,8 @@ class OPDS2Importer(OPDSImporter):
 
         return dates
 
-    def extract_feed_data(self, feed, feed_url=None, custom_identifier=None):
+    def extract_feed_data(self, feed, feed_url=None,
+                          primary_identifier_source=None):
         """Turn an OPDS 2.0 feed into lists of Metadata and CirculationData objects.
 
         :param feed: OPDS 2.0 feed

--- a/opds2_import.py
+++ b/opds2_import.py
@@ -823,8 +823,7 @@ class OPDS2Importer(OPDSImporter):
 
         return dates
 
-    def extract_feed_data(self, feed, feed_url=None,
-                          primary_identifier_source=None):
+    def extract_feed_data(self, feed, feed_url=None):
         """Turn an OPDS 2.0 feed into lists of Metadata and CirculationData objects.
 
         :param feed: OPDS 2.0 feed

--- a/opds2_import.py
+++ b/opds2_import.py
@@ -823,7 +823,7 @@ class OPDS2Importer(OPDSImporter):
 
         return dates
 
-    def extract_feed_data(self, feed, feed_url=None):
+    def extract_feed_data(self, feed, feed_url=None, custom_identifier=None):
         """Turn an OPDS 2.0 feed into lists of Metadata and CirculationData objects.
 
         :param feed: OPDS 2.0 feed

--- a/opds_import.py
+++ b/opds_import.py
@@ -981,9 +981,7 @@ class OPDSImporter(object):
                     new_identifiers = dcterms_ids[1:]
                     # Id must be in the identifiers with lower weight.
                     id_type, id_identifier = Identifier.type_and_identifier_for_urn(id)
-                    id_weight = (dcterms_ids[-1].weight-0.1
-                                            if dcterms_ids[-1].weight > 0.2
-                                            else 0.1)
+                    id_weight = 1
                     new_identifiers.append(IdentifierData(id_type, id_identifier, id_weight))
                     xml_data_dict['identifiers'] = new_identifiers
 

--- a/opds_import.py
+++ b/opds_import.py
@@ -577,7 +577,6 @@ class OPDSImporter(object):
                  identifier_mapping=None, http_get=None,
                  metadata_client=None, content_modifier=None,
                  map_from_collection=None, mirrors=None,
-                 primary_identifier_source=None
     ):
         """:param collection: LicensePools created by this OPDS import
         will be associated with the given Collection. If this is None,
@@ -607,10 +606,6 @@ class OPDSImporter(object):
         :param map_from_collection
 
         :param mirrors
-
-        :param primary_identifier_source: a string to define which identifier
-        must be the primary identifier. If there is no primary_identifier_source
-        <id> will be used.
         """
         self._db = _db
         self.log = logging.getLogger("OPDS Importer")
@@ -641,6 +636,7 @@ class OPDSImporter(object):
         # If not, then attempt to create one.
         covers_mirror = mirrors.get(ExternalIntegrationLink.COVERS, None) if mirrors else None
         books_mirror = mirrors.get(ExternalIntegrationLink.OPEN_ACCESS_BOOKS, None) if mirrors else None
+        self.primary_identifier_source = None
         if collection:
             if not covers_mirror:
                 # If this Collection is configured to mirror the assets it
@@ -653,6 +649,7 @@ class OPDSImporter(object):
                 books_mirror = MirrorUploader.for_collection(
                     collection, ExternalIntegrationLink.OPEN_ACCESS_BOOKS
                 )
+            self.primary_identifier_source = collection.primary_identifier_source
 
         self.mirrors = dict(covers_mirror=covers_mirror, books_mirror=books_mirror)
         self.content_modifier = content_modifier
@@ -662,7 +659,6 @@ class OPDSImporter(object):
         # gutenberg.org.
         self.http_get = http_get or Representation.cautious_http_get
         self.map_from_collection = map_from_collection
-        self.primary_identifier_source = primary_identifier_source
 
     @property
     def collection(self):
@@ -1856,7 +1852,6 @@ class OPDSImportMonitor(CollectionMonitor, HasSelfTests):
 
         self.importer = import_class(
             _db, collection=collection,
-            primary_identifier_source=collection.external_integration.primary_identifier_source,
             **import_class_kwargs
         )
         super(OPDSImportMonitor, self).__init__(_db, collection)

--- a/opds_import.py
+++ b/opds_import.py
@@ -536,7 +536,13 @@ class OPDSImporter(object):
             "key": ExternalIntegration.CUSTOM_ACCEPT_HEADER,
             "label": _("Custom accept header"),
             "required": False,
-            "description": _("Some servers expect an accept header to decide which file to send. You can use */* if the server doesn't expect anything. The default values if left blank is: 'application/atom+xml;profile=opds-catalog;kind=acquisition, application/atom+xml;q=0.9, application/xml;q=0.8, */*;q=0.1'"),
+            "description": _("Some servers expect an accept header to decide which file to send. You can use */* if the server doesn't expect anything."),
+            "default": ','.join([
+                OPDSFeed.ACQUISITION_FEED_TYPE,
+                "application/atom+xml;q=0.9",
+                "application/xml;q=0.8",
+                "*/*;q=0.1",
+            ])
         },
         {
             "key": ExternalIntegration.PRIMARY_IDENTIFIER_SOURCE,

--- a/tests/files/opds/feed_with_id_and_dcterms_identifier.opds
+++ b/tests/files/opds/feed_with_id_and_dcterms_identifier.opds
@@ -49,4 +49,25 @@
   <opds:price currencycode="USD">01.01</opds:price>
 </link>
 </entry>
+<entry schema:additionalType="http://schema.org/Ebook">
+<title>Book 3</title>
+<id>https://root.uri/3</id>
+<dcterms:identifier xsi:type="dcterms:URI">urn:ISBN:9781683351993</dcterms:identifier>
+<dcterms:identifier xsi:type="dcterms:URI">urn:ISBN:9781683351504</dcterms:identifier>
+<dcterms:identifier xsi:type="dcterms:URI">urn:ISBN:9780312939458</dcterms:identifier>
+<author>
+  <name>Author 3</name>
+  <uri>https://book.uri</uri>
+</author>
+<published>2020-01-010T01:00:00Z</published>
+<updated>2020-01-01T01:01:00Z</updated>
+<dcterms:language>en</dcterms:language>
+<dcterms:publisher>The Overlook Press</dcterms:publisher>
+<dcterms:issued>2019-02-18</dcterms:issued>
+<summary>Book 3 summary.</summary>
+<category label="Fiction" term="FBFIC000000" scheme="http://www.feedbooks.com/categories"/>
+<link type="text/html" rel="http://opds-spec.org/acquisition/buy" href="https://book.uri/buy">
+  <opds:price currencycode="USD">01.01</opds:price>
+</link>
+</entry>
 </feed>

--- a/tests/files/opds/feed_with_id_and_dcterms_identifier.opds
+++ b/tests/files/opds/feed_with_id_and_dcterms_identifier.opds
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:dcterms="http://purl.org/dc/terms/" xmlns:thr="http://purl.org/syndication/thread/1.0" xmlns:app="http://www.w3.org/2007/app" xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/" xmlns="http://www.w3.org/2005/Atom" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:lang="en" xmlns:odl="http://opds-spec.org/odl" xmlns:schema="http://schema.org/" xmlns:opf="http://www.idpf.org/2007/opf">
+  <id>https://root.url</id>
+  <title>Books</title>
+  <updated>2020-01-01T01:00:02Z</updated>
+  <icon>/favicon.ico</icon>
+  <author>
+    <name>Na,e</name>
+    <uri>https://root.uri</uri>
+    <email>a@a.a</email>
+  </author>
+  <link rel="self" type="application/atom+xml;profile=odl; charset=utf-8" href="https://root.url"/>
+<opensearch:totalResults>3</opensearch:totalResults>
+<opensearch:itemsPerPage>3</opensearch:itemsPerPage>
+<entry schema:additionalType="http://schema.org/Ebook">
+<title>Book 1</title>
+<id>https://root.uri/1</id>
+<author>
+  <name>Author 1</name>
+  <uri>https://book.uri</uri>
+</author>
+<published>2020-01-010T01:00:00Z</published>
+<updated>2020-01-01T01:01:00Z</updated>
+<dcterms:language>en</dcterms:language>
+<dcterms:publisher>The Overlook Press</dcterms:publisher>
+<dcterms:issued>2019-02-18</dcterms:issued>
+<summary>Book 1 summary.</summary>
+<category label="Fiction" term="FBFIC000000" scheme="http://www.feedbooks.com/categories"/>
+<link type="text/html" rel="http://opds-spec.org/acquisition/buy" href="https://book.uri/buy">
+  <opds:price currencycode="USD">01.01</opds:price>
+</link>
+</entry>
+<entry schema:additionalType="http://schema.org/Ebook">
+<title>Book 2</title>
+<id>https://root.uri/2</id>
+<dcterms:identifier xsi:type="dcterms:URI">urn:ISBN:9781468316438</dcterms:identifier>
+<author>
+  <name>Author 2</name>
+  <uri>https://book.uri</uri>
+</author>
+<published>2020-01-010T01:00:00Z</published>
+<updated>2020-01-01T01:01:00Z</updated>
+<dcterms:language>en</dcterms:language>
+<dcterms:publisher>The Overlook Press</dcterms:publisher>
+<dcterms:issued>2019-02-18</dcterms:issued>
+<summary>Book 2 summary.</summary>
+<category label="Fiction" term="FBFIC000000" scheme="http://www.feedbooks.com/categories"/>
+<link type="text/html" rel="http://opds-spec.org/acquisition/buy" href="https://book.uri/buy">
+  <opds:price currencycode="USD">01.01</opds:price>
+</link>
+</entry>
+</feed>

--- a/tests/models/test_configuration.py
+++ b/tests/models/test_configuration.py
@@ -580,6 +580,14 @@ username='someuser'""" % integration.id
         with_secrets = integration.explain(include_secrets=True)
         assert "password='somepass'" in with_secrets
 
+    def test_custom_accept_header(self):
+        integration = self._external_integration("protocol", "goal")
+        # Must be empty if not set
+        eq_(integration.custom_accept_header, None)
+
+        # Must be the same value if set
+        integration.custom_accept_header = "custom header"
+        eq_(integration.custom_accept_header, "custom header")
 
 SETTING1_KEY = 'setting1'
 SETTING1_LABEL = 'Setting 1\'s label'

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -535,7 +535,7 @@ class TestOPDSImporter(OPDSImporterTest):
         [failure] = failures.values()
         eq_(u"202: I'm working to locate a source for this identifier.", failure.exception)
 
-    def test_use_dcterm_identifier_as_id(self):
+    def test_use_dcterm_identifier_as_id_with_id_and_dcterms_identifier(self):
         data_source_name = "Data source name " + self._str
         importer = OPDSImporter(
             self._db, collection=None, data_source_name=data_source_name
@@ -546,11 +546,25 @@ class TestOPDSImporter(OPDSImporterTest):
         )
 
         # First book doesn't have <dcterms:identifier>, so <id> must be used as identifier
-        print(metadata)
         book_1 = metadata.get('https://root.uri/1')
         assert_not_equal(book_1, None)
         # Seconf book have <id> and <dcterms:identifier>, so <dcters:identifier> must be used as id
         book_2 = metadata.get('urn:isbn:9781468316438')
+        assert_not_equal(book_2, None)
+
+    def test_use_id_with_existing_dcterms_identifier(self):
+        data_source_name = "Data source name " + self._str
+        importer = OPDSImporter(
+            self._db, collection=None, data_source_name=data_source_name
+        )
+        metadata, failures = importer.extract_feed_data(
+            self.feed_with_id_and_dcterms_identifier,
+            custom_identifier=None
+        )
+
+        book_1 = metadata.get('https://root.uri/1')
+        assert_not_equal(book_1, None)
+        book_2 = metadata.get('https://root.uri/2')
         assert_not_equal(book_2, None)
 
     def test_extract_link(self):

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -549,9 +549,17 @@ class TestOPDSImporter(OPDSImporterTest):
         # First book doesn't have <dcterms:identifier>, so <id> must be used as identifier
         book_1 = metadata.get('https://root.uri/1')
         assert_not_equal(book_1, None)
-        # Seconf book have <id> and <dcterms:identifier>, so <dcters:identifier> must be used as id
+        # Second book have <id> and <dcterms:identifier>, so <dcters:identifier> must be used as id
         book_2 = metadata.get('urn:isbn:9781468316438')
         assert_not_equal(book_2, None)
+        # Verify if id was add in the end of identifier
+        book_2_identifiers = book_2.identifiers
+        found = False
+        for entry in book_2.identifiers:
+            if entry.identifier == 'https://root.uri/2':
+                found = True
+                break
+        eq_(found, True)
 
     def test_use_id_with_existing_dcterms_identifier(self):
         data_source_name = "Data source name " + self._str

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -542,10 +542,11 @@ class TestOPDSImporter(OPDSImporterTest):
         )
         metadata, failures = importer.extract_feed_data(
             self.feed_with_id_and_dcterms_identifier,
-            custom_identifier=ExternalIntegration.DCTERMS_IDENTIFIER
+            primary_identifier_source=ExternalIntegration.DCTERMS_IDENTIFIER
         )
 
         # First book doesn't have <dcterms:identifier>, so <id> must be used as identifier
+        print(metadata)
         book_1 = metadata.get('https://root.uri/1')
         assert_not_equal(book_1, None)
         # Seconf book have <id> and <dcterms:identifier>, so <dcters:identifier> must be used as id
@@ -559,7 +560,7 @@ class TestOPDSImporter(OPDSImporterTest):
         )
         metadata, failures = importer.extract_feed_data(
             self.feed_with_id_and_dcterms_identifier,
-            custom_identifier=None
+            primary_identifier_source=None
         )
 
         book_1 = metadata.get('https://root.uri/1')

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -547,7 +547,6 @@ class TestOPDSImporter(OPDSImporterTest):
         )
 
         # First book doesn't have <dcterms:identifier>, so <id> must be used as identifier
-        print(metadata)
         book_1 = metadata.get('https://root.uri/1')
         assert_not_equal(book_1, None)
         # Seconf book have <id> and <dcterms:identifier>, so <dcters:identifier> must be used as id

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -573,13 +573,8 @@ class TestOPDSImporter(OPDSImporterTest):
             '9781683351504',
             '9780312939458',
         ]
-        for target_identifier in expected_identifier:
-            found = False
-            for entry in book_3.identifiers:
-                if entry.identifier == target_identifier:
-                    found = True
-                    break
-            ok_(found, "Cannot find %s" % target_identifier)
+        result_identifier = [entry.identifier for entry in book_3.identifiers]
+        eq_(set(expected_identifier), set(result_identifier))
 
     def test_use_id_with_existing_dcterms_identifier(self):
         data_source_name = "Data source name " + self._str

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -597,6 +597,8 @@ class TestOPDSImporter(OPDSImporterTest):
         assert_not_equal(book_1, None)
         book_2 = metadata.get('https://root.uri/2')
         assert_not_equal(book_2, None)
+        book_3 = metadata.get('https://root.uri/3')
+        assert_not_equal(book_3, None)
 
     def test_extract_link(self):
         no_rel = AtomFeed.E.link(href="http://foo/")

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -538,11 +538,12 @@ class TestOPDSImporter(OPDSImporterTest):
     def test_use_dcterm_identifier_as_id_with_id_and_dcterms_identifier(self):
         data_source_name = "Data source name " + self._str
         importer = OPDSImporter(
-            self._db, collection=None, data_source_name=data_source_name
-        )
-        metadata, failures = importer.extract_feed_data(
-            self.feed_with_id_and_dcterms_identifier,
+            self._db, collection=None, data_source_name=data_source_name,
             primary_identifier_source=ExternalIntegration.DCTERMS_IDENTIFIER
+        )
+
+        metadata, failures = importer.extract_feed_data(
+            self.feed_with_id_and_dcterms_identifier
         )
 
         # First book doesn't have <dcterms:identifier>, so <id> must be used as identifier
@@ -556,11 +557,12 @@ class TestOPDSImporter(OPDSImporterTest):
     def test_use_id_with_existing_dcterms_identifier(self):
         data_source_name = "Data source name " + self._str
         importer = OPDSImporter(
-            self._db, collection=None, data_source_name=data_source_name
-        )
-        metadata, failures = importer.extract_feed_data(
-            self.feed_with_id_and_dcterms_identifier,
+            self._db, collection=None, data_source_name=data_source_name,
             primary_identifier_source=None
+        )
+
+        metadata, failures = importer.extract_feed_data(
+            self.feed_with_id_and_dcterms_identifier
         )
 
         book_1 = metadata.get('https://root.uri/1')


### PR DESCRIPTION
## Description

This PR add:
* the possibility of use the \<dcterm:identifier\> instead of \<id\>
* use custom accept header instead of the system default

## Motivation and Context

[SIMPLY-3392](https://jira.nypl.org/browse/SIMPLY-3392)

## How Has This Been Tested?

* New unit tests were add.
* Was used the real Feedbook XML URL for tests: https://market.feedbooks.com/api/libraries/harvest.atom
* To run the database, elasticsearch and minio were used in a docker-compose environment. The complete env can be found [here](https://github.com/arielmorelli/dev_env_for_circulation/tree/master)

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
