### PR TITLE
Set a default value for licensepools.self_hosted

### DIFF
--- a/lane.py
+++ b/lane.py
@@ -675,7 +675,7 @@ class Facets(FacetsWithEntryPoint):
         available_now = or_(
             LicensePool.open_access == True,
             LicensePool.self_hosted == True,
-            LicensePool.unlimited_access == True,
+            LicensePool.unlimited_access,
             LicensePool.licenses_available > 0
         )
 
@@ -693,7 +693,11 @@ class Facets(FacetsWithEntryPoint):
             # depending on what exactly the wording is.
             availability_clause = LicensePool.open_access == True
         elif self.availability == self.AVAILABLE_NOT_NOW:
-            availability_clause = not_(available_now)
+            # The book must be licensed but currently unavailable.
+            availability_clause = and_(
+                not_(available_now),
+                LicensePool.licenses_owned > 0
+            )
 
         qu = qu.filter(availability_clause)
 

--- a/migration/20200702-add-licensepool-self_hosted-field.sql
+++ b/migration/20200702-add-licensepool-self_hosted-field.sql
@@ -2,7 +2,7 @@ DO $$
  BEGIN
   -- Add the 'self_hosted' column
   BEGIN
-   ALTER TABLE licensepools ADD COLUMN self_hosted BOOLEAN;
+   ALTER TABLE licensepools ADD COLUMN self_hosted BOOLEAN DEFAULT false;
   EXCEPTION
    WHEN duplicate_column THEN RAISE NOTICE 'column licensepools.self_hosted already exists, not creating it.';
   END;

--- a/migration/20210121-self-hosted-is-required.sql
+++ b/migration/20210121-self-hosted-is-required.sql
@@ -1,0 +1,7 @@
+-- The licensepools.self_hosted field has a default value, but the migration
+-- script that added it to old servers didn't set one. Now old servers have
+-- an invalid 'null' value in that field.
+--
+-- (see also 20200702-add-licensepool-self_hosted-field.sql)
+ALTER TABLE licensepools ALTER COLUMN self_hosted SET DEFAULT false;
+UPDATE licensepools SET self_hosted = false WHERE self_hosted is null;

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -178,7 +178,7 @@ class LicensePool(Base):
     patrons_in_hold_queue = Column(Integer,default=0)
 
     # Set to True for collections imported using MirrorUploaded
-    self_hosted = Column(Boolean, index=True, default=False)
+    self_hosted = Column(Boolean, index=True, nullable=False, default=False)
 
     # This lets us cache the work of figuring out the best open access
     # link for this LicensePool.


### PR DESCRIPTION
This branch fixes SIMPLY-3470. I also added unit test coverage for Facets.modify_database_query since we've had a number of problems with its precise semantics.