### PR TITLE
OE-162 / OE-317 fix authentications in authentication_document

### DIFF
--- a/tests/test_authentication_for_opds.py
+++ b/tests/test_authentication_for_opds.py
@@ -139,7 +139,7 @@ class TestAuthenticationForOPDSDocument(object):
         )
 
         doc = doc_obj.to_dict("arg")
-        assert len(doc['authenticatoin']) == 3
+        assert len(doc['authentication']) == 3
         assert (
             {'id': 'id',
              'title': 'title',

--- a/tests/test_authentication_for_opds.py
+++ b/tests/test_authentication_for_opds.py
@@ -126,6 +126,40 @@ class TestAuthenticationForOPDSDocument(object):
             } ==
             doc)
 
+    def test_mutliple_flows(self):
+        """Verify that to_dict() works with multiple flows.
+        """
+        doc_obj = Doc(
+            id="id",
+            title="title",
+            authentication_flows=[MockMultipleFlows(), MockFlow("three")],
+            links=[
+                dict(rel="register", href="http://registration")
+            ]
+        )
+
+        doc = doc_obj.to_dict("arg")
+        assert len(doc['authenticatoin']) == 3
+        assert (
+            {'id': 'id',
+             'title': 'title',
+             'authentication': [
+                    {'description': 'one',
+                     'type': 'http://mock1/'},
+                    {'description': 'two',
+                     'type': 'http://mock2/',
+                     'links': {'rel': 'authenticate',
+                               'href': 'http://mock/'}
+                    },
+                    {'description': 'three',
+                     'arg': 'arg',
+                     'type': 'http://mock1/'}
+                ],
+                'links': [
+                    {'rel': 'register', 'href': 'http://registration'}]
+            } ==
+            doc)
+
     def test_bad_document(self):
         """Test that to_dict() raises ValueError when something is
         wrong with the data.

--- a/util/authentication_for_opds.py
+++ b/util/authentication_for_opds.py
@@ -81,7 +81,12 @@ class AuthenticationForOPDSDocument(object):
         document = dict(id=self.id, title=self.title)
         flow_documents = document.setdefault('authentication', [])
         for flow in self.authentication_flows:
-            flow_documents.append(flow.authentication_flow_document(_db))
+            docs = flow.authentication_flow_document(_db)
+            if isinstance(docs, list):
+                for doc in docs:
+                    flow_documents.append(doc)
+            else:
+                flow_documents.append(docs)
         if self.links:
             doc_links = document.setdefault('links', [])
             for link in self.links:


### PR DESCRIPTION
This fixes the `authentication` list in the `authentication_document` to ensure it is a list of dictionaries rather than a mixed list that contained lists and dictionaries.

Since `BasicAuthenticationProvider` is currently returning a list of authentication flow documents (one for Basic Auth and one for OAuth) `AuthenticationForOPDSDocument.to_dict()` will need to account for it and flatten the list it creates for `authentication`.