### PR TITLE
When finding books that are not currently available, make sure that they are currently licensed.

### DIFF
--- a/external_search.py
+++ b/external_search.py
@@ -2488,9 +2488,10 @@ class Filter(SearchBase):
         elif self.availability==FacetConstants.AVAILABLE_NOT_NOW:
             # Only books that are _not_ currently available should be displayed.
             not_open_access = Term(**{'licensepools.open_access' : False})
+            licensed = Term(**{'licensepools.licensed' : True})
             not_available = Term(**{'licensepools.available' : False})
             nested_filters['licensepools'].append(
-                Bool(must=[not_open_access, not_available])
+                Bool(must=[not_open_access, licensed, not_available])
             )
 
         if self.subcollection==FacetConstants.COLLECTION_FEATURED:

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -2395,14 +2395,15 @@ class TestQuery(DatabaseTest):
         eq_('nested', available_now['name_or_query'])
         eq_('licensepools', available_now['path'])
 
-        # It finds only license pools that are *not* open access *and* have
-        # no active licenses.
+        # It finds only license pools that are licensed, but not
+        # currently available or open access.
         nested_filter = not_available_now['query']
         not_available = {'term': {'licensepools.available': False}}
+        licensed = {'term': {'licensepools.licensed': True}}
         not_open_access = {'term': {'licensepools.open_access': False}}
         eq_(
             nested_filter.to_dict(),
-            {'bool': {'filter': [{'bool': {'must': [not_open_access, not_available]}}]}}
+            {'bool': {'filter': [{'bool': {'must': [not_open_access, licensed, not_available]}}]}}
         )
 
         # If the Filter specifies script fields, those fields are


### PR DESCRIPTION
This branch fixes a bug I found while doing QA on https://jira.nypl.org/browse/SIMPLY-3236.

A book for which the library owns no licenses will be indexed in Elasticsearch as available=false, which is what we were using to find books that are "not currently available". But a book like that isn't available _at all_ and it won't ever show up in an OPDS feed.

To find books that are not _currently_ available we need to check both available=false and licensed=true.