### PR TITLE
Fix two Python 3 conversion errors in Overdrive code

### DIFF
--- a/overdrive.py
+++ b/overdrive.py
@@ -346,7 +346,7 @@ class OverdriveAPI(object):
     @property
     def token_authorization_header(self):
         s = b"%s:%s" % (self.client_key, self.client_secret)
-        return base64.standard_b64encode(s).strip()
+        return "Basic " + base64.standard_b64encode(s).strip()
 
     def token_post(self, url, payload, headers={}, **kwargs):
         """Make an HTTP POST request for purposes of getting an OAuth token."""

--- a/overdrive.py
+++ b/overdrive.py
@@ -1,4 +1,3 @@
-
 import datetime
 import isbnlib
 import os
@@ -439,7 +438,8 @@ class OverdriveAPI(object):
         )
         return self.make_link_safe(url)
 
-    def _get_book_list_page(self, link, rel_to_follow='next'):
+    def _get_book_list_page(self, link, rel_to_follow='next',
+                            extractor_class=None):
         """Process a page of inventory whose circulation we need to check.
 
         Returns a 2-tuple: (availability_info, next_link).
@@ -448,23 +448,19 @@ class OverdriveAPI(object):
            one book.
         `next_link` is a link to the next page of results.
         """
+        extractor_class = extractor_class or OverdriveRepresentationExtractor
         # We don't cache this because it changes constantly.
         status_code, headers, content = self.get(link, {})
         if isinstance(content, (bytes, str)):
             content = json.loads(content)
 
         # Find the link to the next page of results, if any.
-        next_link = OverdriveRepresentationExtractor.link(
-            content, rel_to_follow
-        )
+        next_link = extractor_class.link(content, rel_to_follow)
 
         # Prepare to get availability information for all the books on
         # this page.
-        availability_queue = (
-            OverdriveRepresentationExtractor.availability_link_list(content)
-        )
+        availability_queue = (extractor_class.availability_link_list(content))
         return availability_queue, next_link
-
 
     def recently_changed_ids(self, start, cutoff):
         """Get IDs of books whose status has changed between the start time

--- a/overdrive.py
+++ b/overdrive.py
@@ -344,12 +344,15 @@ class OverdriveAPI(object):
         else:
             return status_code, headers, content
 
+    @property
+    def token_authorization_header(self):
+        s = b"%s:%s" % (self.client_key, self.client_secret)
+        return base64.standard_b64encode(s).strip()
+
     def token_post(self, url, payload, headers={}, **kwargs):
         """Make an HTTP POST request for purposes of getting an OAuth token."""
-        s = b"%s:%s" % (self.client_key, self.client_secret)
-        auth = base64.standard_b64encode(s).strip()
         headers = dict(headers)
-        headers['Authorization'] = "Basic %s" % auth
+        headers['Authorization'] = self.token_authorization_header
         return self._do_post(url, payload, headers, **kwargs)
 
     def _update_credential(self, credential, overdrive_data):

--- a/overdrive.py
+++ b/overdrive.py
@@ -346,7 +346,7 @@ class OverdriveAPI(object):
 
     def token_post(self, url, payload, headers={}, **kwargs):
         """Make an HTTP POST request for purposes of getting an OAuth token."""
-        s = "%s:%s" % (self.client_key, self.client_secret)
+        s = b"%s:%s" % (self.client_key, self.client_secret)
         auth = base64.standard_b64encode(s).strip()
         headers = dict(headers)
         headers['Authorization'] = "Basic %s" % auth
@@ -447,7 +447,7 @@ class OverdriveAPI(object):
         """
         # We don't cache this because it changes constantly.
         status_code, headers, content = self.get(link, {})
-        if isinstance(content, str):
+        if isinstance(content, (bytes, str)):
             content = json.loads(content)
 
         # Find the link to the next page of results, if any.

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -176,8 +176,8 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
     def test_token_authorization_header(self):
         # Verify that the Authorization header needed to get an access
         # token for a given collection is encoded properly.
-        assert self.api.token_authorization_header == "YTpi"
-        assert self.api.token_authorization_header == base64.standard_b64encode(
+        assert self.api.token_authorization_header == "Basic YTpi"
+        assert self.api.token_authorization_header == "Basic " + base64.standard_b64encode(
             b"%s:%s" % (self.api.client_key, self.api.client_secret)
         )
 

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -41,6 +41,7 @@ from ..util.http import (
     BadResponseException,
     HTTP,
 )
+from ..util.string_helpers import base64
 
 from ..testing import DatabaseTest
 
@@ -171,6 +172,14 @@ class TestOverdriveAPI(OverdriveTestWithAPI):
         # appear to contain extra formatting characters.
         assert (result + "%3A" ==
             self.api.endpoint(result +"%3A", extra="something else"))
+
+    def test_token_authorization_header(self):
+        # Verify that the Authorization header needed to get an access
+        # token for a given collection is encoded properly.
+        assert self.api.token_authorization_header == "YTpi"
+        assert self.api.token_authorization_header == base64.standard_b64encode(
+            b"%s:%s" % (self.api.client_key, self.api.client_secret)
+        )
 
     def test_token_post_success(self):
         self.api.queue_response(200, content="some content")


### PR DESCRIPTION
This branch fixes two Python 3 conversion problems in Overdrive code:

* When generating the Authorization header, keys and secrets like `foo` were being encoded as `b'foo'`, leading to authentication failures.
* In one case, Unicode strings were converted to JSON before processing, but bytestrings (which we actually get from Overdrive) were being left alone, causing a crash.

In addition to the unit tests, I ran the overdrive_format_sweep, overdrive_monitor_recent, and overdrive_new_titles scripts using the QA database. Without the first fix in place, all three scripts would fail immediately. Without the second fix in place, a couple of these scripts (overdrive_monitor_recent and overdrive_format_sweep, I think) would fail pretty quickly.