### PR TITLE
Handle the case where there are multiple items in heaviest_child.

### DIFF
--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -1491,7 +1491,10 @@ class WorkClassifier(object):
         #    print("", parent, genre, weight)
         made_it = False
         while not made_it:
-            for parent, (child, weight) in sorted(list(heaviest_child.items())):
+            for parent, (child, weight) in sorted(
+                heaviest_child.items(),
+                key=lambda genre: genre[1][1], reverse=True
+            )
                 parent_weight = consolidated.get(parent, 0)
                 if weight > (subgenre_swallows_parent_at * parent_weight):
                     consolidated[child] += parent_weight

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -1494,7 +1494,7 @@ class WorkClassifier(object):
             for parent, (child, weight) in sorted(
                 heaviest_child.items(),
                 key=lambda genre: genre[1][1], reverse=True
-            )
+            ):
                 parent_weight = consolidated.get(parent, 0)
                 if weight > (subgenre_swallows_parent_at * parent_weight):
                     consolidated[child] += parent_weight

--- a/tests/classifiers/test_classifier.py
+++ b/tests/classifiers/test_classifier.py
@@ -236,6 +236,19 @@ class TestConsolidateWeights(object):
         assert 104 == w2[classifier.Paranormal_Romance]
         assert classifier.Romance not in w2
 
+    def test_consolidate_consolidates_multiple_subgenres(self):
+        # This work is classified under two different sets of
+        # genres/subgenres. Both of the genre/subgenre pairs get
+        # rolled up properly, not just the heavier one.
+        weights = dict()
+        weights[classifier.Women_Detectives] = 150
+        weights[classifier.Mystery] = 10
+        weights[classifier.Historical_Romance] = 200
+        weights[classifier.Romance] = 10
+        w2 = WorkClassifier.consolidate_genre_weights(weights)
+        assert 210 == w2[classifier.Historical_Romance]
+        assert 160 == w2[classifier.Women_Detectives]
+
     def test_consolidate_through_multiple_levels_from_multiple_sources(self):
         # This test can't work anymore because we no longer have a
         # triply-nested category like Romance/Erotica -> Romance ->


### PR DESCRIPTION
This PR fixes https://jira.nypl.org/browse/SIMPLY-3858 by changing the way a sequence of (GenreData : (GenreData, int)) tuples is sorted. GenreData objects aren't comparable, so the correct solution is to sort by the ints.