### PR TITLE
Stop duplicate ConfigurationSetting objects from getting into the database

### DIFF
--- a/migration/20210201-unique-configurationsetting.sql
+++ b/migration/20210201-unique-configurationsetting.sql
@@ -1,0 +1,39 @@
+-- Delete all duplicate credentials before creating unique indexes.
+delete from configurationsettings where id in (select c1.id from configurationsettings c1 join configurationsettings c2 on (c1.external_integration_id = c2.external_integration_id or c1.external_integration_id is null and c2.external_integration_id is null) and (c1.library_id=c2.library_id or c1.library_id is null and c2.library_id is null) and c1.key=c2.key and c1.id < c2.id);
+
+DO $$ 
+ BEGIN
+  -- Drop the ix_configurationsettings key and create a better version
+  -- of it immediately afterwards.
+  DROP INDEX IF EXISTS ix_configurationsettings_key;
+
+  -- If both external_integration_id and library_id are null,
+  -- then the key--the name of a sitewide setting--must be unique.
+  CREATE UNIQUE INDEX ix_configurationsettings_key on configurationsettings (key) where external_integration_id is null and library_id is null;
+
+  -- If external_integration_id is null but library_id is not,
+  -- then (library_id, key) must be unique.
+  BEGIN
+    CREATE UNIQUE INDEX ix_configurationsettings_library_id_key on configurationsettings (library_id, key) where external_integration_id is null;
+  EXCEPTION
+   WHEN duplicate_table THEN RAISE NOTICE 'Index ix_configurationsettings_library_id_key already exists, leaving it alone.';
+  END;
+
+  -- If library_id is null but external_integration_id is not,
+  -- then (external_integration_id, key) must be unique.
+  BEGIN
+    CREATE UNIQUE INDEX ix_configurationsettings_external_integration_id_key on configurationsettings (external_integration_id, key) where library_id is null;
+  EXCEPTION
+   WHEN duplicate_table THEN RAISE NOTICE 'Index ix_configurationsettings_external_integration_id_key already exists, leaving it alone.';
+  END;
+
+  -- If both external_integration_id and library_id have values, then
+  -- (external_integration_id, library_id, key) must be unique.
+  BEGIN
+   CREATE UNIQUE INDEX ix_configurationsettings_external_integration_id_library_id_key on configurationsettings (external_integration_id, library_id, key);
+  EXCEPTION
+   WHEN duplicate_table THEN RAISE NOTICE 'Index ix_configurationsettings_external_integration_id_library_id_key already exists, leaving it alone.';
+  END;
+
+ END;
+$$;

--- a/migration/20210201-unique-configurationsetting.sql
+++ b/migration/20210201-unique-configurationsetting.sql
@@ -1,4 +1,9 @@
--- Delete all duplicate credentials before creating unique indexes.
+-- If there are duplicate values for a single configuration setting,
+-- and one of the values is not null, delete the ones that are null.
+delete from configurationsettings where id in (select c1.id from configurationsettings c1 join configurationsettings c2 on (c1.external_integration_id = c2.external_integration_id or c1.external_integration_id is null and c2.external_integration_id is null) and (c1.library_id=c2.library_id or c1.library_id is null and c2.library_id is null) and c1.key=c2.key and c1.value is null and c2.value is not null);
+
+-- If there are still duplicate values for the a given configuration
+-- setting, delete all but the one with the latest ID.
 delete from configurationsettings where id in (select c1.id from configurationsettings c1 join configurationsettings c2 on (c1.external_integration_id = c2.external_integration_id or c1.external_integration_id is null and c2.external_integration_id is null) and (c1.library_id=c2.library_id or c1.library_id is null and c2.library_id is null) and c1.key=c2.key and c1.id < c2.id);
 
 DO $$ 

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -11,6 +11,7 @@ from flask_babel import lazy_gettext as _
 from sqlalchemy import (
     Column,
     ForeignKey,
+    Index,
     Integer,
     Unicode,
     UniqueConstraint,
@@ -18,6 +19,7 @@ from sqlalchemy import (
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
+from sqlalchemy.sql.expression import and_
 
 from constants import DataSourceConstants
 from hasfulltablecache import HasFullTableCache
@@ -575,11 +577,50 @@ class ConfigurationSetting(Base, HasFullTableCache):
     library_id = Column(
         Integer, ForeignKey('libraries.id'), index=True
     )
-    key = Column(Unicode, index=True)
+    key = Column(Unicode)
     _value = Column(Unicode, name="value")
 
     __table_args__ = (
-        UniqueConstraint('external_integration_id', 'library_id', 'key'),
+        # Unique indexes to prevent the creation of redundant
+        # configuration settings.
+
+        # If both external_integration_id and library_id are null,
+        # then the key--the name of a sitewide setting--must be unique.
+        Index(
+            "ix_configurationsettings_key",
+            key,
+            unique=True,
+            postgresql_where=and_(
+                external_integration_id==None, library_id==None
+            )
+        ),
+
+        # If external_integration_id is null but library_id is not,
+        # then (library_id, key) must be unique.
+        Index(
+            "ix_configurationsettings_library_id_key",
+            library_id, key,
+            unique=True,
+            postgresql_where=(external_integration_id==None)
+        ),
+
+        # If library_id is null but external_integration_id is not,
+        # then (external_integration_id, key) must be unique.
+        Index(
+            "ix_configurationsettings_external_integration_id_key",
+            external_integration_id, key,
+            unique=True,
+            postgresql_where=library_id==None
+        ),
+
+        # If both external_integration_id and library_id have values,
+        # then (external_integration_id, library_id, key) must be
+        # unique.
+        Index(
+            "ix_configurationsettings_external_integration_id_library_id_key",
+            external_integration_id, library_id, key,
+            unique=True,
+        ),
     )
 
     _cache = HasFullTableCache.RESET

--- a/tests/models/test_configuration.py
+++ b/tests/models/test_configuration.py
@@ -296,14 +296,6 @@ nonsecret_setting='2'"""
 
 class TestUniquenessConstraints(DatabaseTest):
 
-    def setup(self):
-        super(TestUniquenessConstraints, self).setup()
-        self.data_source = DataSource.lookup(self._db, DataSource.OVERDRIVE)
-        self.type = 'a credential type'
-        self.patron = self._patron()
-        self.col1 = self._default_collection
-        self.col2 = self._collection()
-
     def test_duplicate_sitewide_setting(self):
         # You can't create two sitewide settings with the same key.
         c1 = ConfigurationSetting(key="key", value="value1")


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-2771 by adding more uniqueness constraints to the `configurationsettings` table.

I've run the unit tests against an old database migrated using the migration script, and a brand-new database. I've also run the migration script on an already migrated database, and it didn't result in a change to the database.