### PR TITLE
All CachedFeeds are served as privately cacheable for libraries that don't show everything to all patrons

### DIFF
--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -197,14 +197,18 @@ class CachedFeed(Base):
             # internal cache.
             response_kwargs['max_age'] = 0
 
-        if library.has_root_lanes:
-            # If this Lane is associated with a library that guides
+        if keys.library and keys.library.has_root_lanes:
+            # If this feed is associated with a Library that guides
             # patrons to different lanes based on their patron type,
-            # all lane feeds need to be treated as private (but
-            # cacheable). Otherwise, a change of credentials on the
-            # client side might cause a cached representation to be
-            # reused when it should have been discarded.
-            response_args['private'] = True
+            # all CachedFeeds need to be treated as private (but
+            # cacheable) on the client side. Otherwise, a change of
+            # client credentials might cause a cached representation
+            # to be reused when it should have been discarded.
+            #
+            # TODO: it might be possible to make this decision in a
+            # more fine-grained way, which would allow intermediaries
+            # to cache these feeds.
+            response_kwargs['private'] = True
 
         return OPDSFeedResponse(
             response=feed_data,

--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -197,6 +197,15 @@ class CachedFeed(Base):
             # internal cache.
             response_kwargs['max_age'] = 0
 
+        if library.has_root_lanes:
+            # If this Lane is associated with a library that guides
+            # patrons to different lanes based on their patron type,
+            # all lane feeds need to be treated as private (but
+            # cacheable). Otherwise, a change of credentials on the
+            # client side might cause a cached representation to be
+            # reused when it should have been discarded.
+            response_args['private'] = True
+
         return OPDSFeedResponse(
             response=feed_data,
             **response_kwargs

--- a/tests/models/test_cachedfeed.py
+++ b/tests/models/test_cachedfeed.py
@@ -389,6 +389,18 @@ class TestCachedFeed(DatabaseTest):
         assert isinstance(r, OPDSFeedResponse)
         assert OPDSFeed.DEFAULT_MAX_AGE == r.max_age
 
+        # If the Library associated with the WorkList used in the feed
+        # has root lanes, `private` is always set to True, even if we
+        # asked for the opposite.
+        from unittest.mock import PropertyMock, patch
+        from ...model import Library
+        Library._has_root_lane_cache[self._default_library.id] = True
+        r = CachedFeed.fetch(
+            self._db, wl, facets, pagination, refresh,
+            private=False
+        )
+        assert isinstance(r, OPDSFeedResponse)
+        assert True == r.private
 
     # Tests of helper methods.
 

--- a/tests/util/test_flask_util.py
+++ b/tests/util/test_flask_util.py
@@ -49,7 +49,13 @@ class TestResponse(object):
         headers = Response(max_age=0, private=False).headers
         assert "public, no-cache" == headers['Cache-Control']
 
-        # Test the case where the response _should_ be cached.
+        # Test the case where the response is private but may be
+        # cached privately.
+        headers = Response(max_age=300, private=True).headers
+        assert "private, no-transform, max-age=300" == headers['Cache-Control']
+
+        # Test the case where the response is public and may be cached,
+        # including by intermediaries.
         max_age = 60*60*24*12
         obj = Response(max_age=max_age)
 

--- a/tests/util/test_flask_util.py
+++ b/tests/util/test_flask_util.py
@@ -40,6 +40,7 @@ class TestResponse(object):
         def assert_not_cached(max_age):
             headers = Response(max_age=max_age).headers
             assert "private, no-cache" == headers['Cache-Control']
+            assert 'Authorization' == headers['Vary']
             assert 'Expires' not in headers
         assert_not_cached(max_age=None)
         assert_not_cached(max_age=0)
@@ -48,11 +49,13 @@ class TestResponse(object):
         # Test the case where the response is public but should not be cached.
         headers = Response(max_age=0, private=False).headers
         assert "public, no-cache" == headers['Cache-Control']
+        assert 'Vary' not in headers
 
         # Test the case where the response is private but may be
         # cached privately.
         headers = Response(max_age=300, private=True).headers
         assert "private, no-transform, max-age=300" == headers['Cache-Control']
+        assert 'Authorization' == headers['Vary']
 
         # Test the case where the response is public and may be cached,
         # including by intermediaries.
@@ -84,6 +87,7 @@ class TestResponse(object):
         cache_control = response.headers['Cache-Control']
         assert 'private' in cache_control
         assert 'max-age=30' in cache_control
+        assert 'Authorization' == response.headers['Vary']
 
     def test_unicode(self):
         # You can easily convert a Response object to Unicode

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -111,8 +111,8 @@ class Response(FlaskResponse):
             else:
                 # A public resource can be cached by intermediaries
                 # for half as long as the end-user can cache it.
-                s_maxage = ", s-maxage=%d" % self.max_age / 2
-            cache_control = "%s, no-transform, max-age=%d,%s" % (
+                s_maxage = ", s-maxage=%d" % (self.max_age / 2)
+            cache_control = "%s, no-transform, max-age=%d%s" % (
                 private, client_cache, s_maxage
             )
 


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/OE-25 by changing the caching rules for all CachedFeeds served for libraries that direct patrons to different lanes based on their patron type. For those libraries, all CachedFeeds are treated as private. 

"Private" here refers to a concept defined in util/flask_util.py:Response as a way of bundling together a few features of HTTP. These feeds are not necessarily "private" in the sense that their contents are secret; "private" here only refers to the rules about when the feeds can be cached. Most of this branch is tweaking what exactly "private" means:
 
Previously, private resources were served with `Cache-Control: private`, meaning they can only be cached by the final recipient, not by intermediaries such as CDNs. This is still true.

As of this branch, private resources are also served with `Vary: Authorization`, meaning they can only be cached by the credentials that requested them. This is the piece that (I hope) actually fixes OE-25.

And as of this branch, private resources are _not_ served with `Cache-Control: s-maxage`. That told intermediaries how long to cache the representation, which conflicted with the `Cache-Control: private` directive.

