### PR TITLE
Convert datetimes on their way in and out of the database to avoid the need for a database migration.

### DIFF
--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -3,6 +3,7 @@
 
 from . import (
     Base,
+    DateTime,
     flush,
     get_one,
     get_one_or_create,
@@ -12,7 +13,6 @@ import datetime
 import logging
 from sqlalchemy import (
     Column,
-    DateTime,
     ForeignKey,
     Index,
     Integer,

--- a/model/circulationevent.py
+++ b/model/circulationevent.py
@@ -5,7 +5,6 @@
 import logging
 from sqlalchemy import (
     Column,
-    DateTime,
     ForeignKey,
     Index,
     Integer,
@@ -15,6 +14,7 @@ from sqlalchemy import (
 
 from . import (
     Base,
+    DateTime,
     get_one_or_create,
 )
 from ..util.datetime_helpers import utc_now

--- a/model/complaint.py
+++ b/model/complaint.py
@@ -3,7 +3,6 @@
 
 from sqlalchemy import (
     Column,
-    DateTime,
     ForeignKey,
     Integer,
     String,
@@ -12,6 +11,7 @@ from sqlalchemy.orm.session import Session
 
 from . import (
     Base,
+    DateTime,
     create,
     get_one_or_create,
 )

--- a/model/coverage.py
+++ b/model/coverage.py
@@ -3,7 +3,6 @@
 
 from sqlalchemy import (
     Column,
-    DateTime,
     Enum,
     ForeignKey,
     Index,
@@ -22,6 +21,7 @@ from sqlalchemy.sql.expression import (
 
 from . import (
     Base,
+    DateTime,
     get_one,
     get_one_or_create,
 )

--- a/model/credential.py
+++ b/model/credential.py
@@ -5,7 +5,6 @@ import uuid
 import sqlalchemy
 from sqlalchemy import (
     Column,
-    DateTime,
     ForeignKey,
     Index,
     Integer,
@@ -16,7 +15,7 @@ from sqlalchemy.orm import backref, relationship
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import and_
 
-from . import Base, get_one, get_one_or_create
+from . import Base, get_one, get_one_or_create, DateTime
 from ..util import is_session
 from ..util.datetime_helpers import utc_now
 

--- a/model/customlist.py
+++ b/model/customlist.py
@@ -7,7 +7,6 @@ import logging
 from sqlalchemy import (
     Boolean,
     Column,
-    DateTime,
     ForeignKey,
     Index,
     Integer,
@@ -20,6 +19,7 @@ from sqlalchemy.orm.session import Session
 
 from . import (
     Base,
+    DateTime,
     get_one_or_create,
 )
 from .datasource import DataSource

--- a/model/integrationclient.py
+++ b/model/integrationclient.py
@@ -6,7 +6,6 @@ import re
 from sqlalchemy import (
     Boolean,
     Column,
-    DateTime,
     Integer,
     Unicode,
 )
@@ -16,6 +15,7 @@ from sqlalchemy.orm import (
 
 from . import (
     Base,
+    DateTime,
     get_one,
     get_one_or_create,
 )

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -5,7 +5,6 @@ import logging
 from sqlalchemy import (
     Boolean,
     Column,
-    DateTime,
     ForeignKey,
     Index,
     Integer,
@@ -23,7 +22,7 @@ from .complaint import Complaint
 from .constants import DataSourceConstants, EditionConstants, LinkRelations, MediaTypes
 from .hasfulltablecache import HasFullTableCache
 from .patron import Hold, Loan, Patron
-from . import Base, create, flush, get_one, get_one_or_create
+from . import Base, create, DateTime, flush, get_one, get_one_or_create
 from ..util.datetime_helpers import utc_now
 
 

--- a/model/measurement.py
+++ b/model/measurement.py
@@ -2,7 +2,7 @@
 # Measurement
 
 
-from . import Base
+from . import Base, DateTime
 from .constants import DataSourceConstants
 
 import bisect
@@ -10,7 +10,6 @@ import logging
 from sqlalchemy import (
     Boolean,
     Column,
-    DateTime,
     Float,
     ForeignKey,
     Integer,

--- a/model/patron.py
+++ b/model/patron.py
@@ -7,7 +7,6 @@ from sqlalchemy import (
     Boolean,
     Column,
     Date,
-    DateTime,
     ForeignKey,
     Index,
     Integer,
@@ -23,6 +22,7 @@ import uuid
 
 from . import (
     Base,
+    DateTime,
     get_one_or_create,
     numericrange_to_tuple
 )

--- a/model/resource.py
+++ b/model/resource.py
@@ -14,7 +14,6 @@ import requests
 from sqlalchemy import (
     Binary,
     Column,
-    DateTime,
     Float,
     ForeignKey,
     Integer,
@@ -35,6 +34,7 @@ from urllib.parse import urlparse, urlsplit, quote
 
 from . import (
     Base,
+    DateTime,
     get_one,
     get_one_or_create,
 )

--- a/model/work.py
+++ b/model/work.py
@@ -6,7 +6,6 @@ from collections import Counter
 from sqlalchemy import (
     Boolean,
     Column,
-    DateTime,
     Enum,
     Float,
     ForeignKey,
@@ -49,6 +48,7 @@ from .identifier import Identifier
 from .measurement import Measurement
 from . import (
     Base,
+    DateTime,
     flush,
     get_one_or_create,
     numericrange_to_string,

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -777,7 +777,8 @@ class TestS3Uploader(S3UploaderTest):
             'SHORT',
             'Lane',
             datetime_utc(2020, 1, 1, 0, 0, 0),
-            'https://marc.s3.amazonaws.com/SHORT/2020-01-01%2000%3A00%3A00%2B00%3A00/Lane.mrc'
+            # TODO-UTC 'https://marc.s3.amazonaws.com/SHORT/2020-01-01%2000%3A00%3A00%2B00%3A00/Lane.mrc'
+            'https://marc.s3.amazonaws.com/SHORT/2020-01-01%2000%3A00%3A00/Lane.mrc'
         ),
         (
             'with_s3_bucket_and_end_time_and_start_time',
@@ -785,7 +786,8 @@ class TestS3Uploader(S3UploaderTest):
             'SHORT',
             'Lane',
             datetime_utc(2020, 1, 2, 0, 0, 0),
-            'https://marc.s3.amazonaws.com/SHORT/2020-01-01%2000%3A00%3A00%2B00%3A00-2020-01-02%2000%3A00%3A00%2B00%3A00/Lane.mrc',
+            # TODO-UTC 'https://marc.s3.amazonaws.com/SHORT/2020-01-01%2000%3A00%3A00%2B00%3A00-2020-01-02%2000%3A00%3A00%2B00%3A00/Lane.mrc',
+            'https://marc.s3.amazonaws.com/SHORT/2020-01-01%2000%3A00%3A00-2020-01-02%2000%3A00%3A00/Lane.mrc',
             datetime_utc(2020, 1, 1, 0, 0, 0),
         ),
         (
@@ -794,7 +796,8 @@ class TestS3Uploader(S3UploaderTest):
             'SHORT',
             'Lane',
             datetime_utc(2020, 1, 2, 0, 0, 0),
-            'https://marc.s3.us-east-2.amazonaws.com/SHORT/2020-01-01%2000%3A00%3A00%2B00%3A00-2020-01-02%2000%3A00%3A00%2B00%3A00/Lane.mrc',
+            # TODO-UTC 'https://marc.s3.us-east-2.amazonaws.com/SHORT/2020-01-01%2000%3A00%3A00%2B00%3A00-2020-01-02%2000%3A00%3A00%2B00%3A00/Lane.mrc',
+            'https://marc.s3.us-east-2.amazonaws.com/SHORT/2020-01-01%2000%3A00%3A00-2020-01-02%2000%3A00%3A00/Lane.mrc',
             datetime_utc(2020, 1, 1, 0, 0, 0),
             'us-east-2'
         ),
@@ -804,7 +807,8 @@ class TestS3Uploader(S3UploaderTest):
             'SHORT',
             'Lane',
             datetime_utc(2020, 1, 2, 0, 0, 0),
-            'http://marc/SHORT/2020-01-01%2000%3A00%3A00%2B00%3A00-2020-01-02%2000%3A00%3A00%2B00%3A00/Lane.mrc',
+            # TODO-UTC 'http://marc/SHORT/2020-01-01%2000%3A00%3A00%2B00%3A00-2020-01-02%2000%3A00%3A00%2B00%3A00/Lane.mrc',
+            'http://marc/SHORT/2020-01-01%2000%3A00%3A00-2020-01-02%2000%3A00%3A00/Lane.mrc',
             datetime_utc(2020, 1, 1, 0, 0, 0)
         ),
         (
@@ -813,7 +817,8 @@ class TestS3Uploader(S3UploaderTest):
             'SHORT',
             'Lane',
             datetime_utc(2020, 1, 2, 0, 0, 0),
-            'https://marc/SHORT/2020-01-01%2000%3A00%3A00%2B00%3A00-2020-01-02%2000%3A00%3A00%2B00%3A00/Lane.mrc',
+            # TODO-UTC 'https://marc/SHORT/2020-01-01%2000%3A00%3A00%2B00%3A00-2020-01-02%2000%3A00%3A00%2B00%3A00/Lane.mrc',
+            'https://marc/SHORT/2020-01-01%2000%3A00%3A00-2020-01-02%2000%3A00%3A00/Lane.mrc',
             datetime_utc(2020, 1, 1, 0, 0, 0)
         )
     ])

--- a/tests/util/test_datetime_helpers.py
+++ b/tests/util/test_datetime_helpers.py
@@ -178,11 +178,16 @@ class TestToUTC(object):
 
         # Passing in a timezone-aware datetime converts the datetime
         # to UTC and removes timezone information.
-        d1 = datetime.datetime(2021, 1, 1, 0, 0, 0)
+        d1 = datetime.datetime(2021, 1, 2, 3, 4, 5)
         d1_eastern = d1.astimezone(pytz.timezone("US/Eastern"))
+
+        # At this point, UTC is 5 hours ahead of Eastern time.
         d1_utc_naive = to_utc(d1_eastern)
+
+        # So we end up with a timezone-naive datetime that
+        # represents the corresponding time in UTC.
         assert d1_utc_naive.tzinfo is None
-        assert d1_utc_naive == datetime.datetime(2021, 1, 1, 5, 0, 0)
+        assert d1_utc_naive == datetime.datetime(2021, 1, 2, 8, 4, 5)
 
     @parameterized.expand([
         ([2021, 1, 1], "2021-01-01", "%Y-%m-%d"),

--- a/tests/util/test_datetime_helpers.py
+++ b/tests/util/test_datetime_helpers.py
@@ -8,6 +8,7 @@ from ...util.datetime_helpers import (
     datetime_utc,
     from_timestamp,
     strptime_utc,
+    to_naive_utc,
     to_utc,
     utc_now,
 )
@@ -183,11 +184,15 @@ class TestToUTC(object):
 
         # At this point, UTC is 5 hours ahead of Eastern time.
         d1_utc_naive = to_utc(d1_eastern)
+        
+        expect_1 = to_naive_utc(d1_eastern.astimezone(pytz.UTC))
+        expect_2 = datetime.datetime(2021, 1, 2, 8, 4, 5)
 
         # So we end up with a timezone-naive datetime that
         # represents the corresponding time in UTC.
+        assert expect_1 == expect_2
         assert d1_utc_naive.tzinfo is None
-        assert d1_utc_naive == datetime.datetime(2021, 1, 2, 8, 4, 5)
+        assert d1_utc_naive == expect_2
 
     @parameterized.expand([
         ([2021, 1, 1], "2021-01-01", "%Y-%m-%d"),

--- a/util/datetime_helpers.py
+++ b/util/datetime_helpers.py
@@ -11,21 +11,21 @@ def datetime_utc(*args, **kwargs):
     """Return a datetime object but with UTC information from pytz.
     :return: datetime object
     """
-    return datetime.datetime(*args, **kwargs, tzinfo=pytz.UTC)
+    return to_naive_utc(datetime.datetime(*args, **kwargs, tzinfo=pytz.UTC))
 
 def from_timestamp(ts):
     """Return a UTC datetime object from a timestamp.
 
     :return: datetime object
     """
-    return datetime.datetime.fromtimestamp(ts, tz=pytz.UTC)
+    return to_naive_utc(datetime.datetime.fromtimestamp(ts, tz=pytz.UTC))
 
 def utc_now():
     """Get the current time in UTC.
 
     :return: datetime object
     """
-    return datetime.datetime.now(tz=pytz.UTC)
+    return to_naive_utc(datetime.datetime.now(tz=pytz.UTC))
 
 def to_utc(dt):
     """This converts a naive datetime object that represents UTC into
@@ -41,11 +41,11 @@ def to_utc(dt):
         # TODO: Not sure about this, maybe it should become midnight.
         return dt
     if dt.tzinfo is None:
-        return dt.replace(tzinfo=pytz.UTC)
+        return to_naive_utc(dt.replace(tzinfo=pytz.UTC))
     if dt.tzinfo == pytz.UTC:
         # Already UTC.
-        return dt
-    return dt.astimezone(pytz.UTC)
+        return to_naive_utc(dt)
+    return to_naive_utc(dt.astimezone(pytz.UTC))
 
 def to_naive_utc(dt):
     """This tries really hard to convert a datetime object into a naive
@@ -54,7 +54,7 @@ def to_naive_utc(dt):
     if dt is None:
         return dt
 
-    if isinstance(dt, datetime.date):
+    if isinstance(dt, datetime.date) and not isinstance(dt, datetime.datetime):
         # Dates don't have timezones.
         # TODO: Not sure about this, maybe it should become midnight.
         return dt

--- a/util/datetime_helpers.py
+++ b/util/datetime_helpers.py
@@ -43,6 +43,26 @@ def to_utc(dt):
         return dt
     return dt.astimezone(pytz.UTC)
 
+def to_naive_utc(dt):
+    """This tries really hard to convert a datetime object into a naive
+    datetime object that represents UTC.
+    """
+    if dt is None:
+        return dt
+
+    if dt.tzinfo is None:
+        # Already naive; we can only assume it also already represents
+        # UTC.
+        return dt
+
+    if dt.tzinfo != pytz.UTC:
+        # Timezone-aware but not UTC. Convert to UTC.
+        dt = to_utc(dt)
+
+    # Now it's a timezone-aware UTC datetime. Remove the tzinfo to
+    # make it naive.
+    return dt.replace(tzinfo=None)
+
 def strptime_utc(date_string, format):
     """Parse a string that describes a time but includes no timezone,
     into a timezone-aware datetime object set to UTC.

--- a/util/datetime_helpers.py
+++ b/util/datetime_helpers.py
@@ -36,7 +36,7 @@ def to_utc(dt):
     """
     if dt is None:
         return None
-    if isinstance(dt, datetime.date):
+    if isinstance(dt, datetime.date) and not isinstance(dt, datetime.datetime):
         # Dates don't have timezones.
         # TODO: Not sure about this, maybe it should become midnight.
         return dt
@@ -74,7 +74,7 @@ def to_naive_utc(dt):
 
 def strptime_utc(date_string, format):
     """Parse a string that describes a time but includes no timezone,
-    into a timezone-aware datetime object set to UTC.
+    into a timezone-naive datetime object.
 
     :raise ValueError: If `format` expects timezone information to be
         present in `date_string`.

--- a/util/datetime_helpers.py
+++ b/util/datetime_helpers.py
@@ -36,6 +36,10 @@ def to_utc(dt):
     """
     if dt is None:
         return None
+    if isinstance(dt, datetime.date):
+        # Dates don't have timezones.
+        # TODO: Not sure about this, maybe it should become midnight.
+        return dt
     if dt.tzinfo is None:
         return dt.replace(tzinfo=pytz.UTC)
     if dt.tzinfo == pytz.UTC:
@@ -48,6 +52,11 @@ def to_naive_utc(dt):
     datetime object that represents UTC.
     """
     if dt is None:
+        return dt
+
+    if isinstance(dt, datetime.date):
+        # Dates don't have timezones.
+        # TODO: Not sure about this, maybe it should become midnight.
         return dt
 
     if dt.tzinfo is None:


### PR DESCRIPTION
This is a speculative branch that would allow us to release 4.0.0 (already a risky release due to the Python 3 migration) without _also_ introducing a long-running database migration.

We've already done the work to make sure that all times go into the database as timezone-aware datetime objects. This branch modifies the `DateTime` database field type so that these values get converted into timezone-naive datetime objects at the last minute, on their way _out to_  the database (converting to UTC if necessary), and then get converted into timezone-aware UTC objects on their way _in from_ the database.

As far as I can tell, this works fine, but it introduces its own kind of risk, especially since I had to change the functions in datetime_helpers.py to return timezone-naive objects. I wouldn't think this would be necessary and it may indicate I have something wrong in the decorator class.

Given that we now only need to do one big 4.0.0 migration, based on code that's been thoroughly QAed, I'm leaning towards closing this PR, but I'd like to get your take first.