### PR TITLE
Simplify UTC timestamp migration, run as single statement transactions

### DIFF
--- a/migration/20210405-update-datetime-columns.sql
+++ b/migration/20210405-update-datetime-columns.sql
@@ -1,73 +1,32 @@
 -- Change all the datetime data columns to use data type `timestamptz`. Dates
 -- are already stored in UTC internally by postgres but are not returned
 -- as timezone aware datetime objects.
+--
+-- Note that the column alteration is sufficient to set the column values to
+-- the equivalent of `some_datetime_column at time zone 'utc'`, because
+-- the cast adds `+00` to the value (which is the utc offset). So no additional
+-- UPDATE is necessary to set the column values.
+--
+-- Force the core migration script to run each command in this file as an individual transaction:
+--   SIMPLYE_MIGRATION_TRANSACTION_PER_STATEMENT
 
 ALTER TABLE cachedfeeds ALTER COLUMN "timestamp" SET DATA TYPE timestamptz;
-ALTER TABLE cachedmarcfiles ALTER COLUMN start_time SET DATA TYPE timestamptz;
-ALTER TABLE cachedmarcfiles ALTER COLUMN end_time SET DATA TYPE timestamptz;
-ALTER TABLE circulationevents ALTER COLUMN "start" SET DATA TYPE timestamptz;
-ALTER TABLE circulationevents ALTER COLUMN "end" SET DATA TYPE timestamptz;
-ALTER TABLE complaints ALTER COLUMN "timestamp" SET DATA TYPE timestamptz;
-ALTER TABLE complaints ALTER COLUMN resolved SET DATA TYPE timestamptz;
-ALTER TABLE timestamps ALTER COLUMN "start" SET DATA TYPE timestamptz;
-ALTER TABLE timestamps ALTER COLUMN finish SET DATA TYPE timestamptz;
+ALTER TABLE cachedmarcfiles ALTER COLUMN start_time SET DATA TYPE timestamptz, ALTER COLUMN end_time SET DATA TYPE timestamptz;
+ALTER TABLE circulationevents ALTER COLUMN "start" SET DATA TYPE timestamptz, ALTER COLUMN "end" SET DATA TYPE timestamptz;
+ALTER TABLE complaints ALTER COLUMN "timestamp" SET DATA TYPE timestamptz, ALTER COLUMN resolved SET DATA TYPE timestamptz;
+ALTER TABLE timestamps ALTER COLUMN "start" SET DATA TYPE timestamptz, ALTER COLUMN finish SET DATA TYPE timestamptz;
 ALTER TABLE coveragerecords ALTER COLUMN "timestamp" SET DATA TYPE timestamptz;
 ALTER TABLE workcoveragerecords ALTER COLUMN "timestamp" SET DATA TYPE timestamptz;
 ALTER TABLE credentials ALTER COLUMN expires SET DATA TYPE timestamptz;
-ALTER TABLE customlists ALTER COLUMN created SET DATA TYPE timestamptz;
-ALTER TABLE customlists ALTER COLUMN updated SET DATA TYPE timestamptz;
-ALTER TABLE customlistentries ALTER COLUMN first_appearance SET DATA TYPE timestamptz;
-ALTER TABLE customlistentries ALTER COLUMN most_recent_appearance SET DATA TYPE timestamptz;
-ALTER TABLE integrationclients ALTER COLUMN created SET DATA TYPE timestamptz;
-ALTER TABLE integrationclients ALTER COLUMN last_accessed SET DATA TYPE timestamptz;
+ALTER TABLE customlists ALTER COLUMN created SET DATA TYPE timestamptz, ALTER COLUMN updated SET DATA TYPE timestamptz;
+ALTER TABLE customlistentries ALTER COLUMN first_appearance SET DATA TYPE timestamptz, ALTER COLUMN most_recent_appearance SET DATA TYPE timestamptz;
+ALTER TABLE integrationclients ALTER COLUMN created SET DATA TYPE timestamptz, ALTER COLUMN last_accessed SET DATA TYPE timestamptz;
 ALTER TABLE licenses ALTER COLUMN expires SET DATA TYPE timestamptz;
-ALTER TABLE licensepools ALTER COLUMN availability_time SET DATA TYPE timestamptz;
-ALTER TABLE licensepools ALTER COLUMN last_checked SET DATA TYPE timestamptz;
+ALTER TABLE licensepools ALTER COLUMN availability_time SET DATA TYPE timestamptz, ALTER COLUMN last_checked SET DATA TYPE timestamptz;
 ALTER TABLE measurements ALTER COLUMN taken_at SET DATA TYPE timestamptz;
-ALTER TABLE patrons ALTER COLUMN last_external_sync SET DATA TYPE timestamptz;
-ALTER TABLE patrons ALTER COLUMN last_loan_activity_sync SET DATA TYPE timestamptz;
-ALTER TABLE loans ALTER COLUMN "start" SET DATA TYPE timestamptz;
-ALTER TABLE loans ALTER COLUMN "end" SET DATA TYPE timestamptz;
-ALTER TABLE holds ALTER COLUMN "start" SET DATA TYPE timestamptz;
-ALTER TABLE holds ALTER COLUMN "end" SET DATA TYPE timestamptz;
+ALTER TABLE patrons ALTER COLUMN last_external_sync SET DATA TYPE timestamptz, ALTER COLUMN last_loan_activity_sync SET DATA TYPE timestamptz;
+ALTER TABLE loans ALTER COLUMN "start" SET DATA TYPE timestamptz, ALTER COLUMN "end" SET DATA TYPE timestamptz;
+ALTER TABLE holds ALTER COLUMN "start" SET DATA TYPE timestamptz, ALTER COLUMN "end" SET DATA TYPE timestamptz;
 ALTER TABLE annotations ALTER COLUMN "timestamp" SET DATA TYPE timestamptz;
-ALTER TABLE representations ALTER COLUMN fetched_at SET DATA TYPE timestamptz;
-ALTER TABLE representations ALTER COLUMN mirrored_at SET DATA TYPE timestamptz;
-ALTER TABLE representations ALTER COLUMN scaled_at SET DATA TYPE timestamptz;
-ALTER TABLE works ALTER COLUMN last_update_time SET DATA TYPE timestamptz;
-ALTER TABLE works ALTER COLUMN presentation_ready_attempt SET DATA TYPE timestamptz;
-
-update cachedfeeds set timestamp = (timestamp at time zone 'utc');
-update cachedmarcfiles set start_time = (start_time at time zone 'utc');
-update cachedmarcfiles set end_time = (end_time at time zone 'utc');
-update circulationevents set "start" = ("start" at time zone 'utc');
-update circulationevents set "end" = ("end" at time zone 'utc');
-update complaints set "timestamp" = ("timestamp" at time zone 'utc');
-update complaints set resolved = (resolved at time zone 'utc');
-update timestamps set "start" = ("start" at time zone 'utc');
-update timestamps set finish = (finish at time zone 'utc');
-update coveragerecords set "timestamp" = ("timestamp" at time zone 'utc');
-update workcoveragerecords set "timestamp" = ("timestamp" at time zone 'utc');
-update credentials set expires = (expires at time zone 'utc');
-update customlists set created = (created at time zone 'utc');
-update customlists set updated = (updated at time zone 'utc');
-update customlistentries set first_appearance = (first_appearance at time zone 'utc');
-update customlistentries set most_recent_appearance = (most_recent_appearance at time zone 'utc');
-update integrationclients set created = (created at time zone 'utc');
-update integrationclients set last_accessed = (last_accessed at time zone 'utc');
-update licenses set expires = (expires at time zone 'utc');
-update licensepools set availability_time = (availability_time at time zone 'utc');
-update licensepools set last_checked = (last_checked at time zone 'utc');
-update measurements set taken_at = (taken_at at time zone 'utc');
-update patrons set last_external_sync = (last_external_sync at time zone 'utc');
-update patrons set last_loan_activity_sync = (last_loan_activity_sync at time zone 'utc');
-update loans set "start" = ("start" at time zone 'utc');
-update loans set "end" = ("end" at time zone 'utc');
-update holds set "start" = ("start" at time zone 'utc');
-update holds set "end" = ("end" at time zone 'utc');
-update annotations set "timestamp" = ("timestamp" at time zone 'utc');
-update representations set fetched_at = (fetched_at at time zone 'utc');
-update representations set mirrored_at = (mirrored_at at time zone 'utc');
-update representations set scaled_at = (scaled_at at time zone 'utc');
-update works set last_update_time = (last_update_time at time zone 'utc');
-update works set presentation_ready_attempt = (presentation_ready_attempt at time zone 'utc');
+ALTER TABLE representations ALTER COLUMN fetched_at SET DATA TYPE timestamptz, ALTER COLUMN mirrored_at SET DATA TYPE timestamptz, ALTER COLUMN scaled_at SET DATA TYPE timestamptz;
+ALTER TABLE works ALTER COLUMN last_update_time SET DATA TYPE timestamptz, ALTER COLUMN presentation_ready_attempt SET DATA TYPE timestamptz;

--- a/scripts.py
+++ b/scripts.py
@@ -2491,7 +2491,7 @@ class DatabaseMigrationScript(Script):
         # Update timestamp for the migration.
         self.update_timestamps(migration_filename)
 
-    def _extract_statements_from_sql_file(filepath):
+    def _extract_statements_from_sql_file(self, filepath):
         """
         From an SQL file, return a python list of the individual statements.
 

--- a/scripts.py
+++ b/scripts.py
@@ -2052,6 +2052,8 @@ class DatabaseMigrationScript(Script):
     # There are some SQL commands that can't be run inside a transaction.
     TRANSACTIONLESS_COMMANDS = ['alter type']
 
+    TRANSACTION_PER_STATEMENT = 'SIMPLYE_MIGRATION_TRANSACTION_PER_STATEMENT'
+
     class TimestampInfo(object):
         """Act like a ORM Timestamp object, but with no database connection."""
 
@@ -2467,8 +2469,14 @@ class DatabaseMigrationScript(Script):
                 sql = clause.read()
 
                 transactionless = any([c for c in self.TRANSACTIONLESS_COMMANDS if c in sql.lower()])
+                one_tx_per_statement = bool(self.TRANSACTION_PER_STATEMENT.lower() in sql.lower())
+
                 if transactionless:
                     new_session = self._run_migration_without_transaction(sql)
+                elif one_tx_per_statement:
+                    commands = self._extract_statements_from_sql_file(migration_path)
+                    for command in commands:
+                        self._db.execute(f"BEGIN;{command}COMMIT;")
                 else:
                     # By wrapping the action in a transation, we can avoid
                     # rolling over errors and losing data in files
@@ -2482,6 +2490,34 @@ class DatabaseMigrationScript(Script):
 
         # Update timestamp for the migration.
         self.update_timestamps(migration_filename)
+
+    def _extract_statements_from_sql_file(filepath):
+        """
+        From an SQL file, return a python list of the individual statements.
+
+        Removes comment lines and extraneous whitespace at the start / end of
+        statements, but that's about it. Use carefully.
+        """
+        with open(filepath) as f:
+            sql_file_lines = f.readlines()
+
+        sql_commands = []
+        current_command = ''
+
+        for line in sql_file_lines:
+            if line.strip().startswith('--'):
+                continue
+            else:
+                if current_command == '':
+                    current_command = line.strip()
+                else:
+                    current_command = current_command + ' ' + line.strip()
+
+            if current_command.endswith(';'):
+                sql_commands.append(current_command)
+                current_command = ''
+
+        return sql_commands
 
     def _run_migration_without_transaction(self, sql_statement):
         """Runs a single SQL statement outside of a transaction."""


### PR DESCRIPTION
I've changed two things:

1. I set the `migration/20210405-update-datetime-columns.sql` file up to use one `ALTER` per table, and removed the `UPDATE` statements because the conversion is actually accomplished during the table alteration.
2. I added some logic to `scripts.py` in the `DatabaseMigrationScript` class, aimed at running individual statements in a migration file within their own transactions. That only triggers if somewhere in the .sql file the string `SIMPLYE_MIGRATION_TRANSACTION_PER_STATEMENT` appears.

I don't have the circ manager set up locally in a way that makes this easy to test, so anything you spot would be good to know about before I build this and try it on QA.