### PR TITLE
Added a reverse migration for timestamptz changes

### DIFF
--- a/migration/20210604-reverse-update-datetime-columns.sql
+++ b/migration/20210604-reverse-update-datetime-columns.sql
@@ -1,0 +1,31 @@
+-- This is a reverse migration for 20210405-update-datetime-columns.sql
+-- It should only be uncommented in the event that you need to deploy this fix
+-- via the build system. Otherwise, you should run the commands by hand.
+--
+-- Force the core migration script to run each command in this file as an individual transaction:
+--   SIMPLYE_MIGRATION_TRANSACTION_PER_STATEMENT
+--
+-- Force the migration script to ignore this migration. Remove the following
+-- line and uncomment the ALTER statements if you need this to be run automatically.
+--   SIMPLYE_MIGRATION_DO_NOT_EXECUTE
+
+--ALTER TABLE cachedfeeds ALTER COLUMN "timestamp" SET DATA TYPE timestamp;
+--ALTER TABLE cachedmarcfiles ALTER COLUMN start_time SET DATA TYPE timestamp, ALTER COLUMN end_time SET DATA TYPE timestamp;
+--ALTER TABLE circulationevents ALTER COLUMN "start" SET DATA TYPE timestamp, ALTER COLUMN "end" SET DATA TYPE timestamp;
+--ALTER TABLE complaints ALTER COLUMN "timestamp" SET DATA TYPE timestamp, ALTER COLUMN resolved SET DATA TYPE timestamp;
+--ALTER TABLE timestamps ALTER COLUMN "start" SET DATA TYPE timestamp, ALTER COLUMN finish SET DATA TYPE timestamp;
+--ALTER TABLE coveragerecords ALTER COLUMN "timestamp" SET DATA TYPE timestamp;
+--ALTER TABLE workcoveragerecords ALTER COLUMN "timestamp" SET DATA TYPE timestamp;
+--ALTER TABLE credentials ALTER COLUMN expires SET DATA TYPE timestamp;
+--ALTER TABLE customlists ALTER COLUMN created SET DATA TYPE timestamp, ALTER COLUMN updated SET DATA TYPE timestamp;
+--ALTER TABLE customlistentries ALTER COLUMN first_appearance SET DATA TYPE timestamp, ALTER COLUMN most_recent_appearance SET DATA TYPE timestamp;
+--ALTER TABLE integrationclients ALTER COLUMN created SET DATA TYPE timestamp, ALTER COLUMN last_accessed SET DATA TYPE timestamp;
+--ALTER TABLE licenses ALTER COLUMN expires SET DATA TYPE timestamp;
+--ALTER TABLE licensepools ALTER COLUMN availability_time SET DATA TYPE timestamp, ALTER COLUMN last_checked SET DATA TYPE timestamp;
+--ALTER TABLE measurements ALTER COLUMN taken_at SET DATA TYPE timestamp;
+--ALTER TABLE patrons ALTER COLUMN last_external_sync SET DATA TYPE timestamp, ALTER COLUMN last_loan_activity_sync SET DATA TYPE timestamp;
+--ALTER TABLE loans ALTER COLUMN "start" SET DATA TYPE timestamp, ALTER COLUMN "end" SET DATA TYPE timestamp;
+--ALTER TABLE holds ALTER COLUMN "start" SET DATA TYPE timestamp, ALTER COLUMN "end" SET DATA TYPE timestamp;
+--ALTER TABLE annotations ALTER COLUMN "timestamp" SET DATA TYPE timestamp;
+--ALTER TABLE representations ALTER COLUMN fetched_at SET DATA TYPE timestamp, ALTER COLUMN mirrored_at SET DATA TYPE timestamp, ALTER COLUMN scaled_at SET DATA TYPE timestamp;
+--ALTER TABLE works ALTER COLUMN last_update_time SET DATA TYPE timestamp, ALTER COLUMN presentation_ready_attempt SET DATA TYPE timestamp;

--- a/scripts.py
+++ b/scripts.py
@@ -2053,6 +2053,7 @@ class DatabaseMigrationScript(Script):
     TRANSACTIONLESS_COMMANDS = ['alter type']
 
     TRANSACTION_PER_STATEMENT = 'SIMPLYE_MIGRATION_TRANSACTION_PER_STATEMENT'
+    DO_NOT_EXECUTE = 'SIMPLYE_MIGRATION_DO_NOT_EXECUTE'
 
     class TimestampInfo(object):
         """Act like a ORM Timestamp object, but with no database connection."""
@@ -2463,6 +2464,7 @@ class DatabaseMigrationScript(Script):
         """Runs a single SQL or Python migration file"""
 
         migration_filename = os.path.split(migration_path)[1]
+        ok_to_execute = True
 
         if migration_path.endswith('.sql'):
             with open(migration_path) as clause:
@@ -2470,26 +2472,29 @@ class DatabaseMigrationScript(Script):
 
                 transactionless = any([c for c in self.TRANSACTIONLESS_COMMANDS if c in sql.lower()])
                 one_tx_per_statement = bool(self.TRANSACTION_PER_STATEMENT.lower() in sql.lower())
+                ok_to_execute = not bool(self.DO_NOT_EXECUTE.lower() in sql.lower())
 
-                if transactionless:
-                    new_session = self._run_migration_without_transaction(sql)
-                elif one_tx_per_statement:
-                    commands = self._extract_statements_from_sql_file(migration_path)
-                    for command in commands:
-                        self._db.execute(f"BEGIN;{command}COMMIT;")
-                else:
-                    # By wrapping the action in a transation, we can avoid
-                    # rolling over errors and losing data in files
-                    # with multiple interrelated SQL actions.
-                    sql = 'BEGIN;\n%s\nCOMMIT;' % sql
-                    self._db.execute(sql)
+                if ok_to_execute:
+                    if transactionless:
+                        new_session = self._run_migration_without_transaction(sql)
+                    elif one_tx_per_statement:
+                        commands = self._extract_statements_from_sql_file(migration_path)
+                        for command in commands:
+                            self._db.execute(f"BEGIN;{command}COMMIT;")
+                    else:
+                        # By wrapping the action in a transation, we can avoid
+                        # rolling over errors and losing data in files
+                        # with multiple interrelated SQL actions.
+                        sql = 'BEGIN;\n%s\nCOMMIT;' % sql
+                        self._db.execute(sql)
 
         if migration_path.endswith('.py'):
             module_name = migration_filename[:-3]
             subprocess.call(migration_path)
 
         # Update timestamp for the migration.
-        self.update_timestamps(migration_filename)
+        if ok_to_execute:
+            self.update_timestamps(migration_filename)
 
     def _extract_statements_from_sql_file(self, filepath):
         """


### PR DESCRIPTION
Does two things, in service of [SIMPLY-3774](https://jira.nypl.org/browse/SIMPLY-3774)

* Adds a migration with ALTER TABLE commands which would reverse what's in [20210405-update-datetime-columns.sql](https://github.com/NYPL-Simplified/server_core/blob/develop/migration/20210405-update-datetime-columns.sql), with the actual lines commented out in case it accidentally gets parsed by the migration job.
* Adds a mechanism for forcing the migration script to skip over a particular SQL migration file, so that nothing ends up in timestamps for migrations, in case this filename ever actually needs to run.