### PR TITLE
Make basic info settings sys-admin-only

### DIFF
--- a/config.py
+++ b/config.py
@@ -226,7 +226,7 @@ class Configuration(ConfigurationConstants):
             "description": _("The library's main website, e.g. \"https://www.nypl.org/\" (not this Circulation Manager's URL)."),
             "required": True,
             "format": "url",
-            "level": ALL_ACCESS
+            "level": SYS_ADMIN_ONLY
         },
         {
             "key": ALLOW_HOLDS,


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-3556 and https://jira.nypl.org/browse/SIMPLY-3557; it turns out that librarians and library managers weren't supposed to have access to the fields in the "Basic Information" section after all. 