### PR TITLE
Pin urllib3 to a pre-1.25 version to work around an Axis 360 ACS problem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,8 @@ singledispatch==3.4.0.3
 six==1.15.0
 SQLAlchemy==1.3.19
 textblob==0.15.3
-urllib3==1.25.10
+# urllib3 is pinned to a pre-1.25 version to work around https://jira.nypl.org/browse/SIMPLY-3477
+urllib3==1.24.3
 uWSGI==2.0.19.1
 # watchtower is for Cloudwatch logging integration
 watchtower==0.8.0


### PR DESCRIPTION
## Description

This branch pins urllib3 to the final 1.24 version as a way of avoiding https://jira.nypl.org/browse/SIMPLY-3477.

This is a temporary measure until either Axis 360 changes their ACS setup or we figure out a better long-term solution.

## How Has This Been Tested?

Axis 360 fulfillment starts succeeding once urllib3 is downgraded to a 1.24 version.