### PR TITLE
Fix UnicodeDecodeError in Identifier.__repr__ and LicensePoolDeliveryMechanism.__repr__

### DIFF
--- a/model/identifier.py
+++ b/model/identifier.py
@@ -83,11 +83,11 @@ class Identifier(Base, IdentifierConstants):
     def __repr__(self):
         records = self.primarily_identifies
         if records and records[0].title:
-            title = u' prim_ed=%d ("%s")' % (records[0].id, records[0].title)
+            title = u' prim_ed=%d ("%s")' % (records[0].id, six.ensure_text(records[0].title))
         else:
-            title = ""
+            title = u""
         return native_string(
-            u"%s/%s ID=%s%s" % (self.type, self.identifier, self.id, title)
+            u"%s/%s ID=%s%s" % (six.ensure_text(self.type), six.ensure_text(self.identifier), self.id, title)
         )
 
     # One Identifier may serve as the primary identifier for

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -4,6 +4,12 @@
 import datetime
 import logging
 
+import six
+from circulationevent import CirculationEvent
+from complaint import Complaint
+from constants import DataSourceConstants, EditionConstants, LinkRelations, MediaTypes
+from hasfulltablecache import HasFullTableCache
+from patron import Hold, Loan, Patron
 from sqlalchemy import (
     Boolean,
     Column,
@@ -20,31 +26,13 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.functions import func
 
-from circulationevent import CirculationEvent
-from complaint import Complaint
-from constants import (
-    DataSourceConstants,
-    EditionConstants,
-    LinkRelations,
-    MediaTypes,
-)
-from hasfulltablecache import HasFullTableCache
-from patron import (
-    Patron,
-    Loan,
-    Hold,
-)
-from . import (
-    Base,
-    create,
-    flush,
-    get_one,
-    get_one_or_create,
-)
+from ..util.string_helpers import native_string
+from . import Base, create, flush, get_one, get_one_or_create
 
 
 class PolicyException(Exception):
     pass
+
 
 class License(Base):
     """A single license for a work from a given source.
@@ -467,11 +455,7 @@ class LicensePool(Base):
 
         # Note: We can do a cleaner solution, if we refactor to not use metadata's
         # methods to update editions.  For now, we're choosing to go with the below approach.
-        from ..metadata_layer import (
-            Metadata,
-            IdentifierData,
-            ReplacementPolicy,
-        )
+        from ..metadata_layer import IdentifierData, Metadata, ReplacementPolicy
 
         if len(all_editions) == 1:
             # There's only one edition associated with this
@@ -1403,7 +1387,13 @@ class LicensePoolDeliveryMechanism(Base):
                 LicensePool.identifier==self.identifier)
 
     def __repr__(self):
-        return "<LicensePoolDeliveryMechanism: data_source=%s, identifier=%r, mechanism=%r>" % (self.data_source, self.identifier, self.delivery_mechanism)
+        return native_string(
+            u"<LicensePoolDeliveryMechanism: data_source={0}, identifier={1}, mechanism={2}>".format(
+                six.ensure_text(str(self.data_source)),
+                six.ensure_text(repr(self.identifier)),
+                six.ensure_text(repr(self.delivery_mechanism))
+            )
+        )
 
     __table_args__ = (
         UniqueConstraint('data_source_id', 'identifier_id',


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR fixes Unicode problems in `Identifier.__repr__` and `LicensePoolDeliveryMechanism.__repr__`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There are two problems:
1. [Mixing Unicode strings and byte literals|https://www.azavea.com/blog/2014/03/24/solving-unicode-problems-in-python-2-7/] in `Identifier.__repr__` . This works only when byte strings contain the first half of the ASCII table (the first 128 characters).

For example, this line works:
```
u'Test: %s' % 'a'
```

But this one throws `UnicodeDecodeError`:
```
u'Test: %s' % 'ą'
```

To make sure this code works we have to use `six.ensure_text` (or 'u' prefix for literals) which make sure that the byte string is converted into a Unicode object using `utf-8` encoding.
```
u'Test: %s' % six.ensure_text('ą')
```

2. Plugging Unicode strings into a byte string in `LicensePoolDeliveryMechanism.__repr__`. It also works only when Unicode strings contain only ASCII symbols, otherwise a `UnicodeDecodeError` is thrown when Python tries implicitly convert Unicode objects into byte strings. 

NOTE: Excessive use of `native_string`, `six.ensure_text` may slow down the system a bit.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
