### PR TITLE
Complete OPDS catalog entries must contain self links

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -63,6 +63,19 @@ class Annotator(object):
 
     opds_cache_field = Work.simple_opds_entry.name
 
+    def is_work_entry_solo(self, work):
+        """Return a boolean value indicating whether the work's OPDS catalog entry is served by itself,
+            rather than as a part of the feed.
+
+        :param work: Work object
+        :type work: core.model.work.Work
+
+        :return: Boolean value indicating whether the work's OPDS catalog entry is served by itself,
+            rather than as a part of the feed
+        :rtype: bool
+        """
+        return False
+
     def annotate_work_entry(self, work, active_license_pool, edition,
                             identifier, feed, entry, updated=None):
         """Make any custom modifications necessary to integrate this
@@ -103,6 +116,12 @@ class Annotator(object):
                 entry, rel='alternate', href=permalink_uri,
                 type=permalink_type
             )
+
+            if self.is_work_entry_solo(work):
+                OPDSFeed.add_link_to_entry(
+                    entry, rel='self', href=permalink_uri,
+                    type=permalink_type
+                )
 
         if active_license_pool:
             data_source = active_license_pool.data_source.name


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds an ability to override `rel` of `application/atom+xml;type=entry;profile=opds-catalog` links: depending on whether the OPDS entry is complete or incomplete `rel` will be set to `self` or `alternate` accordingly.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[SIMPLY-3355](https://jira.nypl.org/browse/SIMPLY-3355)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
