### PR TITLE
Add ConfigurationMetadata.to_bool

### DIFF
--- a/model/configuration.py
+++ b/model/configuration.py
@@ -3,38 +3,24 @@
 import inspect
 import json
 import logging
-from abc import abstractmethod, ABCMeta
+from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
-
 from enum import Enum
+
+from constants import DataSourceConstants
 from flask_babel import lazy_gettext as _
-from sqlalchemy import (
-    Column,
-    ForeignKey,
-    Index,
-    Integer,
-    Unicode,
-    UniqueConstraint,
-)
+from hasfulltablecache import HasFullTableCache
+from library import Library
+from sqlalchemy import Column, ForeignKey, Index, Integer, Unicode, UniqueConstraint
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import and_
 
-from constants import DataSourceConstants
-from hasfulltablecache import HasFullTableCache
-from library import Library
-from . import (
-    Base,
-    get_one,
-    get_one_or_create,
-)
-from ..config import (
-    CannotLoadConfiguration,
-    Configuration,
-)
+from ..config import CannotLoadConfiguration, Configuration
 from ..mirror import MirrorUploader
 from ..util.string_helpers import random_string
+from . import Base, get_one, get_one_or_create
 
 
 class ExternalIntegrationLink(Base, HasFullTableCache):
@@ -1309,6 +1295,20 @@ class ConfigurationMetadata(object):
             ConfigurationAttribute.CATEGORY.value: self.category,
             ConfigurationAttribute.FORMAT.value: self.format
         }
+
+    @staticmethod
+    def to_bool(metadata):
+        """Return a boolean scalar indicating whether the configuration setting
+            contains a value that can be treated as True (see ConfigurationSetting.MEANS_YES).
+
+        :param metadata: ConfigurationMetadata object
+        :type metadata: ConfigurationMetadata
+
+        :return: Boolean scalar indicating
+            whether this configuration setting contains a value that can be treated as True
+        :rtype: bool
+        """
+        return str(metadata).lower() in ConfigurationSetting.MEANS_YES
 
 
 class ConfigurationGrouping(HasConfigurationSettings):


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds `ConfigurationMetadata.to_bool` allowing to convert ConfigurationMetadata instance's values to boolean scalars (True/False).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`ConfigurationMetadata.to_bool` resembles `ConfigurationSetting.bool_value`. I couldn't make it a property because it already has `__get__` magic method returning its internal value in a raw format.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
