### PR TITLE
Adding PYTHONDONTWRITEBYTECODE to run script

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -128,6 +128,9 @@ if [[ ! -f $logfile ]]; then
     touch $logfile
 fi
 
+# Force Python scripts not to write .pyc files
+export PYTHONDONTWRITEBYTECODE=1
+
 # Run the script and append its output to its log file.
 echo "Running $SCRIPT_NAME (PID: $$)"
 source $LIBSIMPLE_DIR/env/bin/activate && \


### PR DESCRIPTION
To keep us from having conflicting / corrupted pyc files, I've added an environment variable to the `core/bin/run` script. I've made this change on the live prod server, and I think we should keep an eye out there for new pyc files for a few days before we promote this as a solution. Further notes in the ticket for [SIMPLY-3873](https://jira.nypl.org/browse/SIMPLY-3873).