### PR TITLE
Convert bytestring ConfigurationSetting values to Unicode before storing in the database

### DIFF
--- a/model/configuration.py
+++ b/model/configuration.py
@@ -733,7 +733,9 @@ class ConfigurationSetting(Base, HasFullTableCache):
 
     @value.setter
     def value(self, new_value):
-        if new_value is not None:
+        if isinstance(new_value, bytes):
+            new_value = new_value.decode("utf8")
+        elif new_value is not None:
             new_value = str(new_value)
         self._value = new_value
 

--- a/tests/models/test_configuration.py
+++ b/tests/models/test_configuration.py
@@ -244,6 +244,19 @@ class TestConfigurationSetting(DatabaseTest):
             assert (
                 cs == get_one(self._db, ConfigurationSetting, id=cs.id))
 
+    @parameterized.expand([
+        ('no value', None, None),
+        ('stringable value', 1, '1'),
+        ('string value', 'snowman', 'snowman'),
+        ('bytes value', '☃'.encode("utf8"), '☃'),
+    ])
+    def test_setter(self, _, set_to, expect):
+        # Values are converted into Unicode strings on the way in to
+        # the 'value' setter.
+        setting = ConfigurationSetting.sitewide(self._db, "setting")
+        setting.value = set_to
+        assert setting.value == expect
+
     def test_int_value(self):
         number = ConfigurationSetting.sitewide(self._db, "number")
         assert None == number.int_value


### PR DESCRIPTION
This branch fixes bugs found during in-person testing of qa-circulation.librarysimplified.org using the SimplyE mobile app.

* Setting `ConfigurationSetting.value` to the bytestring `foo` converted it to its Python representation, `b'foo'`, rather than converting it to the Unicode string `foo`.

I looked through the code for other places where we encrypt or decrypt things, and didn't find any other problems like this. 