### PR TITLE
Split up database migration statements into groups that can be executed in parallel.

### DIFF
--- a/migration/20210405-update-datetime-columns.sql
+++ b/migration/20210405-update-datetime-columns.sql
@@ -10,13 +10,24 @@
 -- Force the core migration script to run each command in this file as an individual transaction:
 --   SIMPLYE_MIGRATION_TRANSACTION_PER_STATEMENT
 
-ALTER TABLE cachedfeeds ALTER COLUMN "timestamp" SET DATA TYPE timestamptz;
+-- NOTE: This migration can take a long time, and you may be able to
+-- speed it up considerably by running the SQL statements in
+-- batches. To do this, open two database sessions, and run the
+-- statements from Group 1A in one session while running the statements
+-- from Group 1B in the other.
+--
+-- Then run the statements from Group 2A in one session while running
+-- the statements from Group 2B in the other.
+--
+-- If you run this migration manually, be sure to update the timestamps
+-- table afterwards:
+--
+-- UPDATE timestamps SET start='2021-04-05', finish='2021-04-05' where service='Database Migration';
+
+-- Group 1A
 ALTER TABLE cachedmarcfiles ALTER COLUMN start_time SET DATA TYPE timestamptz, ALTER COLUMN end_time SET DATA TYPE timestamptz;
-ALTER TABLE circulationevents ALTER COLUMN "start" SET DATA TYPE timestamptz, ALTER COLUMN "end" SET DATA TYPE timestamptz;
 ALTER TABLE complaints ALTER COLUMN "timestamp" SET DATA TYPE timestamptz, ALTER COLUMN resolved SET DATA TYPE timestamptz;
-ALTER TABLE timestamps ALTER COLUMN "start" SET DATA TYPE timestamptz, ALTER COLUMN finish SET DATA TYPE timestamptz;
 ALTER TABLE coveragerecords ALTER COLUMN "timestamp" SET DATA TYPE timestamptz;
-ALTER TABLE workcoveragerecords ALTER COLUMN "timestamp" SET DATA TYPE timestamptz;
 ALTER TABLE credentials ALTER COLUMN expires SET DATA TYPE timestamptz;
 ALTER TABLE customlists ALTER COLUMN created SET DATA TYPE timestamptz, ALTER COLUMN updated SET DATA TYPE timestamptz;
 ALTER TABLE customlistentries ALTER COLUMN first_appearance SET DATA TYPE timestamptz, ALTER COLUMN most_recent_appearance SET DATA TYPE timestamptz;
@@ -28,5 +39,15 @@ ALTER TABLE patrons ALTER COLUMN last_external_sync SET DATA TYPE timestamptz, A
 ALTER TABLE loans ALTER COLUMN "start" SET DATA TYPE timestamptz, ALTER COLUMN "end" SET DATA TYPE timestamptz;
 ALTER TABLE holds ALTER COLUMN "start" SET DATA TYPE timestamptz, ALTER COLUMN "end" SET DATA TYPE timestamptz;
 ALTER TABLE annotations ALTER COLUMN "timestamp" SET DATA TYPE timestamptz;
+
+-- Group 1B
 ALTER TABLE representations ALTER COLUMN fetched_at SET DATA TYPE timestamptz, ALTER COLUMN mirrored_at SET DATA TYPE timestamptz, ALTER COLUMN scaled_at SET DATA TYPE timestamptz;
+
+-- Group 2A
+ALTER TABLE timestamps ALTER COLUMN "start" SET DATA TYPE timestamptz, ALTER COLUMN finish SET DATA TYPE timestamptz;
+ALTER TABLE workcoveragerecords ALTER COLUMN "timestamp" SET DATA TYPE timestamptz;
 ALTER TABLE works ALTER COLUMN last_update_time SET DATA TYPE timestamptz, ALTER COLUMN presentation_ready_attempt SET DATA TYPE timestamptz;
+
+-- Group 2B
+ALTER TABLE cachedfeeds ALTER COLUMN "timestamp" SET DATA TYPE timestamptz;
+ALTER TABLE circulationevents ALTER COLUMN "start" SET DATA TYPE timestamptz, ALTER COLUMN "end" SET DATA TYPE timestamptz;

--- a/migration/20210405-update-datetime-columns.sql
+++ b/migration/20210405-update-datetime-columns.sql
@@ -22,7 +22,18 @@
 -- If you run this migration manually, be sure to update the timestamps
 -- table afterwards:
 --
--- UPDATE timestamps SET start='2021-04-05', finish='2021-04-05' where service='Database Migration';
+--  UPDATE timestamps SET start='2021-04-05', finish='2021-04-05' where service='Database Migration';
+--
+--
+-- The higher your `work_mem` and `temp_buffers`, the faster these
+-- migrations will run. At NYPL we temporarily increased the resources
+-- available to the database specifically for this script, and set
+-- session variables like this before running the ALTER commands:
+--
+--  set work_mem='4096MB'
+--  set temp_buffers='4096MB'
+--
+-- Manually vacuuming the tables beforehand will also help.
 
 -- Group 1A
 ALTER TABLE cachedmarcfiles ALTER COLUMN start_time SET DATA TYPE timestamptz, ALTER COLUMN end_time SET DATA TYPE timestamptz;

--- a/migration/20210604-reverse-update-datetime-columns.sql
+++ b/migration/20210604-reverse-update-datetime-columns.sql
@@ -2,6 +2,11 @@
 -- It should only be uncommented in the event that you need to deploy this fix
 -- via the build system. Otherwise, you should run the commands by hand.
 --
+-- These statements are grouped into the same batches as
+-- 20210405-update-datetime-columns.sql, and it may be possible to
+-- save time by running the batches in parallel, as described in that
+-- file.
+--
 -- Force the core migration script to run each command in this file as an individual transaction:
 --   SIMPLYE_MIGRATION_TRANSACTION_PER_STATEMENT
 --
@@ -9,13 +14,10 @@
 -- line and uncomment the ALTER statements if you need this to be run automatically.
 --   SIMPLYE_MIGRATION_DO_NOT_EXECUTE
 
---ALTER TABLE cachedfeeds ALTER COLUMN "timestamp" SET DATA TYPE timestamp;
+-- Group 1A
 --ALTER TABLE cachedmarcfiles ALTER COLUMN start_time SET DATA TYPE timestamp, ALTER COLUMN end_time SET DATA TYPE timestamp;
---ALTER TABLE circulationevents ALTER COLUMN "start" SET DATA TYPE timestamp, ALTER COLUMN "end" SET DATA TYPE timestamp;
 --ALTER TABLE complaints ALTER COLUMN "timestamp" SET DATA TYPE timestamp, ALTER COLUMN resolved SET DATA TYPE timestamp;
---ALTER TABLE timestamps ALTER COLUMN "start" SET DATA TYPE timestamp, ALTER COLUMN finish SET DATA TYPE timestamp;
 --ALTER TABLE coveragerecords ALTER COLUMN "timestamp" SET DATA TYPE timestamp;
---ALTER TABLE workcoveragerecords ALTER COLUMN "timestamp" SET DATA TYPE timestamp;
 --ALTER TABLE credentials ALTER COLUMN expires SET DATA TYPE timestamp;
 --ALTER TABLE customlists ALTER COLUMN created SET DATA TYPE timestamp, ALTER COLUMN updated SET DATA TYPE timestamp;
 --ALTER TABLE customlistentries ALTER COLUMN first_appearance SET DATA TYPE timestamp, ALTER COLUMN most_recent_appearance SET DATA TYPE timestamp;
@@ -27,5 +29,17 @@
 --ALTER TABLE loans ALTER COLUMN "start" SET DATA TYPE timestamp, ALTER COLUMN "end" SET DATA TYPE timestamp;
 --ALTER TABLE holds ALTER COLUMN "start" SET DATA TYPE timestamp, ALTER COLUMN "end" SET DATA TYPE timestamp;
 --ALTER TABLE annotations ALTER COLUMN "timestamp" SET DATA TYPE timestamp;
+
+
+-- Group 1B
 --ALTER TABLE representations ALTER COLUMN fetched_at SET DATA TYPE timestamp, ALTER COLUMN mirrored_at SET DATA TYPE timestamp, ALTER COLUMN scaled_at SET DATA TYPE timestamp;
+
+-- Group 2A
+--ALTER TABLE timestamps ALTER COLUMN "start" SET DATA TYPE timestamp, ALTER COLUMN finish SET DATA TYPE timestamp;
+--ALTER TABLE workcoveragerecords ALTER COLUMN "timestamp" SET DATA TYPE timestamp;
 --ALTER TABLE works ALTER COLUMN last_update_time SET DATA TYPE timestamp, ALTER COLUMN presentation_ready_attempt SET DATA TYPE timestamp;
+
+-- Group 2B
+
+--ALTER TABLE cachedfeeds ALTER COLUMN "timestamp" SET DATA TYPE timestamp;
+--ALTER TABLE circulationevents ALTER COLUMN "start" SET DATA TYPE timestamp, ALTER COLUMN "end" SET DATA TYPE timestamp;


### PR DESCRIPTION
This branch reorders the SQL statements in the big timezone migration script and adds advice from Ashok Kumar, NYPL's DBA, about executing the statements in two parallelized batches to reduce the time this migration will take.

We're going to try this out in an upcoming migration, and I'm OK with holding off merging this until we see how well it works, but I wanted to keep a record of Ashok's advice in our code base for the benefit of other folks.