### PR TITLE
OE-317 Check authentication_flow_document type

### DIFF
--- a/tests/test_authentication_for_opds.py
+++ b/tests/test_authentication_for_opds.py
@@ -29,7 +29,7 @@ class MockMultipleFlows(Flow):
                 'type': 'http://mock2/',
                 'links': {
                     'rel': 'authenticate',
-                    'href': f'http://{argument}/'
+                    'href': 'http://mock/'
                 }
             }
         ]

--- a/tests/test_authentication_for_opds.py
+++ b/tests/test_authentication_for_opds.py
@@ -15,6 +15,26 @@ class MockFlow(Flow):
                  "type" : "http://mock1/"}
 
 
+class MockMultipleFlows(Flow):
+    """A mock of OPDSAuthenticationFlow that returns a list of dictionaries."""
+
+    def _authentication_flow_document(self, argument):
+        return [
+            {
+                'description': 'one',
+                'type': 'http://mock1/'
+            },
+            {
+                'description': 'two',
+                'type': 'http://mock2/',
+                'links': {
+                    'rel': 'authenticate',
+                    'href': f'http://{argument}/'
+                }
+            }
+        ]
+
+
 class MockFlowWithURI(Flow):
     """A mock OPDSAuthenticationFlow that sets URI."""
     FLOW_TYPE = "http://mock2/"
@@ -44,6 +64,22 @@ class TestOPDSAuthenticationFlow(object):
             {'type': 'http://mock1/', 'description': 'description',
              'arg': 'argument'} ==
             doc)
+
+    def test_flow_returns_two_documents(self):
+        """An OPDSAuthenticationFlow object can
+        return multiple flow documents that differ.
+        """
+        flow = MockMultipleFlows()
+        docs = flow.authentication_flow_document("mock")
+
+        assert len(docs) == 2
+        assert isinstance(docs, list)
+        assert isinstance(docs[0], dict)
+        assert isinstance(docs[1], dict)
+
+        [doc] = list(filter(lambda d: d.get('links'), docs))
+        assert 'authenticate' in doc.get('links').values()
+        assert 'http://mock/' == doc.get('links').get('href')
 
     def test_flow_gets_type_from_uri(self):
         """An OPDSAuthenticationFlow object can define the class variableURI

--- a/util/authentication_for_opds.py
+++ b/util/authentication_for_opds.py
@@ -8,8 +8,9 @@ class OPDSAuthenticationFlow(object):
     FLOW_TYPE = None
 
     def authentication_flow_document(self, _db):
-        """Convert this object into a dictionary that can be used in the
-        `authentication` list of an Authentication For OPDS document.
+        """Convert this object into a dictionary or a
+        list of dictionaries that can be used in the
+        `authentication` list of an AuthenticationFor OPDS document.
         """
         data = self._authentication_flow_document(_db)
         if isinstance(data, list):

--- a/util/authentication_for_opds.py
+++ b/util/authentication_for_opds.py
@@ -12,13 +12,21 @@ class OPDSAuthenticationFlow(object):
         `authentication` list of an Authentication For OPDS document.
         """
         data = self._authentication_flow_document(_db)
+        if isinstance(data, list):
+            for entry in data:
+                self._get_type(entry)
+        else:
+            self._get_type(data)
+
+        return data
+
+    def _get_type(self, data):
         if not data.get('type'):
             data['type'] = self.FLOW_TYPE
         if not data.get('type'):
             raise ValueError(
                 "Authentication flow document for %r does not include required field 'type'" % self
             )
-        return data
 
     def _authentication_flow_document(self, _db):
         raise NotImplementedError()


### PR DESCRIPTION
This first checks if the authentication flow document is a list or a single entry. From there it checks the document's `type` as it was originally.

This change is needed since `BasicAuthenticationProvider` is sending two authentication documents.