### PR TITLE
Modify OverdriveAPI.make_link_safe to also replace "v1" links with "v2" links when appropriate

### DIFF
--- a/overdrive.py
+++ b/overdrive.py
@@ -533,8 +533,9 @@ class OverdriveAPI(object):
         """
         parts = list(urlparse.urlsplit(url))
         parts[2] = urllib.quote(parts[2])
+        endings = ("/availability", "/availability/")
         if (parts[2].startswith("/v1/collections/")
-            and parts[2].endswith("/availability")):
+            and any(parts[2].endswith(x) for x in endings)):
             parts[2] = parts[2].replace(
                 "/v1/collections/", "/v2/collections/", 1
             )

--- a/overdrive.py
+++ b/overdrive.py
@@ -525,11 +525,19 @@ class OverdriveAPI(object):
     def make_link_safe(self, url):
         """Turn a server-provided link into a link the server will accept!
 
-        This is completely obnoxious and I have complained about it to
+        The {} part is completely obnoxious and I have complained about it to
         Overdrive.
+
+        The availability part is to make sure we always use v2 of the
+        availability API, even if Overdrive sent us a link to v1.
         """
         parts = list(urlparse.urlsplit(url))
         parts[2] = urllib.quote(parts[2])
+        if (parts[2].startswith("/v1/collections/")
+            and parts[2].endswith("/availability")):
+            parts[2] = parts[2].replace(
+                "/v1/collections/", "/v2/collections/", 1
+            )
         query_string = parts[3]
         query_string = query_string.replace("+", "%2B")
         query_string = query_string.replace(":", "%3A")
@@ -861,7 +869,6 @@ class OverdriveRepresentationExtractor(object):
         primary_identifier = IdentifierData(
             Identifier.OVERDRIVE_ID, overdrive_id
         )
-
         # TODO: We might be able to use this information to avoid the
         # need for explicit configuration of Advantage collections, or
         # at least to keep Advantage collections more up-to-date than

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -110,8 +110,19 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         eq_("default", self.api.ils_name(l2))
 
     def test_make_link_safe(self):
+        # Unsafe characters are escaped.
         eq_("http://foo.com?q=%2B%3A%7B%7D",
             OverdriveAPI.make_link_safe("http://foo.com?q=+:{}"))
+
+        # Links to version 1 of the availability API are converted
+        # to links to version 2.
+        v1 = "https://qa.api.overdrive.com/v1/collections/abcde/products/12345/availability"
+        v2 = "https://qa.api.overdrive.com/v2/collections/abcde/products/12345/availability"
+        eq_(v2, OverdriveAPI.make_link_safe(v1))
+
+        # Links to other endpoints are not converted
+        leave_alone = "https://qa.api.overdrive.com/v1/collections/abcde/products/12345"
+        eq_(leave_alone, OverdriveAPI.make_link_safe(leave_alone))
 
     def test_hosts(self):
         c = OverdriveAPI

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -120,6 +120,12 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         v2 = "https://qa.api.overdrive.com/v2/collections/abcde/products/12345/availability"
         eq_(v2, OverdriveAPI.make_link_safe(v1))
 
+        # We also handle the case of a trailing slash, just in case Overdrive
+        # starts serving links with trailing slashes.
+        v1 = v1 + "/"
+        v2 = v2 + "/"
+        eq_(v2, OverdriveAPI.make_link_safe(v1))
+
         # Links to other endpoints are not converted
         leave_alone = "https://qa.api.overdrive.com/v1/collections/abcde/products/12345"
         eq_(leave_alone, OverdriveAPI.make_link_safe(leave_alone))


### PR DESCRIPTION
This branch adapts an existing method designed for "fixing" links we get from Overdrive to handle a new case: a case where Overdrive gives us a link to v1 of the availability API, and we need v2. Continuing to use the v1 link causes https://jira.nypl.org/browse/SIMPLY-3370.

[The corresponding circulation branch](https://github.com/NYPL-Simplified/circulation/pull/1540) calls  `make_link_safe` on the actual link that turns out to be a v1 link.