### PR TITLE
Update Python 3 CI Configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch. This prevents duplicated runs on internal PRs.
+    # Some discussion of this here: 
+    # https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ jobs:
     name: Run Core Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ jobs:
   test-core:
     name: Run Core Tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2
@@ -14,27 +17,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install tox
-
-      - name: Run docker containers for Tests
-        run: |
-          docker run -d -p 9005:5432/tcp --name db -e POSTGRES_USER=simplified_test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=simplified_circulation_test postgres:9.6
-          docker run -d -p 9006:9200/tcp --name es -e discovery.type=single-node elasticsearch:6.8.6
-          docker run -d -p 9007:9000/tcp --name minio -e MINIO_ACCESS_KEY=simplified -e MINIO_SECRET_KEY=12345678901234567890 bitnami/minio:latest
-          docker exec es elasticsearch-plugin install -s analysis-icu
-          docker restart es
+          pip install tox tox-gh-actions tox-docker
 
       - name: Run Core Tests
         run: tox
         working-directory: server_core
-        env:
-          SIMPLIFIED_TEST_DATABASE: "postgres://simplified_test:test@localhost:9005/simplified_circulation_test"
-          SIMPLIFIED_TEST_ELASTICSEARCH: "http://localhost:9006"
-          SIMPLIFIED_TEST_MINIO_ENDPOINT_URL: "http://localhost:9007"
-          SIMPLIFIED_TEST_MINIO_USER: "simplified"
-          SIMPLIFIED_TEST_MINIO_PASSWORD: "12345678901234567890"

--- a/README.md
+++ b/README.md
@@ -53,10 +53,14 @@ Test Python 3.8
 tox -e py38
 ```
 
+You need to have the Python versions you are testing against installed on your local system. `tox` searches the system for installed Python versions, but does not install new Python versions. If `tox` doesn't find the Python version its looking for it will give an `InterpreterNotFound` errror.
+
+[Pyenv](https://github.com/pyenv/pyenv) is a useful tool to install multiple Python versions, if you need to install missing Python versions in your system for local testing.
+
 ### Docker
 
 If you install `tox-docker` tox will take care of setting up all the service containers necessary to run the unit tests
-and pass the correct environment variables to configure the tests to use these services.
+and pass the correct environment variables to configure the tests to use these services. Using `tox-docker` is not required, but it is the recommended way to run the tests locally, since it runs the tests in the same way they are run on the Github Actions CI server. 
 
 ```
 pip install tox-docker

--- a/README.md
+++ b/README.md
@@ -23,6 +23,89 @@ Should you need to work on the core alone, use a traditional git workflow:
 $ git clone git@github.com:NYPL/Simplified-server-core.git core
 ```
 
+## Testing
+The github actions CI service runs the unit tests against Python 3.6, 3.7, 3.8 and 3.9 automatically using [tox](https://tox.readthedocs.io/en/latest/). 
+
+To run `pytest` unit tests locally, install `tox`.
+
+```
+pip install tox
+```
+
+Tox has an environment for each python version and an optional `-docker` factor that will automatically use docker to
+deploy service containers used for the tests. You can select the environment you would like to test with the tox `-e` 
+flag.
+
+### Environments
+
+| Environment | Python Version |
+| ----------- | -------------- |
+| py36        | Python 3.6     |
+| py37        | Python 3.7     | 
+| py38        | Python 3.8     | 
+| py39        | Python 3.9     |
+
+All of these environments are tested by default when running tox. To test one specific environment you can use the `-e`
+flag. 
+
+Test Python 3.8
+```
+tox -e py38
+```
+
+### Docker
+
+If you install `tox-docker` tox will take care of setting up all the service containers necessary to run the unit tests
+and pass the correct environment variables to configure the tests to use these services.
+
+```
+pip install tox-docker
+``` 
+
+The docker functionality is included in a `docker` factor that can be added to the environment. To run an environment
+with a particular factor you add it to the end of the environment. 
+
+Test with Python 3.8 using docker containers for the services.
+```
+tox -e py38-docker
+```
+
+### Local services
+
+If you already have elastic search or postgres running locally, you can run them instead by setting the
+following environment variables:
+
+- `SIMPLIFIED_TEST_DATABASE`
+- `SIMPLIFIED_TEST_ELASTICSEARCH`
+- `SIMPLIFIED_TEST_MINIO_ENDPOINT_URL`
+- `SIMPLIFIED_TEST_MINIO_USER`
+- `SIMPLIFIED_TEST_MINIO_PASSWORD`
+
+Make sure the ports and usernames are updated to reflect the local configuration.
+```
+# Set environment variables
+export SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:9005/simplified_circulation_test"
+export SIMPLIFIED_TEST_ELASTICSEARCH="http://localhost:9006"
+export SIMPLIFIED_TEST_MINIO_ENDPOINT_URL="http://localhost:9007"
+export SIMPLIFIED_TEST_MINIO_USER="simplified"
+export SIMPLIFIED_TEST_MINIO_PASSWORD="12345678901234567890"
+
+# Run tox
+tox -e py38
+```
+
+### Override `pytest` arguments
+
+If you wish to pass additional arguments to `pytest` you can do so through `tox`. The default argument passed to `pytest`
+is `tests`, however you can override this. Every argument passed after a `--` to the `tox` command line will the passed 
+to `pytest`, overriding the default.
+
+Only run the `test_cdn` tests with Python 3.6 using docker.
+
+```
+tox -e py36-docker -- tests/test_cdn.py
+```  
+
 ## License
 
 ```

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,57 @@
 [tox]
-envlist = py36
+envlist = py{36,37,38,39}-docker
 skipsdist = true
 
 [testenv]
 deps = -r requirements-dev.txt
 commands_pre =
+    docker: docker exec es elasticsearch-plugin -s install analysis-icu
+    docker: docker restart es
     python -m textblob.download_corpora
 commands =
     pytest --disable-warnings {posargs:"tests"}
 passenv = SIMPLIFIED_*
+setenv =
+    docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9005/simplified_circulation_test
+    docker: SIMPLIFIED_TEST_ELASTICSEARCH=http://localhost:9006
+    docker: SIMPLIFIED_TEST_MINIO_ENDPOINT_URL=http://localhost:9007
+    docker: SIMPLIFIED_TEST_MINIO_USER=simplified
+    docker: SIMPLIFIED_TEST_MINIO_PASSWORD=12345678901234567890
+docker =
+    docker: es
+    docker: db
+    docker: minio
 allowlist_externals =
+    docker: docker
     python
+
+[docker:db]
+image = postgres:9.6
+environment =
+    POSTGRES_USER=simplified_test
+    POSTGRES_PASSWORD=test
+    POSTGRES_DB=simplified_circulation_test
+ports =
+    9005:5432/tcp
+
+[docker:es]
+image = elasticsearch:6.8.6
+environment =
+    discovery.type=single-node
+ports =
+    9006:9200/tcp
+
+[docker:minio]
+image = bitnami/minio:latest
+environment =
+    MINIO_ACCESS_KEY=simplified
+    MINIO_SECRET_KEY=12345678901234567890
+ports =
+    9007:9000/tcp
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39


### PR DESCRIPTION
I wanted to make a suggestion for how we setup CI for Python 3. I pulled this file out of the Python 3 branch I had going, and applied it to @EdwinGuzman Python 3 branch. 

This PR:
- Sets up CI testing to run against multiple Python versions and simplifies the CI config
- Uses tox-docker to simplify the process of testing against containers
- Adds some notes to the readme about different options you can pass to tox

@EdwinGuzman I made this as PR onto your Python 3 branch, since its really just a small add on to that branch. If you want me to target another branch, or wait until the Python 3 PR is merged, just let me know and I'll change the PR.

This PR is showing that branch failing against Python 3.9. I can remove 3.9 from the CI config if we don't want to test against 3.9 for now, but it might be good to support Python 3.9 so I've left it in there for now.