### PR TITLE
Make the OPDS importer update acquisition links

### DIFF
--- a/model/licensing.py
+++ b/model/licensing.py
@@ -1125,7 +1125,7 @@ class LicensePool(Base):
         if not self.identifier:
             return
         q = Identifier.resources_for_identifier_ids(
-            _db, [self.identifier.id], open_access
+            _db, [self.identifier.id], open_access, data_source=self.data_source
         )
         for resource in q:
             yield resource
@@ -1222,7 +1222,13 @@ class LicensePool(Base):
             self.data_source, self.identifier, *args, **kwargs
         )
 
+    def reset_open_access_download_url(self):
+        """Reset this license pool's open-access download url."""
+        self._open_access_download_url = None
+
+
 Index("ix_licensepools_data_source_id_identifier_id_collection_id", LicensePool.collection_id, LicensePool.data_source_id, LicensePool.identifier_id, unique=True)
+
 
 class LicensePoolDeliveryMechanism(Base):
     """A mechanism for delivering a specific book from a specific

--- a/opds_import.py
+++ b/opds_import.py
@@ -829,6 +829,7 @@ class OPDSImporter(object):
         policy = ReplacementPolicy(
             subjects=True,
             links=True,
+            formats=True,
             contributions=True,
             rights=True,
             link_content=True,

--- a/tests/files/opds/content_server_mini_with_different_links.opds
+++ b/tests/files/opds/content_server_mini_with_different_links.opds
@@ -1,0 +1,64 @@
+<feed xmlns:simplified="http://librarysimplified.org/terms/" xmlns:app="http://www.w3.org/2007/app" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom" xmlns:bibframe="http://bibframe.org/vocab/">
+  <id>http://localhost:5000/</id>
+  <title>Open-Access Content</title>
+  <updated>2015-01-02T16:56:40Z</updated>
+  <link href="http://localhost:5000/"/>
+  <link href="http://localhost:5000/" rel="self"/>
+  <entry schema:additionalType="http://schema.org/PublicationIssue">
+    <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441</id>
+    <bibframe:distribution bibframe:ProviderName="Gutenberg"/>
+    <title>The Green Mouse</title>
+    <schema:alternativeHeadline>A Tale of Mousy Terror</schema:alternativeHeadline>
+    <author>
+      <name></name>
+      <simplified:sort_name>Chambers, Robert W. (Robert William)</simplified:sort_name>
+    </author>
+    <summary>This is a summary!</summary>
+    <updated>2015-01-02T16:56:40Z</updated>
+    <published>2014-01-02T16:56:40Z</published>
+    <simplified:pwid>6db4cf90-0129-0eaf-410a-502b20a45e67</simplified:pwid>
+    <schema:Rating schema:ratingValue="0.3333" schema:additionalType="http://librarysimplified.org/terms/rel/quality"/>
+    <schema:Rating schema:ratingValue="0.6000"/>
+    <schema:Rating schema:ratingValue="0.2500" schema:additionalType="http://librarysimplified.org/terms/rel/popularity"/>
+    <link href="/cover1.png" rel="http://opds-spec.org/image"/>
+    <link href="/thumbnail1.png" rel="http://opds-spec.org/image/thumbnail"/>
+    <category term="sh2008100298" label="Courtship -- Fiction" scheme="http://purl.org/dc/terms/LCSH"/>
+    <category term="sh2008108377" label="New York (N.Y.) -- Fiction" scheme="http://purl.org/dc/terms/LCSH"/>
+    <category term="sh85047114" label="Fantasy fiction" scheme="http://purl.org/dc/terms/LCSH"/>
+    <category term="sh2008107174" label="Magic -- Fiction" scheme="http://purl.org/dc/terms/LCSH"/>
+    <category term="PZ" label="Juvenile Fiction" scheme="http://purl.org/dc/terms/LCC"/>
+    <category term="Children" label="Children" scheme="http://schema.org/audience"/>
+    <category term="7" label="7" schema:ratingValue="100" scheme="http://schema.org/typicalAgeRange"/>
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Project Gutenberg</dcterms:publisher>
+    <link href="/book1.epub" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
+  </entry>
+
+  <entry schema:additionalType="http://schema.org/EBook">
+    <id>urn:librarysimplified.org/terms/id/Gutenberg%20ID/10557</id>
+    <title>Johnny Crow's Party</title>
+    <author>
+      <name></name>
+      <simplified:sort_name>Brooke, L. Leslie (Leonard Leslie)</simplified:sort_name>
+    </author>
+    <summary></summary>
+    <updated>2015-01-02T16:56:40Z</updated>
+    <published>2014-01-02T16:56:40Z</published>
+    <simplified:pwid>9acabf17-cea8-c7dd-8440-f12dfa75caa9</simplified:pwid>
+    <link href="cover2.png" rel="http://opds-spec.org/image"/>
+    <category term="Animals -- Juvenile poetry" scheme="http://purl.org/dc/terms/LCSH"/>
+    <category term="Nursery rhymes" scheme="http://purl.org/dc/terms/LCSH"/>
+    <category term="PZ" label="Juvenile Fiction" scheme="http://purl.org/dc/terms/LCC"/>
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Project Gutenberg</dcterms:publisher>
+    <link href="/book2.epub" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
+  </entry>
+
+  <simplified:message>
+   <id>http://www.gutenberg.org/ebooks/1984</id>
+   <simplified:status_code>202</simplified:status_code>
+   <schema:description>I'm working to locate a source for this identifier.</schema:description>
+  </simplified:message>
+
+  <link href="http://localhost:5000/?after=327&amp;size=100" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="next"/>
+</feed>


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR fixes the bug related to the OPDS importer not updating acquisition.

I don't think that adding `LicensePool. reset_open_access_download_url` method is a good solution, maybe it's better to create a setter for `LicensePool.best_open_access_link` property.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Steps to reproduce:

1. Import an OPDS feed using the OPDS importer.
2. Update acquisition links.
3. Reimport the feed.
4. Notice that the links were not updated.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

@tdilauro, I used the following steps for testing:
1. Restore the database dump:
```
pg_restore -d simplified_circulation_dump local-db-simplified_circ_db.dump
```
2. Create a mock service using [SoapUI](https://www.soapui.org/) served at `http://localhost:8080/test` which returns the same feed except `Album de grilles en fer creux et fer massif` book where:
- I updated all acquisition links by adding `1234567890` suffix to the their end.
- I set `<updated>` tag's value to the current date and time in UTC.
3. Update the URL of the OPDS collection:
```
update collections set external_account_id = 'http://localhost:8080/test' where id = 5;
```
4. Run `opds_import_monitor` script to reimport the updated book. 
_Please note that the whole page where `Album de grilles en fer creux et fer massif` is going to be reimported (this is by design)._
5. Recreate the search index. 
_Please note that the actions described above are required only because the local search index doesn't have information about all the books from the dump which is not the case in production._
- Drop the current index: 
```
curl --location --request DELETE 'localhost:9200/_all'
```
- Truncate all the work coverage records:
```
truncate workcoveragerecords;
```
- Refresh the search index by running `search_index_refresh`.
- Drop the cached feeds:
```
truncate cachedfeeds;
```
6. Open the admin UI. Because I don't know the admin's password I had to reset it by running the following query that sets the admin's password to `servers@lyrasistechnology.org`:
```
update admins set password_hashed = '$2a$12$sdOOruVaDzgVqVF6K4zp5.dyYtcykzIlGpZEA.m8RL3nJHaMPTswu' where id = 19;
```
7. Create a basic authentication provider. It's required for the CM's feed to work correctly, otherwise you won't be able to checkout books.
8. Find `Album de grilles en fer creux et fer massif` book and check it out.
9. Try to download the book and check in the logs or using the debugger that the fulfilment link actually contains `1234567890` suffix at the end.

Also I just found out that the change I made doesn't fully fix the issue related to cover links not being updated. In the case of this particular feed, they remain the same. You can confirm this by looking at the loans feed at `http://localhost:6500/190150/loans` after executing **step 8**.

It looks like that there are a couple of more changes required to fix the cover links issue:
1. Remove `Resource` records corresponding to `Hyperlink` records being deleted in `Metadata.apply` that can be implemented by adding `Hyperlink.delete` and `Resource.delete` methods in the same way as `LicensePoolDeliveryMechanism.delete`.
2. Erase `Edition.cover_full_url` and `Edition.cover_thumbnail_url` in `Metadata.apply` if `ReplacementPolicy.links` is `True`.
3. Reinitialize `Edition.cover_full_url` and `Edition.cover_thumbnail_url` using "new" links specified in `Metadata` object.
Unfortunately, I failed when I tried to implement all those steps and I think it can be implemented in a separate PR once this one is merged.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
