### PR TITLE
Circulation Manager ignores patron authentication state when requesting an OPDS feed's alternate link referencing Complete Catalog Entry Resource

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -1010,7 +1010,7 @@ class AcquisitionFeed(OPDSFeed):
 
     @classmethod
     def single_entry(
-            cls, _db, work, annotator, force_create=False, raw=False, **response_kwargs
+            cls, _db, work, annotator, force_create=False, raw=False, use_cache=True, **response_kwargs
     ):
         """Create a single-entry OPDS document for one specific work.
 
@@ -1022,6 +1022,7 @@ class AcquisitionFeed(OPDSFeed):
         :param raw: If this is False (the default), a Flask Response will be returned,
             ready to be sent over the network. Otherwise an object representing
             the underlying OPDS entry will be returned.
+        :param use_cache: Boolean value determining whether the OPDS cache shall be used.
         :param response_kwargs: These keyword arguments will be passed into the Response
             constructor, if it is invoked.
         :return: A Response, if `raw` is false. Otherwise, an OPDSMessage
@@ -1033,7 +1034,7 @@ class AcquisitionFeed(OPDSFeed):
         if not isinstance(work, Edition) and not work.presentation_edition:
             return None
         entry = feed.create_entry(work, even_if_no_license_pool=True,
-                                  force_create=force_create)
+                                  force_create=force_create, use_cache=use_cache)
 
         # Since this <entry> tag is going to be the root of an XML
         # document it's essential that it include an up-to-date nsmap,


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR drops the OPDS cache usage for permalinks returning catalog entries. Depending on the authentication status of the patron it can add to the catalog entry fulfilment links, revocation links, etc.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[SIMPLY-3354](https://jira.nypl.org/browse/SIMPLY-3354)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
