### PR TITLE
Feature/collection monitor command line args

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -42,6 +42,7 @@ class CollectionMonitorLogger(logging.LoggerAdapter):
         self.extra = extra
         collection = self.extra.get('collection', None)
         self.log_prefix = '[{}] '.format(collection.name) if collection else ''
+        self.warn = self.warning
 
     def process(self, msg, kwargs):
         return '{}{}'.format(self.log_prefix, msg), kwargs

--- a/monitor.py
+++ b/monitor.py
@@ -122,6 +122,9 @@ class Monitor(object):
             return self.default_start_time
         return datetime.datetime.utcnow()
 
+    @property
+    def message_prefix(self):
+        return '[{}] '.format(self.collection.name) if self.collection else ''
 
     def timestamp(self):
         """Find or create a Timestamp for this Monitor.
@@ -170,7 +173,7 @@ class Monitor(object):
             if new_timestamp.achievements not in ignorable:
                 # This eliminates the need to create similar-looking
                 # strings for TimestampData.achievements and for the log.
-                self.log.info(new_timestamp.achievements)
+                self.log.info("%s%s", self.message_prefix, new_timestamp.achievements)
             if new_timestamp.exception in ignorable:
                 # run_once() completed with no exceptions being raised.
                 # We can run the cleanup code and finalize the timestamp.
@@ -191,8 +194,8 @@ class Monitor(object):
         except Exception:
             this_run_finish = datetime.datetime.utcnow()
             self.log.exception(
-                "Error running %s monitor. Timestamp will not be updated.",
-                self.service_name
+                "%sError running %s monitor. Timestamp will not be updated.",
+                self.message_prefix, self.service_name
             )
             exception = traceback.format_exc()
         if exception is not None:
@@ -206,8 +209,8 @@ class Monitor(object):
 
         duration = this_run_finish - this_run_start
         self.log.info(
-            "Ran %s monitor in %.2f sec.", self.service_name,
-            duration.total_seconds(),
+            "%sRan %s monitor in %.2f sec.", self.message_prefix,
+            self.service_name, duration.total_seconds(),
         )
 
     def run_once(self, progress):

--- a/scripts.py
+++ b/scripts.py
@@ -298,26 +298,6 @@ class RunMultipleMonitorsScript(Script):
                 )
 
 
-class RunCollectionMonitorScript(RunMultipleMonitorsScript):
-    """Run a CollectionMonitor on every Collection that comes through a
-    certain protocol.
-    """
-    def __init__(self, monitor_class, _db=None, **kwargs):
-        """Constructor.
-
-        :param monitor_class: A class object that derives from
-            CollectionMonitor.
-        :param kwargs: Keyword arguments to pass into the `monitor_class`
-            constructor each time it's called.
-        """
-        super(RunCollectionMonitorScript, self).__init__(_db, **kwargs)
-        self.monitor_class = monitor_class
-        self.name = self.monitor_class.SERVICE_NAME
-
-    def monitors(self, **kwargs):
-        return self.monitor_class.all(self._db, **kwargs)
-
-
 class RunReaperMonitorsScript(RunMultipleMonitorsScript):
     """Run all the monitors found in ReaperMonitor.REGISTRY"""
 
@@ -1819,6 +1799,51 @@ class CollectionInputScript(Script):
             default=CollectionType.OPEN_ACCESS
         )
         return parser
+
+
+class CollectionArgumentsScript(CollectionInputScript):
+
+    @classmethod
+    def arg_parser(cls):
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            'collection_names',
+            help='One or more collection names.',
+            metavar='COLLECTION', nargs='*'
+        )
+        return parser
+
+
+class RunCollectionMonitorScript(RunMultipleMonitorsScript, CollectionArgumentsScript):
+    """Run a CollectionMonitor on every Collection that comes through a
+    certain protocol.
+    """
+
+    def __init__(self, monitor_class, _db=None, cmd_args=None, **kwargs):
+        """Constructor.
+
+        :param monitor_class: A class object that derives from
+            CollectionMonitor.
+        :type monitor_class: CollectionMonitor
+
+        :param cmd_args: Optional command line arguments. These will be
+            passed on to the command line parser.
+        :type cmd_args: Optional[List[str]]
+
+        :param kwargs: Keyword arguments to pass into the `monitor_class`
+            constructor each time it's called.
+
+        """
+        super(RunCollectionMonitorScript, self).__init__(_db, **kwargs)
+        self.monitor_class = monitor_class
+        self.name = self.monitor_class.SERVICE_NAME
+        parsed = vars(self.parse_command_line(self._db, cmd_args=cmd_args))
+        parsed.pop('collection_names', None)
+        self.collections = parsed.pop('collections', None)
+        self.kwargs.update(parsed)
+
+    def monitors(self, **kwargs):
+        return self.monitor_class.all(self._db, collections=self.collections, **kwargs)
 
 
 class OPDSImportScript(CollectionInputScript):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -340,6 +340,30 @@ class TestCollectionMonitor(DatabaseTest):
         # OPDSCollectionMonitor for the Bibliotheca collection.
         assert [o2, o3, o1] == [x.collection for x in monitors]
 
+        # If `collections` are specified, monitors should be yielded in the same order.
+        opds_collections = [o3, o1, o2]
+        monitors = list(OPDSCollectionMonitor.all(self._db, collections=opds_collections))
+        monitor_collections = [m.collection for m in monitors]
+        # We should get a monitor for each collection.
+        assert set(opds_collections) == set(monitor_collections)
+        # We should get them back in order.
+        assert opds_collections == monitor_collections
+
+        # If `collections` are specified, monitors should be yielded in the same order.
+        opds_collections = [o3, o1]
+        monitors = list(OPDSCollectionMonitor.all(self._db, collections=opds_collections))
+        monitor_collections = [m.collection for m in monitors]
+        # We should get a monitor for each collection.
+        assert set(opds_collections) == set(monitor_collections)
+        # We should get them back in order.
+        assert opds_collections == monitor_collections
+
+        # If collections are specified, they must match the monitor's protocol.
+        with pytest.raises(ValueError) as excinfo:
+            monitors = list(OPDSCollectionMonitor.all(self._db, collections=[b1]))
+        assert 'Collection protocol (Bibliotheca) does not match Monitor protocol (OPDS Import)' in str(excinfo.value)
+        assert 'Only the following collections are available: ' in str(excinfo.value)
+
 
 class TestTimelineMonitor(DatabaseTest):
 


### PR DESCRIPTION
## Description

This branch makes some enhancements focused on collection monitors. At the highest level, these changes allow us to:
- run collection monitors with a subset of collections and
- understand to which collection a monitor's log message applies.

Here's a little more detail:
- The monitor's logger provides a prefix that includes the name of the monitor's collection, if a collection is associated with the monitor.
- The `CollectionMonitor.all` method now takes a `collections` parameter to help its (mostly script runner) collaborators control which collections will have monitors generated for them.
  - If none specified, then all collections will be returned, in an order determined by their timestamps.
  - If one or more collections are specified, then a monitor will be run for each, in the order the collections are specified.
- `RunCollectionMonitorScript`s now parses arguments during initialization and accepts zero or more collection names. Those names are transformed to their associated collections and passed on to `CollectionMonitor.all`.

## Motivation and Context

- It is currently difficult or impossible to determine to which collection a monitor's log messages refer.
- Recently, we have needed to run monitors either against specific collections or  against all collections in a controlled manner.

https://jira.nypl.org/browse/SIMPLY-3416

## How Has This Been Tested?

Tested some existing monitors to verify that the new collection name details were present in log messages.
Created new tests and, in addition to running this repo's test suite, I ran that of the current `circulation` repo `develop` branch with `core` updated to this `server_core` commit.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
